### PR TITLE
release: v0.1.9.2 — push Windows-side fixes to existing guests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [0.1.9.2] - 2026-04-26
+
+### Fixed
+- **Windows-side fixes from v0.1.9 / v0.1.9.1 weren't reaching existing guests.** kernalix7 reported "마이그레이션 잘 되는거 맞아? 윈도에 적용 안되는거같은데" — and they were right. install.bat (the OEM script) only runs at dockur's first-boot unattended setup, so users on 0.1.6 / 0.1.7 / 0.1.8 / 0.1.9 / 0.1.9.1 never picked up NIC power-save off (OEM v7), TermService failure-recovery actions (OEM v7), or RDP timeout disable + KeepAlive (OEM v8) without recreating the container. Compounding this, the v0.1.9.1 `_apply_rdp_timeouts` runtime helper was wired into `provisioner.ensure_ready` AFTER its `check_rdp_port` early-return — so the helper never fired against an already-healthy pod.
+  - `provisioner.ensure_ready`: probe `pod_status` once at the top and run all idempotent runtime applies (`_apply_max_sessions`, `_apply_rdp_timeouts`, new `_apply_oem_runtime_fixes`) BEFORE the RDP early-return. Re-applied after pod-start in the cold-pod path. ~1.5s overhead per call; idempotent so re-runs are no-ops.
+  - new `provisioner._apply_oem_runtime_fixes(cfg)` pipes the OEM v7 baseline (NIC `Set-NetAdapterPowerManagement -AllowComputerToTurnOffDevice $false`, `sc.exe failure TermService` recovery actions) to existing guests via `podman exec powershell` — same stdin-pipe transport `discover_apps.ps1` uses.
+  - `winpodx migrate`: when crossing the 0.1.9 boundary, proactively call all three apply helpers (with pod-state probe + interactive offer to start a stopped pod). Output reports per-helper success / failure so users can see exactly what landed without recreating their container.
+
 ## [0.1.9.1] - 2026-04-26
 
 ### Fixed

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+winpodx (0.1.9.2) unstable; urgency=high
+
+  * Fixed: Windows-side fixes from v0.1.9 / v0.1.9.1 (NIC power-save off,
+    TermService failure recovery, RDP timeout disable, KeepAlive) were
+    not reaching existing guests. install.bat only runs on a fresh
+    container, and v0.1.9.1's _apply_rdp_timeouts was wired AFTER the
+    check_rdp_port early-return in ensure_ready so it never fired on
+    healthy pods.
+    - ensure_ready now probes pod_status at the top and runs
+      _apply_max_sessions, _apply_rdp_timeouts, and the new
+      _apply_oem_runtime_fixes BEFORE the RDP early-return.
+    - New _apply_oem_runtime_fixes pipes the OEM v7 baseline (NIC
+      power-save off + sc.exe failure TermService) to existing guests
+      via the same `podman exec` stdin-pipe transport discovery uses.
+    - `winpodx migrate` proactively calls all three applies when
+      crossing the 0.1.9 version boundary, with pod-state probe and
+      an interactive offer to start a stopped pod. Per-helper
+      success/failure output so users see exactly what landed.
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Sun, 26 Apr 2026 02:30:00 +0900
+
 winpodx (0.1.9.1) unstable; urgency=high
 
   * Fixed: GUI SEGV when clicking "Refresh Apps" against a pod that

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,14 @@
 
 ## [Unreleased]
 
