### PR TITLE
feat(platform-qa): guest discovery PS script + tests + CI smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,34 @@ jobs:
       - run: pip install -e ".[dev]"
       - run: pytest tests/ -v
 
+  discover-apps-ps:
+    # Smoke test for scripts/windows/discover_apps.ps1 — runs the script
+    # under -DryRun (no Registry/AppX access) and asserts stdout parses as
+    # a non-empty JSON array with the shape core.discovery expects. Catches
+    # PowerShell syntax regressions before they hit the Windows guest.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure PowerShell Core is available
+        run: |
+          if command -v pwsh >/dev/null 2>&1; then
+            echo "pwsh already installed: $(pwsh --version)"
+          else
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends wget apt-transport-https ca-certificates
+            # Official Microsoft repository for PowerShell on Ubuntu.
+            source /etc/os-release
+            wget -q "https://packages.microsoft.com/config/ubuntu/${VERSION_ID}/packages-microsoft-prod.deb" -O /tmp/packages-microsoft-prod.deb
+            sudo dpkg -i /tmp/packages-microsoft-prod.deb
+            sudo apt-get update
+            sudo apt-get install -y powershell
+            pwsh --version
+          fi
+      - name: Run discover_apps.ps1 -DryRun and validate JSON shape
+        run: |
+          pwsh -NoProfile -File scripts/windows/discover_apps.ps1 -DryRun > /tmp/discover.json
+          python3 scripts/ci/validate_discover_dryrun.py /tmp/discover.json
+
   audit:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added
+- **Dynamic Windows-app discovery.** A new `winpodx app refresh` CLI subcommand and a "Refresh Apps" button on the Qt GUI's Apps page now enumerate the apps actually installed on the Windows guest and register them alongside the 14 bundled profiles. Inside the container, `scripts/windows/discover_apps.ps1` scans Registry `App Paths` (HKLM + HKCU), Start Menu `.lnk` recursion, UWP/MSIX packages via `Get-AppxPackage` + `AppxManifest.xml`, and Chocolatey / Scoop shims, returning a JSON array with base64-encoded icons extracted from the real binaries / package logos. The host side (`winpodx.core.discovery`) copies the script via `podman cp`, executes it with `podman exec powershell`, and writes the results under `~/.local/share/winpodx/discovered/<slug>/` as TOML + PNG/SVG icon files. Bundled profiles, user-authored entries, and discovered entries live in three separate directories and merge at load time (user > discovered > bundled on slug collision) so a rediscovery run only touches the discovered tree.
+- **UWP RemoteApp launching.** `rdp.build_rdp_command` now accepts a `launch_uri` + strict-regex-validated AUMID (`<PackageFamilyName>!<AppId>`) and maps UWP apps to `/app:program:explorer.exe,cmd:shell:AppsFolder\<AUMID>`. Per-slug `winpodx-uwp-<aumid-slug>` fallback for `/wm-class` keeps Linux taskbar grouping distinct when two UWP apps share the same hint.
+- **PowerShell Core smoke test in CI.** A new `discover-apps-ps` job installs `pwsh` on the Ubuntu runner and runs `discover_apps.ps1 -DryRun` on every PR, validating that stdout parses as the JSON array shape `core.discovery` expects.
+
+### Changed
+- `AppInfo` gains `source: "bundled" | "discovered" | "user"`, `args`, `wm_class_hint`, and `launch_uri` fields so the GUI can badge discovered entries and so RDP launches can target UWP apps.
+- `desktop.entry._install_icon` now dispatches between `hicolor/scalable/apps/` (SVG) and `hicolor/32x32/apps/` (PNG) based on the icon file's extension, so discovered apps' extracted PNG icons install cleanly alongside the bundled SVG ones.
+
 ## [0.1.7] - 2026-04-23
 
 ### Changed

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,15 @@
 
 ## [Unreleased]
 
+### 추가
+- **Windows 앱 동적 발견.** 새 CLI `winpodx app refresh` 서브커맨드와 Qt GUI Apps 페이지의 "Refresh Apps" 버튼이 Windows 게스트에 실제 설치된 앱을 열거하고 기본 번들 14개 프로필과 함께 등록합니다. 컨테이너 내부에서 `scripts/windows/discover_apps.ps1` 이 Registry `App Paths` (HKLM + HKCU), Start Menu `.lnk` 재귀, UWP/MSIX (`Get-AppxPackage` + `AppxManifest.xml`), Chocolatey / Scoop shim 4개 소스를 스캔하고 실제 바이너리/패키지 로고에서 추출한 base64 아이콘을 포함한 JSON 배열을 반환합니다. Linux 호스트 (`winpodx.core.discovery`) 는 `podman cp` 로 스크립트를 복사하고 `podman exec powershell` 로 실행한 뒤, 결과를 `~/.local/share/winpodx/discovered/<slug>/` 아래 TOML + PNG/SVG 아이콘 파일로 저장합니다. 번들 / 사용자 직접 추가 / 발견 앱은 세 디렉토리로 분리 관리되며 로딩 시 "사용자 > 발견 > 번들" 우선순위로 병합됩니다 — 재발견 실행은 발견 트리만 건드립니다.
+- **UWP RemoteApp 실행.** `rdp.build_rdp_command` 가 `launch_uri` + 엄격 정규식 검증된 AUMID (`<PackageFamilyName>!<AppId>`) 를 받아 UWP 앱을 `/app:program:explorer.exe,cmd:shell:AppsFolder\<AUMID>` 로 매핑합니다. `/wm-class` fallback 이 `winpodx-uwp-<aumid-slug>` 로 슬러그당 고유하게 지정되어 두 UWP 앱이 같은 힌트를 공유할 때도 Linux 태스크바 그루핑이 분리됩니다.
+- **CI PowerShell Core smoke 테스트.** 새 `discover-apps-ps` 잡이 Ubuntu runner 에 `pwsh` 를 설치하고 모든 PR 에서 `discover_apps.ps1 -DryRun` 을 실행해 `core.discovery` 가 기대하는 JSON 배열 shape 을 stdout 이 파싱 가능한지 검증합니다.
+
+### 변경
+- `AppInfo` 에 `source: "bundled" | "discovered" | "user"`, `args`, `wm_class_hint`, `launch_uri` 필드 추가. GUI 가 발견 엔트리를 뱃지로 구분할 수 있고 RDP 실행이 UWP 앱을 타겟팅할 수 있게 됩니다.
+- `desktop.entry._install_icon` 이 아이콘 파일 확장자에 따라 `hicolor/scalable/apps/` (SVG) vs `hicolor/32x32/apps/` (PNG) 로 분기 설치. 발견 앱의 추출된 PNG 아이콘이 번들 SVG 아이콘과 나란히 깔끔하게 설치됩니다.
+
 ## [0.1.7] - 2026-04-23
 
 ### 변경

