### PR TITLE
release: v0.1.9.4 — runtime apply via FreeRDP RemoteApp (no more silent no-ops)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [0.1.9.4] - 2026-04-26
+
+### Fixed
+- **Runtime apply finally actually applies.** kernalix7 reported on 2026-04-26 that v0.1.9.1 / v0.1.9.2 / v0.1.9.3 runtime apply paths were silently failing — `podman exec winpodx-windows ...\powershell.exe` returned `rc=127 executable file not found in $PATH`. Root cause: `podman exec` runs commands in the **Linux container** that hosts QEMU, not in the **Windows VM** running inside QEMU; the Linux container has no `powershell.exe`. The helpers (`_apply_max_sessions`, `_apply_rdp_timeouts`, `_apply_oem_runtime_fixes`, `_change_windows_password`) all logged a warning and returned, while the public-facing `apply_windows_runtime_fixes` reported per-helper "ok" because the helpers didn't `raise`. So three previous releases shipped silent no-ops. Three changes:
+  1. **New `core/windows_exec.py`** — `run_in_windows(cfg, ps_payload)` launches PowerShell as a FreeRDP RemoteApp and pipes the script through the existing `\\tsclient\home` redirection. Wrapper writes `{rc, stdout, stderr}` JSON back via the same share. The host parses it and returns `WindowsExecResult`. Channel failures (FreeRDP missing, auth fail, timeout, no result file) raise `WindowsExecError`; non-zero script rc surfaces via `WindowsExecResult.rc`.
+  2. **`_apply_max_sessions`, `_apply_rdp_timeouts`, `_apply_oem_runtime_fixes` rewritten** — each builds a PS payload, calls `run_in_windows`, and now `raise RuntimeError` on `rc != 0` so failures actually propagate.
+  3. **`apply_windows_runtime_fixes` honest reporting** — `try/except` on each helper still works the same way, but now an actual `rc != 0` from inside the Windows VM produces `failed: rc=2 ...` instead of fake `ok`.
+
+  Cost: ~5–10 s per call (RDP handshake + auth + script + disconnect) plus a brief PowerShell window flash that `-WindowStyle Hidden` minimizes. Trade-off: works on existing pods (no container recreate) and the rc check actually means something.
+
+  **Caveat**: requires `cfg.rdp.password` to match the Windows guest's actual password. If password rotation has been silently failing for previous releases (same `podman exec` root cause), the first call here will fail with auth error and the user has to reset the Windows-side password (open `winpodx app run desktop`, run `net user User <password-from-config>`).
+
+### Tests
+- 9 new tests in `tests/test_windows_exec.py` covering the full lifecycle: FreeRDP missing, password missing, timeout, no-result-file (auth fail), happy path with result-file roundtrip, non-zero rc propagation, FreeRDP `/app:program:` cmd shape verification, flatpak-style binary splitting, unparseable result JSON.
+- `tests/test_provisioner.py` rewritten to mock `windows_exec.run_in_windows` instead of `subprocess.run`. New tests assert each helper raises `RuntimeError` on `rc != 0` and `WindowsExecError` on channel failure.
+
 ## [0.1.9.3] - 2026-04-26
 
 ### Fixed

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,32 @@
+winpodx (0.1.9.4) unstable; urgency=high
+
+  * Fixed: runtime applies were silent no-ops in v0.1.9.1, v0.1.9.2, and
+    v0.1.9.3. `podman exec winpodx-windows ...\powershell.exe` returns
+    rc=127 because podman exec runs in the Linux container that hosts
+    QEMU, not the Windows VM inside. The helpers logged warnings and
+    returned, while `apply_windows_runtime_fixes` reported "ok" because
+    the helpers didn't raise. Three previous releases shipped fake
+    success.
+    - New `core/windows_exec.py`: `run_in_windows(cfg, ps_payload)`
+      launches PowerShell as a FreeRDP RemoteApp and pipes the script
+      through the `\\tsclient\home` redirection. Wrapper writes
+      {rc,stdout,stderr} JSON back via the same share. Channel
+      failures (FreeRDP missing, auth fail, timeout, no result file)
+      raise WindowsExecError; non-zero script rc surfaces via
+      WindowsExecResult.rc.
+    - `_apply_max_sessions`, `_apply_rdp_timeouts`, and
+      `_apply_oem_runtime_fixes` rewritten to call run_in_windows and
+      raise RuntimeError on rc != 0.
+    - `apply_windows_runtime_fixes` honest reporting: an actual rc != 0
+      now produces "failed: rc=2 ..." instead of fake "ok".
+
+  Cost: ~5-10s per call. Trade-off: works on existing pods (no
+  container recreate). Caveat: requires cfg.rdp.password to match the
+  Windows guest's actual password — auth fail on first call means user
+  has to manually sync via `winpodx app run desktop` + `net user`.
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Sun, 26 Apr 2026 14:30:00 +0900
+
 winpodx (0.1.9.3) unstable; urgency=high
 
   * Fixed: patch-version migrate skipped the Windows-side apply.

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,22 @@
 
 ## [Unreleased]
 
+## [0.1.9.4] - 2026-04-26
+
+### 수정
+- **Runtime apply 가 드디어 실제로 적용됨.** kernalix7 이 2026-04-26 에 v0.1.9.1 / v0.1.9.2 / v0.1.9.3 의 runtime apply 가 silently 실패하고 있다고 보고: `podman exec winpodx-windows ...\powershell.exe` 가 `rc=127 executable file not found in $PATH` 반환. 근본 원인: `podman exec` 는 QEMU 를 호스팅하는 **Linux 컨테이너 안**에서 명령을 실행하지, QEMU 안에서 도는 **Windows VM** 에선 안 돈다. Linux 컨테이너엔 `powershell.exe` 가 없음. 헬퍼들 (`_apply_max_sessions`, `_apply_rdp_timeouts`, `_apply_oem_runtime_fixes`, `_change_windows_password`) 이 모두 warning 만 로그하고 return 하는데, 공개 `apply_windows_runtime_fixes` 는 헬퍼가 raise 안 하니까 "ok" 로 보고. → 3개 릴리즈가 silent no-op 을 ship 했음. 3개 변경:
+  1. **신규 `core/windows_exec.py`** — `run_in_windows(cfg, ps_payload)` 가 FreeRDP RemoteApp 으로 PowerShell 을 띄우고 기존 `\\tsclient\home` 리다이렉션으로 스크립트 파이핑. wrapper 가 `{rc, stdout, stderr}` JSON 을 같은 share 로 다시 씀. 호스트가 파싱해서 `WindowsExecResult` 반환. 채널 실패 (FreeRDP missing / auth fail / timeout / no result file) 는 `WindowsExecError` raise; 스크립트 non-zero rc 는 `WindowsExecResult.rc` 로 표면화.
+  2. **`_apply_max_sessions`, `_apply_rdp_timeouts`, `_apply_oem_runtime_fixes` 재작성** — 각각 PS payload 빌드 → `run_in_windows` 호출 → `rc != 0` 시 `RuntimeError` raise 해서 실패가 진짜 전파됨.
+  3. **`apply_windows_runtime_fixes` 정직한 보고** — `try/except` 구조 동일하지만, Windows VM 내부 rc가 실제로 fake `ok` 대신 `failed: rc=2 ...` 로 보고.
+
+  비용: 호출당 ~5–10 초 (RDP handshake + auth + script + disconnect) + `-WindowStyle Hidden` 으로 최소화한 PowerShell 창 깜박임. 대신 기존 pod 에서 작동 (재생성 불필요) + rc 체크가 진짜 의미 있음.
+
+  **주의사항**: `cfg.rdp.password` 가 Windows 게스트 실제 비밀번호와 일치해야 함. 이전 릴리즈에서 password rotation 이 같은 `podman exec` 원인으로 silently 실패해 왔다면, 첫 호출이 auth error 로 실패. 사용자가 `winpodx app run desktop` 으로 Windows 들어가서 `net user User <config-비밀번호>` 로 동기화 필요.
+
+### 테스트
+- `tests/test_windows_exec.py` 에 9개 신규 테스트 — FreeRDP missing / 비번 missing / timeout / no-result-file (auth fail) / happy path / non-zero rc propagation / FreeRDP `/app:program:` cmd 형태 검증 / flatpak 바이너리 splitting / unparseable JSON.
+- `tests/test_provisioner.py` 재작성 — `subprocess.run` 대신 `windows_exec.run_in_windows` mock. 신규 테스트가 `rc != 0` 에서 `RuntimeError` raise + 채널 실패에서 `WindowsExecError` raise 검증.
+
 ## [0.1.9.3] - 2026-04-26
 
 ### 수정

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.1.9.3"
+version = "0.1.9.4"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.1.9.3"
+__version__ = "0.1.9.4"

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -127,89 +127,44 @@ def _change_windows_password(cfg: Config, new_password: str) -> bool:
 
 
 def _apply_max_sessions(cfg: Config) -> None:
