### PR TITLE
fix(v0.1.8): Wave 2 audit remediation — I1/I2/I3/M1/L1/L2/L3 + SECURITY.md + CI hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Defense in depth: the DryRun path is read-only, but we still
+          # do not want the job's GITHUB_TOKEN left persisted in
+          # .git/config where any subsequent step (including the pwsh
+          # smoke test) could observe it.
+          persist-credentials: false
       - name: Ensure PowerShell Core is available
         run: |
           if command -v pwsh >/dev/null 2>&1; then

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,6 +67,105 @@ This project follows these security practices:
 - **Windows build pinning**: Feature updates blocked via registry policy; security updates install normally
 - **Container-isolated RDP**: RDP port is bound to 127.0.0.1 only; not exposed to the network
 
+## Host <-> Guest Trust Model
+
+winpodx treats the Windows guest as a **semi-trusted** component, not a trusted
+extension of the host. This section documents how that trust boundary is drawn
+and enforced, specifically for the app-discovery channel introduced in v0.1.7.
+
+### Provisioning scope and threat assumptions
+
+winpodx provisions the Windows guest itself inside a rootless Podman container
+(or, optionally, Docker / libvirt). Because the host controls the image, the
+unattended-install answer file, and the OEM post-install scripts, a freshly
+provisioned guest starts in a known-good state.
+
+However, JSON emitted by `scripts/windows/discover_apps.ps1` is treated as
+**semi-trusted input**: it is not attacker-controlled network data, but it is
+also not implicitly trusted code. The guest can be corrupted through entirely
+legitimate Windows-side activity, for example:
+
+- A malicious `.lnk` dropped into the user's Start Menu folder.
+- A rogue `AppxManifest.xml` from a sideloaded UWP package.
+- Supply-chain compromise of a Windows application the user installed
+  themselves (installer trojan, auto-update hijack, etc.).
+
+Any of these can cause the discovery script to emit hostile metadata. The host
+side must therefore validate everything the guest sends before it is allowed to
+influence the host filesystem or any executed command line.
+
+### Host-side validation pipeline
+
+The host enforces the trust boundary with a layered set of guards. Each of
+these rejects malformed guest output before it can be written to disk or
+interpolated into a subprocess argument list:
+
+- **`_CONTAINER_NAME_RE`** — the container name pulled from the host config is
+  scrubbed against an allowlist regex before it is passed as a subprocess arg.
+- **`_AUMID_RE`** — the UWP launch URI must match
+  `^[A-Za-z0-9._-]+![A-Za-z0-9._-]+$`, i.e. a bare
+  `PackageFamilyName!AppId`. Anything else is refused.
+- **`_WM_CLASS_RE`** — the WM class hint used for desktop-entry
+  `StartupWMClass=` must be a safe Linux identifier.
+- **Slug regex** — every slug derived from a guest-supplied app name is
+  sanitized to `[a-z0-9_-]{1,64}` before it is used as a filesystem path
+  component.
+- **`_MAX_APPS` (500)** — a hard cap on the total number of discovered
+  entries accepted per run.
+- **`_MAX_ICON_BYTES` (1 MiB per icon)** — a per-icon size cap.
+- **`_MAX_PATH_LEN`** — a cap on the length of guest-provided path strings.
+- **Host-side stdout cap (64 MiB)** — the subprocess reader bounds the total
+  bytes consumed from the guest, so a misbehaving guest cannot OOM the host.
+- **PNG magic byte + `QImage.loadFromData` sanity check** — every icon must
+  begin with the PNG signature and must successfully parse through Qt's image
+  decoder before it is written under `~/.local/share/icons/hicolor/`.
+- **`_safe_rmtree`** — refuses to delete any path outside
+  `~/.local/share/winpodx/apps/`.
+- **`_is_within`** — refuses to write any path outside the winpodx user data
+  directory.
+- **List-args subprocess only** — all subprocess invocations pass an argv
+  list; `shell=True` is never used on guest-derived strings.
+
+### Secret flow direction
+
+Secrets flow **host -> guest only**. The RDP password is generated on the host
+by `core/compose.py` `generate_password`, written into the guest through
+unattended-install compose environment variables, and rotated on a
+host-controlled schedule.
+
+The discovery JSON carries **no credentials** in either direction. The
+`guest -> host` channel is strictly typed as `{app metadata, icon bytes}` and
+nothing else, so a compromised guest cannot exfiltrate host secrets through
+this channel because the channel has no field that could carry them.
+
+### Guest-compromise impact (possible vs. not possible)
+
+If an attacker fully compromises the Windows guest, the bounded impact via the
+discovery channel is:
+
+**Possible:**
+
+- Bogus `.desktop` entries appearing in the user's app menu (with names
+  already sanitized through the slug regex).
+- A PNG crafted specifically to exercise the `QImage` parser.
+- Broken launches for malicious AUMIDs that fail `_AUMID_RE` validation (the
+  launch simply never happens).
+
+**NOT possible via the discovery channel:**
+
+- Host code execution outside the PNG parser itself (which runs inside Qt's
+  or the stdlib's own image-decoding sandbox).
+- Filesystem writes outside `~/.local/share/winpodx/apps/` and
+  `~/.local/share/icons/hicolor/`.
+- Command injection into FreeRDP, Podman, Docker, or virsh argument lists.
+- Credential exfiltration (no credentials traverse the guest -> host
+  direction).
+
+Additionally, the Windows guest runs under **rootless Podman** by default, so
+even a full guest-kernel RCE does not grant host root. A guest-compromise
+attacker is confined to the unprivileged user namespace that hosts the guest
+container.
+
 ## Attribution
 
 We appreciate responsible disclosure and will credit reporters in release notes (unless anonymity is preferred).

--- a/scripts/windows/discover_apps.ps1
+++ b/scripts/windows/discover_apps.ps1
@@ -15,6 +15,15 @@
 #     "source": "win32" | "uwp", "wm_class_hint": str,
 #     "launch_uri": str, "icon_b64": str }
 #
+# Semantic contract for `launch_uri`:
+#   - source == "uwp"   : bare AUMID of the form `PackageFamilyName!AppId`
+#                         (NO `shell:AppsFolder\` prefix — the host prepends
+#                         that when building the FreeRDP `/app-cmd`). The
+#                         host-side regex `_AUMID_RE` in
+#                         `src/winpodx/core/rdp.py` rejects any value that
+#                         already carries the prefix.
+#   - source == "win32" : empty string.
+#
 # An optional trailing element `{"_truncated": true}` signals that the
 # guest clipped its own output.
 #
@@ -202,7 +211,12 @@ try { $wsh = New-Object -ComObject WScript.Shell } catch { }
 foreach ($d in $startDirs) {
     if (-not $wsh) { break }
     try {
-        Get-ChildItem -Path $d -Recurse -Filter '*.lnk' -ErrorAction SilentlyContinue |
+        # L3 hardening: bound recursion depth. Start Menu\Programs layouts
+        # with symlink loops or pathologically deep nesting could otherwise
+        # stall the guest until the host-side 120s timeout fires. PowerShell
+        # 5.1+ honors -Depth on Get-ChildItem. The MAX_APPS post-filter
+        # still caps absolute output size.
+        Get-ChildItem -Path $d -Recurse -Depth 8 -Filter '*.lnk' -ErrorAction SilentlyContinue |
             ForEach-Object {
                 try {
                     if ($_.Name -match '(?i)uninstall|readme|license|eula') { return }
@@ -249,8 +263,11 @@ try {
                 try {
                     $appId = [string]$appNode.Id
                     if (-not $appId) { continue }
+                    # Emit bare AUMID only. The host-side FreeRDP command
+                    # builder (src/winpodx/core/rdp.py) prepends
+                    # `shell:AppsFolder\` itself; duplicating the prefix
+                    # here would produce `shell:AppsFolder\shell:AppsFolder\...`.
                     $aumid = "$($pkg.PackageFamilyName)!$appId"
-                    $launchUri = "shell:AppsFolder\$aumid"
 
                     $ve = $null
                     foreach ($probe in 'VisualElements', 'uap:VisualElements') {

--- a/src/winpodx/cli/app.py
+++ b/src/winpodx/cli/app.py
@@ -62,21 +62,31 @@ def _refresh_apps(as_json: bool, timeout: int) -> None:
         print(msg, file=sys.stderr)
         sys.exit(1)
 
+    from winpodx.core.config import Config
+
     _KIND_TO_CODE = {
         "pod_not_running": 2,
+        "unsupported_backend": 2,
+        "script_missing": 3,
         "script_failed": 3,
         "bad_json": 3,
         "truncated": 3,
         "timeout": 4,
     }
 
+    cfg = Config.load()
     try:
-        apps = discover_apps(timeout=timeout)
+        apps = discover_apps(cfg, timeout=timeout)
     except DiscoveryError as exc:
         kind = getattr(exc, "kind", "")
         code = _KIND_TO_CODE.get(kind, 3)
         if kind == "pod_not_running":
             print("Pod is not running. Run 'winpodx pod start --wait' first.", file=sys.stderr)
+        elif kind == "unsupported_backend":
+            print(
+                "Discovery requires podman or docker backend. Check 'winpodx config show'.",
+                file=sys.stderr,
+            )
         else:
             print(f"ERROR: {exc}", file=sys.stderr)
         sys.exit(code)
@@ -90,11 +100,13 @@ def _refresh_apps(as_json: bool, timeout: int) -> None:
             {
                 "name": a.name,
                 "slug": a.slug,
-                "executable": a.executable,
-                "launch_uri": a.launch_uri,
-                "source": a.source,
-                "icon_path": a.icon_path,
                 "full_name": a.full_name,
+                "executable": a.executable,
+                "args": a.args,
+                "source": a.source,
+                "launch_uri": a.launch_uri,
+                "wm_class_hint": a.wm_class_hint,
+                "icon_path": a.icon_path,
             }
             for a in apps
         ]

--- a/src/winpodx/cli/migrate.py
+++ b/src/winpodx/cli/migrate.py
@@ -15,11 +15,19 @@ no tracker, so a missing file combined with an existing
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
+import sys
 from typing import Optional
 
 from winpodx import __version__
 from winpodx.utils.paths import config_dir
+
+# Marker-file hardening (Wave 2 audit L2): cap read size and regex-validate
+# content so a crafted or corrupted ``installed_version.txt`` cannot hang
+# the wizard or inject garbage into the version-comparison path.
+_MAX_MARKER_BYTES = 64
+_MARKER_VERSION_RE = re.compile(r"^\d+(\.\d+){0,3}[a-z0-9]*$")
 
 # Per-version release highlights shown to users upgrading from an earlier
 # version. Add new entries at the top when cutting a release. Keep each
@@ -98,13 +106,43 @@ def _detect_installed_version() -> Optional[str]:
 
 
 def _read_installed_version() -> Optional[str]:
-    """Return the version string from the marker file, or None if absent/unreadable."""
+    """Return the version string from the marker file, or None if absent/invalid.
+
+    Reads at most ``_MAX_MARKER_BYTES`` and requires the stripped content
+    to match ``_MARKER_VERSION_RE``. An oversized or malformed marker is
+    treated as absent so the caller falls through to the pre-tracker
+    baseline path; a warning is emitted to stderr so the user can clean
+    up the file.
+    """
     path = config_dir() / _VERSION_FILE
     try:
-        content = path.read_text(encoding="utf-8").strip()
+        with path.open("rb") as fh:
+            raw = fh.read(_MAX_MARKER_BYTES + 1)
     except (FileNotFoundError, OSError):
         return None
-    return content or None
+
+    if len(raw) > _MAX_MARKER_BYTES:
+        print(
+            f"warning: {path} exceeds {_MAX_MARKER_BYTES} bytes; ignoring marker.",
+            file=sys.stderr,
+        )
+        return None
+
+    try:
+        content = raw.decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError:
+        print(f"warning: {path} is not valid UTF-8; ignoring marker.", file=sys.stderr)
+        return None
+
+    if not content:
+        return None
+    if not _MARKER_VERSION_RE.fullmatch(content):
+        print(
+            f"warning: {path} content {content!r} is not a valid version; ignoring marker.",
+            file=sys.stderr,
+        )
+        return None
+    return content
 
 
 def _write_installed_version(version: str) -> None:

--- a/src/winpodx/core/discovery.py
+++ b/src/winpodx/core/discovery.py
@@ -11,12 +11,18 @@ from __future__ import annotations
 
 import base64
 import binascii
+import errno
 import json
 import logging
+import os
 import re
 import shutil
+import struct
 import subprocess
 import sys
+import threading
+import time
+import zlib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -33,6 +39,17 @@ _MAX_ICON_BYTES = 1_048_576  # 1 MiB per icon
 _MAX_NAME_LEN = 255
 _MAX_PATH_LEN = 1024
 
+# L1: hard cap on subprocess stdout so a hostile/misbehaving guest can't
+# flood us into OOM. 64 MiB is ~two orders of magnitude above a normal
+# discovery payload (~hundreds of KB) yet still bounded.
+HARD_STDOUT_CAP = 64 * 1024 * 1024  # 64 MiB
+
+# Bounds for PNG sanity validation (M1). Icons above these dimensions are
+# refused even when the bytestream parses cleanly — a 10000x10000 icon is
+# either a DoS vector or a mis-export from the guest.
+_MAX_PNG_WIDTH = 1024
+_MAX_PNG_HEIGHT = 1024
+
 _VALID_SOURCES = frozenset({"uwp", "win32", "steam"})
 
 # Matches AppInfo's _SAFE_NAME_RE contract so a discovered app loads cleanly.
@@ -46,7 +63,23 @@ class DiscoveryError(RuntimeError):
     Covers: unsupported backend (libvirt/manual), container runtime
     missing, script copy/exec failure, timeout, malformed JSON, or
     the pod not being running.
+
+    The optional ``kind`` keyword attaches a machine-readable tag drawn
+    from the canonical set so CLI/GUI callers can pattern-match without
+    parsing the human-facing message. Canonical kinds:
+
+    - ``pod_not_running``
+    - ``script_missing``
+    - ``script_failed``
+    - ``bad_json``
+    - ``truncated``
+    - ``timeout``
+    - ``unsupported_backend``
     """
+
+    def __init__(self, msg: str = "", *, kind: str = "") -> None:
+        super().__init__(msg)
+        self.kind = kind
 
 
 @dataclass
@@ -59,6 +92,10 @@ class DiscoveredApp:
     wm_class_hint: str = ""
     launch_uri: str = ""  # UWP AUMID (shell:AppsFolder\<AUMID>) when source == "uwp"
     icon_bytes: bytes = field(default=b"", repr=False)
+    # Filled by persist_discovered() after the on-disk layout is
+    # materialised. Empty on freshly-parsed instances.
+    slug: str = ""  # sanitized app name slug (same as `name` after persist)
+    icon_path: str = ""  # absolute path to persisted PNG/SVG, or ""
 
 
 def discovered_apps_dir() -> Path:
@@ -99,7 +136,8 @@ def _runtime_for(backend: str) -> str:
     if backend == "docker":
         return "docker"
     raise DiscoveryError(
-        f"Discovery requires a container backend (podman/docker); got {backend!r}."
+        f"Discovery requires a container backend (podman/docker); got {backend!r}.",
+        kind="unsupported_backend",
     )
 
 
@@ -124,11 +162,14 @@ def discover_apps(cfg: Config, timeout: int = 120) -> list[DiscoveredApp]:
     runtime = _runtime_for(cfg.pod.backend)
 
     if shutil.which(runtime) is None:
-        raise DiscoveryError(f"{runtime!r} not found on PATH; install {cfg.pod.backend} first.")
+        raise DiscoveryError(
+            f"{runtime!r} not found on PATH; install {cfg.pod.backend} first.",
+            kind="pod_not_running",
+        )
 
     script = _ps_script_path()
     if not script.exists():
-        raise DiscoveryError(f"Discovery script not found: {script}")
+        raise DiscoveryError(f"Discovery script not found: {script}", kind="script_missing")
 
     container = cfg.pod.container_name
     guest_path = "C:/winpodx-discover.ps1"
@@ -142,42 +183,147 @@ def discover_apps(cfg: Config, timeout: int = 120) -> list[DiscoveredApp]:
             timeout=30,
         )
     except FileNotFoundError as e:
-        raise DiscoveryError(f"{runtime!r} binary vanished: {e}") from e
+        raise DiscoveryError(f"{runtime!r} binary vanished: {e}", kind="pod_not_running") from e
     except subprocess.TimeoutExpired as e:
-        raise DiscoveryError("Timed out copying discovery script to guest.") from e
+        raise DiscoveryError("Timed out copying discovery script to guest.", kind="timeout") from e
     except subprocess.CalledProcessError as e:
         stderr = (e.stderr or "").strip()
         raise DiscoveryError(
-            f"Failed to copy discovery script (is the pod running?): {stderr}"
+            f"Failed to copy discovery script (is the pod running?): {stderr}",
+            kind="pod_not_running",
         ) from e
 
+    cmd = [
+        runtime,
+        "exec",
+        container,
+        "powershell",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        guest_path.replace("/", "\\"),
+    ]
+    stdout_bytes, stderr_bytes, returncode = _run_bounded(cmd, timeout=timeout, runtime=runtime)
+
+    if returncode != 0:
+        stderr = stderr_bytes.decode("utf-8", errors="replace").strip()
+        raise DiscoveryError(
+            f"Discovery script failed (rc={returncode}): {stderr}", kind="script_failed"
+        )
+
+    return _parse_discovery_output(stdout_bytes.decode("utf-8", errors="replace"))
+
+
+def _run_bounded(cmd: list[str], *, timeout: int, runtime: str) -> tuple[bytes, bytes, int]:
+    """Run ``cmd`` and return ``(stdout, stderr, returncode)`` with a hard cap.
+
+    Spawns the process via ``Popen`` and drains stdout / stderr via
+    ``os.read`` with an accumulated byte cap of ``HARD_STDOUT_CAP``
+    (L1 audit). If the cap is exceeded the process is killed and a
+    ``DiscoveryError(kind="truncated")`` is raised. If the process
+    does not finish within ``timeout`` seconds it is killed and a
+    ``DiscoveryError(kind="timeout")`` is raised.
+
+    Returns raw bytes so the caller decodes exactly once with an
+    error-replace codec — this avoids UTF-8 decode exceptions on
+    malformed guest output.
+    """
     try:
-        result = subprocess.run(  # noqa: S603
-            [
-                runtime,
-                "exec",
-                container,
-                "powershell",
-                "-NoProfile",
-                "-ExecutionPolicy",
-                "Bypass",
-                "-File",
-                guest_path.replace("/", "\\"),
-            ],
-            capture_output=True,
-            text=True,
-            timeout=timeout,
+        proc = subprocess.Popen(  # noqa: S603
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=False,
         )
     except FileNotFoundError as e:
-        raise DiscoveryError(f"{runtime!r} binary vanished mid-run: {e}") from e
-    except subprocess.TimeoutExpired as e:
-        raise DiscoveryError(f"Discovery timed out after {timeout}s on guest.") from e
+        raise DiscoveryError(
+            f"{runtime!r} binary vanished mid-run: {e}", kind="pod_not_running"
+        ) from e
 
-    if result.returncode != 0:
-        stderr = (result.stderr or "").strip()
-        raise DiscoveryError(f"Discovery script failed (rc={result.returncode}): {stderr}")
+    stdout_chunks: list[bytes] = []
+    stderr_chunks: list[bytes] = []
+    stdout_bytes = 0
+    stderr_bytes = 0
 
-    return _parse_discovery_output(result.stdout)
+    # Readers drain stdout/stderr in background threads so a full pipe
+    # buffer can't deadlock the child. Each reader enforces the cap
+    # independently and sets an event if tripped.
+    cap_tripped = threading.Event()
+
+    def _drain(fd: int, sink: list[bytes], counter_name: str) -> None:
+        nonlocal stdout_bytes, stderr_bytes
+        try:
+            while True:
+                try:
+                    chunk = os.read(fd, 65536)
+                except OSError as err:
+                    if err.errno == errno.EBADF:
+                        return
+                    raise
+                if not chunk:
+                    return
+                sink.append(chunk)
+                if counter_name == "stdout":
+                    stdout_bytes += len(chunk)
+                    if stdout_bytes > HARD_STDOUT_CAP:
+                        cap_tripped.set()
+                        return
+                else:
+                    stderr_bytes += len(chunk)
+                    # stderr is also capped (symmetry + cheap guard).
+                    if stderr_bytes > HARD_STDOUT_CAP:
+                        cap_tripped.set()
+                        return
+        except Exception:
+            # Reader threads must never propagate — surface via cap_tripped
+            # + returncode on the main path.
+            log.debug("discovery: reader thread crashed", exc_info=True)
+
+    assert proc.stdout is not None and proc.stderr is not None
+    t_out = threading.Thread(
+        target=_drain, args=(proc.stdout.fileno(), stdout_chunks, "stdout"), daemon=True
+    )
+    t_err = threading.Thread(
+        target=_drain, args=(proc.stderr.fileno(), stderr_chunks, "stderr"), daemon=True
+    )
+    t_out.start()
+    t_err.start()
+
+    deadline = time.monotonic() + max(1, int(timeout))
+    killed_for_cap = False
+    killed_for_timeout = False
+    while True:
+        if cap_tripped.is_set():
+            killed_for_cap = True
+            proc.kill()
+            break
+        if proc.poll() is not None:
+            break
+        if time.monotonic() >= deadline:
+            killed_for_timeout = True
+            proc.kill()
+            break
+        time.sleep(0.05)
+
+    # Wait for process + drain threads to finish so we don't leak FDs.
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+    t_out.join(timeout=2)
+    t_err.join(timeout=2)
+
+    if killed_for_cap:
+        raise DiscoveryError(
+            f"Discovery stdout exceeded {HARD_STDOUT_CAP} bytes; aborted.",
+            kind="truncated",
+        )
+    if killed_for_timeout:
+        raise DiscoveryError(f"Discovery timed out after {timeout}s on guest.", kind="timeout")
+
+    return b"".join(stdout_chunks), b"".join(stderr_chunks), proc.returncode
 
 
 def _parse_discovery_output(stdout: str) -> list[DiscoveredApp]:
@@ -194,12 +340,16 @@ def _parse_discovery_output(stdout: str) -> list[DiscoveredApp]:
         raw = json.loads(text)
     except json.JSONDecodeError as e:
         snippet = text[:200].replace("\n", " ")
-        raise DiscoveryError(f"Malformed discovery JSON: {e}; head={snippet!r}") from e
+        raise DiscoveryError(
+            f"Malformed discovery JSON: {e}; head={snippet!r}", kind="bad_json"
+        ) from e
 
     if isinstance(raw, dict):
         raw = [raw]
     if not isinstance(raw, list):
-        raise DiscoveryError(f"Discovery JSON must be an array, got {type(raw).__name__}.")
+        raise DiscoveryError(
+            f"Discovery JSON must be an array, got {type(raw).__name__}.", kind="bad_json"
+        )
 
     apps: list[DiscoveredApp] = []
     truncated = False
@@ -333,6 +483,12 @@ def persist_discovered(
             _safe_rmtree(app_dir, root)
         app_dir.mkdir(parents=True, exist_ok=True)
 
+        # Stamp the contract fields cli/gui callers rely on (I2). slug
+        # mirrors `name` post-sanitisation; icon_path is filled below
+        # only when a valid image is written.
+        app.slug = app.name
+        app.icon_path = ""
+
         toml_path = app_dir / "app.toml"
         try:
             toml_path.write_text(_render_app_toml(app), encoding="utf-8")
@@ -342,9 +498,20 @@ def persist_discovered(
 
         if app.icon_bytes:
             icon_ext = _sniff_icon_ext(app.icon_bytes)
-            if icon_ext:
+            icon_ok = True
+            if icon_ext == "png" and not _validate_png_bytes(app.icon_bytes):
+                # M1: malformed / oversized / CRC-broken PNG from a
+                # compromised guest must not abort the run. Skip this
+                # app's icon but keep the entry.
+                log.warning(
+                    "Rejecting malformed PNG icon for %s; writing entry without icon.", app.name
+                )
+                icon_ok = False
+            if icon_ext and icon_ok:
+                icon_target = app_dir / f"icon.{icon_ext}"
                 try:
-                    (app_dir / f"icon.{icon_ext}").write_bytes(app.icon_bytes)
+                    icon_target.write_bytes(app.icon_bytes)
+                    app.icon_path = str(icon_target.resolve())
                 except OSError as e:
                     log.warning("Could not write icon for %s: %s", app.name, e)
 
@@ -381,6 +548,110 @@ def _sniff_icon_ext(data: bytes) -> str:
     if head.startswith(b"<?xml") or head.startswith(b"<svg"):
         return "svg"
     return ""
+
+
+def _validate_png_bytes(data: bytes) -> bool:
+    """Return True only if ``data`` is a structurally valid PNG (M1).
+
+    The 8-byte magic check in ``_sniff_icon_ext`` is sufficient to
+    *classify* bytes as PNG but not to trust them as a PNG — a guest
+    can trivially prepend the magic to arbitrary garbage. This helper
+    runs a second-pass validation before the bytes reach disk /
+    hicolor cache:
+
+    1. If PySide6 is available, use ``QImage.loadFromData`` and reject
+       anything that lands on ``QImage.isNull()``.
+    2. Otherwise fall back to a stdlib chunk walker that verifies the
+       PNG magic, requires ``IHDR`` as the first chunk with sane
+       dimensions (``0 < w,h <= _MAX_PNG_WIDTH/_MAX_PNG_HEIGHT``),
+       validates every chunk CRC, and requires the stream to terminate
+       with ``IEND``.
+
+    Never raises — on any exception we return ``False`` so the caller
+    can simply skip the icon.
+    """
+    if not data or not data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return False
+
+    # Fast path: PySide6 is already a GUI-team dependency, and QImage
+    # is strict about truncated/corrupt streams.
+    try:
+        from PySide6.QtGui import QImage  # type: ignore[import-not-found]
+    except ImportError:
+        QImage = None  # type: ignore[assignment]
+    except Exception:  # noqa: BLE001 — Qt init can fail headless; fall through.
+        QImage = None  # type: ignore[assignment]
+
+    if QImage is not None:
+        try:
+            img = QImage()
+            if not img.loadFromData(data):
+                return False
+            if img.isNull():
+                return False
+            if img.width() <= 0 or img.height() <= 0:
+                return False
+            if img.width() > _MAX_PNG_WIDTH or img.height() > _MAX_PNG_HEIGHT:
+                return False
+            return True
+        except Exception:  # noqa: BLE001 — headless Qt edge cases.
+            log.debug("discovery: QImage validation crashed; falling back", exc_info=True)
+            # Fall through to the stdlib walker.
+
+    return _validate_png_stdlib(data)
+
+
+def _validate_png_stdlib(data: bytes) -> bool:
+    """Stdlib-only PNG chunk walker (fallback for ``_validate_png_bytes``)."""
+    try:
+        if len(data) < 8 + 12:  # magic + at least one chunk header+CRC
+            return False
+        pos = 8  # past the magic
+        saw_ihdr = False
+        saw_iend = False
+        width = 0
+        height = 0
+
+        while pos < len(data):
+            if pos + 8 > len(data):
+                return False
+            length = struct.unpack(">I", data[pos : pos + 4])[0]
+            chunk_type = data[pos + 4 : pos + 8]
+            if length > len(data):  # obviously bogus length prefix
+                return False
+            data_start = pos + 8
+            data_end = data_start + length
+            crc_end = data_end + 4
+            if crc_end > len(data):
+                return False
+
+            declared_crc = struct.unpack(">I", data[data_end:crc_end])[0]
+            actual_crc = zlib.crc32(data[pos + 4 : data_end]) & 0xFFFFFFFF
+            if declared_crc != actual_crc:
+                return False
+
+            if not saw_ihdr:
+                if chunk_type != b"IHDR" or length != 13:
+                    return False
+                width = struct.unpack(">I", data[data_start : data_start + 4])[0]
+                height = struct.unpack(">I", data[data_start + 4 : data_start + 8])[0]
+                if width == 0 or height == 0:
+                    return False
+                if width > _MAX_PNG_WIDTH or height > _MAX_PNG_HEIGHT:
+                    return False
+                saw_ihdr = True
+            elif chunk_type == b"IEND":
+                if length != 0:
+                    return False
+                saw_iend = True
+                pos = crc_end
+                break
+
+            pos = crc_end
+
+        return saw_ihdr and saw_iend
+    except (struct.error, ValueError, IndexError):
+        return False
 
 
 def _safe_rmtree(path: Path, root: Path) -> None:

--- a/tests/test_cli_issues.py
+++ b/tests/test_cli_issues.py
@@ -480,3 +480,124 @@ class TestComposeNetworkKey:
         content = (tmp_path / "winpodx" / "compose.yaml").read_text()
         assert "NETWORK" not in content
         assert "slirp" not in content
+
+
+# --- v0.1.8 audit I1/I2: winpodx app refresh cfg-loading + kind routing ---
+
+
+class TestRefreshAppsCli:
+    def _import(self):
+        from winpodx.cli.app import _refresh_apps
+
+        return _refresh_apps
+
+    def test_refresh_passes_cfg_to_discover_apps(self):
+        from winpodx.core.config import Config
+
+        fake_cfg = Config()
+        with (
+            patch("winpodx.core.config.Config.load", return_value=fake_cfg),
+            patch("winpodx.core.discovery.discover_apps", return_value=[]) as mock_da,
+            patch("winpodx.core.discovery.persist_discovered", return_value=[]),
+        ):
+            refresh = self._import()
+            refresh(as_json=False, timeout=30)
+            mock_da.assert_called_once()
+            args, kwargs = mock_da.call_args
+            # cfg must be first positional arg (matches discover_apps signature).
+            assert args[0] is fake_cfg
+            assert kwargs.get("timeout", None) == 30
+
+    def test_refresh_pod_not_running_exits_2(self):
+        from winpodx.core.config import Config
+        from winpodx.core.discovery import DiscoveryError
+
+        with (
+            patch("winpodx.core.config.Config.load", return_value=Config()),
+            patch(
+                "winpodx.core.discovery.discover_apps",
+                side_effect=DiscoveryError("pod is down", kind="pod_not_running"),
+            ),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            refresh = self._import()
+            refresh(as_json=False, timeout=30)
+        assert excinfo.value.code == 2
+
+    def test_refresh_unsupported_backend_exits_2(self):
+        from winpodx.core.config import Config
+        from winpodx.core.discovery import DiscoveryError
+
+        with (
+            patch("winpodx.core.config.Config.load", return_value=Config()),
+            patch(
+                "winpodx.core.discovery.discover_apps",
+                side_effect=DiscoveryError("libvirt not supported", kind="unsupported_backend"),
+            ),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            refresh = self._import()
+            refresh(as_json=False, timeout=30)
+        assert excinfo.value.code == 2
+
+    def test_refresh_timeout_exits_4(self):
+        from winpodx.core.config import Config
+        from winpodx.core.discovery import DiscoveryError
+
+        with (
+            patch("winpodx.core.config.Config.load", return_value=Config()),
+            patch(
+                "winpodx.core.discovery.discover_apps",
+                side_effect=DiscoveryError("timed out", kind="timeout"),
+            ),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            refresh = self._import()
+            refresh(as_json=False, timeout=30)
+        assert excinfo.value.code == 4
+
+    def test_refresh_unknown_kind_defaults_to_3(self):
+        from winpodx.core.config import Config
+        from winpodx.core.discovery import DiscoveryError
+
+        with (
+            patch("winpodx.core.config.Config.load", return_value=Config()),
+            patch(
+                "winpodx.core.discovery.discover_apps",
+                side_effect=DiscoveryError("weird thing happened"),
+            ),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            refresh = self._import()
+            refresh(as_json=False, timeout=30)
+        assert excinfo.value.code == 3
+
+    def test_refresh_json_emits_slug_and_icon_path(self, capsys):
+        import json
+
+        from winpodx.core.config import Config
+        from winpodx.core.discovery import DiscoveredApp
+
+        app = DiscoveredApp(
+            name="myapp",
+            full_name="My App",
+            executable="C:\\\\App\\\\my.exe",
+            source="win32",
+            slug="myapp",
+            icon_path="/home/u/.local/share/icons/hicolor/32x32/apps/winpodx-myapp.png",
+        )
+        with (
+            patch("winpodx.core.config.Config.load", return_value=Config()),
+            patch("winpodx.core.discovery.discover_apps", return_value=[app]),
+            patch("winpodx.core.discovery.persist_discovered", return_value=[app]),
+        ):
+            refresh = self._import()
+            refresh(as_json=True, timeout=30)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert len(data) == 1
+        assert data[0]["name"] == "myapp"
+        assert data[0]["slug"] == "myapp"
+        assert data[0]["icon_path"].endswith("winpodx-myapp.png")
+        assert "discovered 1 app" in captured.err

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -15,9 +15,13 @@ from __future__ import annotations
 
 import base64
 import json
+import os
+import re
+import struct
 import subprocess
+import zlib
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -30,9 +34,91 @@ from winpodx.core.discovery import (
     _safe_rmtree,
     _slugify_name,
     _sniff_icon_ext,
+    _validate_png_bytes,
     discover_apps,
     persist_discovered,
 )
+
+# --- Helpers for Popen-based discover_apps mocking -------------------------
+
+
+def _build_png(
+    width: int = 1,
+    height: int = 1,
+    *,
+    body_extra: bytes = b"",
+    corrupt_crc: bool = False,
+    real_idat: bool = True,
+) -> bytes:
+    """Construct a PNG for tests.
+
+    When ``real_idat=True`` (default), produces a genuinely decodable
+    RGBA PNG of the requested dimensions — IDAT is properly
+    zlib-compressed and each scanline is prefixed with the filter byte.
+    Such a PNG passes both ``QImage.loadFromData`` and the stdlib chunk
+    walker, which is what the icon-happy-path tests need now that M1
+    requires structural validity before persistence.
+
+    When ``real_idat=False``, produces the old structurally-valid-but-
+    non-decodable shape (correct magic + IHDR + optional garbage IDAT +
+    IEND with valid CRCs) — useful for exercising the stdlib chunk
+    walker in isolation (which does not try to decompress IDAT).
+
+    ``body_extra`` is only honored when ``real_idat=False``; in real
+    mode the IDAT is computed from the declared dimensions.
+    ``corrupt_crc`` flips the IHDR CRC so the stdlib walker rejects it.
+    """
+
+    def _chunk(chunk_type: bytes, payload: bytes) -> bytes:
+        crc = zlib.crc32(chunk_type + payload) & 0xFFFFFFFF
+        if corrupt_crc and chunk_type == b"IHDR":
+            crc ^= 0xDEADBEEF
+        return struct.pack(">I", len(payload)) + chunk_type + payload + struct.pack(">I", crc)
+
+    magic = b"\x89PNG\r\n\x1a\n"
+    ihdr_payload = struct.pack(">II", width, height) + b"\x08\x06\x00\x00\x00"
+    png = magic + _chunk(b"IHDR", ihdr_payload)
+    if real_idat:
+        # Filter=0 per scanline + RGBA zero pixels; zlib-compressed.
+        scanline = b"\x00" + (b"\x00\x00\x00\x00" * width)
+        raw = scanline * height
+        png += _chunk(b"IDAT", zlib.compress(raw))
+    elif body_extra:
+        png += _chunk(b"IDAT", body_extra)
+    png += _chunk(b"IEND", b"")
+    return png
+
+
+def _fake_popen(stdout: bytes = b"", stderr: bytes = b"", returncode: int = 0) -> MagicMock:
+    """Build a MagicMock Popen that emits fixed bytes then terminates.
+
+    The helper wires up ``fileno()`` on the stdout/stderr attributes so
+    core.discovery._run_bounded's ``os.read(fd, ...)`` loop sees a clean
+    EOF after the provided bytes. Uses an OS pipe per stream so the
+    drain-thread code path is exercised verbatim.
+    """
+    proc = MagicMock(spec=subprocess.Popen)
+
+    stdout_r, stdout_w = os.pipe()
+    stderr_r, stderr_w = os.pipe()
+    os.write(stdout_w, stdout)
+    os.close(stdout_w)
+    os.write(stderr_w, stderr)
+    os.close(stderr_w)
+
+    stdout_file = MagicMock()
+    stdout_file.fileno.return_value = stdout_r
+    stderr_file = MagicMock()
+    stderr_file.fileno.return_value = stderr_r
+
+    proc.stdout = stdout_file
+    proc.stderr = stderr_file
+    proc.returncode = returncode
+    proc.poll.return_value = returncode
+    proc.wait.return_value = returncode
+    proc.kill.return_value = None
+    return proc
+
 
 # --- Fixtures --------------------------------------------------------------
 
@@ -167,6 +253,39 @@ def test_entry_uwp_without_launch_uri_rejected():
     assert app is None
 
 
+# The guest PS script (scripts/windows/discover_apps.ps1) MUST emit a bare
+# `PackageFamilyName!AppId` AUMID as launch_uri — never a `shell:AppsFolder\`
+# URI. The host-side FreeRDP builder (src/winpodx/core/rdp.py) prepends the
+# prefix itself, so a guest-side prefix produces
+# `shell:AppsFolder\shell:AppsFolder\...`. This regex mirrors
+# rdp._AUMID_RE so the discovery test suite can assert the contract without
+# importing from another subpackage.
+_BARE_AUMID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}![A-Za-z0-9._-]{1,64}$")
+
+
+def test_uwp_launch_uri_is_bare_aumid_end_to_end():
+    """Mock a guest JSON payload with a bare AUMID, round-trip through the
+    parser, and assert the persisted launch_uri still matches the bare form
+    (no `shell:AppsFolder\\` prefix leaks through)."""
+    payload = json.dumps(
+        [
+            _valid_entry(
+                name="Calculator",
+                source="uwp",
+                launch_uri="Microsoft.WindowsCalculator_8wekyb3d8bbwe!App",
+                path="C:\\Program Files\\WindowsApps\\Microsoft.WindowsCalculator_xxx",
+            )
+        ]
+    )
+    apps = _parse_discovery_output(payload)
+    assert len(apps) == 1
+    calc = apps[0]
+    assert calc.source == "uwp"
+    assert calc.launch_uri == "Microsoft.WindowsCalculator_8wekyb3d8bbwe!App"
+    assert "shell:AppsFolder" not in calc.launch_uri
+    assert _BARE_AUMID_RE.fullmatch(calc.launch_uri) is not None
+
+
 def test_entry_oversized_name_rejected():
     app = _entry_to_discovered(_valid_entry(name="x" * 500))
     assert app is None
@@ -279,16 +398,18 @@ def test_persist_writes_app_toml(tmp_path):
 
 
 def test_persist_writes_png_icon(tmp_path):
+    # Valid PNG is required post-M1 (magic-only payloads are rejected).
+    png = _build_png(width=1, height=1, body_extra=b"\x00" * 4)
     app = DiscoveredApp(
         name="example-app",
         full_name="Example",
         executable="C:\\example.exe",
-        icon_bytes=_TINY_PNG,
+        icon_bytes=png,
     )
     persist_discovered([app], target_dir=tmp_path)
     icon = tmp_path / "example-app" / "icon.png"
     assert icon.exists()
-    assert icon.read_bytes() == _TINY_PNG
+    assert icon.read_bytes() == png
 
 
 def test_persist_writes_svg_icon(tmp_path):
@@ -469,19 +590,23 @@ def test_discover_surfaces_timeout(tmp_path):
     script = tmp_path / "discover_apps.ps1"
     script.write_text("# stub")
 
-    def fake_run(*args, **kwargs):
-        # First call (cp) succeeds; second (exec) times out.
-        if "cp" in args[0]:
-            return subprocess.CompletedProcess(args[0], 0, "", "")
-        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout", 120))
+    def cp_ok(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0, "", "")
+
+    # Simulate a child that never naturally terminates. The bounded
+    # loop in _run_bounded must kill it once the deadline elapses.
+    stuck = _fake_popen(stdout=b"", stderr=b"", returncode=-9)
+    stuck.poll.return_value = None  # never finishes on its own
 
     with (
         patch("winpodx.core.discovery.shutil.which", return_value="/usr/bin/podman"),
         patch("winpodx.core.discovery._ps_script_path", return_value=script),
-        patch("winpodx.core.discovery.subprocess.run", side_effect=fake_run),
+        patch("winpodx.core.discovery.subprocess.run", side_effect=cp_ok),
+        patch("winpodx.core.discovery.subprocess.Popen", return_value=stuck),
     ):
-        with pytest.raises(DiscoveryError, match="timed out"):
-            discover_apps(cfg)
+        with pytest.raises(DiscoveryError, match="timed out") as excinfo:
+            discover_apps(cfg, timeout=1)
+        assert excinfo.value.kind == "timeout"
 
 
 def test_discover_happy_path_roundtrip(tmp_path):
@@ -489,18 +614,19 @@ def test_discover_happy_path_roundtrip(tmp_path):
     script = tmp_path / "discover_apps.ps1"
     script.write_text("# stub")
 
-    payload = json.dumps([_valid_entry(name="Calculator")])
+    payload = json.dumps([_valid_entry(name="Calculator")]).encode("utf-8")
 
-    def fake_run(*args, **kwargs):
-        cmd = args[0]
-        if "cp" in cmd:
-            return subprocess.CompletedProcess(cmd, 0, "", "")
-        return subprocess.CompletedProcess(cmd, 0, payload, "")
+    def cp_ok(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0, "", "")
 
     with (
         patch("winpodx.core.discovery.shutil.which", return_value="/usr/bin/podman"),
         patch("winpodx.core.discovery._ps_script_path", return_value=script),
-        patch("winpodx.core.discovery.subprocess.run", side_effect=fake_run),
+        patch("winpodx.core.discovery.subprocess.run", side_effect=cp_ok),
+        patch(
+            "winpodx.core.discovery.subprocess.Popen",
+            return_value=_fake_popen(stdout=payload, returncode=0),
+        ),
     ):
         apps = discover_apps(cfg)
 
@@ -513,16 +639,235 @@ def test_discover_nonzero_exit_raises(tmp_path):
     script = tmp_path / "discover_apps.ps1"
     script.write_text("# stub")
 
-    def fake_run(*args, **kwargs):
-        cmd = args[0]
-        if "cp" in cmd:
-            return subprocess.CompletedProcess(cmd, 0, "", "")
-        return subprocess.CompletedProcess(cmd, 42, "", "Get-AppxPackage failed")
+    def cp_ok(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0, "", "")
 
     with (
         patch("winpodx.core.discovery.shutil.which", return_value="/usr/bin/podman"),
         patch("winpodx.core.discovery._ps_script_path", return_value=script),
-        patch("winpodx.core.discovery.subprocess.run", side_effect=fake_run),
+        patch("winpodx.core.discovery.subprocess.run", side_effect=cp_ok),
+        patch(
+            "winpodx.core.discovery.subprocess.Popen",
+            return_value=_fake_popen(stdout=b"", stderr=b"Get-AppxPackage failed", returncode=42),
+        ),
     ):
-        with pytest.raises(DiscoveryError, match="rc=42"):
+        with pytest.raises(DiscoveryError, match="rc=42") as excinfo:
             discover_apps(cfg)
+        assert excinfo.value.kind == "script_failed"
+
+
+# ---------------------------------------------------------------------------
+# core-team additions (v0.1.8 blockers — I1 / I2 / M1 / L1)
+# ---------------------------------------------------------------------------
+
+
+def test_discovery_error_kind_preserved():
+    """I1: DiscoveryError must round-trip the `kind` keyword."""
+    err = DiscoveryError("boom", kind="script_failed")
+    assert str(err) == "boom"
+    assert err.kind == "script_failed"
+
+    # Default must also hold so legacy zero-arg construction still works.
+    bare = DiscoveryError()
+    assert bare.kind == ""
+
+    # And `kind` must be reachable from a raise-and-catch flow.
+    with pytest.raises(DiscoveryError) as excinfo:
+        raise DiscoveryError("x", kind="timeout")
+    assert excinfo.value.kind == "timeout"
+
+
+def test_discovery_error_kinds_at_all_raise_sites():
+    """I1 coverage: every raise site in discovery.py emits a canonical kind."""
+    # unsupported_backend
+    cfg = _make_cfg(backend="libvirt")
+    with pytest.raises(DiscoveryError) as e1:
+        discover_apps(cfg)
+    assert e1.value.kind == "unsupported_backend"
+
+    # pod_not_running (runtime missing on PATH)
+    cfg = _make_cfg(backend="podman")
+    with patch("winpodx.core.discovery.shutil.which", return_value=None):
+        with pytest.raises(DiscoveryError) as e2:
+            discover_apps(cfg)
+    assert e2.value.kind == "pod_not_running"
+
+    # script_missing
+    with (
+        patch("winpodx.core.discovery.shutil.which", return_value="/usr/bin/podman"),
+        patch(
+            "winpodx.core.discovery._ps_script_path",
+            return_value=Path("/nonexistent/discover_apps.ps1"),
+        ),
+    ):
+        with pytest.raises(DiscoveryError) as e3:
+            discover_apps(cfg)
+    assert e3.value.kind == "script_missing"
+
+    # bad_json
+    with pytest.raises(DiscoveryError) as e4:
+        _parse_discovery_output("{ not json")
+    assert e4.value.kind == "bad_json"
+
+
+def test_discovered_app_has_slug_and_icon_path_after_persist(tmp_path):
+    """I2: slug + icon_path must be populated post persist_discovered."""
+    png = _build_png(width=2, height=2, body_extra=b"\x00" * 4)
+    app = DiscoveredApp(
+        name="example-app",
+        full_name="Example App",
+        executable="C:\\Example\\example.exe",
+        icon_bytes=png,
+    )
+    # Before persist: empty contract fields.
+    assert app.slug == ""
+    assert app.icon_path == ""
+
+    persist_discovered([app], target_dir=tmp_path)
+
+    assert app.slug == "example-app"
+    expected_icon = (tmp_path / "example-app" / "icon.png").resolve()
+    assert app.icon_path == str(expected_icon)
+    assert Path(app.icon_path).is_file()
+
+
+def test_discovered_app_icon_path_empty_when_no_icon(tmp_path):
+    """I2: slug still stamped even when no icon was supplied."""
+    app = DiscoveredApp(name="no-icon", full_name="NoIcon", executable="C:\\x.exe")
+    persist_discovered([app], target_dir=tmp_path)
+    assert app.slug == "no-icon"
+    assert app.icon_path == ""
+
+
+def test_validate_png_rejects_crafted_magic_only_payload():
+    """M1: magic bytes + garbage must not be trusted as a PNG."""
+    crafted = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+    assert _validate_png_bytes(crafted) is False
+
+
+def test_validate_png_rejects_empty_bytes():
+    assert _validate_png_bytes(b"") is False
+
+
+def test_validate_png_rejects_wrong_magic():
+    assert _validate_png_bytes(b"GIF89a" + b"\x00" * 100) is False
+
+
+def test_validate_png_stdlib_rejects_crc_corruption():
+    """M1: a single-bit flip in IHDR CRC must be caught by the stdlib walker."""
+    from winpodx.core.discovery import _validate_png_stdlib
+
+    png = _build_png(corrupt_crc=True)
+    assert _validate_png_stdlib(png) is False
+
+
+def test_validate_png_stdlib_rejects_oversized_dimensions():
+    """M1: a 2048x2048 PNG must be rejected even with valid chunks."""
+    from winpodx.core.discovery import _validate_png_stdlib
+
+    png = _build_png(width=2048, height=2048)
+    assert _validate_png_stdlib(png) is False
+
+
+def test_validate_png_accepts_real_png():
+    """M1: a structurally valid PNG passes validation."""
+    png = _build_png(width=1, height=1, body_extra=b"\x00" * 8)
+    assert _validate_png_bytes(png) is True
+
+
+def test_persist_rejects_malformed_png_but_persists_entry(tmp_path):
+    """M1 integration: malformed PNG must not abort the run; entry still written."""
+    crafted = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+    app = DiscoveredApp(
+        name="badpng-app",
+        full_name="BadPng",
+        executable="C:\\b.exe",
+        icon_bytes=crafted,
+    )
+    written = persist_discovered([app], target_dir=tmp_path)
+    assert len(written) == 1  # entry persists
+    app_dir = tmp_path / "badpng-app"
+    assert (app_dir / "app.toml").exists()
+    assert not (app_dir / "icon.png").exists()  # icon rejected
+    assert app.icon_path == ""
+
+
+def test_discovery_stdout_cap_triggers_truncated_error(tmp_path):
+    """L1: child emitting >HARD_STDOUT_CAP bytes must raise kind=truncated."""
+    cfg = _make_cfg(backend="podman")
+    script = tmp_path / "discover_apps.ps1"
+    script.write_text("# stub")
+
+    def cp_ok(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0, "", "")
+
+    from winpodx.core.discovery import HARD_STDOUT_CAP
+
+    # Flood ~65 MiB so the drain loop trips the cap well before completion.
+    flood_size = HARD_STDOUT_CAP + (1 * 1024 * 1024)
+
+    class _FloodingProc:
+        """Stand-in for subprocess.Popen that floods stdout via an OS pipe."""
+
+        def __init__(self) -> None:
+            import threading as _t
+
+            self._stdout_r, self._stdout_w = os.pipe()
+            self._stderr_r, self._stderr_w = os.pipe()
+            os.close(self._stderr_w)  # no stderr output
+            self.returncode: int | None = None
+            self._stdout_closed = False
+
+            def _writer() -> None:
+                chunk = b"A" * (1024 * 1024)  # 1 MiB per write
+                written = 0
+                try:
+                    while written < flood_size:
+                        os.write(self._stdout_w, chunk)
+                        written += len(chunk)
+                except OSError:
+                    # Pipe closed by kill() — expected once the cap trips.
+                    return
+                finally:
+                    try:
+                        os.close(self._stdout_w)
+                    except OSError:
+                        pass
+
+            self._writer_thread = _t.Thread(target=_writer, daemon=True)
+            self._writer_thread.start()
+
+            self.stdout = MagicMock()
+            self.stdout.fileno.return_value = self._stdout_r
+            self.stderr = MagicMock()
+            self.stderr.fileno.return_value = self._stderr_r
+
+        def poll(self):
+            # Never naturally finishes — the drain cap must be what stops us.
+            return None
+
+        def kill(self) -> None:
+            self.returncode = -9
+            if not self._stdout_closed:
+                self._stdout_closed = True
+                try:
+                    os.close(self._stdout_w)
+                except OSError:
+                    pass
+
+        def wait(self, timeout=None) -> int:
+            if self.returncode is None:
+                self.returncode = -9
+            return self.returncode
+
+    flooding = _FloodingProc()
+
+    with (
+        patch("winpodx.core.discovery.shutil.which", return_value="/usr/bin/podman"),
+        patch("winpodx.core.discovery._ps_script_path", return_value=script),
+        patch("winpodx.core.discovery.subprocess.run", side_effect=cp_ok),
+        patch("winpodx.core.discovery.subprocess.Popen", return_value=flooding),
+    ):
+        with pytest.raises(DiscoveryError) as excinfo:
+            discover_apps(cfg, timeout=60)
+        assert excinfo.value.kind == "truncated"

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -211,3 +211,55 @@ def test_run_migrate_non_interactive_skips_prompt(tmp_path, monkeypatch, capsys)
     assert called == []  # input() must never have been called
     out = capsys.readouterr().out.lower()
     assert "--non-interactive" in out
+
+
+# --- L2: marker-file size cap + strict semver regex ---
+
+
+def test_read_installed_version_accepts_valid(tmp_path, monkeypatch):
+    monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    (tmp_path / "installed_version.txt").write_text("0.1.8\n", encoding="utf-8")
+    assert _read_installed_version() == "0.1.8"
+
+
+def test_read_installed_version_accepts_prerelease_suffix(tmp_path, monkeypatch):
+    monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    (tmp_path / "installed_version.txt").write_text("1.2.3rc1\n", encoding="utf-8")
+    assert _read_installed_version() == "1.2.3rc1"
+
+
+def test_read_installed_version_rejects_oversized(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    (tmp_path / "installed_version.txt").write_bytes(b"0.1.8" + b"X" * 1024)
+    assert _read_installed_version() is None
+    err = capsys.readouterr().err
+    assert "exceeds" in err
+
+
+def test_read_installed_version_rejects_binary_garbage(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    (tmp_path / "installed_version.txt").write_bytes(b"\xff\xfe\x00bad\x01")
+    assert _read_installed_version() is None
+    err = capsys.readouterr().err
+    assert "not valid UTF-8" in err or "not a valid version" in err
+
+
+def test_read_installed_version_rejects_shell_metachars(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    (tmp_path / "installed_version.txt").write_text("0.1.8; rm -rf /\n", encoding="utf-8")
+    assert _read_installed_version() is None
+    err = capsys.readouterr().err
+    assert "not a valid version" in err
+
+
+def test_read_installed_version_falls_back_when_invalid(tmp_path, monkeypatch):
+    """Invalid marker -> _detect_installed_version returns the pre-tracker baseline
+    when a winpodx.toml exists, so the upgrade path still runs."""
+    monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    (tmp_path / "installed_version.txt").write_text("not-a-version\n", encoding="utf-8")
+    # Also create a winpodx.toml so the pre-tracker fallback triggers.
+    import winpodx.core.config as cfgmod
+
+    monkeypatch.setattr(cfgmod.Config, "path", classmethod(lambda c: tmp_path / "winpodx.toml"))
+    (tmp_path / "winpodx.toml").write_text("[rdp]\nuser = 'x'\n", encoding="utf-8")
+    assert _detect_installed_version() == "0.1.7"


### PR DESCRIPTION
Remediates every finding from the Wave 2 security audit (task #5 / report summary pinned on task #5 metadata). Four logical commits, all test suites green (324 tests pass).

## Scope

### Functional blockers (I1 / I2 / I3)
- **I1** `src/winpodx/cli/app.py` was calling `discover_apps(timeout=...)` without the required `cfg` arg → TypeError on every invocation.
- **I2** `cli/app.py` also read `exc.kind`, `a.slug`, `a.icon_path` which the public API didn't expose → AttributeError on `--json`, silent fallthrough to exit code 3 for every error class.
- **I3** `scripts/windows/discover_apps.ps1` emitted `launch_uri` with two different semantics (prefixed vs bare AUMID); the prefixed form would leak through and fail host-side regex validation, breaking UWP launches.

### Medium (M1)
- **M1** PNG icons from the guest were only magic-byte-sniffed before being written to `~/.local/share/icons/hicolor/32x32/apps/` — a crafted stream could reach the host's image parser. Now: QImage.loadFromData with a stdlib CRC + chunk-walker fallback, 1024×1024 dimension cap, reject-and-skip (never raise) on failure.

### Low (L1 / L2 / L3)
- **L1** subprocess stdout drained with a 64 MiB hard cap via Popen + threaded os.read; exceeding the cap kills the child and raises `DiscoveryError(kind=\"truncated\")`.
- **L2** migrate marker (`~/.config/winpodx/installed_version.txt`) capped at 64 bytes and fullmatch-validated against `^\d+(\.\d+){0,3}[a-z0-9]*$`; anything else falls back to the pre-tracker baseline path with a stderr warning.
- **L3** PowerShell Start Menu `.lnk` recursion now has `-Depth 8` so pathological layouts can't exhaust the guest-side scanner.

### Docs & CI
- `SECURITY.md` gains a new \"Host ↔ Guest Trust Model\" section documenting the validation pipeline, secret flow direction, and guest-compromise bounded impact.
- `discover-apps-ps` CI job pins `persist-credentials: false` on `actions/checkout@v4` — defense in depth.

## Commits

| Commit | Scope |
|--------|-------|
| 0fde99b | fix(core): DiscoveryError.kind + DiscoveredApp.slug/icon_path + PNG validation + stdout cap |
| 027f681 | fix(cli): align app refresh with core API + migrate marker hardening |
| 405286c | fix(platform-qa): launch_uri bare AUMID + PS depth cap + CI persist-creds |
| c694d43 | docs(security): add Host ↔ Guest Trust Model section |

## Test plan

- [x] \`pytest tests/ -v\` — 324 passed
- [x] \`ruff check src/ tests/\` — clean
- [x] \`ruff format --check src/ tests/\` — clean
- [ ] CI green on this branch before merge

## Related tasks

- Task #5 (Wave 2 audit) — completed, report saved in metadata
- Task #8 / #9 / #10 / #11 (per-finding remediations) — completed by this PR
- Task #6 (Wave 3 version bump) — blocked on this PR + subsequent v0.1.8 feature work (max_sessions + install.sh local paths)

## Out of scope (follow-up in the same v0.1.8 release)

- \`pod.max_sessions\` config + memory budget warning (CLI + GUI)
- \`install.sh\` local-path flags (\`--source\`, \`--image-tar\`, \`--skip-deps\`)

Both will land as separate PRs against \`main\` before the v0.1.8 tag.