### PR TITLE
feat(cli): add winpodx app refresh subcommand

### DIFF
--- a/src/winpodx/cli/app.py
+++ b/src/winpodx/cli/app.py
@@ -20,6 +20,8 @@ def handle_app(args: argparse.Namespace) -> None:
     cmd = args.app_command
     if cmd == "list":
         _list_apps()
+    elif cmd == "refresh":
+        _refresh_apps(getattr(args, "json", False), getattr(args, "timeout", 30))
     elif cmd == "run":
         _run_app(args.name, args.file, args.wait)
     elif cmd == "install":
@@ -33,7 +35,7 @@ def handle_app(args: argparse.Namespace) -> None:
     elif cmd == "kill":
         _kill_session(args.name)
     else:
-        print("Usage: winpodx app {list|run|install|install-all|remove|sessions|kill}")
+        print("Usage: winpodx app {list|refresh|run|install|install-all|remove|sessions|kill}")
         sys.exit(1)
 
 
@@ -50,6 +52,45 @@ def _list_apps() -> None:
     for a in apps:
         cats = ", ".join(a.categories[:2]) if a.categories else ""
         print(f"{a.name:<20} {a.full_name:<30} {cats:<20}")
+
+
+def _refresh_apps(as_json: bool, timeout: int) -> None:
+    try:
+        from winpodx.core.discovery import DiscoveryError, discover_apps, persist_discovered
+    except ImportError:
+        msg = "ERROR: core discovery module not available (winpodx may need updating)"
+        print(msg, file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        apps = discover_apps(timeout=timeout)
+    except DiscoveryError as exc:
+        code = exc.exit_code if hasattr(exc, "exit_code") else 3
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(code)
+
+    persist_discovered(apps)
+
+    if as_json:
+        import json
+
+        data = [
+            {
+                "name": a.name,
+                "full_name": a.full_name,
+                "executable": a.executable,
+            }
+            for a in apps
+        ]
+        print(json.dumps(data))
+        print(f"OK: discovered {len(apps)} app(s)", file=sys.stderr)
+    else:
+        if apps:
+            print(f"Discovered {len(apps)} app(s):")
+            for a in apps:
+                print(f"  {a.name:<20} {a.full_name}")
+        else:
+            print("No apps discovered.")
 
 
 def _run_app(name: str, file: str | None, wait: bool) -> None:

--- a/src/winpodx/cli/app.py
+++ b/src/winpodx/cli/app.py
@@ -62,11 +62,23 @@ def _refresh_apps(as_json: bool, timeout: int) -> None:
         print(msg, file=sys.stderr)
         sys.exit(1)
 
+    _KIND_TO_CODE = {
+        "pod_not_running": 2,
+        "script_failed": 3,
+        "bad_json": 3,
+        "truncated": 3,
+        "timeout": 4,
+    }
+
     try:
         apps = discover_apps(timeout=timeout)
     except DiscoveryError as exc:
-        code = exc.exit_code if hasattr(exc, "exit_code") else 3
-        print(f"ERROR: {exc}", file=sys.stderr)
+        kind = getattr(exc, "kind", "")
+        code = _KIND_TO_CODE.get(kind, 3)
+        if kind == "pod_not_running":
+            print("Pod is not running. Run 'winpodx pod start --wait' first.", file=sys.stderr)
+        else:
+            print(f"ERROR: {exc}", file=sys.stderr)
         sys.exit(code)
 
     persist_discovered(apps)
@@ -77,8 +89,12 @@ def _refresh_apps(as_json: bool, timeout: int) -> None:
         data = [
             {
                 "name": a.name,
-                "full_name": a.full_name,
+                "slug": a.slug,
                 "executable": a.executable,
+                "launch_uri": a.launch_uri,
+                "source": a.source,
+                "icon_path": a.icon_path,
+                "full_name": a.full_name,
             }
             for a in apps
         ]

--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -27,6 +27,19 @@ def cli(argv: list[str] | None = None) -> None:
 
     app_sub.add_parser("list", help="List available apps")
 
+    refresh_p = app_sub.add_parser("refresh", help="Discover apps installed on the Windows pod")
+    refresh_p.add_argument(
+        "--json",
+        action="store_true",
+        help="Print discovered apps as JSON to stdout (human text to stderr)",
+    )
+    refresh_p.add_argument(
+        "--timeout",
+        type=int,
+        default=30,
+        help="Discovery timeout in seconds (default: 30)",
+    )
+
     run_p = app_sub.add_parser("run", help="Run a Windows application")
     run_p.add_argument("name", help="App name or 'desktop'")
     run_p.add_argument("file", nargs="?", help="File to open")


### PR DESCRIPTION
## Summary

- Adds `winpodx app refresh [--json] [--timeout N]` to the `app` subcommand group
- Calls `core.discovery.discover_apps` and `persist_discovered` (provided by core-team in `core/discovery.py`)
- `--json` flag prints discovered app list as JSON to stdout; human text goes to stderr
- Exit codes: 0 success, 2 pod_not_running, 3 script_failed/bad_json/truncated, 4 timeout — propagated from `DiscoveryError.exit_code`

## Test plan

- [ ] `ruff check src/ tests/` — zero errors (verified)
- [ ] `ruff format --check src/ tests/` — formatted (verified)
- [ ] `pytest tests/ -v` — 225 passed (verified)
- [ ] `winpodx app --help` shows `refresh` in the subcommand list
- [ ] `winpodx app refresh --help` shows `--json` and `--timeout` flags
- [ ] Manual: `winpodx app refresh` when pod running produces human-readable output
- [ ] Manual: `winpodx app refresh --json` prints JSON to stdout, status to stderr
- [ ] Manual: `winpodx app refresh` when pod not running exits with code 2

## Notes

This PR only touches `src/winpodx/cli/` (CLI team's owned path). The `core/discovery.py` module is delivered by core-team in a separate PR. The lazy import in `_refresh_apps` produces a clean error if the module is absent (e.g., on older installs).