### PR TITLE
feat(core): dynamic app discovery + UWP RDP launch (v0.1.8)

### DIFF
--- a/src/winpodx/core/app.py
+++ b/src/winpodx/core/app.py
@@ -30,6 +30,16 @@ class AppInfo:
     categories: list[str] = field(default_factory=list)
     mime_types: list[str] = field(default_factory=list)
     installed: bool = False
+    # Provenance: "bundled" (shipped in data/apps), "discovered" (auto
+    # from guest enumerator), "user" (manually placed in
+    # ~/.local/share/winpodx/apps). Surfaces a Detected/Bundled badge
+    # in the GUI and lets tooling decide what it can safely overwrite
+    # on a rediscovery pass.
+    source: str = "bundled"
+    # Optional extras populated by discovery; blank for bundled entries.
+    args: str = ""
+    wm_class_hint: str = ""
+    launch_uri: str = ""  # UWP AUMID (shell:AppsFolder\<AUMID>)
 
 
 def bundled_apps_dir() -> Path:
@@ -60,8 +70,22 @@ def user_apps_dir() -> Path:
     return data_dir() / "apps"
 
 
-def load_app(app_dir: Path) -> AppInfo | None:
-    """Load an app definition from a directory containing app.toml."""
+def discovered_apps_dir() -> Path:
+    """Path to auto-discovered app definitions (written by discovery)."""
+    return data_dir() / "discovered"
+
+
+_VALID_APP_SOURCES = frozenset({"bundled", "discovered", "user"})
+
+
+def load_app(app_dir: Path, default_source: str = "bundled") -> AppInfo | None:
+    """Load an app definition from a directory containing app.toml.
+
+    ``default_source`` is used when the TOML does not declare a
+    ``source`` field; ``list_available_apps`` passes the provenance of
+    the containing directory so discovered entries are flagged even if
+    the author of the TOML forgot to set the field.
+    """
     toml_path = app_dir / "app.toml"
     if not toml_path.exists():
         return None
@@ -87,13 +111,21 @@ def load_app(app_dir: Path) -> AppInfo | None:
             icon = str(candidate)
             break
 
+    source = data.get("source", default_source)
+    if source not in _VALID_APP_SOURCES:
+        source = default_source
+
     return AppInfo(
         name=name,
         full_name=data.get("full_name", name),
         executable=executable,
         icon_path=icon,
-        categories=data.get("categories", []),
-        mime_types=data.get("mime_types", []),
+        categories=data.get("categories", []) or [],
+        mime_types=data.get("mime_types", []) or [],
+        source=source,
+        args=data.get("args", "") or "",
+        wm_class_hint=data.get("wm_class_hint", "") or "",
+        launch_uri=data.get("launch_uri", "") or "",
     )
 
 
@@ -114,28 +146,42 @@ def _is_within(candidate: Path, root: Path) -> bool:
 
 
 def list_available_apps() -> list[AppInfo]:
-    """List all available app definitions (bundled + user).
+    """List all available app definitions (bundled + discovered + user).
 
