### PR TITLE
release: v0.1.8 — discovery + migrate + max_sessions + offline install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-04-25
+
 ### Added
 - **Dynamic Windows-app discovery.** A new `winpodx app refresh` CLI subcommand and a "Refresh Apps" button on the Qt GUI's Apps page now enumerate the apps actually installed on the Windows guest and register them alongside the 14 bundled profiles. Inside the container, `scripts/windows/discover_apps.ps1` scans Registry `App Paths` (HKLM + HKCU), Start Menu `.lnk` recursion, UWP/MSIX packages via `Get-AppxPackage` + `AppxManifest.xml`, and Chocolatey / Scoop shims, returning a JSON array with base64-encoded icons extracted from the real binaries / package logos. The host side (`winpodx.core.discovery`) copies the script via `podman cp`, executes it with `podman exec powershell`, and writes the results under `~/.local/share/winpodx/discovered/<slug>/` as TOML + PNG/SVG icon files. Bundled profiles, user-authored entries, and discovered entries live in three separate directories and merge at load time (user > discovered > bundled on slug collision) so a rediscovery run only touches the discovered tree.
 - **UWP RemoteApp launching.** `rdp.build_rdp_command` now accepts a `launch_uri` + strict-regex-validated AUMID (`<PackageFamilyName>!<AppId>`) and maps UWP apps to `/app:program:explorer.exe,cmd:shell:AppsFolder\<AUMID>`. Per-slug `winpodx-uwp-<aumid-slug>` fallback for `/wm-class` keeps Linux taskbar grouping distinct when two UWP apps share the same hint.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,36 @@
+winpodx (0.1.8) unstable; urgency=medium
+
+  * Dynamic Windows-app discovery: new `winpodx app refresh` CLI subcommand
+    and "Refresh Apps" button on the Qt GUI's Apps page enumerate apps
+    installed on the Windows guest (Registry App Paths, Start Menu .lnk,
+    UWP/MSIX via AppxManifest, Chocolatey / Scoop shims) and register them
+    alongside the 14 bundled profiles. Icons are extracted from the real
+    binaries / package logos and written under
+    ~/.local/share/winpodx/discovered/<slug>/.
+  * UWP RemoteApp launching: rdp.build_rdp_command now accepts a launch_uri
+    with strict-regex-validated AUMID and maps UWP apps to
+    /app:program:explorer.exe,cmd:shell:AppsFolder\<AUMID>.
+  * Post-upgrade migration wizard: `winpodx migrate` subcommand shows per-
+    version release notes for every version the user has skipped over and
+    can kick off `winpodx app refresh`. install.sh auto-invokes it on
+    detected upgrades; opt out with WINPODX_NO_MIGRATE=1.
+  * Configurable RemoteApp session cap: pod.max_sessions (clamped [1, 50],
+    default 10) is applied to the guest's Terminal Server
+    MaxInstanceCount at ensure_ready time. Memory budget warning fires in
+    CLI (config show/set, info) and GUI Settings only when the value
+    over-subscribes ram_gb — default config stays silent.
+  * install.sh offline / air-gapped flags: --source PATH, --image-tar PATH,
+    --skip-deps (+ matching WINPODX_* env vars) compose for installs
+    without git / registry / package-repo access.
+  * Security audit remediation (Wave 2): PNG QImage validation before
+    hicolor write, 64 MiB bounded subprocess stdout drain, DiscoveryError
+    kind canonicalization, Start Menu .lnk -Depth 8 cap, installed_version
+    marker size + regex hardening, launch_uri semantic unification across
+    PS code paths, CI persist-credentials:false on discover-apps-ps,
+    SECURITY.md Host <-> Guest Trust Model section.
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Fri, 25 Apr 2026 00:00:00 +0900
+
 winpodx (0.1.7) unstable; urgency=high
 
   * Bump bundled rdprrap to v0.1.3 — license-compliance release.

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,8 @@
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-04-25
+
 ### 추가
 - **Windows 앱 동적 발견.** 새 CLI `winpodx app refresh` 서브커맨드와 Qt GUI Apps 페이지의 "Refresh Apps" 버튼이 Windows 게스트에 실제 설치된 앱을 열거하고 기본 번들 14개 프로필과 함께 등록합니다. 컨테이너 내부에서 `scripts/windows/discover_apps.ps1` 이 Registry `App Paths` (HKLM + HKCU), Start Menu `.lnk` 재귀, UWP/MSIX (`Get-AppxPackage` + `AppxManifest.xml`), Chocolatey / Scoop shim 4개 소스를 스캔하고 실제 바이너리/패키지 로고에서 추출한 base64 아이콘을 포함한 JSON 배열을 반환합니다. Linux 호스트 (`winpodx.core.discovery`) 는 `podman cp` 로 스크립트를 복사하고 `podman exec powershell` 로 실행한 뒤, 결과를 `~/.local/share/winpodx/discovered/<slug>/` 아래 TOML + PNG/SVG 아이콘 파일로 저장합니다. 번들 / 사용자 직접 추가 / 발견 앱은 세 디렉토리로 분리 관리되며 로딩 시 "사용자 > 발견 > 번들" 우선순위로 병합됩니다 — 재발견 실행은 발견 트리만 건드립니다.
 - **UWP RemoteApp 실행.** `rdp.build_rdp_command` 가 `launch_uri` + 엄격 정규식 검증된 AUMID (`<PackageFamilyName>!<AppId>`) 를 받아 UWP 앱을 `/app:program:explorer.exe,cmd:shell:AppsFolder\<AUMID>` 로 매핑합니다. `/wm-class` fallback 이 `winpodx-uwp-<aumid-slug>` 로 슬러그당 고유하게 지정되어 두 UWP 앱이 같은 힌트를 공유할 때도 Linux 태스크바 그루핑이 분리됩니다.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.1.7"
