### PR TITLE
release: v0.1.9.1 — Refresh-button SEGV + RDP session timeout disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [0.1.9.1] - 2026-04-26
+
+### Fixed
+- **GUI SEGV when clicking the Apps "Refresh Apps" button on a pod-not-running guest.** Reported by kernalix7 against 0.1.9: `_on_refresh_failed` constructed a `QMessageBox(self)` directly inside the queued-signal callback frame, and PySide6 + Qt 6.x can SEGV deep in the dialog's font-inheritance path (`QApplication::font(parentWidget)` -> `QMetaObject::className()`) when the parent's metaobject is queried mid-callback. The QMessageBox build is now deferred via `QTimer.singleShot(0, ...)` so the signal handler frame unwinds first. The Info page's first-fetch is also deferred out of `__init__` for the same reason. The Info page worker class was hoisted to module level (was redefined every refresh), gains a busy-state reentrancy guard, and now properly `deleteLater`s both the worker and the QThread on completion.
+- **RDP sessions still drop mid-use after host suspend / long idle.** v0.1.9 Bug B fix only handled the "RDP unreachable" path; sessions could still be terminated by the Windows-side TermService timeouts (1h `MaxIdleTime` default). install.bat (OEM v7 -> v8) and a new `_apply_rdp_timeouts` provisioner step now write `MaxIdleTime=0`, `MaxDisconnectionTime=0`, `MaxConnectionTime=0`, `KeepAliveEnable=1` + `KeepAliveInterval=1` to both `HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services` and the `RDP-Tcp` WinStation, plus `KeepAliveTimeout=1` on the WinStation so TCP keep-alive fires every minute. Existing 0.1.x guests get the runtime apply on the next `ensure_ready` without needing container recreation.
+
 ## [0.1.9] - 2026-04-25
 
 ### Changed

--- a/config/oem/install.bat
+++ b/config/oem/install.bat
@@ -1,7 +1,7 @@
 @echo off
 REM First-boot OEM setup for winpodx Windows guest. Runs once during dockur's unattended install. Every action must stay idempotent — there is no guest-side re-run channel in 0.1.6 (push/exec bridge planned for a later release).
 
-set WINPODX_OEM_VERSION=7
+set WINPODX_OEM_VERSION=8
 
 echo [winpodx] Starting post-install configuration (version %WINPODX_OEM_VERSION%)...
 
@@ -35,6 +35,23 @@ echo [winpodx] Configuring TermService recovery actions...
 REM 3 attempts at 5s spacing, 24h reset window — Windows itself recovers
 REM TermService crashes without needing host intervention.
 sc.exe failure TermService reset= 86400 actions= restart/5000/restart/5000/restart/5000 >nul 2>&1
+
+REM v0.1.9.1: RDP session timeout + keep-alive (kernalix7 reported sessions
+REM dropping mid-use even after the v0.1.9 Bug B reachability fix). All four
+REM timeout limits go to "no limit" (0) and TCP keep-alive fires every minute
+REM so NAT/firewall idle-cleanup doesn't kill the connection either. Both the
+REM machine policy and the RDP-Tcp WinStation keys are set; whichever Windows
+REM consults first finds a saner default.
+echo [winpodx] Disabling RDP session timeouts + enabling keep-alive...
+reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" /v MaxIdleTime /t REG_DWORD /d 0 /f >nul 2>&1
+reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" /v MaxDisconnectionTime /t REG_DWORD /d 0 /f >nul 2>&1
+reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" /v MaxConnectionTime /t REG_DWORD /d 0 /f >nul 2>&1
+reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" /v KeepAliveEnable /t REG_DWORD /d 1 /f >nul 2>&1
+reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" /v KeepAliveInterval /t REG_DWORD /d 1 /f >nul 2>&1
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v MaxIdleTime /t REG_DWORD /d 0 /f >nul 2>&1
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v MaxDisconnectionTime /t REG_DWORD /d 0 /f >nul 2>&1
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v MaxConnectionTime /t REG_DWORD /d 0 /f >nul 2>&1
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v KeepAliveTimeout /t REG_DWORD /d 1 /f >nul 2>&1
 
 echo [winpodx] Configuring firewall...
 REM Delete-then-add keeps the rule idempotent; plain add creates duplicates on re-run.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+winpodx (0.1.9.1) unstable; urgency=high