-    """Sync the guest's MaxInstanceCount registry value with cfg.pod.max_sessions.
+    """Sync the guest's MaxInstanceCount with cfg.pod.max_sessions.
 
-    Reads the current value first and only rewrites + restarts TermService
-    when the value differs, so active RemoteApp sessions aren't dropped
-    every time ensure_ready() runs.
-
-    Only runs for container backends (podman/docker). libvirt + manual
-    backends are a v0.2.0 guest-agent concern.
+    Idempotent — if the registry already matches, the wrapper short-
+    circuits and skips the TermService restart so active sessions don't
+    drop. Runs via FreeRDP RemoteApp (see ``windows_exec.run_in_windows``)
+    because podman exec can't reach the Windows VM inside the dockur
+    Linux container.
     """
     if cfg.pod.backend not in ("podman", "docker"):
         return
 
-    # Clamped at __post_init__; re-assert defensively so the integer
-    # interpolated into the PS command is always within [1, 50].
     desired = max(1, min(50, int(cfg.pod.max_sessions)))
-    runtime = "podman" if cfg.pod.backend == "podman" else "docker"
-    ps_exe = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
-    reg_path = r"HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server"
-
-    read_cmd = [
-        runtime,
-        "exec",
-        cfg.pod.container_name,
-        ps_exe,
-        "-ExecutionPolicy",
-        "Bypass",
-        "-Command",
-        f"(Get-ItemProperty '{reg_path}' -Name MaxInstanceCount "
-        f"-ErrorAction SilentlyContinue).MaxInstanceCount",
-    ]
-    try:
-        read_result = subprocess.run(read_cmd, capture_output=True, text=True, timeout=15)
-    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
-        log.warning("max_sessions: failed to read current value: %s", e)
-        return
-
-    current: int | None
-    stdout = read_result.stdout.strip()
-    try:
-        current = int(stdout) if stdout else None
-    except ValueError:
-        current = None
-
-    if current == desired:
-        log.debug("max_sessions: already %d on guest, no apply needed", desired)
-        return
-
-    apply_script = (
-        f"$p = '{reg_path}'; "
-        f"Set-ItemProperty -Path $p -Name MaxInstanceCount -Value {desired} "
-        f"-Type DWord -Force; "
-        f"Set-ItemProperty -Path $p -Name fSingleSessionPerUser -Value 0 "
-        f"-Type DWord -Force; "
-        f"Restart-Service -Force TermService"
+    payload = (
+        f"$p = 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server'\n"
+        f"$desired = {desired}\n"
+        "$current = (Get-ItemProperty $p -Name MaxInstanceCount "
+        "-ErrorAction SilentlyContinue).MaxInstanceCount\n"
+        "if ($current -eq $desired) {\n"
+        '    Write-Output "max_sessions already $desired"\n'
+        "    return\n"
+        "}\n"
+        "Set-ItemProperty -Path $p -Name MaxInstanceCount -Value $desired -Type DWord -Force\n"
+        "Set-ItemProperty -Path $p -Name fSingleSessionPerUser -Value 0 -Type DWord -Force\n"
+        "Restart-Service -Force TermService\n"
+        'Write-Output "max_sessions: $current -> $desired"\n'
     )
-    apply_cmd = [
-        runtime,
-        "exec",
-        cfg.pod.container_name,
-        ps_exe,
-        "-ExecutionPolicy",
-        "Bypass",
-        "-Command",
-        apply_script,
-    ]
-    try:
-        result = subprocess.run(apply_cmd, capture_output=True, text=True, timeout=60)
-    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
-        log.warning("max_sessions: apply failed: %s", e)
-        return
 
-    if result.returncode == 0:
-        log.info(
-            "max_sessions: guest registry updated %s -> %d (TermService restarted)",
-            current if current is not None else "<unset>",
-            desired,
-        )
-    else:
-        log.warning(
-            "max_sessions: apply rc=%d stderr=%s",
-            result.returncode,
-            result.stderr.strip(),
-        )
+    from winpodx.core.windows_exec import WindowsExecError, run_in_windows
+
+    try:
+        result = run_in_windows(cfg, payload, description="apply-max-sessions")
+    except WindowsExecError as e:
+        log.warning("max_sessions: channel failure: %s", e)
+        raise
+    if result.rc != 0:
+        log.warning("max_sessions: rc=%d stderr=%s", result.rc, result.stderr.strip())
+        raise RuntimeError(f"max_sessions apply failed (rc={result.rc}): {result.stderr.strip()}")
+    log.info("max_sessions: %s", result.stdout.strip())
 
 
 def apply_windows_runtime_fixes(cfg: Config) -> dict[str, str]:
@@ -243,115 +198,89 @@ def apply_windows_runtime_fixes(cfg: Config) -> dict[str, str]:
 
 
 def _apply_oem_runtime_fixes(cfg: Config) -> None:
-    """v0.1.9.2: bring existing 0.1.x guests up to OEM v7+ baseline at runtime.
+    """OEM v7 baseline (NIC power-save, TermService failure recovery) at runtime.
 
-    install.bat only runs at dockur's unattended first boot. Users who
-    installed under OEM v6 (winpodx 0.1.6) don't get the v7 NIC
-    power-save off + TermService failure-recovery actions, and v8 RDP
-    timeouts (those are covered by ``_apply_rdp_timeouts``). Without
-    this helper they'd have to recreate the container to get any
-    Windows-side fix shipped after their first install.
+    install.bat only runs at dockur's unattended first boot, so existing
+    0.1.6 / 0.1.7 / 0.1.8 / 0.1.9 / 0.1.9.x guests never picked up the v7
+    fixes shipped after their initial install. This pushes them via
+    FreeRDP RemoteApp so users don't have to recreate the container.
 
-    Stays idempotent — Set-NetAdapterPowerManagement / sc.exe failure
-    are no-op when state already matches. Failure is non-fatal:
-    log warning + return so a flaky exec doesn't block ensure_ready.
+    Idempotent — Set-NetAdapterPowerManagement / sc.exe failure are
+    no-ops when state already matches.
     """
     if cfg.pod.backend not in ("podman", "docker"):
         return
 