+## [0.1.9.2] - 2026-04-26
+
+### 수정
+- **v0.1.9 / v0.1.9.1 의 Windows-측 수정사항이 기존 게스트에 적용 안 되던 버그.** kernalix7 보고: "마이그레이션 잘 되는거 맞아? 윈도에 적용 안되는거같은데" — 사실이었음. install.bat (OEM 스크립트) 은 dockur 무인 설치 첫 부팅 시에만 도므로, 0.1.6 / 0.1.7 / 0.1.8 / 0.1.9 / 0.1.9.1 사용자는 컨테이너 재생성 없이 NIC power-save off (OEM v7), TermService failure-recovery (OEM v7), RDP timeout 비활성 + KeepAlive (OEM v8) 를 받을 수 없었음. 추가로, v0.1.9.1 의 `_apply_rdp_timeouts` runtime 헬퍼가 `provisioner.ensure_ready` 의 `check_rdp_port` early-return **뒤에** 와이어돼 있어서 이미 정상 동작 중인 포드에는 절대 도달하지 못했음.
+  - `provisioner.ensure_ready`: 함수 상단에서 `pod_status` 한 번 probe 해서 idempotent runtime apply 들 (`_apply_max_sessions`, `_apply_rdp_timeouts`, 신규 `_apply_oem_runtime_fixes`) 을 RDP early-return **앞에서** 실행. cold-pod 경로에서는 pod 시작 후 재적용. 호출당 약 1.5s 오버헤드, 재실행은 모두 no-op.
+  - 신규 `provisioner._apply_oem_runtime_fixes(cfg)`: OEM v7 baseline (NIC `Set-NetAdapterPowerManagement -AllowComputerToTurnOffDevice $false`, `sc.exe failure TermService` recovery 액션) 을 기존 게스트에 `podman exec powershell` 로 적용 — `discover_apps.ps1` 가 쓰는 stdin-pipe transport 재사용.
+  - `winpodx migrate`: 0.1.9 boundary 를 넘는 업그레이드 감지 시 세 apply 헬퍼를 proactive 호출 (pod 상태 probe + stopped 시 interactive 시작 옵션). 헬퍼별 성공/실패 출력 — 컨테이너 재생성 없이 어떤 게 적용됐는지 사용자가 직접 확인 가능.
+
 ## [0.1.9.1] - 2026-04-26
 
 ### 수정

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.1.9.1"
+version = "0.1.9.2"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.1.9.1"
+__version__ = "0.1.9.2"

--- a/src/winpodx/cli/migrate.py
+++ b/src/winpodx/cli/migrate.py
@@ -113,6 +113,15 @@ def run_migrate(args: argparse.Namespace) -> int:
     if inst_cmp < (0, 1, 9) <= cur_cmp:
         _maybe_cleanup_legacy_bundled(non_interactive)
 
+    # v0.1.9.2: when upgrading TO v0.1.9 or later, proactively apply
+    # Windows-side fixes (OEM v7+v8 equivalents) to the existing guest
+    # so the user doesn't have to recreate their container. install.bat
+    # only runs on a fresh container, so without this step a 0.1.6 -> 0.1.9.2
+    # user would never see RDP-timeout / NIC-power / TermService-recovery
+    # fixes land on their actual Windows VM.
+    if inst_cmp < (0, 1, 9) <= cur_cmp:
+        _apply_runtime_fixes_to_existing_guest(non_interactive)
+
     if skip_refresh:
         print("\nSkipping app discovery (--no-refresh).")
     elif non_interactive:
@@ -310,6 +319,89 @@ def _prompt_yes(question: str, default: bool = True) -> bool:
     if not response:
         return default
     return response in ("y", "yes")