+
+  * Fixed: GUI SEGV when clicking "Refresh Apps" against a pod that
+    isn't running. The failure path's QMessageBox construction is now
+    deferred via QTimer.singleShot(0, ...) so the queued-signal handler
+    frame unwinds before Qt's font-inheritance lookup walks the parent.
+    Info page first-fetch deferred out of __init__ for the same reason.
+    Info worker class hoisted to module level, busy-state reentrancy
+    guard added, worker + QThread both deleteLater'd on completion.
+  * Fixed: RDP sessions drop mid-use after host suspend / long idle.
+    v0.1.9 Bug B fix only handled "RDP unreachable"; this release
+    disables Windows TermService timeouts (MaxIdleTime / Max
+    DisconnectionTime / MaxConnectionTime = 0), enables KeepAlive
+    every 1 minute, and writes the keys to both the machine-policy
+    path and the RDP-Tcp WinStation. install.bat OEM bumps 7 -> 8;
+    existing 0.1.x guests get a runtime apply via a new
+    `_apply_rdp_timeouts` step in provisioner.ensure_ready (no
+    container recreate needed).
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Sun, 26 Apr 2026 00:00:00 +0900
+
 winpodx (0.1.9) unstable; urgency=medium
 
   * Fixed: `winpodx app refresh` on Windows. The 0.1.8 implementation

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,12 @@
 
 ## [Unreleased]
 
+## [0.1.9.1] - 2026-04-26
+
+### 수정
+- **Apps "Refresh Apps" 버튼 누르면 GUI SEGV (pod 안 켜진 상태).** kernalix7 보고: `_on_refresh_failed` 가 queued-signal 콜백 프레임 안에서 `QMessageBox(self)` 를 바로 생성했는데 PySide6 + Qt 6.x 가 dialog 의 폰트 상속 경로 (`QApplication::font(parentWidget)` → `QMetaObject::className()`) 에서 부모 metaObject 가 콜백 중에 조회되며 SEGV. 이제 `QTimer.singleShot(0, ...)` 으로 dialog 생성을 다음 이벤트 루프 틱으로 미뤄서 signal handler 프레임이 먼저 풀림. Info 페이지의 첫 fetch 도 같은 이유로 `__init__` 에서 빠져나간 뒤 실행. Info worker 클래스를 모듈 레벨로 hoisting (refresh 마다 재정의되던 것), 재진입 busy guard 추가, worker + QThread 모두 정상 `deleteLater`.
+- **호스트 suspend / 장기 유휴 후에도 RDP 세션이 사용 중에 끊기던 문제.** v0.1.9 Bug B 수정은 "RDP 도달 불가" 경로만 다뤘는데, Windows TermService 의 1시간 `MaxIdleTime` 기본값 등으로 활성 세션 자체가 종료될 수 있었음. install.bat (OEM v7 → v8) 와 새 `_apply_rdp_timeouts` provisioner 단계가 `MaxIdleTime=0`, `MaxDisconnectionTime=0`, `MaxConnectionTime=0`, `KeepAliveEnable=1` + `KeepAliveInterval=1` 을 `HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services` 와 `RDP-Tcp` WinStation 양쪽에 기록 + WinStation 에 `KeepAliveTimeout=1` (TCP keep-alive 1분 간격). 기존 0.1.x 게스트도 다음 `ensure_ready` 에서 자동 적용 — 컨테이너 재생성 불필요.
+
 ## [0.1.9] - 2026-04-25
 
 ### 변경

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.1.9"
+version = "0.1.9.1"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.1.9"
+__version__ = "0.1.9.1"

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -51,6 +51,7 @@ def ensure_ready(cfg: Config | None = None, timeout: int = 300) -> Config:
 
     _ensure_pod_running(cfg, timeout)
     _apply_max_sessions(cfg)
+    _apply_rdp_timeouts(cfg)
     # Bug B: after host suspend / long idle the pod can be running but RDP
     # itself is dead while VNC is fine. Probe and try to revive TermService
     # before handing the cfg to the caller — the alternative is the FreeRDP
