### PR TITLE
release: v0.1.9.3 — pod apply-fixes (CLI + GUI) + always-apply migrate path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [0.1.9.3] - 2026-04-26
+
+### Fixed
+- **Patch-version migrate skipped Windows-side apply ("already current" trap).** kernalix7 upgraded from 0.1.9.x to 0.1.9.2 and got `winpodx 0.1.9.2: already current. Nothing to migrate.` — but the actual Windows guest never received the v0.1.9.1 RDP-timeout / v0.1.9.2 OEM v7-baseline runtime fixes. Root cause: `_version_tuple(...)[:3]` truncated `0.1.9.1` and `0.1.9.2` to the same `(0, 1, 9)` tuple, so `inst_cmp >= cur_cmp` triggered the early-return BEFORE the runtime apply step ran. Migrate now still runs the idempotent runtime apply on the "already current" path so patch-version users still receive Windows-side fixes shipped after their last successful migrate.
+
+### Added
+- **`winpodx pod apply-fixes`** standalone CLI command. Idempotent — calls `_apply_max_sessions`, `_apply_rdp_timeouts`, `_apply_oem_runtime_fixes` against the running pod and prints a per-helper OK/FAIL table. Exit code 0 on full success, 2 if pod isn't running / backend unsupported, 3 if any helper failed. Safe to re-run any time.
+- **GUI Tools-page "Apply Windows Fixes" button.** Same runtime apply triggered from the Qt GUI — fires the helpers on a worker thread, surfaces success / failure via the existing toast/info-label channel. Useful for users who want the fixes applied without dropping to the CLI.
+- **install.sh auto-fires `winpodx pod apply-fixes`** at the end of every install, after the migrate wizard. Failure-tolerant (`|| true`) — silent skip if the pod isn't running. This guarantees a fresh `curl | bash` always lands the latest Windows-side fixes on existing guests, regardless of whether migrate's version comparison saw a "real" upgrade.
+- **Public `provisioner.apply_windows_runtime_fixes(cfg)` API** returning a `{helper_name: "ok" | "failed: ..."}` map so the CLI / GUI / migrate paths share a single entry point and surface uniform per-helper status.
+
 ## [0.1.9.2] - 2026-04-26
 
 ### Fixed

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,28 @@
+winpodx (0.1.9.3) unstable; urgency=high
+
+  * Fixed: patch-version migrate skipped the Windows-side apply.
+    `_version_tuple(...)[:3]` truncated 0.1.9.1 and 0.1.9.2 to the same
+    (0, 1, 9) tuple, so migrate exited with "already current" before
+    the runtime apply step. Now runs the idempotent apply even on the
+    "already current" path so patch-version users still receive fixes
+    shipped after their last successful migrate.
+  * Added: standalone `winpodx pod apply-fixes` CLI command.
+    Idempotent runtime apply with per-helper OK/FAIL output. Exits 0
+    on full success, 2 on pod-not-running / backend unsupported, 3 on
+    helper failure.
+  * Added: "Apply Windows Fixes" button on the GUI Tools page —
+    fires the same runtime apply on a worker thread.
+  * Added: install.sh auto-invokes `winpodx pod apply-fixes` at the
+    end of every install (after migrate). Failure-tolerant; silent
+    skip if pod isn't running. Guarantees `curl | bash` always
+    delivers the latest Windows-side fixes regardless of migrate's
+    version comparison verdict.
+  * Added: public `provisioner.apply_windows_runtime_fixes(cfg)` API
+    returning a per-helper status dict — single entry point shared by
+    CLI / GUI / migrate paths.
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Sun, 26 Apr 2026 05:30:00 +0900
+
 winpodx (0.1.9.2) unstable; urgency=high
 
   * Fixed: Windows-side fixes from v0.1.9 / v0.1.9.1 (NIC power-save off,

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,17 @@
 
 ## [Unreleased]
 
+## [0.1.9.3] - 2026-04-26
+
+### 수정
+- **Patch 버전 migrate 가 Windows-측 apply 를 건너뛰던 "already current" 트랩.** kernalix7 이 0.1.9.x 에서 0.1.9.2 로 업그레이드 후 `winpodx 0.1.9.2: already current. Nothing to migrate.` 만 보고 실제 Windows 게스트엔 v0.1.9.1 RDP-timeout / v0.1.9.2 OEM v7-baseline runtime 수정이 들어가지 않음. 원인: `_version_tuple(...)[:3]` 이 `0.1.9.1` 과 `0.1.9.2` 를 같은 `(0, 1, 9)` 튜플로 자르므로 `inst_cmp >= cur_cmp` 가 runtime apply 단계 **앞에서** early-return 시킴. 이제 "already current" 경로에서도 idempotent runtime apply 가 항상 실행됨.
+
+### 추가
+- **`winpodx pod apply-fixes`** 독립 CLI 명령. Idempotent — `_apply_max_sessions`, `_apply_rdp_timeouts`, `_apply_oem_runtime_fixes` 를 실행 중인 pod 에 호출하고 헬퍼별 OK/FAIL 테이블 출력. 성공 시 exit 0, pod 미실행/백엔드 미지원 시 2, 헬퍼 실패 시 3. 언제든 재실행 안전.
+- **GUI Tools 페이지 "Apply Windows Fixes" 버튼.** 동일한 runtime apply 를 Qt GUI 에서 트리거 — worker thread 에서 헬퍼 호출, 기존 toast/info-label 채널로 성공/실패 표시. CLI 안 쓰고 GUI 만으로 적용 가능.
+- **install.sh 가 매 설치 마지막에 `winpodx pod apply-fixes` 자동 호출.** migrate 위자드 다음 단계로 실행. `|| true` 로 실패 무해 — pod 안 켜져 있으면 silent skip. `curl | bash` 한 번이면 항상 최신 Windows-측 수정사항이 기존 게스트에 적용됨, migrate 의 버전 비교가 "진짜" 업그레이드를 봤는지와 무관.
+- **공개 API `provisioner.apply_windows_runtime_fixes(cfg)`** — `{helper_name: "ok" | "failed: ..."}` 맵 반환. CLI / GUI / migrate 경로가 단일 진입점 공유.
+
 ## [0.1.9.2] - 2026-04-26
 
 ### 수정

--- a/install.sh
+++ b/install.sh
@@ -418,6 +418,13 @@ log "Installed winpodx GUI launcher and icon"
 if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_MIGRATE:-}" != "1" ]; then
     log "Running post-upgrade migration wizard..."
     "$HOME/.local/bin/winpodx" migrate || true
