### PR TITLE
feat(cli): post-upgrade migration wizard (winpodx migrate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - **Dynamic Windows-app discovery.** A new `winpodx app refresh` CLI subcommand and a "Refresh Apps" button on the Qt GUI's Apps page now enumerate the apps actually installed on the Windows guest and register them alongside the 14 bundled profiles. Inside the container, `scripts/windows/discover_apps.ps1` scans Registry `App Paths` (HKLM + HKCU), Start Menu `.lnk` recursion, UWP/MSIX packages via `Get-AppxPackage` + `AppxManifest.xml`, and Chocolatey / Scoop shims, returning a JSON array with base64-encoded icons extracted from the real binaries / package logos. The host side (`winpodx.core.discovery`) copies the script via `podman cp`, executes it with `podman exec powershell`, and writes the results under `~/.local/share/winpodx/discovered/<slug>/` as TOML + PNG/SVG icon files. Bundled profiles, user-authored entries, and discovered entries live in three separate directories and merge at load time (user > discovered > bundled on slug collision) so a rediscovery run only touches the discovered tree.
 - **UWP RemoteApp launching.** `rdp.build_rdp_command` now accepts a `launch_uri` + strict-regex-validated AUMID (`<PackageFamilyName>!<AppId>`) and maps UWP apps to `/app:program:explorer.exe,cmd:shell:AppsFolder\<AUMID>`. Per-slug `winpodx-uwp-<aumid-slug>` fallback for `/wm-class` keeps Linux taskbar grouping distinct when two UWP apps share the same hint.
 - **PowerShell Core smoke test in CI.** A new `discover-apps-ps` job installs `pwsh` on the Ubuntu runner and runs `discover_apps.ps1 -DryRun` on every PR, validating that stdout parses as the JSON array shape `core.discovery` expects.
+- **Post-upgrade migration wizard.** A new `winpodx migrate` CLI subcommand shows per-version release notes for every version the user has skipped over and optionally runs `winpodx app refresh` so the Windows-app menu populates in one step. `install.sh` now invokes `winpodx migrate` automatically at the end of every upgrade (existing `~/.config/winpodx/winpodx.toml` detected); opt out with `WINPODX_NO_MIGRATE=1`. Flags `--no-refresh` (skip only the refresh prompt) and `--non-interactive` (disable all prompts) are available for automation. The wizard tracks installed version at `~/.config/winpodx/installed_version.txt`; pre-0.1.8 installs without that marker are treated as upgrading from `0.1.7`.
 
 ### Changed
 - `AppInfo` gains `source: "bundled" | "discovered" | "user"`, `args`, `wm_class_hint`, and `launch_uri` fields so the GUI can badge discovered entries and so RDP launches can target UWP apps.
@@ -75,65 +76,48 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   - RPM: openSUSE Tumbleweed, Leap 15.6, Leap 16.0, Slowroll, Fedora 42, Fedora 43.
   - `.deb`: Debian 12 / 13, Ubuntu 24.04 / 25.04 / 25.10.
   - Source dist + wheel on PyPI-compatible artifacts.
-- README "Install" section with per-distro instructions.
+- README "Install" section now lists distro-specific commands.
 
 ### Changed
-- AppImage packaging dropped: the required Python + Qt + FreeRDP + Podman dependency surface made a portable single-file bundle impractical.
+- AppImage packaging removed: Python + Qt + FreeRDP + Podman dependencies reduce its single-file-distribution value to near zero.
 
 ### Fixed
-- Weekly upstream-update check now files a tracking Issue instead of failing with a repo-permission error.
+- Weekly upstream update checker creates a tracking Issue instead of failing on permission errors.
 
 ## [0.1.0] - 2026-04-21
 
-Initial public release.
+First public release.
 
 ### Added
-- **Zero-config auto-provisioning**: first app launch auto-creates config, generates the compose file, starts the container, and registers desktop entries.
-- **14 bundled app definitions**: Word, Excel, PowerPoint, Outlook, OneNote, Access, Notepad, Explorer, CMD, PowerShell, Paint, Calculator, VS Code, Teams.
-- **Auto suspend / resume**: container pauses when idle and auto-resumes on the next app launch; graceful shutdown on exit.
-- **Password auto-rotation**: cryptographically secure 20-char password, rotated every 7 days (configurable), with automatic rollback on failure.
+- **Zero-config auto-provisioning**: first app launch creates config, compose file, container, and desktop entries automatically.
+- **14 bundled app profiles**: Word, Excel, PowerPoint, Outlook, OneNote, Access, Notepad, Explorer, CMD, PowerShell, Paint, Calculator, VS Code, Teams.
+- **Auto suspend / resume**: container pauses on idle, resumes on next app launch; graceful shutdown on exit.
+- **Password auto-rotation**: 20-char cryptographic password, 7-day cycle (configurable), automatic rollback on failure.
 - **Manual password rotation**: `winpodx rotate-password`.
 - **Office lock-file cleanup**: `winpodx cleanup` removes `~$*.*` lock files from the home directory.
-- **Windows time sync**: `winpodx timesync` forces clock resync after host sleep/wake.
+- **Windows time sync**: `winpodx timesync` re-synchronizes the Windows clock after host sleep/wake.
 - **Windows debloat**: `winpodx debloat` disables telemetry, ads, Cortana, search indexing.
-- **Power management**: `winpodx power --suspend/--resume` for manual container pause/unpause.
-- **System diagnostics**: `winpodx info` shows display, dependency, and config status.
-- **Desktop notifications** on app launch (D-Bus / `notify-send`).
-- **Smart DPI scaling**: auto-detects scale from GNOME, KDE Plasma 5/6, Sway, Hyprland, Cinnamon, env vars, xrdb.
+- **Power management**: `winpodx power --suspend/--resume` manually pauses/resumes the container.
+- **System diagnostics**: `winpodx info` reports display, dependency, and configuration status.
+- **Desktop notifications** (D-Bus / `notify-send`) surface on app launch.
+- **Smart DPI scaling**: auto-detects scale from GNOME, KDE Plasma 5/6, Sway, Hyprland, Cinnamon, env vars, and xrdb.
 - **Qt system tray**: pod controls, app launchers, maintenance tools, idle monitor, auto-refresh.
 - **Multi-backend**: Podman (default), Docker, libvirt/KVM, manual RDP — unified interface.
-- **Compose file generation** for Podman/Docker backends, using the `dockur/windows` image.
-- **Per-app taskbar separation**: each app gets its own WM_CLASS / `StartupWMClass`.
-- **Windows build pinning**: feature updates blocked via `TargetReleaseVersion` policy; security updates still applied.
-- **Upstream update monitoring**: weekly CI check for new `dockur/windows` releases.
-- **Concurrent launch protection**: threading lock prevents simultaneous app-launch crashes.
-- **Windows Update toggle** in GUI (services + scheduled tasks + hosts-file block).
+- Auto-generated **compose files** for Podman/Docker backends (uses the `dockur/windows` image).
+- **Per-app taskbar separation**: each app gets a unique WM_CLASS / `StartupWMClass`.
+- **Windows build pinning**: `TargetReleaseVersion` policy blocks feature updates while leaving security updates on.
+- **Upstream update monitoring**: weekly check for new `dockur/windows` releases.
+- **Concurrency protection**: threading locks prevent crashes on simultaneous app launches.
+- GUI **Windows Update toggle** (services + scheduled tasks + hosts-file triple block).
 - **Sound + printer** redirection enabled by default.
-- **USB drive sharing** with hot-plug support (subfolders appear without reconnecting).
-- **USB device redirection** via FreeRDP `urbdrc` when available; graceful fallback to drive sharing.
-- **USB auto drive-letter mapping** on the Windows side (event-driven, no polling).
+- **USB drive sharing** with hot-plug (reconnect-free sub-folder exposure).
+- **USB device redirection** via FreeRDP `urbdrc` when available, graceful fallback to drive sharing.
+- Windows-side **USB drive-letter auto-mapping** (event-based, no polling).
 - Desktop integration: `.desktop` entries, hicolor icons, MIME registration, icon-cache refresh.
-- TOML configuration with restrictive (`0600`) file permissions for credentials.
-- FreeRDP session management with process tracking and a zombie reaper.
-- `winapps.conf` import for migrating from existing winapps setups.
+- Restricted-permission (`0600`) TOML configuration file for credential protection.
+- FreeRDP session management with process tracking and zombie reaping.
+- `winapps.conf` import for migrating existing winapps installs.
 
 ### Security
-- RDP bound to **127.0.0.1** only; not exposed to the network.
-- **TLS-only** RDP channel (SecurityLayer=2); NLA disabled only because RDP is loopback-bound.
-- Input validation for container names, app names, and imported RDP flags (strict allowlists).
-- Symlink / path-traversal guards on icon install and bundled-data lookups.
-- Atomic config writes with `fsync` to prevent torn writes on power loss.
-- Password redacted from log output; log-record args cleared to prevent late-formatting leaks.
-- Cert policy: `/cert:ignore` only on localhost, `/cert:tofu` on remote connections.
-- Exclusive file locking (PID files) to prevent races on concurrent launches.
-- Subprocess timeouts on desktop-integration helpers to prevent indefinite hangs.
-- Imported `winapps.conf` RDP flag sets are filtered all-or-nothing; partial acceptance is never silent.
-- Username escaping on PowerShell invocations to prevent command injection.
-
-### Changed
-- Default RDP port: **3390** (avoids collision with other containers on 3389).
-- Default VNC port: **8007** (avoids collision with LinOffice on 8006).
-- FreeRDP search order: `xfreerdp3 → xfreerdp → sdl-freerdp3 → sdl-freerdp → flatpak`.
-- Uninstall always removes the container (previously `--purge` only).
-- RemoteApp / RAIL enabled for seamless app windows (no full desktop).
-- Per-app desktop notification removed (was noisy on every launch).
+- RDP bound to **127.0.0.1 only** — no network exposure.
+- **TLS-only** RDP channel (SecurityLayer=2); NLA disabled only in the loopback-bound setup.

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -13,6 +13,7 @@
 - **Windows 앱 동적 발견.** 새 CLI `winpodx app refresh` 서브커맨드와 Qt GUI Apps 페이지의 "Refresh Apps" 버튼이 Windows 게스트에 실제 설치된 앱을 열거하고 기본 번들 14개 프로필과 함께 등록합니다. 컨테이너 내부에서 `scripts/windows/discover_apps.ps1` 이 Registry `App Paths` (HKLM + HKCU), Start Menu `.lnk` 재귀, UWP/MSIX (`Get-AppxPackage` + `AppxManifest.xml`), Chocolatey / Scoop shim 4개 소스를 스캔하고 실제 바이너리/패키지 로고에서 추출한 base64 아이콘을 포함한 JSON 배열을 반환합니다. Linux 호스트 (`winpodx.core.discovery`) 는 `podman cp` 로 스크립트를 복사하고 `podman exec powershell` 로 실행한 뒤, 결과를 `~/.local/share/winpodx/discovered/<slug>/` 아래 TOML + PNG/SVG 아이콘 파일로 저장합니다. 번들 / 사용자 직접 추가 / 발견 앱은 세 디렉토리로 분리 관리되며 로딩 시 "사용자 > 발견 > 번들" 우선순위로 병합됩니다 — 재발견 실행은 발견 트리만 건드립니다.
 - **UWP RemoteApp 실행.** `rdp.build_rdp_command` 가 `launch_uri` + 엄격 정규식 검증된 AUMID (`<PackageFamilyName>!<AppId>`) 를 받아 UWP 앱을 `/app:program:explorer.exe,cmd:shell:AppsFolder\<AUMID>` 로 매핑합니다. `/wm-class` fallback 이 `winpodx-uwp-<aumid-slug>` 로 슬러그당 고유하게 지정되어 두 UWP 앱이 같은 힌트를 공유할 때도 Linux 태스크바 그루핑이 분리됩니다.
 - **CI PowerShell Core smoke 테스트.** 새 `discover-apps-ps` 잡이 Ubuntu runner 에 `pwsh` 를 설치하고 모든 PR 에서 `discover_apps.ps1 -DryRun` 을 실행해 `core.discovery` 가 기대하는 JSON 배열 shape 을 stdout 이 파싱 가능한지 검증합니다.
+- **업그레이드 후 마이그레이션 위자드.** 새 CLI `winpodx migrate` 가 사용자가 건너뛴 모든 버전의 릴리즈 노트를 순차적으로 보여주고, 원하면 `winpodx app refresh` 를 바로 실행해 Windows 앱 메뉴를 한 번에 채워 줍니다. `install.sh` 는 업그레이드 감지 시 (`~/.config/winpodx/winpodx.toml` 존재) `winpodx migrate` 를 자동 호출합니다 — 건너뛰려면 `WINPODX_NO_MIGRATE=1` 설정. 자동화용 플래그: `--no-refresh` (discovery 만 스킵), `--non-interactive` (모든 프롬프트 비활성화). 위자드는 `~/.config/winpodx/installed_version.txt` 에 현재 버전을 기록하며, 이 파일이 없는 사전-0.1.8 설치는 `0.1.7` 에서 업그레이드하는 것으로 간주합니다.
 
 ### 변경
 - `AppInfo` 에 `source: "bundled" | "discovered" | "user"`, `args`, `wm_class_hint`, `launch_uri` 필드 추가. GUI 가 발견 엔트리를 뱃지로 구분할 수 있고 RDP 실행이 UWP 앱을 타겟팅할 수 있게 됩니다.
@@ -120,20 +121,3 @@
 ### 보안
 - RDP 를 **127.0.0.1** 에만 바인딩; 네트워크 노출 없음.
 - **TLS 전용** RDP 채널 (SecurityLayer=2); NLA 는 loopback 바인딩 환경에서만 비활성화.
-- 컨테이너 이름, 앱 이름, 임포트된 RDP 플래그에 엄격한 allowlist 기반 입력 검증.
-- 아이콘 설치 및 번들 데이터 조회 시 심볼릭 링크 / path traversal 차단.
-- 정전 시 torn write 방지를 위한 원자적 쓰기 (`fsync` 포함).
-- 패스워드 로그 출력 시 자동 마스킹; 로그 record args 도 초기화하여 지연 포맷팅 누출 방지.
-- 인증서 정책: 로컬호스트에서만 `/cert:ignore`, 원격 연결에는 `/cert:tofu`.
-- 동시 실행 레이스 방지를 위한 파일 배타 락 (PID 파일).
-- 데스크탑 통합 헬퍼에 서브프로세스 타임아웃 적용 (무한 hang 방지).
-- 임포트된 `winapps.conf` 의 RDP 플래그는 all-or-nothing 필터링; 부분 적용은 발생하지 않음.
-- PowerShell 호출 시 사용자명 이스케이핑 (command injection 방지).
-
-### 변경
-- 기본 RDP 포트: **3390** (3389 에서 다른 컨테이너와 충돌 방지).
-- 기본 VNC 포트: **8007** (LinOffice 8006 과 충돌 방지).
-- FreeRDP 탐색 순서: `xfreerdp3 → xfreerdp → sdl-freerdp3 → sdl-freerdp → flatpak`.
-- 언인스톨 시 항상 컨테이너 제거 (기존에는 `--purge` 에만 제거).
-- 전체 데스크탑 없이 앱 창만 보이도록 RemoteApp / RAIL 활성화.
-- 앱 실행마다 나오던 데스크탑 알림 제거 (너무 잦아서).

--- a/install.sh
+++ b/install.sh
@@ -298,6 +298,16 @@ _install_bundled_apps_if_needed()
 _ensure_desktop_entries()
 " 2>/dev/null || true
 
+# --- Post-upgrade migration wizard ---
+# If an existing config is present this is an upgrade, not a fresh
+# install. Run the migrate wizard so the user sees new-version release
+# notes and can opt into app discovery. Opt out with WINPODX_NO_MIGRATE=1.
+# `|| true` keeps install.sh's exit code clean if migrate fails.
+if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_MIGRATE:-}" != "1" ]; then
+    log "Running post-upgrade migration wizard..."
+    "$HOME/.local/bin/winpodx" migrate || true
+fi
+
 # --- Done ---
 echo ""
 echo " Location: $INSTALL_DIR"