-    runtime = "podman" if cfg.pod.backend == "podman" else "docker"
-    ps_exe = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
-
-    apply_script = (
-        # v0.1.9 OEM v7: stop Windows from putting the virtual NIC to sleep.
-        "$ErrorActionPreference = 'SilentlyContinue'; "
+    payload = (
+        "$ErrorActionPreference = 'SilentlyContinue'\n"
         "Get-NetAdapter | Where-Object { $_.Status -ne 'Disabled' } | "
-        "Set-NetAdapterPowerManagement -AllowComputerToTurnOffDevice $false; "
-        # v0.1.9 OEM v7: TermService recovery actions (3 attempts at 5s, 24h reset).
-        # `sc.exe failure` is non-PowerShell but we can shell to it.
+        "Set-NetAdapterPowerManagement -AllowComputerToTurnOffDevice $false\n"
         "& sc.exe failure TermService reset= 86400 "
-        "actions= restart/5000/restart/5000/restart/5000 | Out-Null"
+        "actions= restart/5000/restart/5000/restart/5000 | Out-Null\n"
+        "Write-Output 'oem v7 baseline applied'\n"
     )
-    cmd = [
-        runtime,
-        "exec",
-        cfg.pod.container_name,
-        ps_exe,
-        "-NoProfile",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-Command",
-        apply_script,
-    ]
+
+    from winpodx.core.windows_exec import WindowsExecError, run_in_windows
+
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
-        log.warning("oem_runtime_fixes: apply failed: %s", e)
-        return
-    if result.returncode != 0:
-        log.warning(
-            "oem_runtime_fixes: rc=%d stderr=%s",
-            result.returncode,
-            result.stderr.strip(),
+        result = run_in_windows(cfg, payload, description="apply-oem")
+    except WindowsExecError as e:
+        log.warning("oem_runtime_fixes: channel failure: %s", e)
+        raise
+    if result.rc != 0:
+        log.warning("oem_runtime_fixes: rc=%d stderr=%s", result.rc, result.stderr.strip())
+        raise RuntimeError(
+            f"oem_runtime_fixes apply failed (rc={result.rc}): {result.stderr.strip()}"
         )
+    log.info("oem_runtime_fixes: %s", result.stdout.strip())
 
 
 def _apply_rdp_timeouts(cfg: Config) -> None:
-    """v0.1.9.1: disable RDP idle/disconnect/connection timeouts + enable keep-alive.
+    """Disable RDP idle/disconnect/connection timeouts + enable keep-alive.
 
-    Without this Windows will drop active RemoteApp sessions after its
-    default timeouts (1h idle), and NAT/firewall keep-alive cleanup can
-    kill the underlying TCP. Idempotent: writes the same key set every
-    provision; reg add is no-op when value already matches.
-
-    Mirrors the OEM v8 install.bat changes for guests that were
-    provisioned under an older OEM version (so users don't have to
-    recreate their container to pick this up).
+    Without this Windows drops active RemoteApp sessions after the 1h
+    default idle, and NAT/firewall idle-cleanup can kill the underlying
+    TCP. Idempotent: ``Set-ItemProperty -Force`` with the same value is
+    a no-op. Mirrors install.bat OEM v8 for guests provisioned under
+    older OEM versions.
     """
     if cfg.pod.backend not in ("podman", "docker"):
         return
 
-    runtime = "podman" if cfg.pod.backend == "podman" else "docker"
-    ps_exe = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
-
-    apply_script = (
-        # Machine policy keys (override per-user / per-WinStation defaults).
-        r"$mp = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services'; "
-        r"if (-not (Test-Path $mp)) { New-Item -Path $mp -Force | Out-Null }; "
-        r"Set-ItemProperty -Path $mp -Name MaxIdleTime -Value 0 -Type DWord -Force; "
-        r"Set-ItemProperty -Path $mp -Name MaxDisconnectionTime -Value 0 -Type DWord -Force; "
-        r"Set-ItemProperty -Path $mp -Name MaxConnectionTime -Value 0 -Type DWord -Force; "
-        r"Set-ItemProperty -Path $mp -Name KeepAliveEnable -Value 1 -Type DWord -Force; "
-        r"Set-ItemProperty -Path $mp -Name KeepAliveInterval -Value 1 -Type DWord -Force; "
-        # Per-WinStation keys (the actual TermService consults these).
-        r"$ws = 'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp'; "
-        r"Set-ItemProperty -Path $ws -Name MaxIdleTime -Value 0 -Type DWord -Force; "
-        r"Set-ItemProperty -Path $ws -Name MaxDisconnectionTime -Value 0 -Type DWord -Force; "
-        r"Set-ItemProperty -Path $ws -Name MaxConnectionTime -Value 0 -Type DWord -Force; "
-        r"Set-ItemProperty -Path $ws -Name KeepAliveTimeout -Value 1 -Type DWord -Force"
+    payload = (
+        # Machine policy (overrides per-user defaults).
+        "$mp = 'HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'\n"
+        "if (-not (Test-Path $mp)) { New-Item -Path $mp -Force | Out-Null }\n"
+        "Set-ItemProperty -Path $mp -Name MaxIdleTime -Value 0 -Type DWord -Force\n"
+        "Set-ItemProperty -Path $mp -Name MaxDisconnectionTime -Value 0 "
+        "-Type DWord -Force\n"
+        "Set-ItemProperty -Path $mp -Name MaxConnectionTime -Value 0 "
+        "-Type DWord -Force\n"
+        "Set-ItemProperty -Path $mp -Name KeepAliveEnable -Value 1 -Type DWord -Force\n"
+        "Set-ItemProperty -Path $mp -Name KeepAliveInterval -Value 1 -Type DWord -Force\n"
+        # Per-WinStation (TermService actually consults these).
+        "$ws = 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\"
+        "WinStations\\RDP-Tcp'\n"
+        "Set-ItemProperty -Path $ws -Name MaxIdleTime -Value 0 -Type DWord -Force\n"
+        "Set-ItemProperty -Path $ws -Name MaxDisconnectionTime -Value 0 "
+        "-Type DWord -Force\n"
+        "Set-ItemProperty -Path $ws -Name MaxConnectionTime -Value 0 "
+        "-Type DWord -Force\n"
+        "Set-ItemProperty -Path $ws -Name KeepAliveTimeout -Value 1 -Type DWord -Force\n"
+        "Write-Output 'rdp_timeouts applied'\n"
     )
-    cmd = [
-        runtime,
-        "exec",
-        cfg.pod.container_name,
-        ps_exe,
-        "-NoProfile",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-Command",
-        apply_script,
-    ]
+
+    from winpodx.core.windows_exec import WindowsExecError, run_in_windows
+
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
-        log.warning("rdp_timeouts: apply failed: %s", e)
-        return
-    if result.returncode != 0:
-        log.warning(
-            "rdp_timeouts: rc=%d stderr=%s",
-            result.returncode,
-            result.stderr.strip(),
-        )
+        result = run_in_windows(cfg, payload, description="apply-rdp-timeouts")
+    except WindowsExecError as e:
+        log.warning("rdp_timeouts: channel failure: %s", e)
+        raise
+    if result.rc != 0:
+        log.warning("rdp_timeouts: rc=%d stderr=%s", result.rc, result.stderr.strip())
+        raise RuntimeError(f"rdp_timeouts apply failed (rc={result.rc}): {result.stderr.strip()}")
+    log.info("rdp_timeouts: %s", result.stdout.strip())
 
 
 def _auto_rotate_password(cfg: Config) -> Config:

--- a/src/winpodx/core/windows_exec.py
+++ b/src/winpodx/core/windows_exec.py
@@ -1,0 +1,216 @@
+r"""Execute PowerShell inside the Windows guest via FreeRDP RemoteApp.
+
+Why this module exists
+======================
+
+``podman exec winpodx-windows ...`` runs inside the **Linux container**
+that hosts QEMU, not in the **Windows VM** running inside QEMU. The
+Linux container has no ``powershell.exe`` on $PATH, so any host-side
+attempt to push registry / service / NIC changes via ``podman exec``
+fails with rc=127. This bit v0.1.9.1, v0.1.9.2, and v0.1.9.3 — the
+runtime apply functions appeared to succeed because they only logged
+warnings on rc!=0 instead of raising. kernalix7 reported the silent-
+fail symptom on 2026-04-26.
+
+The reliable channel for actually-running-in-Windows commands is the
+same RemoteApp launch path winpodx already uses to start Word, Excel,
+etc.: launch ``powershell.exe`` as a RemoteApp via FreeRDP, have it
+read its script body from the host-shared ``\\tsclient\home`` directory
+(already mounted via ``+home-drive``), write its result back to that
+same share, then exit so the RemoteApp window closes.
+
+Cost
+----
+
+- ~5-10 seconds per call (RDP handshake + auth + script + disconnect).
+- Brief PowerShell window flash unless the payload is wrapped in
+  ``-WindowStyle Hidden`` (we do).
+- Requires the configured RDP password to actually match the Windows
+  guest's; if password rotation has been silently failing for months
+  (which it has — same root cause: ``_change_windows_password`` also
+  used podman exec), the first call here will fail with auth error and
+  the user will need to manually sync.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shlex
+import shutil
+import subprocess
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+
+from winpodx.core.config import Config
+from winpodx.core.rdp import find_freerdp
+from winpodx.utils.paths import data_dir
+
+log = logging.getLogger(__name__)
+
+
+class WindowsExecError(RuntimeError):
+    """Raised when a Windows-guest PowerShell exec attempt fails to even
+    return a parseable result.
+
+    Distinct from a non-zero ``rc`` inside ``WindowsExecResult``: this
+    means the channel itself broke (FreeRDP missing / auth failed /
+    timeout / no result file written) rather than the script just
+    exiting with a failure code.
+    """
+
+
+@dataclass
+class WindowsExecResult:
+    rc: int
+    stdout: str
+    stderr: str
+
+    @property
+    def ok(self) -> bool:
+        return self.rc == 0
+
+
+def run_in_windows(
+    cfg: Config,
+    payload: str,
+    *,
+    timeout: int = 60,
+    description: str = "winpodx-exec",
+) -> WindowsExecResult:
+    r"""Run ``payload`` (PowerShell source) inside the Windows guest.
+
+    The payload is wrapped to capture stdout / stderr / rc and write a
+    JSON result file under ``data_dir() / "windows-exec" /``. The wrapper
+    is written as a ``.ps1`` and FreeRDP launches PowerShell as a
+    RemoteApp pointing at it via the ``\\tsclient\home`` redirection.
+
+    ``description`` becomes the file stem so concurrent / sequential
+    callers can disambiguate temp files. Avoid characters that aren't
+    safe in a filename — caller is trusted, no validation here.
+
+    Raises ``WindowsExecError`` when the channel itself fails (FreeRDP
+    missing, auth fail, timeout, no result file). Returns
+    ``WindowsExecResult`` with the script's own rc otherwise — caller
+    inspects ``.ok`` / ``.rc`` to decide success.
+    """
+    found = find_freerdp()
+    if found is None:
+        raise WindowsExecError("FreeRDP not found on $PATH")
+    binary, _flavor = found
+
+    if not cfg.rdp.password:
+        raise WindowsExecError("RDP password not set in config — cannot authenticate")
+
+    work_dir = data_dir() / "windows-exec"
+    work_dir.mkdir(parents=True, exist_ok=True)
+    script_path = work_dir / f"{description}.ps1"
+    result_path = work_dir / f"{description}-result.json"
+
+    home = Path.home().resolve()
+    try:
+        rel_script = script_path.resolve().relative_to(home)
+        rel_result = result_path.resolve().relative_to(home)
+    except ValueError as e:
+        raise WindowsExecError(
+            f"work paths must be under $HOME for tsclient redirection: {e}"
+        ) from e
+
+    win_script_unc = "\\\\tsclient\\home\\" + str(rel_script).replace("/", "\\")
+    win_result_unc = "\\\\tsclient\\home\\" + str(rel_result).replace("/", "\\")
+
+    # The wrapper runs the user payload, captures combined output, and
+    # writes a JSON {rc,stdout,stderr} blob to the result path. Single
+    # quotes in the result path are escaped because we wrap it in single
+    # quotes inside the PowerShell string literal.
+    indented_payload = textwrap.indent(payload.rstrip(), "                ")
+    safe_result_path = win_result_unc.replace("'", "''")
+    wrapper = textwrap.dedent(
+        f"""\
+        $ErrorActionPreference = 'Continue'
+        $rc = 0
+        $stdout = ''
+        $stderr = ''
+        try {{
+            $stdout = & {{
+{indented_payload}
+            }} 2>&1 | Out-String
+            if ($null -ne $LASTEXITCODE) {{
+                $rc = $LASTEXITCODE
+            }}
+        }} catch {{
+            $rc = 1
+            $stderr = $_.Exception.Message
+        }}
+        $payload = @{{rc=$rc; stdout=$stdout; stderr=$stderr}} | ConvertTo-Json -Compress
+        # -Force lets us overwrite stale results from prior runs.
+        $payload | Out-File -FilePath '{safe_result_path}' -Encoding utf8 -Force
+        exit $rc
+        """
+    )
+    script_path.write_text(wrapper, encoding="utf-8")
+    result_path.unlink(missing_ok=True)
+
+    # FreeRDP RemoteApp invocation. -WindowStyle Hidden keeps the PS
+    # window from flashing; `cmd:` value is a single string passed as
+    # PowerShell's command-line args.
+    ps_args = f'-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -File "{win_script_unc}"'
+    app_arg = f"/app:program:powershell.exe,name:{description},cmd:{ps_args}"
+
+    # Split a flatpak-style binary like "flatpak run com.freerdp.FreeRDP".
+    cmd_parts = shlex.split(binary) if " " in binary else [binary]
+    cmd_parts += [
+        f"/v:{cfg.rdp.ip}:{cfg.rdp.port}",
+        f"/u:{cfg.rdp.user}",
+        f"/p:{cfg.rdp.password}",
+        "+home-drive",
+        "/sec:tls",
+        "/cert:ignore",
+        app_arg,
+    ]
+    if cfg.rdp.domain:
+        cmd_parts.append(f"/d:{cfg.rdp.domain}")
+
+    try:
+        proc = subprocess.run(
+            cmd_parts,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError as e:
+        raise WindowsExecError(f"FreeRDP binary vanished: {e}") from e
+    except subprocess.TimeoutExpired as e:
+        raise WindowsExecError(
+            f"FreeRDP timed out after {timeout}s waiting for the script to complete"
+        ) from e
+    finally:
+        # Script file is no longer needed — the result, if any, is in the JSON.
+        script_path.unlink(missing_ok=True)
+
+    if not result_path.exists():
+        # Nothing landed — likely auth failure, FreeRDP couldn't connect,
+        # or the +home-drive redirection didn't work. Surface the
+        # FreeRDP stderr verbatim (truncated) so the user can debug.
+        stderr_tail = (proc.stderr or "").strip()[-400:]
+        raise WindowsExecError(
+            f"No result file written (FreeRDP rc={proc.returncode}). stderr tail: {stderr_tail!r}"
+        )
+
+    try:
+        data = json.loads(result_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        raise WindowsExecError(f"result file unparseable: {e}") from e
+    finally:
+        result_path.unlink(missing_ok=True)
+
+    return WindowsExecResult(
+        rc=int(data.get("rc", 0)),
+        stdout=str(data.get("stdout", "")),
+        stderr=str(data.get("stderr", "")),
+    )
+
+
+# Local fallback noqa-suppress for `shutil` import when tests stub it out.
+_ = shutil

--- a/tests/test_provisioner.py
+++ b/tests/test_provisioner.py
@@ -130,157 +130,112 @@ def test_rotation_marker_cleared_on_success(_rotation_cfg, monkeypatch):
     assert not marker.exists()
 
 
-# --- v0.1.8: _apply_max_sessions runtime registry sync ---
+# --- v0.1.9.4: runtime applies via FreeRDP RemoteApp (windows_exec.run_in_windows) ---
+#
+# The v0.1.9.0-v0.1.9.3 versions of these tests mocked podman-exec subprocess
+# calls — but podman exec can't reach the Windows VM inside the dockur Linux
+# container, so the helpers never actually applied anything (they just logged
+# warnings). v0.1.9.4 routes them through windows_exec.run_in_windows, which
+# launches PowerShell as a FreeRDP RemoteApp. These tests mock that helper.
 
 
-def test_apply_max_sessions_skips_libvirt_backend():
+def _mock_run_in_windows(monkeypatch, *, rc: int = 0, stdout: str = "", stderr: str = ""):
+    """Return a list that captures every (description, payload) call."""
+    from winpodx.core.windows_exec import WindowsExecResult
+
+    captured: list[tuple[str, str]] = []
+
+    def fake(cfg, payload, *, timeout=60, description="windows-exec"):
+        captured.append((description, payload))
+        return WindowsExecResult(rc=rc, stdout=stdout, stderr=stderr)
+
+    import winpodx.core.provisioner as prov
+
+    monkeypatch.setattr("winpodx.core.windows_exec.run_in_windows", fake)
+    # Make sure the lazy-imported reference inside provisioner picks up the patched fn.
+    monkeypatch.setattr(prov, "_apply_max_sessions", prov._apply_max_sessions)
+    return captured
+
+
+def test_apply_max_sessions_skips_libvirt_backend(monkeypatch):
     from winpodx.core import provisioner
     from winpodx.core.config import Config
 
     cfg = Config()
     cfg.pod.backend = "libvirt"
-    # Must return without raising and without calling subprocess.
+    captured = _mock_run_in_windows(monkeypatch)
     provisioner._apply_max_sessions(cfg)
+    assert captured == []
 
 
-def test_apply_max_sessions_noop_when_registry_matches(monkeypatch):
-    from unittest.mock import MagicMock
-
-    from winpodx.core import provisioner
-    from winpodx.core.config import Config
-
-    cfg = Config()
-    cfg.pod.max_sessions = 20
-
-    calls = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append(cmd)
-        # First call = read; stdout says current value is already 20.
-        result = MagicMock()
-        result.stdout = "20\n"
-        result.stderr = ""
-        result.returncode = 0
-        return result
-
-    monkeypatch.setattr(provisioner.subprocess, "run", fake_run)
-    provisioner._apply_max_sessions(cfg)
-
-    # Only the read call should have fired — no write, no TermService restart.
-    assert len(calls) == 1
-    assert "-Command" in calls[0]
-    assert "Get-ItemProperty" in calls[0][-1]
-
-
-def test_apply_max_sessions_writes_and_restarts_when_differs(monkeypatch):
-    from unittest.mock import MagicMock
-
+def test_apply_max_sessions_runs_via_windows_exec(monkeypatch):
     from winpodx.core import provisioner
     from winpodx.core.config import Config
 
     cfg = Config()
     cfg.pod.max_sessions = 25
-
-    calls = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append(cmd)
-        result = MagicMock()
-        if "Get-ItemProperty" in cmd[-1]:
-            result.stdout = "10\n"  # guest is still at install.bat's default
-        else:
-            result.stdout = ""
-        result.stderr = ""
-        result.returncode = 0
-        return result
-
-    monkeypatch.setattr(provisioner.subprocess, "run", fake_run)
+    captured = _mock_run_in_windows(monkeypatch, rc=0, stdout="max_sessions: 10 -> 25")
     provisioner._apply_max_sessions(cfg)
-
-    # Two subprocess calls: read, then apply.
-    assert len(calls) == 2
-    apply_cmd = calls[1][-1]
-    assert "Set-ItemProperty" in apply_cmd
-    assert "MaxInstanceCount" in apply_cmd
-    assert "-Value 25" in apply_cmd
-    assert "fSingleSessionPerUser" in apply_cmd
-    assert "Restart-Service" in apply_cmd
-    assert "TermService" in apply_cmd
+    assert len(captured) == 1
+    description, payload = captured[0]
+    assert description == "apply-max-sessions"
+    assert "MaxInstanceCount" in payload
+    assert "$desired = 25" in payload
+    assert "fSingleSessionPerUser" in payload
+    assert "Restart-Service" in payload
 
 
-def test_apply_max_sessions_survives_missing_registry_key(monkeypatch):
-    """When the read returns empty stdout (key missing), apply still fires."""
-    from unittest.mock import MagicMock
+def test_apply_max_sessions_raises_on_nonzero_rc(monkeypatch):
+    """v0.1.9.4: helpers no longer silently swallow non-zero rc."""
+    import pytest
 
     from winpodx.core import provisioner
     from winpodx.core.config import Config
 
     cfg = Config()
-    cfg.pod.max_sessions = 15
-
-    calls = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append(cmd)
-        result = MagicMock()
-        result.stdout = "" if "Get-ItemProperty" in cmd[-1] else ""
-        result.stderr = ""
-        result.returncode = 0
-        return result
-
-    monkeypatch.setattr(provisioner.subprocess, "run", fake_run)
-    provisioner._apply_max_sessions(cfg)
-
-    # Missing key -> current == None, which != desired, so apply fires.
-    assert len(calls) == 2
+    _mock_run_in_windows(monkeypatch, rc=2, stderr="permission denied")
+    with pytest.raises(RuntimeError, match="rc=2"):
+        provisioner._apply_max_sessions(cfg)
 
 
-def test_apply_max_sessions_tolerates_timeout(monkeypatch):
+def test_apply_max_sessions_propagates_channel_error(monkeypatch):
+    import pytest
+
     from winpodx.core import provisioner
     from winpodx.core.config import Config
+    from winpodx.core.windows_exec import WindowsExecError
 
     cfg = Config()
 
-    def fake_run(cmd, **kwargs):
-        raise provisioner.subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 0))
+    def fake(*a, **k):
+        raise WindowsExecError("FreeRDP not found")
 
-    monkeypatch.setattr(provisioner.subprocess, "run", fake_run)
-    # Must not raise — timeout just logs and returns.
-    provisioner._apply_max_sessions(cfg)
-
-
-# --- v0.1.9.1: _apply_rdp_timeouts ---
+    monkeypatch.setattr("winpodx.core.windows_exec.run_in_windows", fake)
+    with pytest.raises(WindowsExecError, match="FreeRDP not found"):
+        provisioner._apply_max_sessions(cfg)
 
 
-def test_apply_rdp_timeouts_skips_libvirt():
+def test_apply_rdp_timeouts_skips_libvirt(monkeypatch):
     from winpodx.core import provisioner
     from winpodx.core.config import Config
 
     cfg = Config()
     cfg.pod.backend = "libvirt"
-    provisioner._apply_rdp_timeouts(cfg)  # must not raise / not subprocess
+    captured = _mock_run_in_windows(monkeypatch)
+    provisioner._apply_rdp_timeouts(cfg)
+    assert captured == []
 
 
-def test_apply_rdp_timeouts_writes_all_keys(monkeypatch):
-    from unittest.mock import MagicMock
-
+def test_apply_rdp_timeouts_payload_contains_all_keys(monkeypatch):
     from winpodx.core import provisioner
     from winpodx.core.config import Config
 
     cfg = Config()
-    captured = []
-
-    def fake_run(cmd, **kw):
-        captured.append(cmd)
-        m = MagicMock()
-        m.returncode = 0
-        m.stderr = ""
-        return m
-
-    monkeypatch.setattr(provisioner.subprocess, "run", fake_run)
+    captured = _mock_run_in_windows(monkeypatch, rc=0, stdout="rdp_timeouts applied")
     provisioner._apply_rdp_timeouts(cfg)
     assert len(captured) == 1
-    script = captured[0][-1]
+    description, payload = captured[0]
+    assert description == "apply-rdp-timeouts"
     for token in (
         "MaxIdleTime",
         "MaxDisconnectionTime",
@@ -291,72 +246,34 @@ def test_apply_rdp_timeouts_writes_all_keys(monkeypatch):
         "RDP-Tcp",
         "Terminal Services",
     ):
-        assert token in script
+        assert token in payload, f"missing {token!r} in payload"
 
 
-def test_apply_rdp_timeouts_tolerates_timeout(monkeypatch):
-    from winpodx.core import provisioner
-    from winpodx.core.config import Config
-
-    cfg = Config()
-
-    def boom(cmd, **kw):
-        raise provisioner.subprocess.TimeoutExpired(cmd, kw.get("timeout", 0))
-
-    monkeypatch.setattr(provisioner.subprocess, "run", boom)
-    # Must swallow the exception.
-    provisioner._apply_rdp_timeouts(cfg)
-
-
-# --- v0.1.9.2: _apply_oem_runtime_fixes + ensure_ready early-apply path ---
-
-
-def test_apply_oem_runtime_fixes_skips_libvirt():
+def test_apply_oem_runtime_fixes_skips_libvirt(monkeypatch):
     from winpodx.core import provisioner
     from winpodx.core.config import Config
 
     cfg = Config()
     cfg.pod.backend = "libvirt"
-    provisioner._apply_oem_runtime_fixes(cfg)  # must not raise / not subprocess
+    captured = _mock_run_in_windows(monkeypatch)
+    provisioner._apply_oem_runtime_fixes(cfg)
+    assert captured == []
 
 
-def test_apply_oem_runtime_fixes_writes_nic_and_termservice(monkeypatch):
-    from unittest.mock import MagicMock
-
+def test_apply_oem_runtime_fixes_payload_contains_nic_and_termservice(monkeypatch):
     from winpodx.core import provisioner
     from winpodx.core.config import Config
 
     cfg = Config()
-    captured = []
-
-    def fake_run(cmd, **kw):
-        captured.append(cmd)
-        m = MagicMock()
-        m.returncode = 0
-        m.stderr = ""
-        return m
-
-    monkeypatch.setattr(provisioner.subprocess, "run", fake_run)
+    captured = _mock_run_in_windows(monkeypatch, rc=0, stdout="oem v7 baseline applied")
     provisioner._apply_oem_runtime_fixes(cfg)
     assert len(captured) == 1
-    script = captured[0][-1]
-    assert "Set-NetAdapterPowerManagement" in script
-    assert "AllowComputerToTurnOffDevice" in script
-    assert "sc.exe failure TermService" in script
-    assert "restart/5000/restart/5000/restart/5000" in script
-
-
-def test_apply_oem_runtime_fixes_tolerates_timeout(monkeypatch):
-    from winpodx.core import provisioner
-    from winpodx.core.config import Config
-
-    cfg = Config()
-
-    def boom(cmd, **kw):
-        raise provisioner.subprocess.TimeoutExpired(cmd, kw.get("timeout", 0))
-
-    monkeypatch.setattr(provisioner.subprocess, "run", boom)
-    provisioner._apply_oem_runtime_fixes(cfg)
+    description, payload = captured[0]
+    assert description == "apply-oem"
+    assert "Set-NetAdapterPowerManagement" in payload
+    assert "AllowComputerToTurnOffDevice" in payload
+    assert "sc.exe failure TermService" in payload
+    assert "restart/5000/restart/5000/restart/5000" in payload
 
 
 def test_ensure_ready_runs_apply_before_early_return_when_rdp_alive(monkeypatch):
@@ -438,17 +355,16 @@ def test_apply_windows_runtime_fixes_skips_libvirt():
 
 
 def test_apply_windows_runtime_fixes_returns_per_helper_status(monkeypatch):
-    from unittest.mock import MagicMock
-
     from winpodx.core import provisioner
     from winpodx.core.config import Config
+    from winpodx.core.windows_exec import WindowsExecResult
 
     cfg = Config()
-    monkeypatch.setattr(
-        provisioner.subprocess,
-        "run",
-        lambda *a, **k: MagicMock(returncode=0, stdout="", stderr=""),
-    )
+
+    def fake(cfg_inner, payload, *, timeout=60, description="windows-exec"):
+        return WindowsExecResult(rc=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("winpodx.core.windows_exec.run_in_windows", fake)
     result = provisioner.apply_windows_runtime_fixes(cfg)
     assert set(result.keys()) == {"max_sessions", "rdp_timeouts", "oem_runtime_fixes"}
     for v in result.values():

--- a/tests/test_windows_exec.py
+++ b/tests/test_windows_exec.py
@@ -1,0 +1,243 @@
+"""Tests for winpodx.core.windows_exec — FreeRDP RemoteApp PowerShell channel."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from winpodx.core.config import Config
+from winpodx.core.windows_exec import WindowsExecError, WindowsExecResult, run_in_windows
+
+
+def _cfg(password: str = "secret") -> Config:
+    cfg = Config()
+    cfg.pod.backend = "podman"
+    cfg.rdp.ip = "127.0.0.1"
+    cfg.rdp.port = 3390
+    cfg.rdp.user = "User"
+    cfg.rdp.password = password
+    return cfg
+
+
+def _patch_data_dir(monkeypatch, tmp_path):
+    """Force windows_exec to use tmp_path so the test can predict the result file."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    fake_data = fake_home / ".local" / "share" / "winpodx"
+    fake_data.mkdir(parents=True)
+    monkeypatch.setattr("winpodx.core.windows_exec.data_dir", lambda: fake_data)
+    monkeypatch.setattr("winpodx.core.windows_exec.Path.home", staticmethod(lambda: fake_home))
+    return fake_home, fake_data
+
+
+def test_run_in_windows_raises_when_freerdp_missing(monkeypatch, tmp_path):
+    _patch_data_dir(monkeypatch, tmp_path)
+    monkeypatch.setattr("winpodx.core.windows_exec.find_freerdp", lambda: None)
+    with pytest.raises(WindowsExecError, match="FreeRDP not found"):
+        run_in_windows(_cfg(), "Write-Output 'hello'")
+
+
+def test_run_in_windows_raises_when_password_missing(monkeypatch, tmp_path):
+    _patch_data_dir(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "winpodx.core.windows_exec.find_freerdp", lambda: ("/usr/bin/xfreerdp", "xfreerdp")
+    )
+    cfg = _cfg(password="")
+    with pytest.raises(WindowsExecError, match="password not set"):
+        run_in_windows(cfg, "Write-Output 'hello'")
+
+
+def test_run_in_windows_raises_on_freerdp_timeout(monkeypatch, tmp_path):
+    _patch_data_dir(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "winpodx.core.windows_exec.find_freerdp", lambda: ("/usr/bin/xfreerdp", "xfreerdp")
+    )
+
+    def boom(cmd, **kw):
+        raise subprocess.TimeoutExpired(cmd, kw.get("timeout", 0))
+
+    monkeypatch.setattr("winpodx.core.windows_exec.subprocess.run", boom)
+    with pytest.raises(WindowsExecError, match="timed out"):
+        run_in_windows(_cfg(), "Write-Output 'hello'", timeout=1)
+
+
+def test_run_in_windows_raises_when_no_result_file(monkeypatch, tmp_path):
+    """FreeRDP exits but the wrapper PS never wrote a result — likely auth/connect failure."""
+    _patch_data_dir(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "winpodx.core.windows_exec.find_freerdp", lambda: ("/usr/bin/xfreerdp", "xfreerdp")
+    )
+
+    def fake_run(cmd, **kw):
+        # FreeRDP "succeeded" (rc=0) but produced no result file.
+        m = MagicMock()
+        m.returncode = 0
+        m.stdout = ""
+        m.stderr = "auth failure: NTLM"
+        return m
+
+    monkeypatch.setattr("winpodx.core.windows_exec.subprocess.run", fake_run)
+    with pytest.raises(WindowsExecError, match="No result file"):
+        run_in_windows(_cfg(), "Write-Output 'hello'")
+
+
+def test_run_in_windows_returns_result_when_wrapper_writes_json(monkeypatch, tmp_path):
+    """Happy path — simulate the wrapper writing the JSON result file."""
+    _, fake_data = _patch_data_dir(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "winpodx.core.windows_exec.find_freerdp", lambda: ("/usr/bin/xfreerdp", "xfreerdp")
+    )
+
+    work_dir = fake_data / "windows-exec"
+    work_dir.mkdir(parents=True, exist_ok=True)
+    result_path = work_dir / "winpodx-exec-result.json"
+
+    def fake_run(cmd, **kw):
+        # Simulate the in-guest wrapper writing the result file before exiting.
+        result_path.write_text(
+            json.dumps({"rc": 0, "stdout": "registry updated", "stderr": ""}),
+            encoding="utf-8",
+        )
+        m = MagicMock()
+        m.returncode = 0
+        m.stdout = ""
+        m.stderr = ""
+        return m
+
+    monkeypatch.setattr("winpodx.core.windows_exec.subprocess.run", fake_run)
+    result = run_in_windows(_cfg(), "Write-Output 'registry updated'")
+    assert isinstance(result, WindowsExecResult)
+    assert result.rc == 0
+    assert result.ok is True
+    assert "registry updated" in result.stdout
+    # Result file cleaned up afterwards.
+    assert not result_path.exists()
+
+
+def test_run_in_windows_propagates_nonzero_rc_from_wrapper(monkeypatch, tmp_path):
+    """If the user payload returned non-zero, surface it in WindowsExecResult.rc."""
+    _, fake_data = _patch_data_dir(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "winpodx.core.windows_exec.find_freerdp", lambda: ("/usr/bin/xfreerdp", "xfreerdp")
+    )
+
+    work_dir = fake_data / "windows-exec"
+    work_dir.mkdir(parents=True, exist_ok=True)
+    result_path = work_dir / "winpodx-exec-result.json"
+
+    def fake_run(cmd, **kw):
+        result_path.write_text(
+            json.dumps({"rc": 7, "stdout": "", "stderr": "boom"}), encoding="utf-8"
+        )
+        m = MagicMock()
+        m.returncode = 7
+        m.stdout = ""
+        m.stderr = ""
+        return m
+
+    monkeypatch.setattr("winpodx.core.windows_exec.subprocess.run", fake_run)
+    result = run_in_windows(_cfg(), "exit 7")
+    assert result.rc == 7
+    assert result.ok is False
+    assert result.stderr == "boom"
+
+
+def test_run_in_windows_command_uses_freerdp_app_remoteapp(monkeypatch, tmp_path):
+    """The cmd passed to subprocess.run must look like a RemoteApp /app:program: launch."""
+    _, fake_data = _patch_data_dir(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "winpodx.core.windows_exec.find_freerdp", lambda: ("/usr/bin/xfreerdp", "xfreerdp")
+    )
+
+    captured: list[list[str]] = []
+    work_dir = fake_data / "windows-exec"
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    def fake_run(cmd, **kw):
+        captured.append(list(cmd))
+        # Write a successful result so the function returns cleanly.
+        (work_dir / "apply-X-result.json").write_text(
+            json.dumps({"rc": 0, "stdout": "", "stderr": ""}), encoding="utf-8"
+        )
+        m = MagicMock()
+        m.returncode = 0
+        m.stdout = ""
+        m.stderr = ""
+        return m
+
+    monkeypatch.setattr("winpodx.core.windows_exec.subprocess.run", fake_run)
+    run_in_windows(_cfg(), "Write-Output 'hi'", description="apply-X")
+
+    assert len(captured) == 1
+    cmd = captured[0]
+    assert cmd[0] == "/usr/bin/xfreerdp"
+    # Standard winpodx RDP flags must be there.
+    joined = " ".join(cmd)
+    assert "/v:127.0.0.1:3390" in joined
+    assert "/u:User" in joined
+    assert "/p:secret" in joined
+    assert "+home-drive" in joined
+    assert "/sec:tls" in joined
+    assert "/cert:ignore" in joined
+    # The /app:program: payload should target powershell.exe with -File pointing
+    # at a tsclient UNC path.
+    app_arg = next((a for a in cmd if a.startswith("/app:program:")), "")
+    assert "powershell.exe" in app_arg
+    assert "tsclient" in app_arg
+    assert "-WindowStyle Hidden" in app_arg
+    assert "-NoProfile" in app_arg
+    assert "-File" in app_arg
+
+
+def test_run_in_windows_supports_flatpak_freerdp_with_spaces(monkeypatch, tmp_path):
+    """flatpak-style binary 'flatpak run com.freerdp.FreeRDP' must split correctly."""
+    _, fake_data = _patch_data_dir(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "winpodx.core.windows_exec.find_freerdp",
+        lambda: ("flatpak run com.freerdp.FreeRDP", "flatpak"),
+    )
+
+    captured: list[list[str]] = []
+    work_dir = fake_data / "windows-exec"
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    def fake_run(cmd, **kw):
+        captured.append(list(cmd))
+        (work_dir / "winpodx-exec-result.json").write_text(
+            json.dumps({"rc": 0, "stdout": "", "stderr": ""}), encoding="utf-8"
+        )
+        m = MagicMock()
+        m.returncode = 0
+        m.stdout = ""
+        m.stderr = ""
+        return m
+
+    monkeypatch.setattr("winpodx.core.windows_exec.subprocess.run", fake_run)
+    run_in_windows(_cfg(), "Write-Output 'flatpak'")
+    assert captured[0][:3] == ["flatpak", "run", "com.freerdp.FreeRDP"]
+
+
+def test_run_in_windows_handles_unparseable_result_file(monkeypatch, tmp_path):
+    _, fake_data = _patch_data_dir(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "winpodx.core.windows_exec.find_freerdp", lambda: ("/usr/bin/xfreerdp", "xfreerdp")
+    )
+
+    work_dir = fake_data / "windows-exec"
+    work_dir.mkdir(parents=True, exist_ok=True)
+    result_path = work_dir / "winpodx-exec-result.json"
+
+    def fake_run(cmd, **kw):
+        result_path.write_text("not valid json", encoding="utf-8")
+        m = MagicMock()
+        m.returncode = 0
+        m.stdout = ""
+        m.stderr = ""
+        return m
+
+    monkeypatch.setattr("winpodx.core.windows_exec.subprocess.run", fake_run)
+    with pytest.raises(WindowsExecError, match="unparseable"):
+        run_in_windows(_cfg(), "Write-Output 'hi'")


### PR DESCRIPTION
Hotfix for kernalix7's report on the v0.1.9.3 install:

\`\`\`
2026-04-26 14:08:53 [WARNING] winpodx.core.provisioner: max_sessions: apply rc=127 stderr=Error: runc: exec failed: ... exec: \"C:\\\\Windows\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe\": executable file not found in \$PATH
\`\`\`

Three previous releases shipped fake success.

## Root cause

\`podman exec winpodx-windows ...\` runs in the **Linux container** that hosts QEMU, NOT in the **Windows VM** inside. The Linux container has no \`powershell.exe\` on \$PATH, so every \`_apply_*\` call returned rc=127, the helper logged a warning and returned, and the public \`apply_windows_runtime_fixes\` reported per-helper \"ok\" because the helper didn't raise.

## Fix

- **New \`core/windows_exec.py\`** — \`run_in_windows(cfg, payload, ...)\`. Writes a wrapper PS that runs the user payload, captures stdout/stderr/rc, and writes a JSON result file via \`\\\\tsclient\\home\\.local\\share\\winpodx\\windows-exec\\\`. Launches FreeRDP with \`/app:program:powershell.exe,cmd:-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -File \"\\\\tsclient\\home\\...\"\`. Reads + cleans up the result file.
- **\`_apply_max_sessions\`, \`_apply_rdp_timeouts\`, \`_apply_oem_runtime_fixes\` rewritten** to use \`run_in_windows\` and \`raise RuntimeError\` on rc != 0.
- **\`apply_windows_runtime_fixes\` honest reporting** — actual rc != 0 now produces \`failed: rc=2 ...\` instead of \"ok\".

## Trade-offs

- ~5-10s per call (RDP handshake + auth + script + disconnect).
- Brief PowerShell window flash; \`-WindowStyle Hidden\` minimizes it.
- **Requires \`cfg.rdp.password\` to match Windows guest's actual password.** If password rotation has been silently failing for previous releases (same \`podman exec\` root cause as the apply helpers), first call fails with auth error. User must manually sync via \`winpodx app run desktop\` then \`net user User <password-from-config>\`.

## Test plan

- [x] \`pytest tests/ -v\` — 380 passed
- [x] \`ruff check src/ tests/\` — clean
- [x] \`ruff format --check\` — clean
- [x] 9 new tests in \`tests/test_windows_exec.py\` covering: FreeRDP missing / password missing / timeout / no-result-file (auth fail) / happy path / non-zero rc / cmd shape / flatpak binary / unparseable JSON.
- [x] \`tests/test_provisioner.py\` rewritten to mock \`windows_exec.run_in_windows\` instead of subprocess.run.

Manual verification on real hardware after merge:
- [ ] Existing 0.1.x guest with healthy RDP password: \`curl | bash\` upgrade reports per-helper OK with non-zero wall time (~15-30s for the three applies). PowerShell windows flash briefly.
- [ ] Same: 1h+ idle session no longer disconnects.
- [ ] Auth-failure scenario (intentionally mismatched cfg password): apply-fixes reports \`failed: WindowsExecError: No result file written ... auth failure\`. User then manually syncs.

## What still doesn't work

- \`_change_windows_password\` is still on the broken \`podman exec\` path (separate code path, not migrated this release). Password rotation failures from prior versions persist until v0.1.9.5 or later. Workaround: opt out of rotation via \`pod.password_max_age = 0\` if it's a problem.