+    # v0.1.9.3: also fire the standalone apply-fixes command. migrate's
+    # version-comparison can short-circuit ("already current") if the
+    # marker matches — but the Windows-side apply still needs to run,
+    # because patch-version bumps collapse to the same (X,Y,Z) tuple.
+    # `pod apply-fixes` is idempotent and self-skips when the pod is
+    # stopped, so this is safe to call unconditionally.
+    "$HOME/.local/bin/winpodx" pod apply-fixes 2>/dev/null || true
 fi
 
 # --- Done ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.1.9.2"
+version = "0.1.9.3"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.1.9.2"
+__version__ = "0.1.9.3"

--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -76,6 +76,14 @@ def cli(argv: list[str] | None = None) -> None:
     pod_sub.add_parser("stop", help="Stop the pod")
     pod_sub.add_parser("status", help="Show pod status")
     pod_sub.add_parser("restart", help="Restart the pod")
+    pod_sub.add_parser(
+        "apply-fixes",
+        help=(
+            "Apply Windows-side runtime fixes (RDP timeouts, NIC power-save, "
+            "TermService recovery, MaxSessions) to the existing pod. "
+            "Idempotent — safe to run any time."
+        ),
+    )
 
     # --- config ---
     cfg_parser = sub.add_parser("config", help="Manage configuration")

--- a/src/winpodx/cli/migrate.py
+++ b/src/winpodx/cli/migrate.py
@@ -98,7 +98,15 @@ def run_migrate(args: argparse.Namespace) -> int:
 
     if inst_cmp >= cur_cmp:
         _write_installed_version(current)