+
+
+def _apply_runtime_fixes_to_existing_guest(non_interactive: bool) -> None:
+    """v0.1.9.2: push OEM v7+v8 equivalents to the guest without recreating it.
+
+    install.bat only runs on dockur's first-boot unattended path — existing
+    containers from 0.1.6 / 0.1.7 / 0.1.8 / 0.1.9 / 0.1.9.1 never picked up
+    NIC-power, TermService-failure, max_sessions, or RDP-timeout fixes
+    shipped in later versions. We pipe the equivalent PowerShell to the
+    running guest via the same `podman exec` channel discovery uses.
+
+    Best-effort — log + skip on any failure (pod stopped, exec error, etc.)
+    so a transient problem doesn't block the rest of migrate.
+    """
+    print("\nApplying Windows-side fixes to your existing pod...")
+    try:
+        from winpodx.core.config import Config
+        from winpodx.core.pod import PodState, pod_status
+        from winpodx.core.provisioner import (
+            _apply_max_sessions,
+            _apply_oem_runtime_fixes,
+            _apply_rdp_timeouts,
+        )
+    except ImportError as e:
+        print(f"  warning: cannot load provisioner helpers ({e}); skipping.")
+        return
+
+    cfg = Config.load()
+    if cfg.pod.backend not in ("podman", "docker"):
+        print(f"  Skipped: backend {cfg.pod.backend!r} doesn't support runtime apply.")
+        return
+
+    try:
+        state = pod_status(cfg).state
+    except Exception as e:  # noqa: BLE001
+        print(f"  warning: cannot probe pod state ({e}); skipping runtime apply.")
+        return
+
+    if state != PodState.RUNNING:
+        print(f"  Pod is {state.value if hasattr(state, 'value') else state}, not running.")
+        if non_interactive:
+            print(
+                "  Skipping (--non-interactive). "
+                "Run `winpodx app run desktop` later — apply fires automatically."
+            )
+            return
+        if not _prompt_yes("  Start the pod now and apply?", default=True):
+            print("  Skipped — apply will run automatically next time the pod starts.")
+            return
+        try:
+            from winpodx.core.provisioner import ensure_ready
+
+            ensure_ready(cfg)
+            print("  Pod started + Windows-side fixes applied.")
+        except Exception as e:  # noqa: BLE001
+            print(f"  warning: pod start failed ({e}). Try `winpodx pod start --wait`.")
+        return
+
+    # Pod is running — three idempotent applies.
+    failures: list[str] = []
+    for name, fn in (
+        ("max_sessions", _apply_max_sessions),
+        ("rdp_timeouts", _apply_rdp_timeouts),
+        ("oem_runtime_fixes", _apply_oem_runtime_fixes),
+    ):
+        try:
+            fn(cfg)
+        except Exception as e:  # noqa: BLE001
+            failures.append(f"{name}: {e}")
+
+    if failures:
+        print("  warning: some applies failed (others may have succeeded):")
+        for f in failures:
+            print(f"    - {f}")
+        print(
+            "  Re-run `winpodx migrate` after fixing the underlying issue, "
+            "or recreate the container as a last resort."
+        )
+    else:
+        print(
+            "  OK: applied to existing guest (no container recreate needed). "
+            "RDP timeouts / NIC power-save / TermService recovery now active."
+        )
 
 
 def _attempt_refresh() -> None:

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -37,6 +37,19 @@ def ensure_ready(cfg: Config | None = None, timeout: int = 300) -> Config:
     _check_rotation_pending()
     cfg = _auto_rotate_password(cfg)
 
+    # v0.1.9.2: probe pod state once and run idempotent runtime fixes BEFORE
+    # the RDP-port early-return. install.bat changes only land on first boot
+    # of a new container; without this block, existing 0.1.x guests would
+    # never pick up OEM v7/v8 changes (NIC power-save, TermService failure
+    # recovery, RDP timeouts, max_sessions sync) until they recreated their
+    # container. Each apply is idempotent — `Set-ItemProperty -Force` is a
+    # no-op when the value already matches — so running them on every
+    # ensure_ready is cheap (~1.5s overhead) and self-healing.
+    if cfg.pod.backend in ("podman", "docker") and pod_status(cfg).state == PodState.RUNNING:
+        _apply_max_sessions(cfg)
+        _apply_rdp_timeouts(cfg)
+        _apply_oem_runtime_fixes(cfg)
+
     if check_rdp_port(cfg.rdp.ip, cfg.rdp.port, timeout=0.3):
         return cfg
 