+version = "0.1.8"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"


### PR DESCRIPTION
Version bump for the v0.1.8 tag. All feature work has already merged to main via PR #10 (Wave 2 audit remediation) and PR #11 (max_sessions + install.sh flags). This PR is just the version-string + changelog promotion so the tag push fires publish workflows with the right metadata.

## Bumps

- \`pyproject.toml\`: 0.1.7 → 0.1.8
- \`src/winpodx/__init__.py\`: 0.1.7 → 0.1.8
- \`debian/changelog\`: new 0.1.8 entry
- \`CHANGELOG.md\`: \`[Unreleased]\` → \`[0.1.8] - 2026-04-25\`
- \`docs/CHANGELOG.ko.md\`: same

## 0.1.8 highlights

1. **Dynamic app discovery** — \`winpodx app refresh\` CLI + GUI button enumerate the user's actually-installed Windows apps (Registry App Paths, Start Menu .lnk, UWP/MSIX, Chocolatey/Scoop) with icons extracted from the real binaries. Replaces the old "14 bundled profiles only" ceiling.
2. **UWP RemoteApp** launching via regex-validated AUMID.
3. **Post-upgrade migration wizard** (\`winpodx migrate\`) auto-invoked from install.sh.
4. **Configurable \`pod.max_sessions\`** [1, 50] with memory budget warning that stays quiet on the default config.
5. **Offline install flags** (\`--source\`, \`--image-tar\`, \`--skip-deps\`) for air-gapped boxes.
6. **Wave 2 security audit remediation** — PNG validation, 64 MiB stdout cap, DiscoveryError.kind, PS -Depth 8, marker hardening, launch_uri unification, CI persist-credentials, Host↔Guest Trust Model doc.

## Test plan

- [x] \`pytest tests/ -v\` — 337 passed
- [x] \`ruff check src/ tests/\` — clean
- [x] \`ruff format --check src/ tests/\` — clean

## Post-merge

User-gated: tag push triggers OBS RPM / RHEL RPM / .deb / AUR / GitHub Release workflows. Closes task #6.

Related tasks: #1-#5, #7-#13 all completed in prior PRs.