-        print(f"winpodx {current}: already current. Nothing to migrate.")
+        print(f"winpodx {current}: already current.")
+        # v0.1.9.3: even on "already current" still run the idempotent
+        # Windows-side apply. Patch versions (0.1.9.x) collapse to the
+        # same (0,1,9) tuple under [:3] truncation, so without this an
+        # upgrade from 0.1.9.0 -> 0.1.9.2 would skip the apply entirely
+        # — exactly the bug kernalix7 hit. Helpers are idempotent so a
+        # no-op run is harmless if everything was already applied.
+        non_interactive = bool(getattr(args, "non_interactive", False))
+        _apply_runtime_fixes_to_existing_guest(non_interactive)
         return 0
 
     print(f"winpodx: {installed} -> {current} detected\n")

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -17,8 +17,10 @@ def handle_pod(args: argparse.Namespace) -> None:
         _status()
     elif cmd == "restart":
         _restart()
+    elif cmd == "apply-fixes":
+        _apply_fixes()
     else:
-        print("Usage: winpodx pod {start|stop|status|restart}")
+        print("Usage: winpodx pod {start|stop|status|restart|apply-fixes}")
         sys.exit(1)
 
 
@@ -98,6 +100,53 @@ def _status() -> None:
 
     if s.error:
         print(f"Error:    {s.error}")
+
+
+def _apply_fixes() -> None:
+    """v0.1.9.3: standalone idempotent runtime apply for existing guests.
+
+    Use case: user upgraded from 0.1.6/0.1.7/0.1.8/0.1.9.x but migrate
+    short-circuited with "already current" so the OEM v7+v8 runtime
+    fixes never landed on their actual Windows VM. This command pushes
+    them all in one shot. Safe to re-run any time — every helper is
+    idempotent.
+    """
+    from winpodx.core.config import Config
+    from winpodx.core.pod import PodState, pod_status
+    from winpodx.core.provisioner import apply_windows_runtime_fixes
+
+    cfg = Config.load()
+
+    if cfg.pod.backend not in ("podman", "docker"):
+        print(
+            f"Backend {cfg.pod.backend!r} doesn't support runtime apply. "
+            "Recreate your container after upgrading to pick up Windows-side fixes."
+        )
+        sys.exit(2)
+
+    state = pod_status(cfg).state
+    if state != PodState.RUNNING:
+        print(f"Pod is {state.value}, not running.")
+        print("Start the pod first with: winpodx pod start --wait")
+        sys.exit(2)
+
+    print("Applying Windows-side runtime fixes...")
+    results = apply_windows_runtime_fixes(cfg)
+
+    failures = []
+    for name, status_str in results.items():
+        marker = "OK" if status_str == "ok" else "FAIL"
+        print(f"  [{marker}] {name}: {status_str}")
+        if status_str != "ok":
+            failures.append(name)
+
+    if failures:
+        print(
+            f"\n{len(failures)} of {len(results)} apply(s) failed. "
+            "Check `winpodx info` and try again, or recreate the container."
+        )
+        sys.exit(3)
+    print("\nAll fixes applied to existing guest (no container recreate needed).")
 
 
 def _restart() -> None:

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -212,6 +212,36 @@ def _apply_max_sessions(cfg: Config) -> None:
         )
 
 