@@ -189,6 +190,64 @@ def _apply_max_sessions(cfg: Config) -> None:
     else:
         log.warning(
             "max_sessions: apply rc=%d stderr=%s",
+            result.returncode,
+            result.stderr.strip(),
+        )
+
+
+def _apply_rdp_timeouts(cfg: Config) -> None:
+    """v0.1.9.1: disable RDP idle/disconnect/connection timeouts + enable keep-alive.
+
+    Without this Windows will drop active RemoteApp sessions after its
+    default timeouts (1h idle), and NAT/firewall keep-alive cleanup can
+    kill the underlying TCP. Idempotent: writes the same key set every
+    provision; reg add is no-op when value already matches.
+
+    Mirrors the OEM v8 install.bat changes for guests that were
+    provisioned under an older OEM version (so users don't have to
+    recreate their container to pick this up).
+    """
+    if cfg.pod.backend not in ("podman", "docker"):
+        return
+
+    runtime = "podman" if cfg.pod.backend == "podman" else "docker"
+    ps_exe = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+
+    apply_script = (
+        # Machine policy keys (override per-user / per-WinStation defaults).
+        r"$mp = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'; "
+        r"if (-not (Test-Path $mp)) { New-Item -Path $mp -Force | Out-Null }; "
+        r"Set-ItemProperty -Path $mp -Name MaxIdleTime -Value 0 -Type DWord -Force; "
+        r"Set-ItemProperty -Path $mp -Name MaxDisconnectionTime -Value 0 -Type DWord -Force; "
+        r"Set-ItemProperty -Path $mp -Name MaxConnectionTime -Value 0 -Type DWord -Force; "
+        r"Set-ItemProperty -Path $mp -Name KeepAliveEnable -Value 1 -Type DWord -Force; "
+        r"Set-ItemProperty -Path $mp -Name KeepAliveInterval -Value 1 -Type DWord -Force; "
+        # Per-WinStation keys (the actual TermService consults these).
+        r"$ws = 'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp'; "
+        r"Set-ItemProperty -Path $ws -Name MaxIdleTime -Value 0 -Type DWord -Force; "
+        r"Set-ItemProperty -Path $ws -Name MaxDisconnectionTime -Value 0 -Type DWord -Force; "
+        r"Set-ItemProperty -Path $ws -Name MaxConnectionTime -Value 0 -Type DWord -Force; "
+        r"Set-ItemProperty -Path $ws -Name KeepAliveTimeout -Value 1 -Type DWord -Force"
+    )
+    cmd = [
+        runtime,
+        "exec",
+        cfg.pod.container_name,
+        ps_exe,
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        apply_script,
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        log.warning("rdp_timeouts: apply failed: %s", e)
+        return
+    if result.returncode != 0:
+        log.warning(
+            "rdp_timeouts: rc=%d stderr=%s",
             result.returncode,
             result.stderr.strip(),
         )

--- a/src/winpodx/gui/main_window.py
+++ b/src/winpodx/gui/main_window.py
@@ -123,6 +123,32 @@ def _looks_like_pod_down(exc: BaseException) -> bool:
     return any(tok in text for tok in ("pod", "container", "connection refused", "not running"))
 
 
+class _InfoWorker(QObject):
+    """Background worker for the Info page's gather_info() call.
+
+    Hoisted to module level (was nested inside _refresh_info) so PySide6
+    doesn't re-create the QObject metaclass on every refresh — repeated
+    nested-class definition has been observed to interact badly with
+    Qt's metaobject cache, contributing to the v0.1.9 SEGV path.
+    """
+
+    done = Signal(dict)
+    failed = Signal(str)
+
+    def __init__(self, cfg) -> None:
+        super().__init__()
+        self.cfg = cfg
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            from winpodx.core.info import gather_info
+
+            self.done.emit(gather_info(self.cfg))
+        except Exception as e:  # noqa: BLE001 — surface to UI via signal
+            self.failed.emit(str(e))
+
+
 class WinpodxWindow(QMainWindow):
     """Main window with horizontal top navigation bar."""
 
@@ -1317,8 +1343,12 @@ class WinpodxWindow(QMainWindow):
         scroll.setWidget(content)
         outer.addWidget(scroll)
 
-        # Kick off first fetch so the page isn't permanently "Loading...".
-        self._refresh_info()
+        # v0.1.9.1: Defer the first fetch out of __init__. Calling
+        # _refresh_info() synchronously here can race with the rest of
+        # the main-window construction — the worker thread fires its
+        # `done` signal back into a partially-built window and hits the
+        # same QMessageBox font-lookup SEGV the Apps refresh path saw.
+        QTimer.singleShot(0, self._refresh_info)
         return page
 
     def _info_card(self, title: str) -> QFrame:
@@ -1387,33 +1417,38 @@ class WinpodxWindow(QMainWindow):
 
     def _refresh_info(self) -> None:
         """Re-run gather_info on a worker thread; populate cards on completion."""
-        from PySide6.QtCore import QObject, QThread, Signal
+        # Reentrancy guard: ignore rapid re-clicks while a previous worker
+        # is still in flight. The previous worker's `done` will land first
+        # and then the user can refresh again. Without this guard, a fast
+        # double-click leaks a QThread + worker pair and races the
+        # _info_card_bodies mutation in _apply_info_snapshot.
+        if getattr(self, "_info_busy", False):
+            return
+        self._info_busy = True
 
-        class _InfoWorker(QObject):
-            done = Signal(dict)
-            failed = Signal(str)
+        thread = QThread(self)
+        worker = _InfoWorker(self.cfg)
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+        worker.done.connect(self._apply_info_snapshot)
+        # done/failed both end the worker — chain quit + deleteLater on
+        # both worker and thread so neither leaks across refreshes.
+        worker.done.connect(thread.quit)
+        worker.failed.connect(thread.quit)
+        worker.done.connect(worker.deleteLater)
+        worker.failed.connect(worker.deleteLater)
+        thread.finished.connect(thread.deleteLater)
+        # Clear the busy flag whichever way the worker finishes.
+        worker.done.connect(self._on_info_done)
+        worker.failed.connect(self._on_info_done)
+        self._info_thread = thread
+        self._info_worker = worker
+        thread.start()
 
-            def __init__(self, cfg) -> None:
-                super().__init__()
-                self.cfg = cfg
-
-            def run(self) -> None:
-                try:
-                    from winpodx.core.info import gather_info
-
-                    self.done.emit(gather_info(self.cfg))
-                except Exception as e:  # noqa: BLE001
-                    self.failed.emit(str(e))
-
-        self._info_thread = QThread(self)
-        self._info_worker = _InfoWorker(self.cfg)
-        self._info_worker.moveToThread(self._info_thread)
-        self._info_thread.started.connect(self._info_worker.run)
-        self._info_worker.done.connect(self._apply_info_snapshot)
-        self._info_worker.done.connect(self._info_thread.quit)
-        self._info_worker.failed.connect(self._info_thread.quit)
-        self._info_thread.finished.connect(self._info_thread.deleteLater)
-        self._info_thread.start()
+    @Slot()
+    def _on_info_done(self, *_args) -> None:
+        """Slot fired when the info worker finishes (success or failure)."""
+        self._info_busy = False
 
     def _apply_info_snapshot(self, info: dict) -> None:
         """Map gather_info output into per-card row pairs."""
@@ -1665,6 +1700,16 @@ class WinpodxWindow(QMainWindow):
         self._refresh_worker = None
         self.info_label.setText("App discovery failed")
 
+        # v0.1.9.1: defer the QMessageBox creation to a clean event-loop tick.
+        # PySide6 + Qt 6.x can SEGV in QMessageBox's font-inheritance lookup
+        # when the dialog is constructed inside the queued-signal callback
+        # frame — kernalix7 hit this on `_on_refresh_failed` after a
+        # pod-not-running discovery failure. Re-dispatching via QTimer
+        # unwinds the signal handler stack first.
+        QTimer.singleShot(0, lambda: self._show_refresh_failure_dialog(kind, detail))
+
+    def _show_refresh_failure_dialog(self, kind: str, detail: str) -> None:
+        """Build the failure QMessageBox after the signal handler has unwound."""
         if kind == "pod_not_running":
             box = QMessageBox(self)
             box.setIcon(QMessageBox.Icon.Warning)

--- a/tests/test_provisioner.py
+++ b/tests/test_provisioner.py
@@ -247,3 +247,62 @@ def test_apply_max_sessions_tolerates_timeout(monkeypatch):
     monkeypatch.setattr(provisioner.subprocess, "run", fake_run)
     # Must not raise — timeout just logs and returns.
     provisioner._apply_max_sessions(cfg)
+
+
+# --- v0.1.9.1: _apply_rdp_timeouts ---
+
+
+def test_apply_rdp_timeouts_skips_libvirt():
+    from winpodx.core import provisioner
+    from winpodx.core.config import Config
+
+    cfg = Config()
+    cfg.pod.backend = "libvirt"
+    provisioner._apply_rdp_timeouts(cfg)  # must not raise / not subprocess
+
+
+def test_apply_rdp_timeouts_writes_all_keys(monkeypatch):
+    from unittest.mock import MagicMock
+
+    from winpodx.core import provisioner
+    from winpodx.core.config import Config
+
+    cfg = Config()
+    captured = []
+
+    def fake_run(cmd, **kw):
+        captured.append(cmd)
+        m = MagicMock()
+        m.returncode = 0
+        m.stderr = ""
+        return m
+
+    monkeypatch.setattr(provisioner.subprocess, "run", fake_run)
+    provisioner._apply_rdp_timeouts(cfg)
+    assert len(captured) == 1
+    script = captured[0][-1]
+    for token in (
+        "MaxIdleTime",
+        "MaxDisconnectionTime",
+        "MaxConnectionTime",
+        "KeepAliveEnable",
+        "KeepAliveInterval",
+        "KeepAliveTimeout",
+        "RDP-Tcp",
+        "Terminal Services",
+    ):
+        assert token in script
+
+
+def test_apply_rdp_timeouts_tolerates_timeout(monkeypatch):
+    from winpodx.core import provisioner
+    from winpodx.core.config import Config
+
+    cfg = Config()
+
+    def boom(cmd, **kw):
+        raise provisioner.subprocess.TimeoutExpired(cmd, kw.get("timeout", 0))
+
+    monkeypatch.setattr(provisioner.subprocess, "run", boom)
+    # Must swallow the exception.
+    provisioner._apply_rdp_timeouts(cfg)


### PR DESCRIPTION
Hotfix for two user-reported regressions in v0.1.9.

## 1. GUI SEGV on Apps \"Refresh Apps\"

**Reported by kernalix7** (coredump at \`/var/lib/systemd/coredump/...\` showing PID 210804 \`python3 -m winpodx gui\` SIGSEGV).

Stack:
\`PySide SignalManager → Python slot → QMessageBox(self) → setLayout → reparentChildWidgets → setParent → resolveFont → QApplication::font(parent) → QMetaObject::className() → SEGV\`

Root cause: PySide6 + Qt 6.x races in the dialog's font-inheritance walk when the parent's metaobject is queried from inside a queued-signal callback frame. Hits any GUI path that builds a QMessageBox synchronously from a slot wired to a worker QThread's \`failed\`/\`succeeded\` signal — exactly what \`_on_refresh_failed\` did.

**Fix**:
- \`_on_refresh_failed\`: extract the dialog-building code to a new \`_show_refresh_failure_dialog\` and dispatch it via \`QTimer.singleShot(0, ...)\`. The signal handler frame unwinds first; the dialog is constructed in a clean event-loop tick.
- Info page first-fetch: same defer (was called synchronously from \`_build_info_page\` inside \`__init__\`).
- \`_InfoWorker\` hoisted to module level (was redefined every refresh — every redefinition created a fresh QObject metaclass entry).
- Reentrancy guard (\`_info_busy\` flag) so rapid Refresh clicks can't leak QThread+worker pairs.
- Worker + thread both \`deleteLater\` on completion (worker was leaking).

## 2. RDP sessions drop mid-use after host suspend / long idle

Reported by kernalix7: \`마이그레이션 해도 윈도 rdp 세션 끊기는건 여전해\` — even after migrating to v0.1.9, RDP sessions still terminate mid-use.

Diagnosis: v0.1.9 Bug B fix only handled \"RDP unreachable\" (TermService stalled, NIC asleep). It didn't disable Windows' default 1-hour \`MaxIdleTime\`, so active RemoteApp sessions still died on schedule.

**Fix**:
- \`config/oem/install.bat\` bumps OEM 7 → 8 with new \`reg add\` lines: \`MaxIdleTime=0\`, \`MaxDisconnectionTime=0\`, \`MaxConnectionTime=0\`, \`KeepAliveEnable=1\`, \`KeepAliveInterval=1\` on both \`HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services\` and the \`RDP-Tcp\` WinStation, plus \`KeepAliveTimeout=1\` on the WinStation.
- New \`provisioner._apply_rdp_timeouts(cfg)\` runs the equivalent PowerShell on every \`ensure_ready\` so existing 0.1.x guests get the fix immediately without container recreation. Idempotent — \`Set-ItemProperty -Force\` is a no-op when the value already matches.

## Test plan

- [x] \`pytest tests/ -v\` — 366 passed (363 + 3 new for \`_apply_rdp_timeouts\`)
- [x] \`ruff check src/ tests/\` — clean
- [x] \`ruff format --check\` — clean
- [x] \`PYTHONPATH=$(pwd)/src python3 -c \"from winpodx.gui.main_window import WinpodxWindow\"\` — clean import

Manual verification on real hardware:
- [ ] Click \"Refresh Apps\" with pod stopped — should now show the \"Pod Not Running\" dialog instead of SEGV.
- [ ] Leave a RemoteApp session idle for 70+ minutes — should stay connected.
- [ ] Suspend host, wake, confirm RDP recovers and session continues.

## Version bumps

- \`pyproject.toml\`: 0.1.9 → 0.1.9.1
- \`src/winpodx/__init__.py\`: 0.1.9 → 0.1.9.1
- \`debian/changelog\`: 0.1.9.1 entry added
- \`CHANGELOG.md\` + \`docs/CHANGELOG.ko.md\`: 0.1.9.1 section