-    Skips any entry that resolves outside the source directory so a
-    malicious symlink cannot cause us to load attacker-controlled TOML.
+    Entries found under the discovered dir are loaded with
+    ``source="discovered"``; the user dir defaults to ``"user"``.
+    If two dirs define the same ``name`` the later one wins in the
+    search order ``bundled -> discovered -> user`` so a user-authored
+    override beats both. Skips any entry that resolves outside its
+    containing dir so a malicious symlink cannot cause us to load
+    attacker-controlled TOML.
     """
-    apps: list[AppInfo] = []
-    for source in (bundled_apps_dir(), user_apps_dir()):
-        if not source.exists():
+    sources: list[tuple[Path, str]] = [
+        (bundled_apps_dir(), "bundled"),
+        (discovered_apps_dir(), "discovered"),
+        (user_apps_dir(), "user"),
+    ]
+    by_name: dict[str, AppInfo] = {}
+    order: list[str] = []
+    for source_dir, provenance in sources:
+        if not source_dir.exists():
             continue
-        for app_dir in sorted(source.iterdir()):
+        for app_dir in sorted(source_dir.iterdir()):
             if not app_dir.is_dir():
                 continue
-            if not _is_within(app_dir, source):
+            if not _is_within(app_dir, source_dir):
                 log.warning(
                     "Rejecting app entry that escapes its source dir: %s",
                     app_dir,
                 )
                 continue
-            app = load_app(app_dir)
-            if app:
-                apps.append(app)
-    return apps
+            app = load_app(app_dir, default_source=provenance)
+            if app is None:
+                continue
+            if app.name not in by_name:
+                order.append(app.name)
+            by_name[app.name] = app
+    return [by_name[n] for n in order]
 
 
 def find_app(name: str) -> AppInfo | None:

--- a/src/winpodx/core/discovery.py
+++ b/src/winpodx/core/discovery.py
@@ -1,0 +1,403 @@
+"""Dynamic discovery of installed Windows apps on the guest.
+
+Invokes a guest-side PowerShell script (``scripts/windows/discover_apps.ps1``,
+owned by platform-qa) which enumerates UWP/MSIX, Start Menu, and common
+Win32 install locations and emits a JSON array on stdout. Results are
+parsed into ``DiscoveredApp`` records and can be persisted under the
+user data dir so they appear alongside bundled apps in the GUI and CLI.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import logging
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from winpodx.core.app import discovered_apps_dir as _app_discovered_apps_dir
+from winpodx.core.config import Config
+from winpodx.utils.toml_writer import dumps as toml_dumps
+
+log = logging.getLogger(__name__)
+
+# Upper bound so a runaway guest enumerator can't fill the user's disk.
+_MAX_APPS = 500
+_MAX_ICON_BYTES = 1_048_576  # 1 MiB per icon
+_MAX_NAME_LEN = 255
+_MAX_PATH_LEN = 1024
+
+_VALID_SOURCES = frozenset({"uwp", "win32", "steam"})
+
+# Matches AppInfo's _SAFE_NAME_RE contract so a discovered app loads cleanly.
+_SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+_NAME_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9_-]+")
+
+
+class DiscoveryError(RuntimeError):
+    """Raised when guest-side discovery cannot complete.
+
+    Covers: unsupported backend (libvirt/manual), container runtime
+    missing, script copy/exec failure, timeout, malformed JSON, or
+    the pod not being running.
+    """
+
+
+@dataclass
+class DiscoveredApp:
+    name: str
+    full_name: str
+    executable: str
+    args: str = ""
+    source: str = "win32"  # uwp | win32 | steam
+    wm_class_hint: str = ""
+    launch_uri: str = ""  # UWP AUMID (shell:AppsFolder\<AUMID>) when source == "uwp"
+    icon_bytes: bytes = field(default=b"", repr=False)
+
+
+def discovered_apps_dir() -> Path:
+    """Path under which persisted discovered apps are stored.
+
+    Thin alias over ``winpodx.core.app.discovered_apps_dir`` so callers
+    of ``core.discovery`` don't need a second import. Kept separate
+    from bundled and user-authored entries so a rediscovery run can
+    safely clear/replace only discovered entries.
+    """
+    return _app_discovered_apps_dir()
+
+
+def _ps_script_path() -> Path:
+    """Locate ``scripts/windows/discover_apps.ps1``.
+
+    Checks repo layout first, then wheel / user install prefixes. Uses
+    the same search order as ``winpodx.core.app.bundled_apps_dir`` so
+    behaviour is consistent across install modes.
+    """
+    candidates = [
+        Path(__file__).resolve().parent.parent.parent.parent
+        / "scripts"
+        / "windows"
+        / "discover_apps.ps1",
+        Path(sys.prefix) / "share" / "winpodx" / "scripts" / "windows" / "discover_apps.ps1",
+        Path.home() / ".local" / "share" / "winpodx" / "scripts" / "windows" / "discover_apps.ps1",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
+
+def _runtime_for(backend: str) -> str:
+    if backend == "podman":
+        return "podman"
+    if backend == "docker":
+        return "docker"
+    raise DiscoveryError(
+        f"Discovery requires a container backend (podman/docker); got {backend!r}."
+    )
+
+
+def discover_apps(cfg: Config, timeout: int = 120) -> list[DiscoveredApp]:
+    """Run guest-side discovery and return the parsed apps.
+
+    Copies ``discover_apps.ps1`` into the running Windows container and
+    executes it via ``{runtime} exec``. The script is expected to print
+    a JSON array of objects shaped as::
+
+        [{"name","path","args","source","wm_class_hint",
+          "launch_uri","icon_b64"}, ...]
+
+    and may include ``"_truncated": true`` as its last element to
+    indicate the guest clipped its own output.
+
+    Raises:
+        DiscoveryError: backend unsupported, runtime missing, pod not
+            running, script copy/exec failure, timeout, or malformed
+            output.
+    """
+    runtime = _runtime_for(cfg.pod.backend)
+
+    if shutil.which(runtime) is None:
+        raise DiscoveryError(f"{runtime!r} not found on PATH; install {cfg.pod.backend} first.")
+
+    script = _ps_script_path()
+    if not script.exists():
+        raise DiscoveryError(f"Discovery script not found: {script}")
+
+    container = cfg.pod.container_name
+    guest_path = "C:/winpodx-discover.ps1"
+
+    try:
+        subprocess.run(  # noqa: S603
+            [runtime, "cp", str(script), f"{container}:{guest_path}"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError as e:
+        raise DiscoveryError(f"{runtime!r} binary vanished: {e}") from e
+    except subprocess.TimeoutExpired as e:
+        raise DiscoveryError("Timed out copying discovery script to guest.") from e
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        raise DiscoveryError(
+            f"Failed to copy discovery script (is the pod running?): {stderr}"
+        ) from e
+
+    try:
+        result = subprocess.run(  # noqa: S603
+            [
+                runtime,
+                "exec",
+                container,
+                "powershell",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                guest_path.replace("/", "\\"),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError as e:
+        raise DiscoveryError(f"{runtime!r} binary vanished mid-run: {e}") from e
+    except subprocess.TimeoutExpired as e:
+        raise DiscoveryError(f"Discovery timed out after {timeout}s on guest.") from e
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        raise DiscoveryError(f"Discovery script failed (rc={result.returncode}): {stderr}")
+
+    return _parse_discovery_output(result.stdout)
+
+
+def _parse_discovery_output(stdout: str) -> list[DiscoveredApp]:
+    """Parse the JSON array emitted by ``discover_apps.ps1``."""
+    text = stdout.strip()
+    if not text:
+        return []
+
+    # PowerShell may prepend a UTF-8 BOM to Out-String/ConvertTo-Json output.
+    if text.startswith("﻿"):
+        text = text[1:]
+
+    try:
+        raw = json.loads(text)
+    except json.JSONDecodeError as e:
+        snippet = text[:200].replace("\n", " ")
+        raise DiscoveryError(f"Malformed discovery JSON: {e}; head={snippet!r}") from e
+
+    if isinstance(raw, dict):
+        raw = [raw]
+    if not isinstance(raw, list):
+        raise DiscoveryError(f"Discovery JSON must be an array, got {type(raw).__name__}.")
+
+    apps: list[DiscoveredApp] = []
+    truncated = False
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("_truncated") is True:
+            truncated = True
+            continue
+        parsed = _entry_to_discovered(entry)
+        if parsed is not None:
+            apps.append(parsed)
+        if len(apps) >= _MAX_APPS:
+            truncated = True
+            break
+
+    if truncated:
+        log.warning(
+            "Discovery output was truncated (>%d apps or guest-side clip); showing the first %d.",
+            _MAX_APPS,
+            len(apps),
+        )
+    return apps
+
+
+def _entry_to_discovered(entry: dict[str, Any]) -> DiscoveredApp | None:
+    """Validate and convert one JSON entry into a ``DiscoveredApp``."""
+    raw_name = entry.get("name")
+    path = entry.get("path")
+    if not isinstance(raw_name, str) or not raw_name.strip():
+        return None
+    if not isinstance(path, str) or not path.strip():
+        return None
+    if len(raw_name) > _MAX_NAME_LEN or len(path) > _MAX_PATH_LEN:
+        return None
+
+    source = entry.get("source", "win32")
+    if source not in _VALID_SOURCES:
+        source = "win32"
+
+    args = entry.get("args", "")
+    if not isinstance(args, str) or len(args) > _MAX_PATH_LEN:
+        args = ""
+
+    wm_class_hint = entry.get("wm_class_hint", "")
+    if not isinstance(wm_class_hint, str) or len(wm_class_hint) > _MAX_NAME_LEN:
+        wm_class_hint = ""
+
+    launch_uri = entry.get("launch_uri", "")
+    if not isinstance(launch_uri, str) or len(launch_uri) > _MAX_PATH_LEN:
+        launch_uri = ""
+
+    # UWP entries must have a launch_uri (AUMID); otherwise they are unlaunchable.
+    if source == "uwp" and not launch_uri:
+        return None
+
+    icon_b64 = entry.get("icon_b64", "")
+    icon_bytes = b""
+    if isinstance(icon_b64, str) and icon_b64:
+        try:
+            icon_bytes = base64.b64decode(icon_b64, validate=True)
+        except (binascii.Error, ValueError):
+            icon_bytes = b""
+        if len(icon_bytes) > _MAX_ICON_BYTES:
+            icon_bytes = b""
+
+    slug = _slugify_name(raw_name)
+    if not slug:
+        return None
+
+    return DiscoveredApp(
+        name=slug,
+        full_name=raw_name.strip(),
+        executable=path.strip(),
+        args=args,
+        source=source,
+        wm_class_hint=wm_class_hint,
+        launch_uri=launch_uri,
+        icon_bytes=icon_bytes,
+    )
+
+
+def _slugify_name(raw: str) -> str:
+    """Convert a display name into a safe AppInfo ``name`` slug.
+
+    Lowercases, replaces runs of unsafe chars with ``-``, trims leading
+    and trailing dashes and underscores, and bounds the length.
+    """
+    slug = _NAME_SANITIZE_RE.sub("-", raw.strip().lower()).strip("-_")
+    if not slug:
+        return ""
+    if len(slug) > 64:
+        slug = slug[:64].rstrip("-_")
+    if not _SAFE_NAME_RE.match(slug):
+        return ""
+    return slug
+
+
+def persist_discovered(
+    apps: list[DiscoveredApp],
+    target_dir: Path | None = None,
+    replace: bool = True,
+) -> list[Path]:
+    """Write discovered apps as ``<dir>/<name>/{app.toml, icon.*}`` entries.
+
+    Args:
+        apps: Output of ``discover_apps``.
+        target_dir: Destination root. Defaults to ``discovered_apps_dir()``.
+        replace: If True, removes any existing per-app subdir before
+            writing. Bundled / user-authored entries are untouched —
+            only the discovered tree is affected.
+
+    Returns:
+        List of ``app.toml`` paths written (skipped entries are
+        omitted).
+    """
+    root = target_dir if target_dir is not None else discovered_apps_dir()
+    root.mkdir(parents=True, exist_ok=True)
+
+    written: list[Path] = []
+    seen: set[str] = set()
+    for app in apps:
+        if app.name in seen:
+            continue
+        if not _SAFE_NAME_RE.match(app.name):
+            continue
+        seen.add(app.name)
+
+        app_dir = root / app.name
+        if replace and app_dir.exists():
+            _safe_rmtree(app_dir, root)
+        app_dir.mkdir(parents=True, exist_ok=True)
+
+        toml_path = app_dir / "app.toml"
+        try:
+            toml_path.write_text(_render_app_toml(app), encoding="utf-8")
+        except OSError as e:
+            log.warning("Could not write %s: %s", toml_path, e)
+            continue
+
+        if app.icon_bytes:
+            icon_ext = _sniff_icon_ext(app.icon_bytes)
+            if icon_ext:
+                try:
+                    (app_dir / f"icon.{icon_ext}").write_bytes(app.icon_bytes)
+                except OSError as e:
+                    log.warning("Could not write icon for %s: %s", app.name, e)
+
+        written.append(toml_path)
+
+    return written
+
+
+def _render_app_toml(app: DiscoveredApp) -> str:
+    """Render a ``DiscoveredApp`` into the AppInfo-loadable TOML shape."""
+    data: dict[str, Any] = {
+        "name": app.name,
+        "full_name": app.full_name,
+        "executable": app.executable,
+        "categories": [],
+        "mime_types": [],
+    }
+    if app.args:
+        data["args"] = app.args
+    if app.source:
+        data["source"] = app.source
+    if app.wm_class_hint:
+        data["wm_class_hint"] = app.wm_class_hint
+    if app.launch_uri:
+        data["launch_uri"] = app.launch_uri
+    return toml_dumps(data)
+
+
+def _sniff_icon_ext(data: bytes) -> str:
+    """Return ``'png'``, ``'svg'``, or ``''`` based on the icon header."""
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "png"
+    head = data[:256].lstrip().lower()
+    if head.startswith(b"<?xml") or head.startswith(b"<svg"):
+        return "svg"
+    return ""
+
+
+def _safe_rmtree(path: Path, root: Path) -> None:
+    """Remove ``path`` if and only if it sits inside ``root``.
+
+    Guards against a crafted ``name`` resolving outside the discovered
+    tree (e.g. via a pre-existing symlink at the target location).
+    """
+    try:
+        resolved = path.resolve(strict=False)
+        root_resolved = root.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return
+    if not resolved.is_relative_to(root_resolved):
+        log.warning("Refusing to remove %s: escapes discovered root %s", resolved, root_resolved)
+        return
+    if path.is_symlink():
+        path.unlink(missing_ok=True)
+        return
+    shutil.rmtree(path, ignore_errors=True)

--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -43,6 +43,32 @@ def _is_safe_wm_class(value: str) -> bool:
     return _WM_CLASS_RE.fullmatch(value) is not None
 
 
+def _uwp_fallback_wm_class(aumid: str) -> str:
+    """Derive a unique wm-class from a validated AUMID.
+
+    Used when ``wm_class_hint`` is missing or fails ``_is_safe_wm_class``.
+    A single ``winpodx-uwp`` bucket would collide pid files and make
+    the Linux WM group unrelated UWP apps as one taskbar entry, so we
+    slug the AUMID (already ``_is_valid_aumid``-validated) to produce
+    ``winpodx-uwp-<slug>`` — unique per app, still bounded and shell-safe.
+    """
+    # AUMID is already validated to [A-Za-z0-9._-]+!..., so lowercasing
+    # and replacing '!'/'.' with '-' keeps it inside the _WM_CLASS_RE alphabet.
+    slug = aumid.lower().replace("!", "-").replace(".", "-")
+    # Collapse any run of dashes introduced by the substitution.
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    slug = slug.strip("-_")
+    candidate = f"winpodx-uwp-{slug}" if slug else "winpodx-uwp"
+    # /wm-class tokens are bounded at 64 chars by _WM_CLASS_RE; truncate
+    # rather than fail because the AUMID itself is legitimately long.
+    if len(candidate) > 64:
+        candidate = candidate[:64].rstrip("-_")
+    if not _is_safe_wm_class(candidate):
+        return "winpodx-uwp"
+    return candidate
+
+
 @dataclass
 class RDPSession:
     app_name: str
@@ -211,9 +237,9 @@ def build_rdp_command(
         aumid = launch_uri.strip()
         if not _is_valid_aumid(aumid):
             raise RuntimeError(f"Invalid UWP AUMID: {aumid!r}")
-        wm_class = (wm_class_hint or "").strip().lower() or "winpodx-uwp"
-        if not _is_safe_wm_class(wm_class):
-            wm_class = "winpodx-uwp"
+        wm_class = (wm_class_hint or "").strip().lower()
+        if not wm_class or not _is_safe_wm_class(wm_class):
+            wm_class = _uwp_fallback_wm_class(aumid)
         app_arg = f"/app:program:explorer.exe,name:{wm_class},cmd:shell:AppsFolder\\{aumid}"
         cmd.append(app_arg)
         cmd.append(f"/wm-class:{wm_class}")
@@ -406,7 +432,15 @@ def launch_app(
 
     if launch_uri:
         hint = (wm_class_hint or "").strip().lower()
-        app_name = hint if _is_safe_wm_class(hint) else "winpodx-uwp"
+        if hint and _is_safe_wm_class(hint):
+            app_name = hint
+        else:
+            # Derive a per-app slug so two UWP apps with invalid hints
+            # don't collide on the same pid_file. If the AUMID itself
+            # is malformed, build_rdp_command will reject it shortly;
+            # for pid-file purposes just fall back to the bare bucket.
+            aumid = launch_uri.strip()
+            app_name = _uwp_fallback_wm_class(aumid) if _is_valid_aumid(aumid) else "winpodx-uwp"
     elif app_executable:
         from pathlib import PureWindowsPath
 

--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -19,6 +19,29 @@ log = logging.getLogger(__name__)
 # Characters invalid in Windows file paths; rejected by linux_to_unc.
 _INVALID_WIN_CHARS: frozenset[str] = frozenset('*?"<>|')
 
+# UWP AUMID: <PackageFamilyName>!<AppId>
+#   PackageFamilyName := <Name>_<PublisherId>  (Name dotted, PublisherId is
+#   a 13-char hash; Microsoft docs don't fix its alphabet but all observed
+#   values are [a-z0-9])
+#   AppId := up to 64 chars of word / dot / hyphen.
+# Kept strict to block values with separators FreeRDP parses (``,``) or
+# shell metacharacters a malicious discovery JSON could smuggle in.
+_AUMID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}![A-Za-z0-9._-]{1,64}$")
+
+# /wm-class and the /app name: sub-key must be a bounded, shell-safe token;
+# we lowercase first so the regex only needs to cover the trimmed form.
+_WM_CLASS_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+
+
+def _is_valid_aumid(value: str) -> bool:
+    """Return True if ``value`` is a syntactically valid UWP AUMID."""
+    return _AUMID_RE.fullmatch(value) is not None
+
+
+def _is_safe_wm_class(value: str) -> bool:
+    """Return True if ``value`` is a safe /wm-class / name: token."""
+    return _WM_CLASS_RE.fullmatch(value) is not None
+
 
 @dataclass
 class RDPSession:
@@ -118,8 +141,19 @@ def build_rdp_command(
     app_executable: str | None = None,
     file_path: str | None = None,
     auto_scale: bool = True,
+    launch_uri: str | None = None,
+    wm_class_hint: str | None = None,
 ) -> tuple[list[str], str]:
-    """Build the xfreerdp command line for launching an app."""
+    """Build the xfreerdp command line for launching an app.
+
+    For classic Win32 apps, pass ``app_executable`` (and optionally
+    ``file_path``). For UWP/MSIX apps, pass ``launch_uri`` containing
+    the AUMID (e.g. ``"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App"``);
+    the builder forwards ``explorer.exe shell:AppsFolder\\<AUMID>`` as
+    the RemoteApp program. ``wm_class_hint`` overrides the default
+    ``/wm-class`` (exe stem) so the Linux window lines up with the
+    discovered app's desktop entry rather than ``explorer``.
+    """
     found = find_freerdp()
     if not found:
         raise RuntimeError("FreeRDP 3+ not found. Install xfreerdp3 or xfreerdp.")
@@ -169,11 +203,29 @@ def build_rdp_command(
         password = ""  # signal launch_app to skip stdin write
 
     # RemoteApp (RAIL) launch; requires fDisabledAllowList=1 set by install.bat.
-    if app_executable:
+    if launch_uri:
+        # UWP/MSIX: launch via explorer + shell:AppsFolder\<AUMID>. The
+        # AUMID must be a bare package-family!app-id token — reject
+        # anything that looks like a flag payload or embeds separators
+        # FreeRDP treats specially ("," splits /app sub-args).
+        aumid = launch_uri.strip()
+        if not _is_valid_aumid(aumid):
+            raise RuntimeError(f"Invalid UWP AUMID: {aumid!r}")
+        wm_class = (wm_class_hint or "").strip().lower() or "winpodx-uwp"
+        if not _is_safe_wm_class(wm_class):
+            wm_class = "winpodx-uwp"
+        app_arg = f"/app:program:explorer.exe,name:{wm_class},cmd:shell:AppsFolder\\{aumid}"
+        cmd.append(app_arg)
+        cmd.append(f"/wm-class:{wm_class}")
+        cmd.append("+grab-keyboard")
+    elif app_executable:
         from pathlib import PureWindowsPath
 
         stem = PureWindowsPath(app_executable).stem.lower()
-        app_arg = f"/app:program:{app_executable},name:{stem}"
+        name_token = (wm_class_hint or "").strip().lower() or stem
+        if not _is_safe_wm_class(name_token):
+            name_token = stem
+        app_arg = f"/app:program:{app_executable},name:{name_token}"
         if file_path:
             try:
                 unc_path = linux_to_unc(file_path)
@@ -182,7 +234,7 @@ def build_rdp_command(
                 raise RuntimeError(f"Cannot open file: {e}") from e
             app_arg += f",cmd:{unc_path}"
         cmd.append(app_arg)
-        cmd.append(f"/wm-class:{stem}")
+        cmd.append(f"/wm-class:{name_token}")
         cmd.append("+grab-keyboard")
 
     # TLS for all backends: install.bat forces SecurityLayer=2 and podman unshare breaks NLA.
@@ -340,11 +392,22 @@ def launch_app(
     cfg: Config,
     app_executable: str | None = None,
     file_path: str | None = None,
+    launch_uri: str | None = None,
+    wm_class_hint: str | None = None,
 ) -> RDPSession:
-    """Launch a Windows app via RDP and return the session handle."""
+    """Launch a Windows app via RDP and return the session handle.
+
+    Pass ``launch_uri`` for UWP/MSIX apps (takes precedence over
+    ``app_executable``) and ``wm_class_hint`` to override the default
+    ``/wm-class`` token (needed for UWP so the Linux window doesn't
+    come up labelled ``explorer``).
+    """
     import threading
 
-    if app_executable:
+    if launch_uri:
+        hint = (wm_class_hint or "").strip().lower()
+        app_name = hint if _is_safe_wm_class(hint) else "winpodx-uwp"
+    elif app_executable:
         from pathlib import PureWindowsPath
 
         app_name = PureWindowsPath(app_executable).stem.lower()
@@ -355,7 +418,13 @@ def launch_app(
     if existing is not None:
         return existing
 
-    cmd, password = build_rdp_command(cfg, app_executable, file_path)
+    cmd, password = build_rdp_command(
+        cfg,
+        app_executable=app_executable,
+        file_path=file_path,
+        launch_uri=launch_uri,
+        wm_class_hint=wm_class_hint,
+    )
 
     log.info("Launching RDP: %s", " ".join(cmd))
 


### PR DESCRIPTION
## Summary

Core-team slice of the v0.1.8 dynamic app-discovery feature:

- New `src/winpodx/core/discovery.py` with `DiscoveredApp`, `DiscoveryError`, `discover_apps()`, `persist_discovered()`. Copies/runs the guest-side PS script via `{podman,docker} exec`, parses a bounded JSON array (max 500 apps, 1 MiB icons each), persists under `~/.local/share/winpodx/discovered/<name>/app.toml` + `icon.{svg,png}`. libvirt/manual backends raise `DiscoveryError` cleanly until a guest-agent path exists.
- `AppInfo` gains `source` (`bundled` | `discovered` | `user`), `args`, `wm_class_hint`, `launch_uri`. `list_available_apps()` unions bundled + discovered + user with user-authored entries winning on name collision.
- `build_rdp_command()` / `launch_app()` take `launch_uri` and `wm_class_hint` so UWP/MSIX apps launch via `explorer.exe shell:AppsFolder\<AUMID>`. AUMID and wm-class tokens are regex-validated before hitting the FreeRDP command line to block `/app` sub-separator injection from discovery JSON.
- `install_desktop_entry(app: AppInfo)` signature unchanged (desktop-team contract preserved).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `pytest tests/ -v` — 225 passed, 0 failed (baseline; discovery-specific tests land in the platform-qa PR)
- [x] Python 3.9+ compat: `from __future__ import annotations` throughout, all `|` unions sit in annotation positions
- [ ] Integration smoke: run `discover_apps(cfg)` against a live Windows pod once the PS script from platform-qa is merged
- [ ] UWP launch smoke: launch Calculator (`Microsoft.WindowsCalculator_8wekyb3d8bbwe!App`) via `launch_app(cfg, launch_uri=..., wm_class_hint="calc")` and confirm window maps to the winpodx-calc.desktop entry

## Coordination notes

- **platform-qa**: `discover_apps` expects the PS script at `scripts/windows/discover_apps.ps1` to emit `[{"name","path","args","source","wm_class_hint","launch_uri","icon_b64"}, ...]` with optional `_truncated: true`. Will reach out via SendMessage if the JSON shape diverges.
- **desktop-team**: `install_desktop_entry(app: AppInfo)` signature is preserved. `AppInfo.source` is available for the Detected/Bundled badge.
- **cli-team**: public API is `DiscoveredApp`, `DiscoveryError`, `discover_apps`, `persist_discovered` from `winpodx.core.discovery`.