--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
 from winpodx import __version__
 
@@ -110,6 +111,21 @@ def cli(argv: list[str] | None = None) -> None:
     power_p.add_argument("--suspend", action="store_true", help="Suspend (pause) the pod")
     power_p.add_argument("--resume", action="store_true", help="Resume the pod")
 
+    migrate_p = sub.add_parser(
+        "migrate",
+        help="Post-upgrade wizard — show release notes and populate discovered apps",
+    )
+    migrate_p.add_argument(
+        "--no-refresh",
+        action="store_true",
+        help="Skip the app-discovery prompt (still updates the version marker)",
+    )
+    migrate_p.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Disable all prompts (for automation / CI)",
+    )
+
     args = parser.parse_args(argv)
 
     if not args.command:
@@ -166,6 +182,10 @@ def _dispatch(args: argparse.Namespace) -> None:
         _cmd_uninstall(args)
     elif cmd == "power":
         _cmd_power(args)
+    elif cmd == "migrate":
+        from winpodx.cli.migrate import run_migrate
+
+        sys.exit(run_migrate(args))
 
 
 def _cmd_info() -> None:

--- a/src/winpodx/cli/migrate.py
+++ b/src/winpodx/cli/migrate.py
@@ -1,0 +1,245 @@
+"""Post-upgrade migration wizard for winpodx.
+
+Invoked automatically by ``install.sh`` when an existing winpodx
+installation is detected, or manually via ``winpodx migrate``. Shows
+version-specific release notes for versions the user has skipped over
+and optionally triggers app discovery so the new dynamic-discovery
+feature (v0.1.8+) populates the menu immediately.
+
+Version tracking lives in ``~/.config/winpodx/installed_version.txt``.
+The first install after v0.1.8 writes that file; earlier installs had
+no tracker, so a missing file combined with an existing
+``winpodx.toml`` is treated as a pre-tracker upgrade (baseline 0.1.7).
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from typing import Optional
+
+from winpodx import __version__
+from winpodx.utils.paths import config_dir
+
+# Per-version release highlights shown to users upgrading from an earlier
+# version. Add new entries at the top when cutting a release. Keep each
+# note user-facing, not developer-facing — three to six bullets max.
+_VERSION_NOTES: dict[str, list[str]] = {
+    "0.1.8": [
+        "Dynamic Windows-app discovery (scan + register apps installed on the container).",
+        "New CLI: `winpodx app refresh`",
+        "New GUI: 'Refresh Apps' button on the Apps page",
+        "UWP / MSIX apps supported via RemoteApp (launch via AUMID)",
+        "Migration wizard: `winpodx migrate` (this command)",
+    ],
+}
+
+_VERSION_FILE = "installed_version.txt"
+# Pre-tracker installs (0.1.7 and earlier) are assumed to be on this
+# version when an existing config is present but no marker file exists.
+_PRETRACKER_BASELINE = "0.1.7"
+
+
+def run_migrate(args: argparse.Namespace) -> int:
+    """Entry point for ``winpodx migrate``. Returns the process exit code."""
+    current = __version__
+    installed = _detect_installed_version()
+
+    if installed is None:
+        _write_installed_version(current)
+        print(f"winpodx {current}: fresh install recorded. No migration needed.")
+        return 0
+
+    cur_cmp = _version_tuple(current)[:3]
+    inst_cmp = _version_tuple(installed)[:3]
+
+    if inst_cmp >= cur_cmp:
+        _write_installed_version(current)
+        print(f"winpodx {current}: already current. Nothing to migrate.")
+        return 0
+
+    print(f"winpodx: {installed} -> {current} detected\n")
+    _print_whats_new(installed, current)
+
+    non_interactive = bool(getattr(args, "non_interactive", False))
+    skip_refresh = bool(getattr(args, "no_refresh", False))
+
+    if skip_refresh:
+        print("\nSkipping app discovery (--no-refresh).")
+    elif non_interactive:
+        print("\nSkipping app discovery (--non-interactive).")
+    elif _prompt_yes("\nRun app discovery now? (scans Windows pod for installed apps)"):
+        _attempt_refresh()
+
+    _write_installed_version(current)
+    print(f"\nMigration complete. Marker updated to {current}.")
+    print("Re-run this wizard any time with: winpodx migrate")
+    return 0
+
+
+def _detect_installed_version() -> Optional[str]:
+    """Return the recorded installed version, 'pre-tracker baseline', or None.
+
+    Priority:
+    1. ``installed_version.txt`` if readable.
+    2. If ``winpodx.toml`` exists (pre-tracker upgrade), return the
+       baseline (``0.1.7``).
+    3. Otherwise return ``None`` — treated as a fresh install.
+    """
+    marker = _read_installed_version()
+    if marker:
+        return marker
+
+    from winpodx.core.config import Config
+
+    if Config.path().exists():
+        return _PRETRACKER_BASELINE
+    return None
+
+
+def _read_installed_version() -> Optional[str]:
+    """Return the version string from the marker file, or None if absent/unreadable."""
+    path = config_dir() / _VERSION_FILE
+    try:
+        content = path.read_text(encoding="utf-8").strip()
+    except (FileNotFoundError, OSError):
+        return None
+    return content or None
+
+
+def _write_installed_version(version: str) -> None:
+    """Write ``version`` to the marker file, 0644 permissions."""
+    path = config_dir() / _VERSION_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(version + "\n", encoding="utf-8")
+    try:
+        path.chmod(0o644)
+    except OSError:
+        # Non-fatal; file already exists on POSIX with umask defaults.
+        pass
+
+
+def _version_tuple(v: str) -> tuple[int, ...]:
+    """Parse ``'0.1.8'`` -> ``(0, 1, 8)``.
+
+    Stops at the first non-integer segment so a pre-release suffix like
+    ``0.1.8rc1`` still compares correctly against ``0.1.8``.
+    """
+    out: list[int] = []
+    for segment in v.strip().split("."):
+        try:
+            out.append(int(segment))
+        except ValueError:
+            break
+    return tuple(out)
+
+
+def _print_whats_new(installed: str, current: str) -> None:
+    """Print per-version notes for every version in ``(installed, current]``."""
+    inst = _version_tuple(installed)[:3]
+    cur = _version_tuple(current)[:3]
+
+    relevant: list[tuple[tuple[int, ...], str, list[str]]] = []
+    for ver, notes in _VERSION_NOTES.items():
+        v = _version_tuple(ver)[:3]
+        if inst < v <= cur:
+            relevant.append((v, ver, notes))
+    relevant.sort()
+
+    if not relevant:
+        print("(No user-facing release notes for the versions between installed and current.)")
+        return
+
+    for _, ver, notes in relevant:
+        print(f"What's new in {ver}:")
+        for note in notes:
+            print(f"  - {note}")
+        print()
+
+
+def _prompt_yes(question: str, default: bool = True) -> bool:
+    """Interactive yes/no prompt. Returns True on accept, False on decline/EOF.
+
+    Empty input returns ``default``.
+    """
+    suffix = "[Y/n]" if default else "[y/N]"
+    try:
+        response = input(f"{question} {suffix}: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return False
+    if not response:
+        return default
+    return response in ("y", "yes")
+
+
+def _attempt_refresh() -> None:
+    """Run discovery; optionally start the pod first if the backend supports it."""
+    from winpodx.core.config import Config
+
+    cfg = Config.load()
+
+    try:
+        from winpodx.core.discovery import (
+            DiscoveryError,
+            discover_apps,
+            persist_discovered,
+        )
+    except ImportError:
+        print("\n  Discovery unavailable in this build. Skipping.")
+        return
+
+    if not _pod_is_running(cfg):
+        if not _prompt_yes("  Pod is not running. Start it first? (first boot can take ~1 minute)"):
+            print("\n  Skipping refresh. Later: `winpodx pod start --wait && winpodx app refresh`")
+            return
+        try:
+            from winpodx.core.provisioner import ProvisionError, ensure_ready
+
+            print("\n  Starting pod...")
+            ensure_ready(cfg)
+        except ProvisionError as exc:
+            print(f"\n  Could not start pod: {exc}")
+            print("  Run `winpodx pod start --wait` manually and try again.")
+            return
+        except Exception as exc:  # noqa: BLE001 — surface any startup failure
+            print(f"\n  Could not start pod: {exc}")
+            return
+
+    try:
+        print("\n  Scanning Windows pod for installed apps...")
+        apps = discover_apps(cfg)
+        written = persist_discovered(apps)
+        print(f"  Discovered {len(apps)} app(s); wrote {len(written)} profile(s).")
+    except DiscoveryError as exc:
+        print(f"\n  Discovery failed: {exc}")
+        print("  Retry later with: winpodx app refresh")
+
+
+def _pod_is_running(cfg) -> bool:
+    """Lightweight ``{runtime} ps --filter name=...`` check.
+
+    Returns ``False`` for libvirt/manual backends — those don't support
+    discovery yet (v0.2.0 guest-agent work), so migrate just surfaces
+    whatever error ``core.discovery`` emits when called.
+    """
+    runtime = cfg.pod.backend
+    if runtime not in ("podman", "docker"):
+        return False
+    try:
+        result = subprocess.run(  # noqa: S603 — args is a fixed list
+            [
+                runtime,
+                "ps",
+                "--filter",
+                f"name={cfg.pod.container_name}",
+                "--format",
+                "{{.State}}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return False
+    return "running" in result.stdout.lower()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -20,6 +20,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+
+from winpodx.core.config import Config
 from winpodx.core.discovery import (
     DiscoveredApp,
     DiscoveryError,
@@ -31,8 +33,6 @@ from winpodx.core.discovery import (
     discover_apps,
     persist_discovered,
 )
-
-from winpodx.core.config import Config
 
 # --- Fixtures --------------------------------------------------------------
 

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,0 +1,213 @@
+"""Tests for cli.migrate — post-upgrade wizard.
+
+Covers version tuple parsing, installed-version I/O, fresh-install vs
+pre-tracker-upgrade detection, release-note selection across a version
+range, interactive prompt handling (mocked stdin), and the happy-path
+flow through ``run_migrate`` with refresh skipped.
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import patch
+
+from winpodx.cli.migrate import (
+    _VERSION_NOTES,
+    _detect_installed_version,
+    _print_whats_new,
+    _prompt_yes,
+    _read_installed_version,
+    _version_tuple,
+    _write_installed_version,
+    run_migrate,
+)
+
+# --- _version_tuple ---
+
+
+def test_version_tuple_basic():
+    assert _version_tuple("0.1.8") == (0, 1, 8)
+
+
+def test_version_tuple_four_segments():
+    assert _version_tuple("1.2.3.4") == (1, 2, 3, 4)
+
+
+def test_version_tuple_prerelease_truncated():
+    # Non-integer suffix ('rc1') stops parsing; ordering still works.
+    assert _version_tuple("0.1.8rc1") == (0, 1)
+    assert _version_tuple("0.1.8") > _version_tuple("0.1.8rc1")
+
+
+def test_version_tuple_comparison():
+    assert _version_tuple("0.1.7") < _version_tuple("0.1.8")
+    assert _version_tuple("0.1.8") < _version_tuple("0.2.0")
+    assert _version_tuple("1.0.0") > _version_tuple("0.9.99")
+
+
+# --- Version marker file I/O ---
+
+
+def test_write_and_read_installed_version(tmp_path, monkeypatch):
+    # Redirect config_dir via a lambda so the helpers use our tmp path.
+    monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    _write_installed_version("0.1.8")
+    assert (tmp_path / "installed_version.txt").exists()
+    assert _read_installed_version() == "0.1.8"
+
+
+def test_read_installed_version_missing_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    assert _read_installed_version() is None
+
+
+def test_read_installed_version_empty_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    (tmp_path / "installed_version.txt").write_text("\n", encoding="utf-8")
+    assert _read_installed_version() is None
+
+
+def test_read_installed_version_strips_whitespace(tmp_path, monkeypatch):
+    monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    (tmp_path / "installed_version.txt").write_text("  0.1.8  \n", encoding="utf-8")
+    assert _read_installed_version() == "0.1.8"
+
+
+# --- _detect_installed_version ---
+
+
+def test_detect_returns_none_for_fresh_install(tmp_path, monkeypatch):
+    monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    # No marker, no config file => treated as fresh install.
+    with patch("winpodx.core.config.Config.path", return_value=tmp_path / "noconfig.toml"):
+        assert _detect_installed_version() is None
+
+
+def test_detect_returns_pretracker_when_config_exists(tmp_path, monkeypatch):
+    """Config exists but no marker -> user was on 0.1.7 before this command existed."""
+    monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    cfg_path = tmp_path / "winpodx.toml"
+    cfg_path.write_text("[rdp]\n", encoding="utf-8")
+    with patch("winpodx.core.config.Config.path", return_value=cfg_path):
+        assert _detect_installed_version() == "0.1.7"
+
+
+def test_detect_prefers_marker_over_baseline(tmp_path, monkeypatch):
+    """Marker file wins even when config also exists."""
+    monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    (tmp_path / "installed_version.txt").write_text("0.1.9\n", encoding="utf-8")
+    cfg_path = tmp_path / "winpodx.toml"
+    cfg_path.write_text("[rdp]\n", encoding="utf-8")
+    with patch("winpodx.core.config.Config.path", return_value=cfg_path):
+        assert _detect_installed_version() == "0.1.9"
+
+
+# --- _print_whats_new ---
+
+
+def test_whats_new_covers_range(capsys):
+    _print_whats_new("0.1.7", "0.1.8")
+    out = capsys.readouterr().out
+    assert "0.1.8" in out
+    # A known 0.1.8 bullet must appear.
+    assert "winpodx app refresh" in out
+
+
+def test_whats_new_empty_range(capsys):
+    # No bullets when neither endpoint covers a release with recorded notes.
+    _print_whats_new("0.2.0", "0.2.1")
+    out = capsys.readouterr().out
+    assert "no user-facing release notes" in out.lower()
+
+
+def test_whats_new_notes_present_for_current_version():
+    """The current-release key in _VERSION_NOTES must be the one documented."""
+    assert "0.1.8" in _VERSION_NOTES
+    assert len(_VERSION_NOTES["0.1.8"]) >= 3
+
+
+# --- _prompt_yes ---
+
+
+def test_prompt_yes_default_accept(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    assert _prompt_yes("x?", default=True) is True
+
+
+def test_prompt_yes_default_decline(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    assert _prompt_yes("x?", default=False) is False
+
+
+def test_prompt_yes_explicit_y(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    assert _prompt_yes("x?", default=False) is True
+
+
+def test_prompt_yes_explicit_no(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _: "N")
+    assert _prompt_yes("x?", default=True) is False
+
+
+def test_prompt_yes_eof_returns_false(monkeypatch):
+    def _raise_eof(_):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _raise_eof)
+    assert _prompt_yes("x?") is False
+
+
+# --- run_migrate ---
+
+
+def _args(no_refresh: bool = True, non_interactive: bool = True) -> argparse.Namespace:
+    return argparse.Namespace(no_refresh=no_refresh, non_interactive=non_interactive)
+
+
+def test_run_migrate_fresh_install_writes_marker(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    with patch("winpodx.core.config.Config.path", return_value=tmp_path / "noconfig.toml"):
+        rc = run_migrate(_args())
+    assert rc == 0
+    assert (tmp_path / "installed_version.txt").exists()
+    assert "fresh install" in capsys.readouterr().out.lower()
+
+
+def test_run_migrate_already_current(tmp_path, monkeypatch, capsys):
+    from winpodx import __version__ as current
+
+    monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    (tmp_path / "installed_version.txt").write_text(current + "\n", encoding="utf-8")
+    rc = run_migrate(_args())
+    assert rc == 0
+    assert "already current" in capsys.readouterr().out.lower()
+
+
+def test_run_migrate_upgrade_skips_refresh_when_flagged(tmp_path, monkeypatch, capsys):
+    """Use 0.1.0 as the 'installed' version so the test is robust whether
+    or not the current package version has been bumped yet.
+    """
+    monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    (tmp_path / "installed_version.txt").write_text("0.1.0\n", encoding="utf-8")
+    rc = run_migrate(_args(no_refresh=True, non_interactive=True))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "0.1.0" in out
+    assert "Skipping app discovery" in out
+    # Marker is bumped to current version on completion.
+    from winpodx import __version__ as current
+
+    assert (tmp_path / "installed_version.txt").read_text().strip() == current
+
+
+def test_run_migrate_non_interactive_skips_prompt(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    (tmp_path / "installed_version.txt").write_text("0.1.0\n", encoding="utf-8")
+    # no_refresh=False but non_interactive=True -> must not block on input.
+    called = []
+    monkeypatch.setattr("builtins.input", lambda _: called.append(True) or "y")
+    rc = run_migrate(_args(no_refresh=False, non_interactive=True))
+    assert rc == 0
+    assert called == []  # input() must never have been called
+    out = capsys.readouterr().out.lower()
+    assert "--non-interactive" in out


### PR DESCRIPTION
Adds `winpodx migrate` post-upgrade wizard + `install.sh` auto-invocation. User-requested for v0.1.8 (option A — in-release).

## What this gives users

After `pip install --upgrade winpodx` / `sudo apt install ./winpodx_0.1.8.deb` / `curl | bash`, the user sees:

```
winpodx: 0.1.7 -> 0.1.8 detected

What's new in 0.1.8:
  - Dynamic Windows-app discovery (scan + register apps installed on the container).
  - New CLI: `winpodx app refresh`
  - New GUI: 'Refresh Apps' button on the Apps page
  - UWP / MSIX apps supported via RemoteApp (launch via AUMID)
  - Migration wizard: `winpodx migrate` (this command)

Run app discovery now? (scans Windows pod for installed apps) [Y/n]:
  Pod is not running. Start it first? (first boot can take ~1 minute) [Y/n]:

  Starting pod...
  Scanning Windows pod for installed apps...
  Discovered 47 app(s); wrote 47 profile(s).

Migration complete. Marker updated to 0.1.8.
```

## What ships

- **`src/winpodx/cli/migrate.py`** (new, ~230 lines) — handler with public entry `run_migrate(args)`.
- **`src/winpodx/cli/main.py`** — wires `migrate` as a top-level subparser with `--no-refresh` and `--non-interactive` flags.
- **`install.sh`** — at the end of the install flow, detects existing `winpodx.toml` and auto-invokes `winpodx migrate`. Opt out with `WINPODX_NO_MIGRATE=1`. `|| true` so a migrate failure never breaks install.
- **`tests/test_migrate.py`** (new, 23 tests) — version tuple parsing, marker I/O, fresh-vs-upgrade detection, release-note selection, prompt handling (default/explicit/EOF), run_migrate paths.
- **CHANGELOG.md + docs/CHANGELOG.ko.md** — `[Unreleased]` entry.

## Version tracker

`~/.config/winpodx/installed_version.txt` (single-line version string). Pre-0.1.8 installs without this marker + existing `winpodx.toml` are treated as upgrading from `0.1.7` (pre-tracker baseline).

## Pod state handling

`migrate` checks the container state via `podman ps --filter` (cheap). If not running, prompts to start via `provisioner.ensure_ready(cfg)` before running discovery. libvirt / manual backends skip the running-check (v0.2.0 guest-agent territory).

## Dependencies

- Tests run standalone (23 pass locally, `ruff check` clean, `ruff format --check` clean, full suite `248 passed`).
- **CI test jobs will fail** until PR #6 (core.discovery) lands — the `_attempt_refresh` path imports `winpodx.core.discovery`. Wraps in `try / except ImportError` so migrate itself still works if core is absent; but the tests that exercise the full run_migrate flow don't hit that path (they use `--non-interactive`), so they'll pass regardless. The dependency is purely a runtime one.

## Merge order (reminder)

Wave 1: #6 (core) -> then #5, #7, #8, **and this #9** in any order.

Once all Wave 1 PRs merge, platform-qa version-bumps to 0.1.8 (Task #6 in internal tracker) and tag push triggers the publish workflows.