--- a/scripts/ci/validate_discover_dryrun.py
+++ b/scripts/ci/validate_discover_dryrun.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Smoke-test validator for ``scripts/windows/discover_apps.ps1 -DryRun``.
+
+Run from CI: ``python3 scripts/ci/validate_discover_dryrun.py <json_file>``.
+
+Asserts that the PS script's canned output parses as a JSON array with at
+least one entry whose keys match the schema ``core.discovery`` expects.
+Factored out of ``.github/workflows/ci.yml`` so the assertions don't need
+to survive a round-trip through YAML + bash + Python quoting.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_FIELDS = frozenset(
+    {"name", "path", "args", "source", "wm_class_hint", "launch_uri", "icon_b64"}
+)
+VALID_SOURCES = frozenset({"win32", "uwp", "steam"})
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: validate_discover_dryrun.py <json_file>", file=sys.stderr)
+        return 2
+
+    raw = Path(argv[1]).read_text(encoding="utf-8")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"FAIL: not valid JSON: {exc}", file=sys.stderr)
+        print(f"head: {raw[:200]!r}", file=sys.stderr)
+        return 1
+
+    if not isinstance(data, list):
+        print(f"FAIL: expected array, got {type(data).__name__}", file=sys.stderr)
+        return 1
+    if not data:
+        print("FAIL: expected at least one canned entry", file=sys.stderr)
+        return 1
+
+    first = data[0]
+    if not isinstance(first, dict):
+        print(f"FAIL: first element must be object, got {type(first).__name__}", file=sys.stderr)
+        return 1
+
+    missing = REQUIRED_FIELDS - set(first.keys())
+    if missing:
+        print(f"FAIL: canned entry missing fields: {sorted(missing)}", file=sys.stderr)
+        return 1
+
+    source = first.get("source")
+    if source not in VALID_SOURCES:
+        print(
+            f"FAIL: invalid source {source!r}; must be one of {sorted(VALID_SOURCES)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("OK: discover_apps.ps1 -DryRun JSON shape valid")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/windows/discover_apps.ps1
+++ b/scripts/windows/discover_apps.ps1
@@ -1,0 +1,359 @@
+# discover_apps.ps1 — enumerate installed Windows apps and emit JSON on stdout
+#
+# Consumed by winpodx.core.discovery. Four sources are scanned inside the
+# running guest and unioned, deduping by lowercase executable path or UWP
+# AUMID:
+#
+#   1. Registry App Paths (HKLM + HKCU)
+#   2. Start Menu .lnk recursion (ProgramData + every user profile)
+#   3. UWP / MSIX packages via Get-AppxPackage + AppxManifest.xml
+#   4. Chocolatey + Scoop shims
+#
+# Output schema per entry (JSON array on stdout):
+#
+#   { "name": str, "path": str, "args": str,
+#     "source": "win32" | "uwp", "wm_class_hint": str,
+#     "launch_uri": str, "icon_b64": str }
+#
+# An optional trailing element `{"_truncated": true}` signals that the
+# guest clipped its own output.
+#
+# Invocation: run inside the Windows guest under Administrator (required
+# for Get-AppxPackage -AllUsers). Host side pipes stdout into json.loads.
+# `-DryRun` returns a single canned entry without touching Registry/AppX
+# so CI runners (no Windows) can smoke-test the JSON shape.
+
+[CmdletBinding()]
+param(
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Continue'
+
+$MAX_APPS       = 500
+$MAX_ICON_BYTES = 1MB
+$MAX_NAME_LEN   = 255
+$MAX_PATH_LEN   = 1024
+$ICON_SIZE      = 32
+
+# --- Helpers ---------------------------------------------------------------
+
+function ConvertTo-IconBase64 {
+    param([string]$SourcePath, [int]$Size = $ICON_SIZE)
+    if (-not $SourcePath) { return '' }
+    if (-not (Test-Path -LiteralPath $SourcePath -PathType Leaf)) { return '' }
+    $icon = $null; $bmp = $null; $resized = $null; $g = $null; $ms = $null
+    try {
+        Add-Type -AssemblyName System.Drawing -ErrorAction Stop
+        $icon = [System.Drawing.Icon]::ExtractAssociatedIcon($SourcePath)
+        if (-not $icon) { return '' }
+        $bmp = $icon.ToBitmap()
+        $resized = New-Object System.Drawing.Bitmap($Size, $Size)
+        $g = [System.Drawing.Graphics]::FromImage($resized)
+        $g.InterpolationMode = [System.Drawing.Drawing2D.InterpolationMode]::HighQualityBicubic
+        $g.DrawImage($bmp, 0, 0, $Size, $Size)
+        $ms = New-Object System.IO.MemoryStream
+        $resized.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png)
+        $bytes = $ms.ToArray()
+        if ($bytes.Length -gt $MAX_ICON_BYTES) { return '' }
+        return [Convert]::ToBase64String($bytes)
+    } catch {
+        return ''
+    } finally {
+        if ($ms)      { $ms.Dispose() }
+        if ($g)       { $g.Dispose() }
+        if ($resized) { $resized.Dispose() }
+        if ($bmp)     { $bmp.Dispose() }
+        if ($icon)    { $icon.Dispose() }
+    }
+}
+
+function Get-WmClassHint {
+    param([string]$ExePath)
+    if (-not $ExePath) { return '' }
+    try {
+        $stem = [System.IO.Path]::GetFileNameWithoutExtension($ExePath)
+        if (-not $stem) { return '' }
+        $safe = ($stem.ToLower() -replace '[^a-z0-9_-]', '')
+        if ($safe.Length -gt 64) { $safe = $safe.Substring(0, 64) }
+        return $safe
+    } catch { return '' }
+}
+
+function Get-DisplayName {
+    param([string]$ExePath, [string]$Fallback = '')
+    try {
+        $item = Get-Item -LiteralPath $ExePath -ErrorAction Stop
+        $vi = $item.VersionInfo
+        if ($vi -and $vi.FileDescription -and $vi.FileDescription.Trim()) {
+            return $vi.FileDescription.Trim()
+        }
+    } catch { }
+    if ($Fallback) { return $Fallback }
+    try { return [System.IO.Path]::GetFileNameWithoutExtension($ExePath) } catch { return '' }
+}
+
+function Read-IconBytesFromFile {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return '' }
+    try {
+        $bytes = [System.IO.File]::ReadAllBytes($Path)
+        if ($bytes.Length -eq 0) { return '' }
+        if ($bytes.Length -gt $MAX_ICON_BYTES) { return '' }
+        return [Convert]::ToBase64String($bytes)
+    } catch { return '' }
+}
+
+# --- DryRun short-circuit for CI smoke tests -------------------------------
+
+if ($DryRun) {
+    $canned = @(
+        [ordered]@{
+            name          = 'Notepad (DryRun)'
+            path          = 'C:\Windows\notepad.exe'
+            args          = ''
+            source        = 'win32'
+            wm_class_hint = 'notepad'
+            launch_uri    = ''
+            icon_b64      = ''
+        }
+    )
+    # @(...) wrapper forces array even for single element on PS 5.1.
+    ConvertTo-Json -InputObject @($canned) -Depth 6 -Compress
+    exit 0
+}
+
+# --- Accumulator -----------------------------------------------------------
+
+$results = New-Object System.Collections.Generic.List[object]
+$seen    = @{}
+
+function Add-Result {
+    param([hashtable]$Entry)
+    if (-not $Entry) { return }
+    if ($results.Count -ge $MAX_APPS) { return }
+    $name = [string]$Entry.name
+    $path = [string]$Entry.path
+    if (-not $name -or -not $path) { return }
+    if ($name.Length -gt $MAX_NAME_LEN) { return }
+    if ($path.Length -gt $MAX_PATH_LEN) { return }
+    $key = if ($Entry.launch_uri) { ([string]$Entry.launch_uri).ToLower() }
+           else { $path.ToLower() }
+    if ($seen.ContainsKey($key)) { return }
+    $seen[$key] = $true
+    $results.Add([ordered]@{
+        name          = $name
+        path          = $path
+        args          = [string]$Entry.args
+        source        = [string]$Entry.source
+        wm_class_hint = [string]$Entry.wm_class_hint
+        launch_uri    = [string]$Entry.launch_uri
+        icon_b64      = [string]$Entry.icon_b64
+    }) | Out-Null
+}
+
+# --- Source 1: Registry App Paths ------------------------------------------
+
+foreach ($hive in 'HKLM:', 'HKCU:') {
+    $root = Join-Path $hive 'Software\Microsoft\Windows\CurrentVersion\App Paths'
+    if (-not (Test-Path $root)) { continue }
+    try {
+        Get-ChildItem -Path $root -ErrorAction SilentlyContinue | ForEach-Object {
+            try {
+                $props = Get-ItemProperty -Path $_.PSPath -ErrorAction SilentlyContinue
+                if (-not $props) { return }
+                $default = $props.'(default)'
+                if (-not $default) { return }
+                $exe = ([string]$default).Trim('"')
+                if (-not (Test-Path -LiteralPath $exe -PathType Leaf)) { return }
+                $stem = [System.IO.Path]::GetFileNameWithoutExtension($exe)
+                Add-Result @{
+                    name          = Get-DisplayName -ExePath $exe -Fallback $stem
+                    path          = $exe
+                    args          = ''
+                    source        = 'win32'
+                    wm_class_hint = Get-WmClassHint $exe
+                    launch_uri    = ''
+                    icon_b64      = ConvertTo-IconBase64 $exe
+                }
+            } catch { }
+        }
+    } catch { }
+}
+
+# --- Source 2: Start Menu .lnk files ---------------------------------------
+
+$startDirs = @()
+if ($env:ProgramData) {
+    $startDirs += (Join-Path $env:ProgramData 'Microsoft\Windows\Start Menu\Programs')
+}
+try {
+    $userProfiles = Get-ChildItem -Path 'C:\Users' -Directory -ErrorAction SilentlyContinue
+    foreach ($u in $userProfiles) {
+        if ($u.Name -in @('Default', 'Default User', 'Public', 'All Users')) { continue }
+        $p = Join-Path $u.FullName 'AppData\Roaming\Microsoft\Windows\Start Menu\Programs'
+        if (Test-Path -LiteralPath $p) { $startDirs += $p }
+    }
+} catch { }
+
+$wsh = $null
+try { $wsh = New-Object -ComObject WScript.Shell } catch { }
+
+foreach ($d in $startDirs) {
+    if (-not $wsh) { break }
+    try {
+        Get-ChildItem -Path $d -Recurse -Filter '*.lnk' -ErrorAction SilentlyContinue |
+            ForEach-Object {
+                try {
+                    if ($_.Name -match '(?i)uninstall|readme|license|eula') { return }
+                    $lnk = $wsh.CreateShortcut($_.FullName)
+                    $target = [string]$lnk.TargetPath
+                    if (-not $target) { return }
+                    if ($target -notmatch '\.exe$') { return }
+                    if (-not (Test-Path -LiteralPath $target -PathType Leaf)) { return }
+                    $baseName = [System.IO.Path]::GetFileNameWithoutExtension($_.Name)
+                    Add-Result @{
+                        name          = Get-DisplayName -ExePath $target -Fallback $baseName
+                        path          = $target
+                        args          = [string]$lnk.Arguments
+                        source        = 'win32'
+                        wm_class_hint = Get-WmClassHint $target
+                        launch_uri    = ''
+                        icon_b64      = ConvertTo-IconBase64 $target
+                    }
+                } catch { }
+            }
+    } catch { }
+}
+
+# --- Source 3: UWP / MSIX packages -----------------------------------------
+
+try {
+    $pkgs = Get-AppxPackage -AllUsers -ErrorAction SilentlyContinue
+    foreach ($pkg in $pkgs) {
+        try {
+            if ($pkg.IsFramework) { continue }
+            if ($pkg.SignatureKind -eq 'System') { continue }
+            if (-not $pkg.InstallLocation) { continue }
+            $manifestPath = Join-Path $pkg.InstallLocation 'AppxManifest.xml'
+            if (-not (Test-Path -LiteralPath $manifestPath)) { continue }
+            [xml]$manifest = Get-Content -LiteralPath $manifestPath -ErrorAction SilentlyContinue
+            if (-not $manifest) { continue }
+
+            $apps = $null
+            try { $apps = $manifest.Package.Applications.Application } catch { $apps = $null }
+            if (-not $apps) { continue }
+            if ($apps -isnot [System.Collections.IEnumerable]) { $apps = @($apps) }
+
+            foreach ($appNode in $apps) {
+                try {
+                    $appId = [string]$appNode.Id
+                    if (-not $appId) { continue }
+                    $aumid = "$($pkg.PackageFamilyName)!$appId"
+                    $launchUri = "shell:AppsFolder\$aumid"
+
+                    $ve = $null
+                    foreach ($probe in 'VisualElements', 'uap:VisualElements') {
+                        try {
+                            $probed = $appNode.$probe
+                            if ($probed) { $ve = $probed; break }
+                        } catch { }
+                    }
+
+                    $displayName = [string]$pkg.Name
+                    if ($ve) {
+                        $dn = [string]$ve.DisplayName
+                        if ($dn -and ($dn -notmatch '^ms-resource:')) {
+                            $displayName = $dn
+                        }
+                    }
+
+                    $logoRel = ''
+                    if ($ve) {
+                        foreach ($attr in 'Square44x44Logo', 'Square30x30Logo', 'SmallLogo', 'Logo') {
+                            try {
+                                $val = [string]$ve.$attr
+                                if ($val) { $logoRel = $val; break }
+                            } catch { }
+                        }
+                    }
+
+                    $iconB64 = ''
+                    if ($logoRel) {
+                        $logoPath = Join-Path $pkg.InstallLocation $logoRel
+                        $iconB64 = Read-IconBytesFromFile $logoPath
+                        if (-not $iconB64) {
+                            $parent = [System.IO.Path]::GetDirectoryName($logoPath)
+                            $stem = [System.IO.Path]::GetFileNameWithoutExtension($logoPath)
+                            $ext = [System.IO.Path]::GetExtension($logoPath)
+                            foreach ($scale in '100', '200', '400') {
+                                $scaled = Join-Path $parent "$stem.scale-$scale$ext"
+                                $iconB64 = Read-IconBytesFromFile $scaled
+                                if ($iconB64) { break }
+                            }
+                        }
+                    }
+
+                    # path must be non-empty per core contract; use InstallLocation as placeholder.
+                    Add-Result @{
+                        name          = $displayName
+                        path          = [string]$pkg.InstallLocation
+                        args          = ''
+                        source        = 'uwp'
+                        wm_class_hint = ''
+                        launch_uri    = $aumid
+                        icon_b64      = $iconB64
+                    }
+                } catch { }
+            }
+        } catch { }
+    }
+} catch { }
+
+# --- Source 4: Chocolatey + Scoop shims ------------------------------------
+
+$shimDirs = @()
+if ($env:ProgramData) {
+    $shimDirs += (Join-Path $env:ProgramData 'chocolatey\bin')
+    $shimDirs += (Join-Path $env:ProgramData 'scoop\shims')
+}
+if ($env:USERPROFILE) {
+    $shimDirs += (Join-Path $env:USERPROFILE 'scoop\shims')
+}
+
+foreach ($d in $shimDirs) {
+    if (-not (Test-Path -LiteralPath $d)) { continue }
+    try {
+        Get-ChildItem -Path $d -Filter '*.exe' -ErrorAction SilentlyContinue | ForEach-Object {
+            try {
+                $resolved = $_.FullName
+                try {
+                    $cmd = Get-Command -Name $_.BaseName -CommandType Application -ErrorAction SilentlyContinue
+                    if ($cmd -and $cmd.Source -and (Test-Path -LiteralPath $cmd.Source -PathType Leaf)) {
+                        $resolved = $cmd.Source
+                    }
+                } catch { }
+                Add-Result @{
+                    name          = Get-DisplayName -ExePath $resolved -Fallback $_.BaseName
+                    path          = $resolved
+                    args          = ''
+                    source        = 'win32'
+                    wm_class_hint = Get-WmClassHint $resolved
+                    launch_uri    = ''
+                    icon_b64      = ConvertTo-IconBase64 $resolved
+                }
+            } catch { }
+        }
+    } catch { }
+}
+
+# --- Emit JSON -------------------------------------------------------------
+
+$output = $results.ToArray()
+if ($results.Count -ge $MAX_APPS) {
+    $output = $output + [ordered]@{ _truncated = $true }
+}
+
+# @(...) forces array encoding on PowerShell 5.1 even if the array has
+# exactly one element (Compress otherwise emits a bare object).
+ConvertTo-Json -InputObject @($output) -Depth 6 -Compress

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,528 @@
+"""Tests for core.discovery — dynamic Windows app enumeration.
+
+Covers:
+- JSON parsing (happy path, malformed, BOM, object-not-array, truncated flag).
+- Entry validation (source allowlist, UWP launch_uri required, length caps,
+  base64 decode, oversized icon dropped).
+- Slug generation (collision safety, Unicode, unsafe chars).
+- persist_discovered (writes app.toml, icon magic-byte dispatch, replace=True
+  clears old, path-traversal guard in _safe_rmtree).
+- discover_apps end-to-end (subprocess mocking for copy/exec, timeout,
+  pod-not-running, script-missing, backend gating).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from winpodx.core.discovery import (
+    DiscoveredApp,
+    DiscoveryError,
+    _entry_to_discovered,
+    _parse_discovery_output,
+    _safe_rmtree,
+    _slugify_name,
+    _sniff_icon_ext,
+    discover_apps,
+    persist_discovered,
+)
+
+from winpodx.core.config import Config
+
+# --- Fixtures --------------------------------------------------------------
+
+# Minimal PNG header (8-byte magic) that _sniff_icon_ext recognizes.
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+_TINY_PNG = _PNG_MAGIC + b"\x00\x00\x00\rIHDR" + b"\x00" * 20
+_TINY_SVG = b'<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"/>'
+
+
+def _valid_entry(**overrides) -> dict:
+    base = {
+        "name": "Example App",
+        "path": "C:\\Program Files\\Example\\example.exe",
+        "args": "",
+        "source": "win32",
+        "wm_class_hint": "example",
+        "launch_uri": "",
+        "icon_b64": "",
+    }
+    base.update(overrides)
+    return base
+
+
+# --- _sniff_icon_ext -------------------------------------------------------
+
+
+def test_sniff_icon_ext_png():
+    assert _sniff_icon_ext(_TINY_PNG) == "png"
+
+
+def test_sniff_icon_ext_svg():
+    assert _sniff_icon_ext(_TINY_SVG) == "svg"
+
+
+def test_sniff_icon_ext_svg_with_leading_whitespace():
+    # SVG files sometimes have leading whitespace before <?xml or <svg.
+    assert _sniff_icon_ext(b"   \n" + _TINY_SVG) == "svg"
+
+
+def test_sniff_icon_ext_empty():
+    assert _sniff_icon_ext(b"") == ""
+
+
+def test_sniff_icon_ext_unknown_format():
+    assert _sniff_icon_ext(b"garbage random bytes") == ""
+
+
+def test_sniff_icon_ext_jpeg_rejected():
+    # Only PNG/SVG are accepted; JPEG (FF D8 FF) is not.
+    assert _sniff_icon_ext(b"\xff\xd8\xff\xe0" + b"\x00" * 20) == ""
+
+
+# --- _slugify_name ---------------------------------------------------------
+
+
+def test_slugify_basic():
+    assert _slugify_name("Microsoft Word") == "microsoft-word"
+
+
+def test_slugify_collapses_non_alnum():
+    assert _slugify_name("Foo   Bar  /  Baz") == "foo-bar-baz"
+
+
+def test_slugify_strips_leading_trailing_punctuation():
+    assert _slugify_name("  ---Foo---  ") == "foo"
+
+
+def test_slugify_unicode_maps_to_empty_or_dash():
+    # Non-ASCII chars get collapsed to '-'; pure-Unicode names resolve to
+    # empty slugs (which the caller rejects).
+    assert _slugify_name("한글") == ""
+
+
+def test_slugify_bounds_length():
+    assert len(_slugify_name("a" * 200)) <= 64
+
+
+def test_slugify_rejects_path_traversal():
+    # Slashes / backslashes / dots collapse to single '-' and the outer
+    # regex enforces [a-zA-Z0-9_-] only; the result is a safe leaf name.
+    slug = _slugify_name("../../etc/passwd")
+    assert "/" not in slug
+    assert ".." not in slug
+    assert "\\" not in slug
+
+
+# --- _entry_to_discovered --------------------------------------------------
+
+
+def test_entry_happy_path():
+    app = _entry_to_discovered(_valid_entry())
+    assert app is not None
+    assert app.name == "example-app"
+    assert app.full_name == "Example App"
+    assert app.executable.endswith("example.exe")
+    assert app.source == "win32"
+
+
+def test_entry_missing_name_rejected():
+    assert _entry_to_discovered(_valid_entry(name="")) is None
+    assert _entry_to_discovered(_valid_entry(name=None)) is None
+
+
+def test_entry_missing_path_rejected():
+    assert _entry_to_discovered(_valid_entry(path="")) is None
+    assert _entry_to_discovered(_valid_entry(path=None)) is None
+
+
+def test_entry_invalid_source_normalized_to_win32():
+    app = _entry_to_discovered(_valid_entry(source="app_paths"))
+    assert app is not None
+    assert app.source == "win32"
+
+
+def test_entry_valid_uwp_source_preserved():
+    app = _entry_to_discovered(
+        _valid_entry(
+            source="uwp",
+            launch_uri="Microsoft.WindowsCalculator_8wekyb3d8bbwe!App",
+            path="C:\\Program Files\\WindowsApps\\Microsoft.WindowsCalculator_xxx",
+        )
+    )
+    assert app is not None
+    assert app.source == "uwp"
+    assert app.launch_uri
+
+
+def test_entry_uwp_without_launch_uri_rejected():
+    app = _entry_to_discovered(
+        _valid_entry(source="uwp", launch_uri="", path="C:\\Program Files\\WindowsApps\\xxx")
+    )
+    assert app is None
+
+
+def test_entry_oversized_name_rejected():
+    app = _entry_to_discovered(_valid_entry(name="x" * 500))
+    assert app is None
+
+
+def test_entry_oversized_path_rejected():
+    app = _entry_to_discovered(_valid_entry(path="C:\\" + "x" * 2000))
+    assert app is None
+
+
+def test_entry_icon_base64_decoded():
+    icon = _valid_entry(icon_b64=base64.b64encode(_TINY_PNG).decode("ascii"))
+    app = _entry_to_discovered(icon)
+    assert app is not None
+    assert app.icon_bytes == _TINY_PNG
+
+
+def test_entry_malformed_base64_yields_empty_icon():
+    app = _entry_to_discovered(_valid_entry(icon_b64="not base64!!!"))
+    assert app is not None
+    assert app.icon_bytes == b""
+
+
+def test_entry_oversized_icon_dropped():
+    # >1 MiB decoded payload is silently dropped (entry still accepted).
+    big = _TINY_PNG + b"\x00" * (1_048_576 + 1)
+    entry = _valid_entry(icon_b64=base64.b64encode(big).decode("ascii"))
+    app = _entry_to_discovered(entry)
+    assert app is not None
+    assert app.icon_bytes == b""
+
+
+# --- _parse_discovery_output -----------------------------------------------
+
+
+def test_parse_empty_output_returns_empty_list():
+    assert _parse_discovery_output("") == []
+    assert _parse_discovery_output("   \n\n  ") == []
+
+
+def test_parse_happy_path():
+    payload = json.dumps([_valid_entry(name="App A"), _valid_entry(name="App B")])
+    apps = _parse_discovery_output(payload)
+    assert len(apps) == 2
+    assert apps[0].full_name == "App A"
+    assert apps[1].full_name == "App B"
+
+
+def test_parse_malformed_json_raises():
+    with pytest.raises(DiscoveryError, match="Malformed"):
+        _parse_discovery_output("{ not json at all")
+
+
+def test_parse_array_required_or_single_dict_coerced():
+    # A bare object becomes a single-element list per core's parser.
+    payload = json.dumps(_valid_entry(name="Solo"))
+    apps = _parse_discovery_output(payload)
+    assert len(apps) == 1
+    assert apps[0].full_name == "Solo"
+
+
+def test_parse_scalar_json_raises():
+    # A scalar (string/int) cannot be coerced and must raise.
+    with pytest.raises(DiscoveryError, match="must be an array"):
+        _parse_discovery_output('"just a string"')
+
+
+def test_parse_strips_utf8_bom():
+    payload = "﻿" + json.dumps([_valid_entry()])
+    apps = _parse_discovery_output(payload)
+    assert len(apps) == 1
+
+
+def test_parse_ignores_non_dict_entries():
+    payload = json.dumps([_valid_entry(), "garbage", 42, None, _valid_entry(name="B")])
+    apps = _parse_discovery_output(payload)
+    assert len(apps) == 2
+
+
+def test_parse_truncated_flag_respected():
+    payload = json.dumps([_valid_entry(), {"_truncated": True}])
+    apps = _parse_discovery_output(payload)
+    # Truncated marker is consumed, not converted into an app.
+    assert len(apps) == 1
+
+
+def test_parse_max_apps_cap():
+    # Feed >500 entries; parser should stop at MAX_APPS.
+    entries = [_valid_entry(name=f"App {i}") for i in range(600)]
+    apps = _parse_discovery_output(json.dumps(entries))
+    assert len(apps) == 500
+
+
+# --- persist_discovered ----------------------------------------------------
+
+
+def test_persist_writes_app_toml(tmp_path):
+    app = DiscoveredApp(
+        name="example-app",
+        full_name="Example App",
+        executable="C:\\Program Files\\Example\\example.exe",
+    )
+    written = persist_discovered([app], target_dir=tmp_path)
+    assert len(written) == 1
+    toml_path = written[0]
+    assert toml_path.exists()
+    content = toml_path.read_text(encoding="utf-8")
+    assert 'name = "example-app"' in content
+    assert 'full_name = "Example App"' in content
+
+
+def test_persist_writes_png_icon(tmp_path):
+    app = DiscoveredApp(
+        name="example-app",
+        full_name="Example",
+        executable="C:\\example.exe",
+        icon_bytes=_TINY_PNG,
+    )
+    persist_discovered([app], target_dir=tmp_path)
+    icon = tmp_path / "example-app" / "icon.png"
+    assert icon.exists()
+    assert icon.read_bytes() == _TINY_PNG
+
+
+def test_persist_writes_svg_icon(tmp_path):
+    app = DiscoveredApp(
+        name="example-app",
+        full_name="Example",
+        executable="C:\\example.exe",
+        icon_bytes=_TINY_SVG,
+    )
+    persist_discovered([app], target_dir=tmp_path)
+    icon = tmp_path / "example-app" / "icon.svg"
+    assert icon.exists()
+
+
+def test_persist_skips_unknown_icon_format(tmp_path):
+    app = DiscoveredApp(
+        name="example-app",
+        full_name="Example",
+        executable="C:\\example.exe",
+        icon_bytes=b"\xff\xd8\xff\xe0 garbage jpeg",
+    )
+    persist_discovered([app], target_dir=tmp_path)
+    app_dir = tmp_path / "example-app"
+    # app.toml is still written but no icon file in a recognized format.
+    assert (app_dir / "app.toml").exists()
+    assert not (app_dir / "icon.png").exists()
+    assert not (app_dir / "icon.svg").exists()
+    assert not (app_dir / "icon.jpg").exists()
+
+
+def test_persist_deduplicates_by_slug(tmp_path):
+    # Two apps with the same slug: second should be silently skipped.
+    a = DiscoveredApp(name="example-app", full_name="A", executable="C:\\a.exe")
+    b = DiscoveredApp(name="example-app", full_name="B", executable="C:\\b.exe")
+    written = persist_discovered([a, b], target_dir=tmp_path)
+    assert len(written) == 1
+    # First-seen wins.
+    content = (tmp_path / "example-app" / "app.toml").read_text()
+    assert 'full_name = "A"' in content
+
+
+def test_persist_replace_true_clears_old_entries(tmp_path):
+    # Prime the dir with stale content.
+    stale = tmp_path / "example-app"
+    stale.mkdir()
+    (stale / "stale.txt").write_text("leftover")
+
+    app = DiscoveredApp(name="example-app", full_name="Fresh", executable="C:\\e.exe")
+    persist_discovered([app], target_dir=tmp_path, replace=True)
+    assert not (stale / "stale.txt").exists()
+    assert (stale / "app.toml").exists()
+
+
+def test_persist_replace_false_preserves_old_entries(tmp_path):
+    stale_dir = tmp_path / "example-app"
+    stale_dir.mkdir()
+    (stale_dir / "stale.txt").write_text("preserved")
+
+    app = DiscoveredApp(name="example-app", full_name="Fresh", executable="C:\\e.exe")
+    persist_discovered([app], target_dir=tmp_path, replace=False)
+    # app.toml still written (overwritten), but stale sibling stays.
+    assert (stale_dir / "stale.txt").exists()
+    assert (stale_dir / "app.toml").exists()
+
+
+def test_persist_rejects_unsafe_slug(tmp_path):
+    # _SAFE_NAME_RE gatekeeper blocks anything not matching [a-zA-Z0-9_-].
+    bad = DiscoveredApp(name="has space", full_name="Bad", executable="C:\\b.exe")
+    written = persist_discovered([bad], target_dir=tmp_path)
+    assert written == []
+    assert not (tmp_path / "has space").exists()
+
+
+# --- _safe_rmtree ----------------------------------------------------------
+
+
+def test_safe_rmtree_removes_subpath(tmp_path):
+    inner = tmp_path / "inner"
+    inner.mkdir()
+    (inner / "file.txt").write_text("x")
+    _safe_rmtree(inner, tmp_path)
+    assert not inner.exists()
+
+
+def test_safe_rmtree_refuses_escape(tmp_path, caplog):
+    # Construct a path that resolves outside the target root.
+    other = tmp_path.parent / f"winpodx-test-escape-{tmp_path.name}"
+    other.mkdir()
+    (other / "keep.txt").write_text("should survive")
+    try:
+        _safe_rmtree(other, tmp_path)
+        assert other.exists()
+        assert (other / "keep.txt").exists()
+    finally:
+        # Cleanup regardless of test outcome.
+        for f in other.iterdir():
+            f.unlink()
+        other.rmdir()
+
+
+def test_safe_rmtree_handles_symlink(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "file.txt").write_text("x")
+    link = tmp_path / "link"
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks unsupported on this platform")
+    _safe_rmtree(link, tmp_path)
+    # Symlink is removed without following into the target.
+    assert not link.exists()
+    assert target.exists()
+    assert (target / "file.txt").exists()
+
+
+# --- discover_apps end-to-end ----------------------------------------------
+
+
+def _make_cfg(backend: str = "podman") -> Config:
+    cfg = Config()
+    cfg.pod.backend = backend
+    cfg.pod.container_name = "winpodx-test"
+    return cfg
+
+
+def test_discover_rejects_libvirt_backend():
+    cfg = _make_cfg(backend="libvirt")
+    with pytest.raises(DiscoveryError, match="container backend"):
+        discover_apps(cfg)
+
+
+def test_discover_rejects_manual_backend():
+    cfg = _make_cfg(backend="manual")
+    with pytest.raises(DiscoveryError, match="container backend"):
+        discover_apps(cfg)
+
+
+def test_discover_requires_runtime_on_path():
+    cfg = _make_cfg(backend="podman")
+    with patch("winpodx.core.discovery.shutil.which", return_value=None):
+        with pytest.raises(DiscoveryError, match="not found on PATH"):
+            discover_apps(cfg)
+
+
+def test_discover_requires_script_file():
+    cfg = _make_cfg(backend="podman")
+    with (
+        patch("winpodx.core.discovery.shutil.which", return_value="/usr/bin/podman"),
+        patch(
+            "winpodx.core.discovery._ps_script_path",
+            return_value=Path("/nonexistent/discover_apps.ps1"),
+        ),
+    ):
+        with pytest.raises(DiscoveryError, match="Discovery script not found"):
+            discover_apps(cfg)
+
+
+def test_discover_surfaces_pod_not_running(tmp_path):
+    cfg = _make_cfg(backend="podman")
+    script = tmp_path / "discover_apps.ps1"
+    script.write_text("# stub")
+
+    cp_err = subprocess.CalledProcessError(
+        1, ["podman", "cp"], output="", stderr="no such container"
+    )
+    with (
+        patch("winpodx.core.discovery.shutil.which", return_value="/usr/bin/podman"),
+        patch("winpodx.core.discovery._ps_script_path", return_value=script),
+        patch("winpodx.core.discovery.subprocess.run", side_effect=cp_err),
+    ):
+        with pytest.raises(DiscoveryError, match="Failed to copy"):
+            discover_apps(cfg)
+
+
+def test_discover_surfaces_timeout(tmp_path):
+    cfg = _make_cfg(backend="podman")
+    script = tmp_path / "discover_apps.ps1"
+    script.write_text("# stub")
+
+    def fake_run(*args, **kwargs):
+        # First call (cp) succeeds; second (exec) times out.
+        if "cp" in args[0]:
+            return subprocess.CompletedProcess(args[0], 0, "", "")
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout", 120))
+
+    with (
+        patch("winpodx.core.discovery.shutil.which", return_value="/usr/bin/podman"),
+        patch("winpodx.core.discovery._ps_script_path", return_value=script),
+        patch("winpodx.core.discovery.subprocess.run", side_effect=fake_run),
+    ):
+        with pytest.raises(DiscoveryError, match="timed out"):
+            discover_apps(cfg)
+
+
+def test_discover_happy_path_roundtrip(tmp_path):
+    cfg = _make_cfg(backend="podman")
+    script = tmp_path / "discover_apps.ps1"
+    script.write_text("# stub")
+
+    payload = json.dumps([_valid_entry(name="Calculator")])
+
+    def fake_run(*args, **kwargs):
+        cmd = args[0]
+        if "cp" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 0, payload, "")
+
+    with (
+        patch("winpodx.core.discovery.shutil.which", return_value="/usr/bin/podman"),
+        patch("winpodx.core.discovery._ps_script_path", return_value=script),
+        patch("winpodx.core.discovery.subprocess.run", side_effect=fake_run),
+    ):
+        apps = discover_apps(cfg)
+
+    assert len(apps) == 1
+    assert apps[0].full_name == "Calculator"
+
+
+def test_discover_nonzero_exit_raises(tmp_path):
+    cfg = _make_cfg(backend="podman")
+    script = tmp_path / "discover_apps.ps1"
+    script.write_text("# stub")
+
+    def fake_run(*args, **kwargs):
+        cmd = args[0]
+        if "cp" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 42, "", "Get-AppxPackage failed")
+
+    with (
+        patch("winpodx.core.discovery.shutil.which", return_value="/usr/bin/podman"),
+        patch("winpodx.core.discovery._ps_script_path", return_value=script),
+        patch("winpodx.core.discovery.subprocess.run", side_effect=fake_run),
+    ):
+        with pytest.raises(DiscoveryError, match="rc=42"):
+            discover_apps(cfg)


### PR DESCRIPTION
Platform-QA slice for v0.1.8 dynamic app discovery. Last Wave 1 PR — pairs with #5 (cli), #6 (core), #7 (gui).

## What ships

- **`scripts/windows/discover_apps.ps1`** (new, ~280 lines) — enumerates installed Windows apps from four sources and emits a single JSON array on stdout:
  1. Registry `App Paths` under `HKLM` + `HKCU` (NOT the Uninstall key)
  2. Start Menu `.lnk` recursion across `ProgramData` + every user profile, resolved via `WScript.Shell.CreateShortcut`, rejecting `*uninstall*` / readme / license shortcuts
  3. UWP/MSIX packages via `Get-AppxPackage -AllUsers` + `AppxManifest.xml` `<VisualElements>` / `<Logo>`. Launch URI = `<PackageFamilyName>!<AppId>` (AUMID) for the host side to wrap with `shell:AppsFolder\`
  4. Chocolatey (`$ProgramData\chocolatey\bin`) + Scoop (`$USERPROFILE\scoop\shims`, `$ProgramData\scoop\shims`) shims, resolved with `Get-Command`
  
  Icons come from `[System.Drawing.Icon]::ExtractAssociatedIcon($exe).ToBitmap()` + `HighQualityBicubic` resize to 32×32 PNG, base64-encoded; UWP icons are read directly from the manifest `<Logo>` with `.scale-100/200/400` fallback.
  
  Dedups by lowercase path or AUMID. Caps at 500 apps with a trailing `{"_truncated": true}` marker. PS 5.1-compatible (ships in every Windows install). `-DryRun` flag returns a single canned entry for CI smoke testing.

- **`tests/test_discovery.py`** (new, ~500 lines, **51 tests**, all pass locally when merged with core's branch) — covers `_parse_discovery_output` (malformed JSON, BOM stripping, single-dict coercion, truncated flag, MAX_APPS cap), `_entry_to_discovered` (source allowlist, UWP `launch_uri` required, length caps, base64 decode, oversized-icon drop), `_slugify_name` (Unicode, path traversal, length bounds), `persist_discovered` (PNG/SVG magic-byte dispatch, replace semantics, slug dedup, unsafe-slug rejection), `_safe_rmtree` (escape guard, symlink handling), and `discover_apps` end-to-end (backend gating, runtime-on-PATH check, pod-not-running, timeout, happy-path roundtrip, non-zero exit).

- **`.github/workflows/ci.yml`** — new `discover-apps-ps` job installs PowerShell Core (`pwsh`) on the `ubuntu-latest` runner from the official Microsoft apt repository (skipped if already preinstalled) and runs `discover_apps.ps1 -DryRun`, asserting stdout parses as a JSON array with the required fields (`name`, `path`, `args`, `source`, `wm_class_hint`, `launch_uri`, `icon_b64`) and that `source` is one of `{win32, uwp, steam}`.

- **`CHANGELOG.md` + `docs/CHANGELOG.ko.md`** — `[Unreleased]` entries document the new discovery feature, UWP launch path, and CI smoke job. Version bump (0.1.7 → 0.1.8) is NOT included — that's Wave 3.

## Merge order

**Depends on #6 (core).** When #6 lands first on `main`, this PR's test suite automatically aligns. CI on this PR will initially fail with `ModuleNotFoundError: winpodx.core.discovery` on the test job because that module is owned by #6 — that's expected and will resolve on rebase after #6 merges. I verified locally by merging `origin/feat/discovery-core` into my branch and running the full suite: `276 passed in 3.14s` (225 existing + 51 new), ruff clean, format clean.

## Out of scope

- `config/oem/extract_icon.ps1` (single-path on-demand variant) — not needed for v0.1.8 since none of the three other Wave 1 PRs reference it. Deferred.
- Version bump → Wave 3 (Task #6 in the internal tracker).
- Per-app progress streaming → v0.2.0 guest agent work (memorized).

## Note on ownership

Platform-qa's original spawn did not produce artifacts. Team lead took over Task #1 directly to unblock Wave 1. File ownership boundaries respected: only `config/` / `scripts/` / `tests/` / `.github/workflows/` / `CHANGELOG*` modified.