@@ -50,8 +63,12 @@ def ensure_ready(cfg: Config | None = None, timeout: int = 300) -> Config:
     ensure_pod_awake(cfg)
 
     _ensure_pod_running(cfg, timeout)
+    # Re-apply once more after starting (cold-pod path); same idempotency
+    # guarantees mean this only does work the first time after a fresh
+    # start. The earlier branch handles the warm-pod case.
     _apply_max_sessions(cfg)
     _apply_rdp_timeouts(cfg)
+    _apply_oem_runtime_fixes(cfg)
     # Bug B: after host suspend / long idle the pod can be running but RDP
     # itself is dead while VNC is fine. Probe and try to revive TermService
     # before handing the cfg to the caller — the alternative is the FreeRDP
@@ -190,6 +207,60 @@ def _apply_max_sessions(cfg: Config) -> None:
     else:
         log.warning(
             "max_sessions: apply rc=%d stderr=%s",
+            result.returncode,
+            result.stderr.strip(),
+        )
+
+
+def _apply_oem_runtime_fixes(cfg: Config) -> None:
+    """v0.1.9.2: bring existing 0.1.x guests up to OEM v7+ baseline at runtime.
+
+    install.bat only runs at dockur's unattended first boot. Users who
+    installed under OEM v6 (winpodx 0.1.6) don't get the v7 NIC
+    power-save off + TermService failure-recovery actions, and v8 RDP
+    timeouts (those are covered by ``_apply_rdp_timeouts``). Without
+    this helper they'd have to recreate the container to get any
+    Windows-side fix shipped after their first install.
+
+    Stays idempotent — Set-NetAdapterPowerManagement / sc.exe failure
+    are no-op when state already matches. Failure is non-fatal:
+    log warning + return so a flaky exec doesn't block ensure_ready.
+    """
+    if cfg.pod.backend not in ("podman", "docker"):
+        return
+
+    runtime = "podman" if cfg.pod.backend == "podman" else "docker"
+    ps_exe = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+
+    apply_script = (
+        # v0.1.9 OEM v7: stop Windows from putting the virtual NIC to sleep.
+        "$ErrorActionPreference = 'SilentlyContinue'; "
+        "Get-NetAdapter | Where-Object { $_.Status -ne 'Disabled' } | "
+        "Set-NetAdapterPowerManagement -AllowComputerToTurnOffDevice $false; "
+        # v0.1.9 OEM v7: TermService recovery actions (3 attempts at 5s, 24h reset).
+        # `sc.exe failure` is non-PowerShell but we can shell to it.
+        "& sc.exe failure TermService reset= 86400 "
+        "actions= restart/5000/restart/5000/restart/5000 | Out-Null"
+    )
+    cmd = [
+        runtime,
+        "exec",
+        cfg.pod.container_name,
+        ps_exe,
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        apply_script,
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        log.warning("oem_runtime_fixes: apply failed: %s", e)
+        return
+    if result.returncode != 0:
+        log.warning(
+            "oem_runtime_fixes: rc=%d stderr=%s",
             result.returncode,
             result.stderr.strip(),
         )

--- a/tests/test_provisioner.py
+++ b/tests/test_provisioner.py
@@ -306,3 +306,118 @@ def test_apply_rdp_timeouts_tolerates_timeout(monkeypatch):
     monkeypatch.setattr(provisioner.subprocess, "run", boom)
     # Must swallow the exception.
     provisioner._apply_rdp_timeouts(cfg)
+
+
+# --- v0.1.9.2: _apply_oem_runtime_fixes + ensure_ready early-apply path ---
+
+
+def test_apply_oem_runtime_fixes_skips_libvirt():
+    from winpodx.core import provisioner
+    from winpodx.core.config import Config
+
+    cfg = Config()
+    cfg.pod.backend = "libvirt"
+    provisioner._apply_oem_runtime_fixes(cfg)  # must not raise / not subprocess
+
+
+def test_apply_oem_runtime_fixes_writes_nic_and_termservice(monkeypatch):
+    from unittest.mock import MagicMock
+
+    from winpodx.core import provisioner
+    from winpodx.core.config import Config
+
+    cfg = Config()
+    captured = []
+
+    def fake_run(cmd, **kw):
+        captured.append(cmd)
+        m = MagicMock()
+        m.returncode = 0
+        m.stderr = ""
+        return m
+
+    monkeypatch.setattr(provisioner.subprocess, "run", fake_run)
+    provisioner._apply_oem_runtime_fixes(cfg)
+    assert len(captured) == 1
+    script = captured[0][-1]
+    assert "Set-NetAdapterPowerManagement" in script
+    assert "AllowComputerToTurnOffDevice" in script
+    assert "sc.exe failure TermService" in script
+    assert "restart/5000/restart/5000/restart/5000" in script
+
+
+def test_apply_oem_runtime_fixes_tolerates_timeout(monkeypatch):
+    from winpodx.core import provisioner
+    from winpodx.core.config import Config
+
+    cfg = Config()
+
+    def boom(cmd, **kw):
+        raise provisioner.subprocess.TimeoutExpired(cmd, kw.get("timeout", 0))
+
+    monkeypatch.setattr(provisioner.subprocess, "run", boom)
+    provisioner._apply_oem_runtime_fixes(cfg)
+
+
+def test_ensure_ready_runs_apply_before_early_return_when_rdp_alive(monkeypatch):
+    """v0.1.9.2: existing healthy pods must still get runtime fixes applied."""
+    from winpodx.core import provisioner
+    from winpodx.core.config import Config
+    from winpodx.core.pod import PodState, PodStatus
+
+    cfg = Config()
+    cfg.pod.backend = "podman"
+
+    monkeypatch.setattr(provisioner, "_check_rotation_pending", lambda: None)
+    monkeypatch.setattr(provisioner, "_auto_rotate_password", lambda c: c)
+    monkeypatch.setattr(provisioner, "_ensure_config", lambda: cfg)
+    monkeypatch.setattr(provisioner, "pod_status", lambda c: PodStatus(state=PodState.RUNNING))
+    # RDP alive -> must trigger early return AFTER runtime apply.
+    monkeypatch.setattr(provisioner, "check_rdp_port", lambda *a, **k: True)
+
+    calls = {"max_sessions": 0, "rdp_timeouts": 0, "oem_runtime_fixes": 0}
+
+    def make_recorder(name):
+        def f(c):
+            calls[name] += 1
+
+        return f
+
+    monkeypatch.setattr(provisioner, "_apply_max_sessions", make_recorder("max_sessions"))
+    monkeypatch.setattr(provisioner, "_apply_rdp_timeouts", make_recorder("rdp_timeouts"))
+    monkeypatch.setattr(provisioner, "_apply_oem_runtime_fixes", make_recorder("oem_runtime_fixes"))
+
+    result = provisioner.ensure_ready(cfg, timeout=1)
+    assert result is cfg
+    # All three idempotent applies fired exactly once even though the
+    # function early-returned at the RDP-port check.
+    assert calls == {"max_sessions": 1, "rdp_timeouts": 1, "oem_runtime_fixes": 1}
+
+
+def test_ensure_ready_skips_apply_when_pod_not_running(monkeypatch):
+    """When pod isn't running, the early-apply branch is skipped (later branch handles)."""
+    from winpodx.core import provisioner
+    from winpodx.core.config import Config
+    from winpodx.core.pod import PodState, PodStatus
+
+    cfg = Config()
+    cfg.pod.backend = "podman"
+
+    monkeypatch.setattr(provisioner, "_check_rotation_pending", lambda: None)
+    monkeypatch.setattr(provisioner, "_auto_rotate_password", lambda c: c)
+    monkeypatch.setattr(provisioner, "_ensure_config", lambda: cfg)
+    monkeypatch.setattr(provisioner, "pod_status", lambda c: PodStatus(state=PodState.STOPPED))
+    monkeypatch.setattr(provisioner, "check_rdp_port", lambda *a, **k: True)
+    early_calls = {"n": 0}
+
+    def recorder(c):
+        early_calls["n"] += 1
+
+    monkeypatch.setattr(provisioner, "_apply_oem_runtime_fixes", recorder)
+    monkeypatch.setattr(provisioner, "_apply_max_sessions", recorder)
+    monkeypatch.setattr(provisioner, "_apply_rdp_timeouts", recorder)
+
+    provisioner.ensure_ready(cfg, timeout=1)
+    # Stopped pod -> the early-branch `pod_status==RUNNING` guard prevents
+    # the apply calls from firing on the early return path.
+    assert early_calls["n"] == 0


### PR DESCRIPTION
Hotfix for kernalix7's report: \"마이그레이션 잘 되는거 맞아? 윈도에 적용 안되는거같은데\" — confirmed: v0.1.9 / v0.1.9.1 Windows-side fixes were NOT reaching existing guests.

## Two compounding bugs

### Bug 1 — install.bat only runs on fresh container

OEM script changes (v7 NIC power-save / TermService failure recovery, v8 RDP timeouts) only apply when dockur runs unattended setup on a brand-new container. Existing 0.1.x users would never receive them without nuking their pod + redoing the 5-10 minute Windows install.

### Bug 2 — \`_apply_rdp_timeouts\` runtime helper was unreachable on healthy pods

\`provisioner.ensure_ready\` short-circuits when RDP is already responsive. The v0.1.9.1 helper was wired AFTER that early-return:

\`\`\`python
if check_rdp_port(...):
    return cfg                     # ← healthy pods exit here
...
_apply_rdp_timeouts(cfg)            # ← never reached
\`\`\`

Result: every existing user with a working pod silently received zero of the v0.1.9.1 fixes.

## Three changes

1. **\`provisioner.ensure_ready\`** — probe \`pod_status\` at the top and run the three idempotent applies BEFORE the early-return. Re-applied after pod-start on the cold-pod path. ~1.5s overhead, all no-ops on second call.

2. **\`provisioner._apply_oem_runtime_fixes(cfg)\`** (new) — pipes OEM v7 baseline (NIC \`Set-NetAdapterPowerManagement\` + \`sc.exe failure TermService\`) to existing guests via the same \`podman exec\` stdin-pipe transport discovery uses. Joins the family alongside \`_apply_max_sessions\` and \`_apply_rdp_timeouts\`.

3. **\`winpodx migrate\`** — when crossing the 0.1.9 boundary, proactively calls all three apply helpers (with pod-state probe and interactive offer to start a stopped pod). Per-helper success/failure output so users can see what landed.

## Test plan

- [x] \`pytest tests/ -v\` — 371 passed (366 + 5 new)
- [x] \`ruff check src/ tests/\` — clean
- [x] \`ruff format --check\` — clean
- [x] New tests cover: \`_apply_oem_runtime_fixes\` libvirt skip / NIC+TermService present / timeout tolerance, \`ensure_ready\` early-apply path firing when RDP alive + pod RUNNING, early-apply path skipped when pod STOPPED.

Manual verification on real hardware after merge:
- [ ] Existing 0.1.7 / 0.1.8 / 0.1.9 / 0.1.9.1 guest: \`winpodx migrate\` reports the runtime apply step as successful.
- [ ] Same guest: 1h+ idle session no longer disconnects.
- [ ] Same guest: \`winpodx app run desktop\` triggers ensure_ready, applies fire silently and the pod is unchanged-but-fixed.

## Architectural note (out of scope)

This release establishes the \"runtime apply\" pattern as the way to ship Windows-side fixes for existing pods. v0.2.0's planned guest agent will subsume these helpers behind a unified channel. Some changes (disk_size, dockur image swap, unattend.xml, compose.yml) still require container recreation — those will remain documented as breaking-update territory.