+def apply_windows_runtime_fixes(cfg: Config) -> dict[str, str]:
+    """Public entry point: run all idempotent Windows-side runtime applies.
+
+    Used by the standalone ``winpodx pod apply-fixes`` CLI command, the
+    GUI Tools-page button, and v0.1.9.3+ migrate (which always invokes
+    this regardless of version comparison so users on a "already current"
+    marker still receive fixes that landed in patch releases).
+
+    Returns a per-helper result map: ``{helper_name: "ok" | "failed: ..."}``
+    so the caller can render success/failure rows. Backend gating returns
+    ``{"backend": "skipped (libvirt/manual not supported)"}`` so the caller
+    knows nothing was attempted.
+    """
+    if cfg.pod.backend not in ("podman", "docker"):
+        return {"backend": f"skipped (backend={cfg.pod.backend} not supported)"}
+
+    results: dict[str, str] = {}
+    for name, fn in (
+        ("max_sessions", _apply_max_sessions),
+        ("rdp_timeouts", _apply_rdp_timeouts),
+        ("oem_runtime_fixes", _apply_oem_runtime_fixes),
+    ):
+        try:
+            fn(cfg)
+            results[name] = "ok"
+        except Exception as e:  # noqa: BLE001
+            results[name] = f"failed: {e}"
+    return results
+
+
 def _apply_oem_runtime_fixes(cfg: Config) -> None:
     """v0.1.9.2: bring existing 0.1.x guests up to OEM v7+ baseline at runtime.
 

--- a/src/winpodx/gui/main_window.py
+++ b/src/winpodx/gui/main_window.py
@@ -1094,6 +1094,12 @@ class WinpodxWindow(QMainWindow):
                 "Disable telemetry & ads",
                 self._on_debloat,
             ),
+            (
+                "\u2699",  # gear
+                "Apply Windows Fixes",
+                "Re-apply RDP timeout / NIC / TermService recovery to existing pod",
+                self._on_apply_fixes,
+            ),
         ]
         for i, (icon, label, desc, handler) in enumerate(sys_tools):
             layout.addWidget(self._make_action_row(icon, label, desc, handler, i + 3))
@@ -2081,6 +2087,51 @@ class WinpodxWindow(QMainWindow):
                 except (subprocess.TimeoutExpired, FileNotFoundError):
                     pass
             self.pod_status_updated.emit("running", cfg.rdp.ip)
+
+        threading.Thread(target=_do, daemon=True).start()
+
+    def _on_apply_fixes(self) -> None:
+        """v0.1.9.3: Apply Windows-side runtime fixes to the existing pod.
+
+        Same idempotent helpers fired by `winpodx pod apply-fixes` and by
+        `provisioner.ensure_ready` — but on demand from the GUI for users
+        whose migrate short-circuited with "already current" so the
+        Windows VM never received the OEM v7+v8 fixes.
+        """
+        self.info_label.setText("Applying Windows-side fixes...")
+
+        def _do() -> None:
+            from winpodx.core.pod import PodState, pod_status
+            from winpodx.core.provisioner import apply_windows_runtime_fixes
+
+            cfg = Config.load()
+            try:
+                state = pod_status(cfg).state
+            except Exception as e:  # noqa: BLE001
+                self.app_launch_failed.emit(f"Apply fixes failed (pod probe): {e}")
+                return
+
+            if state != PodState.RUNNING:
+                self.app_launch_failed.emit(
+                    "Pod is not running — start it first via the Apps page or "
+                    "`winpodx pod start --wait`."
+                )
+                return
+
+            try:
+                results = apply_windows_runtime_fixes(cfg)
+            except Exception as e:  # noqa: BLE001
+                self.app_launch_failed.emit(f"Apply fixes raised: {e}")
+                return
+
+            ok_count = sum(1 for v in results.values() if v == "ok")
+            total = len(results)
+            failed = [k for k, v in results.items() if v != "ok"]
+            if failed:
+                detail = ", ".join(failed)
+                self.app_launch_failed.emit(f"Apply fixes: {ok_count}/{total} OK; failed: {detail}")
+            else:
+                self.app_launched.emit(f"Windows-side fixes applied ({ok_count}/{total} OK)")
 
         threading.Thread(target=_do, daemon=True).start()
 

--- a/tests/test_provisioner.py
+++ b/tests/test_provisioner.py
@@ -421,3 +421,53 @@ def test_ensure_ready_skips_apply_when_pod_not_running(monkeypatch):
     # Stopped pod -> the early-branch `pod_status==RUNNING` guard prevents
     # the apply calls from firing on the early return path.
     assert early_calls["n"] == 0
+
+
+# --- v0.1.9.3: apply_windows_runtime_fixes public API ---
+
+
+def test_apply_windows_runtime_fixes_skips_libvirt():
+    from winpodx.core import provisioner
+    from winpodx.core.config import Config
+
+    cfg = Config()
+    cfg.pod.backend = "libvirt"
+    result = provisioner.apply_windows_runtime_fixes(cfg)
+    assert "backend" in result
+    assert "skipped" in result["backend"]
+
+
+def test_apply_windows_runtime_fixes_returns_per_helper_status(monkeypatch):
+    from unittest.mock import MagicMock
+
+    from winpodx.core import provisioner
+    from winpodx.core.config import Config
+
+    cfg = Config()
+    monkeypatch.setattr(
+        provisioner.subprocess,
+        "run",
+        lambda *a, **k: MagicMock(returncode=0, stdout="", stderr=""),
+    )
+    result = provisioner.apply_windows_runtime_fixes(cfg)
+    assert set(result.keys()) == {"max_sessions", "rdp_timeouts", "oem_runtime_fixes"}
+    for v in result.values():
+        assert v == "ok"
+
+
+def test_apply_windows_runtime_fixes_records_individual_failures(monkeypatch):
+    from winpodx.core import provisioner
+    from winpodx.core.config import Config
+
+    cfg = Config()
+
+    def fake_max_sessions(c):
+        raise RuntimeError("boom max_sessions")
+
+    monkeypatch.setattr(provisioner, "_apply_max_sessions", fake_max_sessions)
+    monkeypatch.setattr(provisioner, "_apply_rdp_timeouts", lambda c: None)
+    monkeypatch.setattr(provisioner, "_apply_oem_runtime_fixes", lambda c: None)
+    result = provisioner.apply_windows_runtime_fixes(cfg)
+    assert result["max_sessions"].startswith("failed: ")
+    assert result["rdp_timeouts"] == "ok"
+    assert result["oem_runtime_fixes"] == "ok"


### PR DESCRIPTION
Hotfix for kernalix7's report on the v0.1.9.2 install:

\`\`\`
[winpodx] Running post-upgrade migration wizard...
winpodx 0.1.9.2: already current. Nothing to migrate.
\`\`\`

migrate exited "already current" before firing the runtime-apply step, so the user's Windows guest never received the v0.1.9.x fixes.

## Root cause

\`_version_tuple("0.1.9.1")[:3]\` and \`_version_tuple("0.1.9.2")[:3]\` both collapse to \`(0, 1, 9)\`. The \`inst_cmp >= cur_cmp\` check triggered before runtime-apply ran. Patch-version bumps to anyone already on \`0.1.9.x\` look identical to migrate.

## Three changes

1. **migrate always runs the apply** — even on "already current" path. Helpers are idempotent.

2. **\`winpodx pod apply-fixes\` standalone CLI** — manual trigger any time, no upgrade required. Prints per-helper [OK]/[FAIL] table. Exit 0 / 2 (pod down) / 3 (helper failed).

3. **GUI Tools-page button "Apply Windows Fixes"** — same flow, no terminal needed. Worker-thread + toast / info-label signal.

4. **install.sh auto-fires apply-fixes** at install end. Silent skip when pod is stopped. Guarantees \`curl | bash\` lands the latest Windows-side fixes regardless of migrate's verdict.

5. **public API \`provisioner.apply_windows_runtime_fixes(cfg)\`** — single entry point returning \`{helper_name: "ok" | "failed: ..."}\`, shared by CLI / GUI / migrate.

## Test plan

- [x] \`pytest tests/ -v\` — 374 passed (371 + 3 new for the public API)
- [x] \`ruff check\` / \`ruff format --check\` — clean
- [x] GUI imports cleanly

Manual:
- [ ] kernalix7's exact scenario: upgrade 0.1.9.x → 0.1.9.3 via \`curl | bash\`. Migrate may still say "already current" but the apply-fixes pass that follows it (in install.sh) should fire and report per-helper status.
- [ ] \`winpodx pod apply-fixes\` from a fresh shell — same per-helper output.
- [ ] GUI Tools page → "Apply Windows Fixes" button — toast confirms application.

## Architectural note

Going forward every Windows-side change should ship with both a runtime helper AND tests that verify the helper fires — not just \`reg add\` lines in install.bat. v0.2.0 guest-agent will subsume these into a unified channel; until then this CLI/GUI/migrate triple-entry is how we route around install.bat being first-boot-only.