### PR TITLE
release: v0.1.9.5 — BOM + Restart-Service fixes + migrate all 6 broken host->Windows paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [0.1.9.5] - 2026-04-26
+
+### Fixed
+- **BOM in result file caused fake "fail" reports.** v0.1.9.4 routed runtime applies through FreeRDP RemoteApp PowerShell, but the wrapper used `Out-File -Encoding utf8` which (in Windows PowerShell 5.1) writes a UTF-8 BOM. The host then `json.loads`'d the file with the default `utf-8` codec which rejected the BOM and reported "result file unparseable: Unexpected UTF-8 BOM". The registry changes from rdp_timeouts and oem_runtime_fixes had **actually applied successfully** — only the parse step failed, leaving the user thinking nothing worked. `windows_exec.run_in_windows` now reads with `utf-8-sig` so the BOM is consumed transparently.
+- **`_apply_max_sessions` killed its own RDP session.** The payload included `Restart-Service -Force TermService` to make the new MaxInstanceCount take effect immediately — but TermService is exactly what's hosting the FreeRDP RemoteApp session running the script. The restart killed the session before the wrapper could write its result file, the host saw `ERRINFO_RPC_INITIATED_DISCONNECT [0x00010001]`, and the apply was incorrectly classified as a channel failure even when the registry write itself had landed. v0.1.9.5 removes the in-script `Restart-Service`; the registry write alone is enough, and TermService picks up the new value on its next natural cycle (next pod boot or `winpodx pod restart`).
+
+### Changed (architectural)
+- **Migrated every remaining host-to-Windows command path off the broken `podman exec ... powershell.exe` channel** onto `windows_exec.run_in_windows`. Six functions had been silently no-op'ing for releases 0.1.0 through 0.1.9.4 — `podman exec` only reaches the Linux container that hosts QEMU, not the Windows VM running inside, so any call to `powershell.exe` returned `rc=127 executable file not found in $PATH` and the helpers logged a warning then returned. v0.1.9.5 ports them all:
+  - `provisioner._change_windows_password` (password rotation — silent for years)
+  - `pod.recover_rdp_if_needed` (Bug B TermService restart — never worked; replaced with a container restart since FreeRDP can't authenticate against a dead RDP listener anyway)
+  - `daemon.sync_windows_time` (w32tm)
+  - `core.updates._exec_toggle` (Windows Update enable/disable/status)
+  - `cli/main._cmd_debloat` and `gui/main_window._on_debloat` (debloat.ps1 — was double-broken: `podman cp` to copy the script + `podman exec` to run it)
+  - `core/discovery.discover_apps` (Bug A's "fix" via stdin pipe was on the same broken path; now actually goes via FreeRDP RemoteApp)
+
+### Added
+- **`winpodx pod sync-password`** CLI command to recover from password drift accumulated under prior releases. Prompts for the "last known working" password (typically the one from initial setup, or the value still in `compose.yml`'s `PASSWORD` env var), authenticates FreeRDP with it, then runs `net user` inside Windows to set the account password to the current cfg.password value. Once the sync completes, password rotation works normally going forward.
+- **migrate auto-detects password drift.** When `winpodx migrate` runs and the user is on the "already current" path, it now fires a no-op `Write-Output 'sync-check'` payload through the FreeRDP channel first. If FreeRDP fails with auth/no-result-file, migrate prints a clear "run `winpodx pod sync-password`" pointer instead of letting all three subsequent applies fail with confusing channel errors.
+- **Lint test `tests/test_no_broken_podman_exec.py`** — fails CI if any future code under `src/winpodx/` (other than `windows_exec.py` itself) reintroduces the `podman exec ... powershell.exe` pattern. Single canonical channel for Windows-side commands going forward.
+
+### Tests
+- `tests/test_provisioner.py` updated to mock `windows_exec.run_in_windows` for `_apply_max_sessions` and assert that `Restart-Service` is no longer in the payload.
+- `tests/test_security.py::TestPowerShellEscape` rewritten — `_change_windows_password` now goes through `windows_exec`, so the test inspects the payload string instead of subprocess argv.
+- `tests/test_pod.py::test_recover_rdp_*` updated — recover-rdp now restarts the container instead of attempting an exec-based TermService restart.
+- `tests/test_daemon.py::test_sync_windows_time_uses_windows_exec_channel` rewritten for the new transport.
+- `tests/test_discovery.py` — five tests rewritten to mock `windows_exec.run_in_windows` instead of `subprocess.Popen` + stdin pipe. The `HARD_STDOUT_CAP` flooding test was removed; the cap was specific to the `_run_bounded` path that discovery no longer uses.
+
 ## [0.1.9.4] - 2026-04-26
 
 ### Fixed

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,32 @@
+winpodx (0.1.9.5) unstable; urgency=high
+
+  * Fixed: BOM in result file caused fake "fail" reports. v0.1.9.4
+    PowerShell wrapper used Out-File -Encoding utf8 which writes a BOM;
+    host then json.loads with utf-8 codec rejected it. The actual
+    registry changes had landed; only the parse failed. Now read with
+    utf-8-sig.
+  * Fixed: _apply_max_sessions killed its own RDP session by calling
+    Restart-Service TermService — the very service hosting the
+    FreeRDP RemoteApp running the script. Removed the in-script
+    restart; registry write alone is enough, change picks up on next
+    natural service cycle.
+  * Migrated every remaining host-to-Windows command path off the
+    broken podman exec channel: _change_windows_password (password
+    rotation), recover_rdp_if_needed (now does container restart),
+    sync_windows_time, Windows Update toggle, debloat (CLI + GUI),
+    and discover_apps. All six were silent no-ops in releases 0.1.0
+    through 0.1.9.4.
+  * Added: `winpodx pod sync-password` CLI to recover from password
+    drift accumulated under the broken rotation path. Prompts for the
+    last-known-working password and resets Windows to match cfg.
+  * Added: migrate auto-detects password drift before attempting
+    apply, points users at sync-password instead of letting them
+    watch all three applies fail confusingly.
+  * Added: lint test that fails CI if any future code reintroduces
+    the podman-exec-to-powershell pattern outside windows_exec.py.
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Sun, 26 Apr 2026 16:00:00 +0900
+
 winpodx (0.1.9.4) unstable; urgency=high
 
   * Fixed: runtime applies were silent no-ops in v0.1.9.1, v0.1.9.2, and

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,26 @@
 
 ## [Unreleased]
 
+## [0.1.9.5] - 2026-04-26
+
+### 수정
+- **결과 파일의 BOM 으로 인한 거짓 "fail" 보고.** v0.1.9.4 가 runtime apply 를 FreeRDP RemoteApp PowerShell 로 라우팅했는데, wrapper 가 `Out-File -Encoding utf8` 사용 → Windows PowerShell 5.1 은 UTF-8 BOM 을 붙임 → 호스트가 기본 utf-8 코덱으로 `json.loads` 시 BOM 거부 → "result file unparseable: Unexpected UTF-8 BOM". 사실 rdp_timeouts 와 oem_runtime_fixes 의 레지스트리 변경은 **실제 적용 성공**했고, 파싱만 실패해서 사용자가 "안 됐다" 고 본 것. `windows_exec.run_in_windows` 가 이제 `utf-8-sig` 로 읽어 BOM 자동 흡수.
+- **`_apply_max_sessions` 가 자기 RDP 세션을 죽이던 문제.** payload 가 `Restart-Service -Force TermService` 호출했는데, TermService 가 바로 그 FreeRDP RemoteApp 세션 호스팅 중. 재기동 → 세션 강제 종료 → wrapper 가 결과 파일 쓰기 전 죽음 → 호스트는 `ERRINFO_RPC_INITIATED_DISCONNECT [0x00010001]` 봄. 레지스트리 쓰기는 됐을 수도 있지만 채널 실패로 잘못 분류. v0.1.9.5 는 in-script `Restart-Service` 제거; 레지스트리만 쓰면 충분, TermService 가 다음 자연 사이클 (다음 부팅 / 사용자 수동 `winpodx pod restart`) 때 새 값 반영.
+
+### 변경 (아키텍처)
+- **모든 host→Windows 명령 경로를 깨진 `podman exec ... powershell.exe` 에서 `windows_exec.run_in_windows` 로 마이그레이션**. 6개 함수가 0.1.0 ~ 0.1.9.4 동안 silent no-op 이었음 — `podman exec` 는 QEMU 호스팅하는 Linux 컨테이너만 도달, 그 안 Windows VM 에는 못 가서 `powershell.exe` 호출이 모두 `rc=127 executable file not found in $PATH` 로 실패하는데 헬퍼들이 warning 만 로그하고 return 했음. v0.1.9.5 는 모두 마이그레이션:
+  - `provisioner._change_windows_password` (비밀번호 회전 — 수년간 silent fail)
+  - `pod.recover_rdp_if_needed` (Bug B TermService 재기동 — 작동 안 했음; FreeRDP 도 죽은 RDP 리스너 인증 못하므로 컨테이너 재시작으로 대체)
+  - `daemon.sync_windows_time` (w32tm)
+  - `core.updates._exec_toggle` (Windows Update 활성화/비활성화/상태)
+  - `cli/main._cmd_debloat` 와 `gui/main_window._on_debloat` (debloat.ps1 — `podman cp` + `podman exec` 둘 다 깨졌었음)
+  - `core/discovery.discover_apps` (Bug A 의 stdin pipe "수정" 도 같은 깨진 경로; 이제 FreeRDP RemoteApp 로 진짜 적용)
+
+### 추가
+- **`winpodx pod sync-password`** CLI — 이전 릴리즈에서 누적된 비번 drift 복구. "마지막으로 작동한" 비번 (보통 초기 설치 시 또는 `compose.yml` 의 `PASSWORD` env var 값) 을 입력받아 FreeRDP 인증 → Windows 안에서 `net user` 실행 → 계정 비번을 현재 cfg.password 로 설정. 동기화 완료 후 비번 회전이 정상 작동.
+- **migrate 자동 drift 감지.** `winpodx migrate` 가 "already current" 경로에서 작은 `Write-Output 'sync-check'` payload 를 FreeRDP 채널로 먼저 발사. auth/no-result-file 로 실패하면 "`winpodx pod sync-password` 실행" 안내 메시지 출력 → 그 이후 3개 apply 가 혼란스러운 채널 에러로 실패하는 것 방지.
+- **Lint 테스트 `tests/test_no_broken_podman_exec.py`** — 향후 `src/winpodx/` 아래 (`windows_exec.py` 자체 제외) 에 `podman exec ... powershell.exe` 패턴 재도입 시 CI 실패. Windows-측 명령은 단일 채널로 강제.
+
 ## [0.1.9.4] - 2026-04-26
 
 ### 수정

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.1.9.4"
+version = "0.1.9.5"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.1.9.4"
+__version__ = "0.1.9.5"

--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -84,6 +84,20 @@ def cli(argv: list[str] | None = None) -> None:
             "Idempotent — safe to run any time."
         ),
     )
+    sync_p = pod_sub.add_parser(
+        "sync-password",
+        help=(
+            "Re-sync the Windows guest's account password to the value in "
+            "winpodx config. Use when password rotation has drifted (cfg "
+            "and Windows disagree). Prompts for the last-known-working "
+            "password to authenticate one final time."
+        ),
+    )
+    sync_p.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Read the recovery password from $WINPODX_RECOVERY_PASSWORD env var.",
+    )
 
     # --- config ---
     cfg_parser = sub.add_parser("config", help="Manage configuration")
@@ -287,60 +301,50 @@ def _cmd_timesync() -> None:
 
 
 def _cmd_debloat() -> None:
-    import subprocess
+    """Run debloat.ps1 inside the Windows VM via FreeRDP RemoteApp.
+
+    v0.1.9.5: was on the broken `podman cp + podman exec` path which
+    couldn't reach the Windows VM. Now reads the script body locally
+    and pipes it through ``windows_exec.run_in_windows``.
+    """
     from pathlib import Path
 
     from winpodx.core.config import Config
+    from winpodx.core.windows_exec import WindowsExecError, run_in_windows
 
     cfg = Config.load()
     if cfg.pod.backend not in ("podman", "docker"):
         print("Debloat only supported for Podman/Docker backends.")
         return
 
-    script = Path(__file__).parent.parent.parent.parent / "scripts" / "windows" / "debloat.ps1"
-    if not script.exists():
-        print(f"Debloat script not found: {script}")
+    candidates = [
+        Path(__file__).parent.parent.parent.parent / "scripts" / "windows" / "debloat.ps1",
+        Path.home() / ".local" / "bin" / "winpodx-app" / "scripts" / "windows" / "debloat.ps1",
+    ]
+    script = next((p for p in candidates if p.exists()), None)
+    if script is None:
+        print(f"Debloat script not found in any of: {[str(p) for p in candidates]}")
         return
 
-    runtime = "podman" if cfg.pod.backend == "podman" else "docker"
-    container = cfg.pod.container_name
-
-    print("Copying debloat script to Windows...")
     try:
-        subprocess.run([runtime, "cp", str(script), f"{container}:C:/debloat.ps1"], check=True)
-    except subprocess.CalledProcessError:
-        print("Failed to copy script. Is the pod running? Try: winpodx pod start")
-        return
-    except FileNotFoundError:
-        print(f"'{runtime}' not found. Is {cfg.pod.backend} installed?")
+        payload = script.read_text(encoding="utf-8")
+    except OSError as e:
+        print(f"Cannot read debloat script {script}: {e}")
         return
 
     print("Running debloat (this may take a minute)...")
     try:
-        result = subprocess.run(
-            [
-                runtime,
-                "exec",
-                container,
-                "powershell",
-                "-ExecutionPolicy",
-                "Bypass",
-                "-File",
-                "C:\\debloat.ps1",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-    except subprocess.TimeoutExpired:
-        print("Debloat timed out after 120 seconds.")
+        result = run_in_windows(cfg, payload, description="debloat", timeout=180)
+    except WindowsExecError as e:
+        print(f"Debloat channel failure: {e}")
         return
 
-    if result.returncode == 0:
-        print(result.stdout)
+    if result.rc == 0:
+        if result.stdout.strip():
+            print(result.stdout.rstrip())
         print("Debloat complete.")
     else:
-        print(f"Debloat failed: {result.stderr}")
+        print(f"Debloat failed (rc={result.rc}): {result.stderr.strip() or result.stdout.strip()}")
 
 
 def _cmd_power(args: argparse.Namespace) -> None:

--- a/src/winpodx/cli/migrate.py
+++ b/src/winpodx/cli/migrate.py
@@ -106,6 +106,11 @@ def run_migrate(args: argparse.Namespace) -> int:
         # — exactly the bug kernalix7 hit. Helpers are idempotent so a
         # no-op run is harmless if everything was already applied.
         non_interactive = bool(getattr(args, "non_interactive", False))
+        # v0.1.9.5: probe for password drift before attempting apply.
+        # If FreeRDP auth fails, point the user at `winpodx pod sync-password`
+        # rather than letting them watch all three applies fail in confusing
+        # ways.
+        _probe_password_sync(non_interactive)
         _apply_runtime_fixes_to_existing_guest(non_interactive)
         return 0
 
@@ -327,6 +332,61 @@ def _prompt_yes(question: str, default: bool = True) -> bool:
     if not response:
         return default
     return response in ("y", "yes")
+
+
+def _probe_password_sync(non_interactive: bool) -> None:
+    """v0.1.9.5: detect cfg/Windows password drift before apply.
+
+    Fires a tiny no-op PS payload through the FreeRDP RemoteApp channel.
+    If the channel returns a parseable result, auth worked and the
+    password is in sync. If it raises a "no result file" or auth-flavored
+    error, we know cfg.password no longer matches Windows. In that case
+    we surface the recovery instructions and let the apply fall through
+    naturally (it will fail the same way and the user has the context).
+    """
+    try:
+        from winpodx.core.config import Config
+        from winpodx.core.pod import PodState, pod_status
+        from winpodx.core.windows_exec import WindowsExecError, run_in_windows
+    except ImportError as e:
+        print(f"  (skipping password-sync probe: {e})")
+        return
+
+    cfg = Config.load()
+    if cfg.pod.backend not in ("podman", "docker"):
+        return
+    try:
+        if pod_status(cfg).state != PodState.RUNNING:
+            return
+    except Exception:  # noqa: BLE001
+        return
+
+    print("\nProbing Windows-side authentication...")
+    try:
+        run_in_windows(
+            cfg,
+            "Write-Output 'sync-check'",
+            description="probe-password-sync",
+            timeout=20,
+        )
+    except WindowsExecError as e:
+        msg = str(e).lower()
+        if "no result file" in msg or "auth" in msg:
+            print(
+                "  WARNING: cfg.password does not match Windows guest's account "
+                "password (FreeRDP authentication failed).\n"
+                "  This usually means password rotation has been silently failing "
+                "for prior winpodx versions (the runtime apply path was broken).\n"
+                "\n"
+                "  To fix: run `winpodx pod sync-password` and provide the "
+                "password Windows currently accepts (typically the original "
+                "from your initial setup). The Windows-side apply step below "
+                "will fail until you do this."
+            )
+        else:
+            print(f"  (probe inconclusive: {e})")
+    else:
+        print("  Password sync OK.")
 
 
 def _apply_runtime_fixes_to_existing_guest(non_interactive: bool) -> None:

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -19,8 +19,10 @@ def handle_pod(args: argparse.Namespace) -> None:
         _restart()
     elif cmd == "apply-fixes":
         _apply_fixes()
+    elif cmd == "sync-password":
+        _sync_password(getattr(args, "non_interactive", False))
     else:
-        print("Usage: winpodx pod {start|stop|status|restart|apply-fixes}")
+        print("Usage: winpodx pod {start|stop|status|restart|apply-fixes|sync-password}")
         sys.exit(1)
 
 
@@ -147,6 +149,91 @@ def _apply_fixes() -> None:
         )
         sys.exit(3)
     print("\nAll fixes applied to existing guest (no container recreate needed).")
+
+
+def _sync_password(non_interactive: bool) -> None:
+    """v0.1.9.5: rescue path when cfg.password no longer matches Windows.
+
+    Use case: prior releases (0.1.0 through 0.1.9.4) ran password rotation
+    via a broken `podman exec ... powershell.exe net user` path that never
+    actually reached the Windows VM. Host-side cfg.password has drifted
+    while Windows still has whatever the original install.bat / OEM
+    unattend.xml set it to. Symptom: FreeRDP launches fail with auth
+    error.
+
+    This command authenticates ONCE with a user-supplied "last known
+    working" password (typically the original from initial setup, or the
+    value in compose.yml's PASSWORD env var), then runs `net user` inside
+    Windows to reset the account password to the current cfg.password.
+    On success, password rotation works normally going forward (now that
+    v0.1.9.5 has migrated `_change_windows_password` to FreeRDP RemoteApp).
+    """
+    import getpass
+    import os
+
+    from winpodx.core.config import Config
+    from winpodx.core.windows_exec import WindowsExecError, run_in_windows
+
+    cfg = Config.load()
+    if cfg.pod.backend not in ("podman", "docker"):
+        print(f"sync-password not supported for backend {cfg.pod.backend!r}.")
+        sys.exit(2)
+
+    if not cfg.rdp.password:
+        print("No password set in cfg — nothing to sync to.")
+        sys.exit(2)
+
+    if non_interactive:
+        recovery_pw = os.environ.get("WINPODX_RECOVERY_PASSWORD", "")
+        if not recovery_pw:
+            print("ERROR: --non-interactive requires WINPODX_RECOVERY_PASSWORD env var.")
+            sys.exit(2)
+    else:
+        print(
+            "winpodx will authenticate once with a recovery password (the password "
+            "Windows currently accepts), then reset the Windows account to the "
+            "value in your winpodx config."
+        )
+        print()
+        print("Common recovery passwords to try:")
+        print("  - The password from your original setup (compose.yml PASSWORD env)")
+        print("  - The first password you set when winpodx was installed")
+        print()
+        recovery_pw = getpass.getpass("Recovery password (input hidden): ")
+        if not recovery_pw:
+            print("Aborted.")
+            sys.exit(2)
+
+    # Build a temporary Config copy with the recovery password so
+    # run_in_windows uses the right credentials for FreeRDP auth.
+    rescue_cfg = Config.load()
+    rescue_cfg.rdp.password = recovery_pw
+
+    target_pw = cfg.rdp.password.replace("'", "''")
+    user = cfg.rdp.user.replace("'", "''")
+    payload = f"& net user '{user}' '{target_pw}' | Out-Null\nWrite-Output 'password reset'\n"
+
+    print("Authenticating with recovery password and resetting Windows account...")
+    try:
+        result = run_in_windows(rescue_cfg, payload, description="sync-password", timeout=45)
+    except WindowsExecError as e:
+        print(f"FAIL: channel failure with recovery password: {e}")
+        print(
+            "\nThe recovery password didn't authenticate either. Options:\n"
+            "  1. Try sync-password again with a different recovery password.\n"
+            "  2. Open `winpodx app run desktop` and reset manually:\n"
+            f"       net user {cfg.rdp.user} <password from `winpodx config show`>\n"
+            "  3. As a last resort, recreate the container with `podman rm -f` + "
+            "`winpodx pod start --wait`."
+        )
+        sys.exit(3)
+
+    if result.rc != 0:
+        print(f"FAIL: password reset script failed (rc={result.rc}): {result.stderr.strip()}")
+        sys.exit(3)
+
+    print("OK: Windows account password is now in sync with winpodx config.")
+    print("Password rotation will now work normally.")
 
 
 def _restart() -> None:

--- a/src/winpodx/core/daemon.py
+++ b/src/winpodx/core/daemon.py
@@ -145,36 +145,30 @@ def cleanup_lock_files(search_dirs: list[Path] | None = None) -> list[Path]:
 
 
 def sync_windows_time(cfg: Config) -> bool:
-    """Force Windows time resync via RDP command execution.
+    """Force Windows time resync via FreeRDP RemoteApp PowerShell.
 
-    Uses podman/docker exec to run w32tm inside the container.
+    v0.1.9.5: was on the broken `podman exec ... cmd /c w32tm` path —
+    podman exec only reaches the Linux container, not the Windows VM
+    inside, so this never actually ran. Migrated to
+    ``windows_exec.run_in_windows`` along with the rest of the Windows-
+    side helpers.
     """
-    backend = cfg.pod.backend
-    container = cfg.pod.container_name
-
-    if backend not in ("podman", "docker"):
+    if cfg.pod.backend not in ("podman", "docker"):
         return False
 
-    runtime = "podman" if backend == "podman" else "docker"
-    cmd = [
-        runtime,
-        "exec",
-        container,
-        "cmd",
-        "/c",
-        "w32tm /resync /force",
-    ]
+    payload = "& w32tm /resync /force | Out-Null\nWrite-Output 'time synced'\n"
+    from winpodx.core.windows_exec import WindowsExecError, run_in_windows
 
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+        result = run_in_windows(cfg, payload, description="sync-time", timeout=30)
+    except WindowsExecError as e:
+        log.warning("Time sync channel failure: %s", e)
         return False
-    if result.returncode == 0:
-        log.info("Windows time synced")
-        return True
-
-    log.warning("Time sync failed: %s", result.stderr.strip())
-    return False
+    if result.rc != 0:
+        log.warning("Time sync failed (rc=%d): %s", result.rc, result.stderr.strip())
+        return False
+    log.info("Windows time synced")
+    return True
 
 
 # --- Idle Monitor ---

--- a/src/winpodx/core/discovery.py
+++ b/src/winpodx/core/discovery.py
@@ -171,17 +171,11 @@ def discover_apps(cfg: Config, timeout: int = 120) -> list[DiscoveredApp]:
     if not script.exists():
         raise DiscoveryError(f"Discovery script not found: {script}", kind="script_missing")
 
-    container = cfg.pod.container_name
-
-    # Why we don't use `podman cp host:script container:C:\path`:
-    # dockur/windows is a Linux container that runs the actual Windows guest
-    # inside QEMU; the Windows C: drive lives inside that VM's virtual disk,
-    # *not* on the container's own filesystem. `podman cp` interprets the
-    # destination as a path *on the container* — so it tries to write to a
-    # nonexistent `/C:/...` path and fails with "could not be found on
-    # container". The reliable transport is to feed the script body to the
-    # guest's powershell.exe via stdin: `powershell -Command -` reads the
-    # full script from stdin and executes it, no staging file required.
+    # v0.1.9.5: was on the broken `podman exec -i ... powershell -Command -`
+    # path (kernalix7's machine showed rc=127 "powershell.exe not found in
+    # $PATH" because podman exec only reaches the dockur Linux container,
+    # not the Windows VM inside). Migrated to ``windows_exec.run_in_windows``
+    # alongside the rest of the host->Windows command paths.
     try:
         script_body = script.read_text(encoding="utf-8")
     except OSError as e:
@@ -189,44 +183,27 @@ def discover_apps(cfg: Config, timeout: int = 120) -> list[DiscoveredApp]:
             f"Cannot read discovery script {script}: {e}", kind="script_missing"
         ) from e
 
-    cmd = [
-        runtime,
-        "exec",
-        "-i",
-        container,
-        "powershell",
-        "-NoProfile",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-Command",
-        "-",
-    ]
-    stdout_bytes, stderr_bytes, returncode = _run_bounded(
-        cmd, timeout=timeout, runtime=runtime, stdin_bytes=script_body.encode("utf-8")
-    )
+    from winpodx.core.windows_exec import WindowsExecError, run_in_windows
 
-    if returncode != 0:
-        stderr = stderr_bytes.decode("utf-8", errors="replace").strip()
-        # podman/docker emit recognizable strings when the container is stopped
-        # or missing; surface these as pod_not_running so the cli routes to
-        # exit code 2 + the "run `winpodx pod start --wait`" hint instead of
-        # generic script-failure code 3. Bug A: with the cp dropped, this is
-        # the only place we still distinguish the two error classes.
-        stderr_lower = stderr.lower()
-        if (
-            "no such container" in stderr_lower
-            or "is not running" in stderr_lower
-            or "container not running" in stderr_lower
-            or "no such object" in stderr_lower
-        ):
-            raise DiscoveryError(
-                f"Pod not running (rc={returncode}): {stderr}", kind="pod_not_running"
-            )
+    try:
+        result = run_in_windows(cfg, script_body, description="discover-apps", timeout=timeout)
+    except WindowsExecError as e:
+        msg = str(e).lower()
+        # FreeRDP failed to connect at the channel level — most often
+        # because the pod is stopped (no RDP listener) or the auth
+        # password drifted from cfg. Surface as pod_not_running so cli
+        # routes to exit code 2 + the helpful "run `winpodx pod start
+        # --wait` first" hint.
+        kind = "pod_not_running" if "no result file" in msg or "auth" in msg else "script_failed"
+        raise DiscoveryError(f"Discovery channel failure: {e}", kind=kind) from e
+
+    if result.rc != 0:
         raise DiscoveryError(
-            f"Discovery script failed (rc={returncode}): {stderr}", kind="script_failed"
+            f"Discovery script failed (rc={result.rc}): {result.stderr.strip()}",
+            kind="script_failed",
         )
 
-    return _parse_discovery_output(stdout_bytes.decode("utf-8", errors="replace"))
+    return _parse_discovery_output(result.stdout)
 
 
 def _run_bounded(

--- a/src/winpodx/core/pod.py
+++ b/src/winpodx/core/pod.py
@@ -101,21 +101,24 @@ def stop_pod(cfg: Config) -> PodStatus:
 
 
 def recover_rdp_if_needed(cfg: Config, *, max_attempts: int = 3) -> bool:
-    """Bug B: kick TermService when RDP is dead but VNC is alive.
+    """Detect "RDP dead but VNC alive" and recover by restarting the container.
 
-    After host suspend / long idle, Windows TermService can hang and
-    the virtual NIC can drop into power-save and stop accepting RDP
-    traffic — VNC keeps working because it talks to the QEMU display
-    directly. We detect the asymmetry and force a TermService restart
-    plus a w32tm resync, then re-probe RDP up to ``max_attempts`` times
-    with simple linear backoff.
+    After host suspend / long idle, Windows TermService can hang or the
+    virtual NIC can drop into power-save while VNC keeps working (VNC
+    talks to the QEMU display, not Windows). The fundamental constraint
+    here is that any host-driven Windows-side recovery (TermService
+    restart, w32tm resync) needs RDP itself to authenticate via
+    ``windows_exec.run_in_windows`` — and RDP is exactly what's broken.
 
-    Returns True if RDP is reachable when this function returns (either
-    because it was already up, or recovery succeeded). Returns False if
-    recovery couldn't bring it back, or if VNC was also dead (whole pod
-    is sick — caller should surface a different error). Backends other
-    than podman / docker skip silently with True so libvirt + manual
-    users aren't blocked by a no-op.
+    v0.1.9.5: previous releases tried ``podman exec`` which doesn't
+    actually reach the Windows VM (rc=127), so this function has been
+    silently no-op'ing since it was added. The honest fix is to restart
+    the container — dockur respawns the VM cleanly, OEM hardening
+    re-applies on boot, and RDP comes back. Cost is ~30 s pod restart
+    vs. some unknown hung-state.
+
+    Returns True if RDP is reachable on return, False if recovery failed.
+    Skips silently for libvirt / manual backends.
     """
     backend = cfg.pod.backend
     if backend not in ("podman", "docker"):
@@ -126,9 +129,7 @@ def recover_rdp_if_needed(cfg: Config, *, max_attempts: int = 3) -> bool:
 
     # Whole pod sick? Don't try to bandage RDP.
     if not check_rdp_port(cfg.rdp.ip, cfg.pod.vnc_port, timeout=2.0):
-        log.warning(
-            "RDP and VNC both unreachable; skipping TermService recovery (pod likely down)."
-        )
+        log.warning("RDP and VNC both unreachable; skipping recovery (pod likely down).")
         return False
 
     container = cfg.pod.container_name
@@ -136,39 +137,27 @@ def recover_rdp_if_needed(cfg: Config, *, max_attempts: int = 3) -> bool:
         log.warning("Refusing to recover RDP on non-conforming container name: %r", container)
         return False
 
-    runtime = "podman" if backend == "podman" else "docker"
-    ps_recover = (
-        "Restart-Service -Force TermService; "
-        "Start-Sleep -Seconds 2; "
-        "w32tm /resync /force | Out-Null"
+    log.info(
+        "RDP unreachable while VNC is alive; restarting the pod to recover "
+        "(no host-driven TermService restart channel exists for an unauthenticated session)."
     )
-    cmd = [
-        runtime,
-        "exec",
-        container,
-        "powershell",
-        "-NoProfile",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-Command",
-        ps_recover,
-    ]
+    runtime = "podman" if backend == "podman" else "docker"
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        subprocess.run(
+            [runtime, "restart", "--time", "10", container],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
     except (FileNotFoundError, subprocess.TimeoutExpired) as e:
-        log.warning("RDP recovery: TermService restart command failed: %s", e)
+        log.warning("RDP recovery: pod restart failed: %s", e)
         return False
 
-    if result.returncode != 0:
-        log.warning("RDP recovery: rc=%d stderr=%s", result.returncode, result.stderr.strip())
-        # Even on rc!=0 retry the probe — TermService may already be
-        # back from a Windows-side `sc.exe failure` action.
-
-    backoff = 2.0
+    backoff = 3.0
     for _attempt in range(max(1, max_attempts)):
         time.sleep(backoff)
         if check_rdp_port(cfg.rdp.ip, cfg.rdp.port, timeout=3.0):
-            log.info("RDP recovery succeeded after TermService restart.")
+            log.info("RDP recovery succeeded after pod restart.")
             return True
         backoff *= 2
 

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -88,42 +88,39 @@ def ensure_ready(cfg: Config | None = None, timeout: int = 300) -> Config:
 
 
 def _change_windows_password(cfg: Config, new_password: str) -> bool:
-    """Change Windows user password inside the container via PowerShell."""
-    backend = cfg.pod.backend
-    if backend not in ("podman", "docker"):
+    """Change the Windows user account password via FreeRDP RemoteApp.
+
+    Uses the CURRENT cfg.password to authenticate FreeRDP, then runs
+    ``net user <User> <new>`` inside Windows. On success, the caller
+    updates cfg.password. The existing rotation rollback marker
+    (``_ROTATION_PENDING_MARKER``) handles the partial-failure window
+    where the host saved the new password to disk but the guest didn't
+    accept it — on next ensure_ready the marker is detected and the
+    cfg.password is reverted to whatever Windows actually accepts.
+
+    v0.1.9.5: was on the broken `podman exec ... powershell.exe` path
+    which silently failed for every release back to 0.1.0. Migrated to
+    the FreeRDP RemoteApp channel along with all the other Windows-
+    side commands.
+    """
+    if cfg.pod.backend not in ("podman", "docker"):
         return False
 
-    runtime = "podman" if backend == "podman" else "docker"
-    # Escape single quotes in username to prevent PowerShell injection.
     user = cfg.rdp.user.replace("'", "''")
     pw = new_password.replace("'", "''")
-    ps_cmd = f"net user '{user}' '{pw}'"
-    cmd = [
-        runtime,
-        "exec",
-        cfg.pod.container_name,
-        r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-Command",
-        ps_cmd,
-    ]
+    payload = f"& net user '{user}' '{pw}' | Out-Null\nWrite-Output 'password set'\n"
+
+    from winpodx.core.windows_exec import WindowsExecError, run_in_windows
 
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
-        log.warning("Failed to exec password change: %s", e)
+        result = run_in_windows(cfg, payload, description="rotate-password", timeout=45)
+    except WindowsExecError as e:
+        log.warning("Password change channel failure: %s", e)
         return False
-
-    if result.returncode == 0:
-        return True
-
-    log.warning(
-        "Password change failed (rc=%d): %s",
-        result.returncode,
-        result.stderr.strip(),
-    )
-    return False
+    if result.rc != 0:
+        log.warning("Password change failed (rc=%d): %s", result.rc, result.stderr.strip())
+        return False
+    return True
 
 
 def _apply_max_sessions(cfg: Config) -> None:
@@ -139,6 +136,15 @@ def _apply_max_sessions(cfg: Config) -> None:
         return
 
     desired = max(1, min(50, int(cfg.pod.max_sessions)))
+    # v0.1.9.5: do NOT call `Restart-Service -Force TermService` here.
+    # The whole reason this script is running is that we're already inside
+    # an RDP session served by that very TermService — restarting it kills
+    # the session, the wrapper never gets to write its result file, and the
+    # host sees ERRINFO_RPC_INITIATED_DISCONNECT (kernalix7 saw exactly
+    # this on 2026-04-26). Registry write alone is enough; TermService
+    # picks up MaxInstanceCount on its next natural cycle (next pod boot
+    # or next manual `winpodx pod restart`). Idempotent so repeated runs
+    # eventually converge.
     payload = (
         f"$p = 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server'\n"
         f"$desired = {desired}\n"
@@ -150,8 +156,8 @@ def _apply_max_sessions(cfg: Config) -> None:
         "}\n"
         "Set-ItemProperty -Path $p -Name MaxInstanceCount -Value $desired -Type DWord -Force\n"
         "Set-ItemProperty -Path $p -Name fSingleSessionPerUser -Value 0 -Type DWord -Force\n"
-        "Restart-Service -Force TermService\n"
-        'Write-Output "max_sessions: $current -> $desired"\n'
+        'Write-Output "max_sessions: $current -> $desired '
+        '(takes effect on next TermService restart)"\n'
     )
 
     from winpodx.core.windows_exec import WindowsExecError, run_in_windows

--- a/src/winpodx/core/updates.py
+++ b/src/winpodx/core/updates.py
@@ -1,49 +1,43 @@
-r"""Windows Update toggle via container exec."""
+r"""Windows Update toggle via FreeRDP RemoteApp PowerShell.
+
+The actual toggle logic lives in ``config/oem/toggle_updates.ps1`` which
+dockur stages into ``C:\OEM\`` during unattended install. v0.1.9.5
+migrated this off the broken ``podman exec ... powershell.exe`` path
+(which never reached the Windows VM) onto ``windows_exec.run_in_windows``.
+"""
 
 from __future__ import annotations
 
 import logging
-import subprocess
 
 from winpodx.core.config import Config
 
 log = logging.getLogger(__name__)
 
-_SCRIPT = r"C:\OEM\toggle_updates.ps1"
-_PS = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
-
 
 def _exec_toggle(cfg: Config, action: str) -> tuple[bool, str]:
-    """Run toggle_updates.ps1 with the given action."""
-    backend = cfg.pod.backend
-    if backend not in ("podman", "docker"):
+    """Run ``toggle_updates.ps1 -Action <action>`` inside the Windows VM."""
+    if cfg.pod.backend not in ("podman", "docker"):
         return False, "Only supported for podman/docker backends"
 
-    runtime = "podman" if backend == "podman" else "docker"
-    cmd = [
-        runtime,
-        "exec",
-        cfg.pod.container_name,
-        _PS,
-        "-ExecutionPolicy",
-        "Bypass",
-        "-File",
-        _SCRIPT,
-        "-Action",
-        action,
-    ]
+    if action not in ("enable", "disable", "status"):
+        return False, f"unknown action {action!r}"
+
+    payload = (
+        f"& 'C:\\OEM\\toggle_updates.ps1' -Action '{action}'\n"
+        "if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE }\n"
+    )
+    from winpodx.core.windows_exec import WindowsExecError, run_in_windows
 
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-    except FileNotFoundError:
-        return False, f"{runtime} not found"
-    except subprocess.TimeoutExpired:
-        return False, "Command timed out"
+        result = run_in_windows(cfg, payload, description=f"updates-{action}", timeout=45)
+    except WindowsExecError as e:
+        return False, str(e)
 
-    output = result.stdout.strip()
-    if result.returncode == 0:
+    output = (result.stdout or "").strip()
+    if result.rc == 0:
         return True, output
-    return False, result.stderr.strip() or output
+    return False, (result.stderr.strip() or output) or f"rc={result.rc}"
 
 
 def disable_updates(cfg: Config) -> bool:

--- a/src/winpodx/core/windows_exec.py
+++ b/src/winpodx/core/windows_exec.py
@@ -199,7 +199,14 @@ def run_in_windows(
         )
 
     try:
-        data = json.loads(result_path.read_text(encoding="utf-8"))
+        # PowerShell's `Out-File -Encoding utf8` writes a UTF-8 BOM (the
+        # 5.1 / Windows-PowerShell behavior; PS Core 7+ doesn't). Use
+        # `utf-8-sig` so the BOM is consumed transparently. v0.1.9.5
+        # caught this — kernalix7's apply-fixes returned "result file
+        # unparseable: Unexpected UTF-8 BOM" when the wrapper actually
+        # *had* succeeded.
+        raw = result_path.read_text(encoding="utf-8-sig")
+        data = json.loads(raw)
     except (json.JSONDecodeError, OSError) as e:
         raise WindowsExecError(f"result file unparseable: {e}") from e
     finally:

--- a/src/winpodx/gui/main_window.py
+++ b/src/winpodx/gui/main_window.py
@@ -2043,49 +2043,44 @@ class WinpodxWindow(QMainWindow):
         self.info_label.setText("Running debloat...")
 
         def _do() -> None:
-            import subprocess
+            from winpodx.core.windows_exec import WindowsExecError, run_in_windows
 
             cfg = Config.load()
-            runtime = "podman" if cfg.pod.backend == "podman" else "docker"
-            container = cfg.pod.container_name
             base = Path(__file__).parent.parent.parent.parent
-            script = base / "scripts" / "windows" / "debloat.ps1"
-            if script.exists():
-                try:
-                    subprocess.run(
-                        [
-                            runtime,
-                            "cp",
-                            str(script),
-                            f"{container}:C:/debloat.ps1",
-                        ],
-                        capture_output=True,
-                        check=True,
-                        timeout=30,
-                    )
-                except (
-                    subprocess.CalledProcessError,
-                    subprocess.TimeoutExpired,
-                    FileNotFoundError,
-                ):
-                    return
-                try:
-                    subprocess.run(
-                        [
-                            runtime,
-                            "exec",
-                            container,
-                            "powershell",
-                            "-ExecutionPolicy",
-                            "Bypass",
-                            "-File",
-                            "C:\\debloat.ps1",
-                        ],
-                        capture_output=True,
-                        timeout=120,
-                    )
-                except (subprocess.TimeoutExpired, FileNotFoundError):
-                    pass
+            candidates = [
+                base / "scripts" / "windows" / "debloat.ps1",
+                Path.home()
+                / ".local"
+                / "bin"
+                / "winpodx-app"
+                / "scripts"
+                / "windows"
+                / "debloat.ps1",
+            ]
+            script = next((p for p in candidates if p.exists()), None)
+            if script is None:
+                self.app_launch_failed.emit("Debloat script not found")
+                return
+
+            try:
+                payload = script.read_text(encoding="utf-8")
+            except OSError as e:
+                self.app_launch_failed.emit(f"Cannot read debloat script: {e}")
+                return
+
+            try:
+                result = run_in_windows(cfg, payload, description="debloat", timeout=180)
+            except WindowsExecError as e:
+                self.app_launch_failed.emit(f"Debloat channel failure: {e}")
+                return
+
+            if result.rc == 0:
+                self.app_launched.emit("Debloat complete")
+            else:
+                self.app_launch_failed.emit(
+                    f"Debloat failed (rc={result.rc}): "
+                    f"{result.stderr.strip() or result.stdout.strip()[:200]}"
+                )
             self.pod_status_updated.emit("running", cfg.rdp.ip)
 
         threading.Thread(target=_do, daemon=True).start()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -94,18 +94,26 @@ def test_is_pod_paused_uses_configured_container_name():
     assert "winpodx-windows" not in cmd
 
 
-def test_sync_windows_time_uses_configured_container_name():
+def test_sync_windows_time_uses_windows_exec_channel(monkeypatch):
+    """v0.1.9.5: sync_windows_time migrated from podman exec to FreeRDP RemoteApp."""
+    from winpodx.core.windows_exec import WindowsExecResult
+
     cfg = Config()
     cfg.pod.backend = "podman"
     cfg.pod.container_name = "alt-winpod"
+    cfg.rdp.password = "secret"
 
-    with patch("winpodx.core.daemon.subprocess.run", return_value=_mock_run_ok()) as mr:
-        assert sync_windows_time(cfg) is True
+    captured: dict[str, str] = {}
 
-    cmd = mr.call_args.args[0]
-    assert cmd[0] == "podman"
-    assert cmd[1] == "exec"
-    assert cmd[2] == "alt-winpod"
+    def fake(cfg_inner, payload, *, timeout=60, description="windows-exec"):
+        captured["payload"] = payload
+        captured["description"] = description
+        return WindowsExecResult(rc=0, stdout="time synced", stderr="")
+
+    monkeypatch.setattr("winpodx.core.windows_exec.run_in_windows", fake)
+    assert sync_windows_time(cfg) is True
+    assert "w32tm" in captured["payload"]
+    assert captured["description"] == "sync-time"
 
 
 def test_cleanup_ignores_symlinks(tmp_path):

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -575,113 +575,109 @@ def test_discover_requires_script_file():
             discover_apps(cfg)
 
 
-def test_discover_surfaces_pod_not_running(tmp_path):
-    """Bug A: stderr containing 'no such container' is reclassified to pod_not_running."""
+def _stub_run_in_windows(
+    monkeypatch,
+    *,
+    rc: int = 0,
+    stdout: str = "[]",
+    stderr: str = "",
+    raise_exc: Exception | None = None,
+):
+    """v0.1.9.5: discover_apps now goes through windows_exec.run_in_windows.
+    Tests stub the new entry point and capture the (description, payload) pair.
+    """
+    from winpodx.core.windows_exec import WindowsExecResult
+
+    captured: dict[str, str] = {}
+
+    def fake(cfg_inner, payload, *, timeout=60, description="windows-exec"):
+        captured["description"] = description
+        captured["payload"] = payload
+        captured["timeout"] = timeout
+        if raise_exc is not None:
+            raise raise_exc
+        return WindowsExecResult(rc=rc, stdout=stdout, stderr=stderr)
+
+    monkeypatch.setattr("winpodx.core.windows_exec.run_in_windows", fake)
+    return captured
+
+
+def test_discover_surfaces_pod_not_running(tmp_path, monkeypatch):
+    """v0.1.9.5: WindowsExecError with auth/no-result-file → pod_not_running kind."""
+    from winpodx.core.windows_exec import WindowsExecError
+
     cfg = _make_cfg(backend="podman")
     script = tmp_path / "discover_apps.ps1"
     script.write_text("# stub")
 
+    _stub_run_in_windows(
+        monkeypatch,
+        raise_exc=WindowsExecError(
+            "No result file written (FreeRDP rc=1). stderr tail: 'auth failure'"
+        ),
+    )
     with (
         patch("winpodx.core.discovery.shutil.which", return_value="/usr/bin/podman"),
         patch("winpodx.core.discovery._ps_script_path", return_value=script),
-        patch(
-            "winpodx.core.discovery.subprocess.Popen",
-            return_value=_fake_popen(
-                stdout=b"", stderr=b"Error: no such container winpodx-windows", returncode=125
-            ),
-        ),
     ):
-        with pytest.raises(DiscoveryError, match="Pod not running") as excinfo:
+        with pytest.raises(DiscoveryError, match="channel failure") as excinfo:
             discover_apps(cfg)
         assert excinfo.value.kind == "pod_not_running"
 
 
-def test_discover_surfaces_timeout(tmp_path):
+def test_discover_happy_path_roundtrip(tmp_path, monkeypatch):
     cfg = _make_cfg(backend="podman")
     script = tmp_path / "discover_apps.ps1"
     script.write_text("# stub")
 
-    # Simulate a child that never naturally terminates. The bounded
-    # loop in _run_bounded must kill it once the deadline elapses.
-    stuck = _fake_popen(stdout=b"", stderr=b"", returncode=-9)
-    stuck.poll.return_value = None  # never finishes on its own
+    payload = json.dumps([_valid_entry(name="Calculator")])
+    captured = _stub_run_in_windows(monkeypatch, rc=0, stdout=payload)
 
     with (
         patch("winpodx.core.discovery.shutil.which", return_value="/usr/bin/podman"),
         patch("winpodx.core.discovery._ps_script_path", return_value=script),
-        patch("winpodx.core.discovery.subprocess.Popen", return_value=stuck),
-    ):
-        with pytest.raises(DiscoveryError, match="timed out") as excinfo:
-            discover_apps(cfg, timeout=1)
-        assert excinfo.value.kind == "timeout"
-
-
-def test_discover_happy_path_roundtrip(tmp_path):
-    cfg = _make_cfg(backend="podman")
-    script = tmp_path / "discover_apps.ps1"
-    script.write_text("# stub")
-
-    payload = json.dumps([_valid_entry(name="Calculator")]).encode("utf-8")
-
-    with (
-        patch("winpodx.core.discovery.shutil.which", return_value="/usr/bin/podman"),
-        patch("winpodx.core.discovery._ps_script_path", return_value=script),
-        patch(
-            "winpodx.core.discovery.subprocess.Popen",
-            return_value=_fake_popen(stdout=payload, returncode=0),
-        ),
     ):
         apps = discover_apps(cfg)
 
     assert len(apps) == 1
     assert apps[0].full_name == "Calculator"
+    assert captured["description"] == "discover-apps"
+    # Payload must be the script contents (windows_exec wraps it).
+    assert "# stub" in captured["payload"]
 
 
-def test_discover_nonzero_exit_raises(tmp_path):
+def test_discover_nonzero_exit_raises(tmp_path, monkeypatch):
     cfg = _make_cfg(backend="podman")
     script = tmp_path / "discover_apps.ps1"
     script.write_text("# stub")
 
+    _stub_run_in_windows(monkeypatch, rc=42, stderr="Get-AppxPackage failed")
     with (
         patch("winpodx.core.discovery.shutil.which", return_value="/usr/bin/podman"),
         patch("winpodx.core.discovery._ps_script_path", return_value=script),
-        patch(
-            "winpodx.core.discovery.subprocess.Popen",
-            return_value=_fake_popen(stdout=b"", stderr=b"Get-AppxPackage failed", returncode=42),
-        ),
     ):
         with pytest.raises(DiscoveryError, match="rc=42") as excinfo:
             discover_apps(cfg)
         assert excinfo.value.kind == "script_failed"
 
 
-def test_discover_pipes_script_via_stdin(tmp_path):
-    """Bug A: the script body must be piped via stdin, not staged via podman cp."""
+def test_discover_uses_windows_exec_channel(tmp_path, monkeypatch):
+    """v0.1.9.5: the discover_apps.ps1 body is forwarded to windows_exec, NOT
+    sent through podman exec (which only reaches the Linux container)."""
     cfg = _make_cfg(backend="podman")
     script = tmp_path / "discover_apps.ps1"
-    script.write_text("# the actual ps1 body that should travel over stdin")
+    script.write_text("# the actual ps1 body that should reach Windows")
 
-    captured = _fake_popen(stdout=b"[]", returncode=0)
+    captured = _stub_run_in_windows(monkeypatch, rc=0, stdout="[]")
 
     with (
         patch("winpodx.core.discovery.shutil.which", return_value="/usr/bin/podman"),
         patch("winpodx.core.discovery._ps_script_path", return_value=script),
-        patch("winpodx.core.discovery.subprocess.Popen", return_value=captured) as popen_mock,
     ):
         discover_apps(cfg)
 
-    # The single Popen invocation must use `exec -i ... powershell ... -Command -`.
-    assert popen_mock.call_count == 1
-    cmd = popen_mock.call_args.args[0]
-    assert "exec" in cmd
-    assert "-i" in cmd  # stdin must be open
-    assert "-Command" in cmd
-    assert cmd[-1] == "-"  # final arg = stdin marker
-    # And the script body must have been written to stdin then closed.
-    captured.stdin.write.assert_called_once()
-    written = captured.stdin.write.call_args.args[0]
-    assert b"the actual ps1 body" in written
-    captured.stdin.close.assert_called_once()
+    assert "the actual ps1 body that should reach Windows" in captured["payload"]
+    assert captured["description"] == "discover-apps"
 
 
 # ---------------------------------------------------------------------------
@@ -820,87 +816,33 @@ def test_persist_rejects_malformed_png_but_persists_entry(tmp_path):
     assert app.icon_path == ""
 
 
-def test_discovery_stdout_cap_triggers_truncated_error(tmp_path):
-    """L1: child emitting >HARD_STDOUT_CAP bytes must raise kind=truncated."""
+# test_discovery_stdout_cap_triggers_truncated_error: removed in v0.1.9.5.
+# discover_apps used to drive subprocess.Popen via _run_bounded with a 64 MiB
+# stdout cap; the migration to windows_exec.run_in_windows replaces that
+# transport entirely (the FreeRDP RemoteApp wrapper writes a JSON file via
+# tsclient redirection, no streaming subprocess). The cap is no longer the
+# right invariant to test — the analogous L1-style guard would be a result-
+# file size limit, which can be added if real-world JSON gets unmanageable.
+
+
+def test_discover_surfaces_timeout(tmp_path, monkeypatch):
+    """v0.1.9.5: timeouts now surface from windows_exec, not _run_bounded."""
+    from winpodx.core.windows_exec import WindowsExecError
+
     cfg = _make_cfg(backend="podman")
     script = tmp_path / "discover_apps.ps1"
     script.write_text("# stub")
 
-    from winpodx.core.discovery import HARD_STDOUT_CAP
-
-    # Flood ~65 MiB so the drain loop trips the cap well before completion.
-    flood_size = HARD_STDOUT_CAP + (1 * 1024 * 1024)
-
-    class _FloodingProc:
-        """Stand-in for subprocess.Popen that floods stdout via an OS pipe."""
-
-        def __init__(self) -> None:
-            import threading as _t
-
-            self._stdout_r, self._stdout_w = os.pipe()
-            self._stderr_r, self._stderr_w = os.pipe()
-            os.close(self._stderr_w)  # no stderr output
-            self.returncode: int | None = None
-            self._stdout_closed = False
-
-            def _writer() -> None:
-                chunk = b"A" * (1024 * 1024)  # 1 MiB per write
-                written = 0
-                try:
-                    while written < flood_size:
-                        os.write(self._stdout_w, chunk)
-                        written += len(chunk)
-                except OSError:
-                    # Pipe closed by kill() — expected once the cap trips.
-                    return
-                finally:
-                    try:
-                        os.close(self._stdout_w)
-                    except OSError:
-                        pass
-
-            self._writer_thread = _t.Thread(target=_writer, daemon=True)
-            self._writer_thread.start()
-
-            self.stdout = MagicMock()
-            self.stdout.fileno.return_value = self._stdout_r
-            self.stderr = MagicMock()
-            self.stderr.fileno.return_value = self._stderr_r
-            # Bug A: discover_apps now writes the PS script to stdin.
-            self.stdin = MagicMock()
-            self.stdin.write.return_value = None
-            self.stdin.close.return_value = None
-
-        def poll(self):
-            # Never naturally finishes — the drain cap must be what stops us.
-            return None
-
-        def kill(self) -> None:
-            self.returncode = -9
-            if not self._stdout_closed:
-                self._stdout_closed = True
-                try:
-                    os.close(self._stdout_w)
-                except OSError:
-                    pass
-
-        def wait(self, timeout=None) -> int:
-            if self.returncode is None:
-                self.returncode = -9
-            return self.returncode
-
-    flooding = _FloodingProc()
-
-    # _FloodingProc must also expose stdin so the new pipe path works.
-    flooding.stdin = MagicMock()
-    flooding.stdin.write.return_value = None
-    flooding.stdin.close.return_value = None
-
+    _stub_run_in_windows(
+        monkeypatch,
+        raise_exc=WindowsExecError("FreeRDP timed out after 1s"),
+    )
     with (
         patch("winpodx.core.discovery.shutil.which", return_value="/usr/bin/podman"),
         patch("winpodx.core.discovery._ps_script_path", return_value=script),
-        patch("winpodx.core.discovery.subprocess.Popen", return_value=flooding),
     ):
-        with pytest.raises(DiscoveryError) as excinfo:
-            discover_apps(cfg, timeout=60)
-        assert excinfo.value.kind == "truncated"
+        with pytest.raises(DiscoveryError, match="channel failure") as excinfo:
+            discover_apps(cfg, timeout=1)
+        # Timeout is a channel-level failure; classifies as script_failed
+        # since the script never got a chance to actually fail.
+        assert excinfo.value.kind == "script_failed"

--- a/tests/test_no_broken_podman_exec.py
+++ b/tests/test_no_broken_podman_exec.py
@@ -1,0 +1,83 @@
+"""Lint test: prevent regression to the broken `podman exec ... powershell.exe` path.
+
+v0.1.9.5 migrated every host-to-Windows command path to
+``winpodx.core.windows_exec.run_in_windows``. The previous architecture
+that called ``podman exec winpodx-windows ...\\powershell.exe`` only
+reached the dockur Linux container — never the Windows VM inside QEMU —
+and so silently no-op'd for releases 0.1.0 through 0.1.9.4.
+
+This test fails if any new code under ``src/winpodx/`` (other than
+``windows_exec.py`` itself, which is the canonical channel implementation)
+combines the strings ``"exec"`` and ``"powershell"`` in a single file.
+That heuristic is loose enough to catch the broken pattern without
+flagging legitimate uses of either word in isolation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Files that are allowed to contain both tokens. Add new entries here only
+# when the file legitimately wraps the windows_exec channel itself or is
+# documentation/test/comment scaffolding.
+_ALLOWLIST = {
+    "src/winpodx/core/windows_exec.py",
+    # discovery.py historically had a podman-exec call site; v0.1.9.5
+    # migrated it to windows_exec but the comment block still references
+    # the old approach for posterity. The active code uses run_in_windows.
+}
+
+
+def test_no_broken_podman_exec_callers():
+    repo_root = Path(__file__).resolve().parent.parent
+    src_dir = repo_root / "src" / "winpodx"
+
+    offenders: list[tuple[str, list[int]]] = []
+    for py_file in src_dir.rglob("*.py"):
+        rel = py_file.relative_to(repo_root).as_posix()
+        if rel in _ALLOWLIST:
+            continue
+
+        try:
+            text = py_file.read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        # Skip files that don't have both tokens at all.
+        if "exec" not in text or "powershell" not in text.lower():
+            continue
+
+        # Walk lines looking for the pattern: a line containing the literal
+        # string ``"exec"`` (the subprocess argument) AND a nearby line
+        # containing ``"powershell"`` or the WindowsPowerShell path.
+        # Allow ``windows_exec`` (module-name uses) and ``run_in_windows``
+        # (the canonical helper) without flagging.
+        bad_lines: list[int] = []
+        lines = text.splitlines()
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            # Skip pure comments / docstrings — they document the migration.
+            if stripped.startswith("#") or stripped.startswith('"""'):
+                continue
+            if '"exec"' not in line:
+                continue
+            # `"exec"` shows up in subprocess arglists for legitimate
+            # purposes too (e.g. `podman exec winpodx-windows restart`).
+            # The broken pattern is when it's followed within a few lines
+            # by a literal `"powershell"` or the powershell.exe path.
+            window = "\n".join(lines[i : i + 12]).lower()
+            if "powershell" in window and "windows_exec" not in window:
+                bad_lines.append(i + 1)
+
+        if bad_lines:
+            offenders.append((rel, bad_lines))
+
+    if offenders:
+        msg_parts = [
+            "Found broken `podman exec ... powershell` patterns. "
+            "All Windows-side commands must go through "
+            "winpodx.core.windows_exec.run_in_windows. Offending files:"
+        ]
+        for rel, line_numbers in offenders:
+            msg_parts.append(f"  {rel}: lines {line_numbers}")
+        raise AssertionError("\n".join(msg_parts))

--- a/tests/test_pod.py
+++ b/tests/test_pod.py
@@ -100,13 +100,12 @@ def test_recover_rdp_fires_termservice_when_vnc_alive(monkeypatch):
     assert recover_rdp_if_needed(cfg) is True
     assert len(captured_cmds) == 1
     cmd = captured_cmds[0]
+    # v0.1.9.5: recovery now restarts the *container* (the TermService
+    # path was on the broken podman exec channel and never worked). The
+    # restart subcommand is what the test should verify.
     assert cmd[0] == "podman"
-    assert "exec" in cmd
-    assert cmd[2] == cfg.pod.container_name  # container name is third arg, no shell=True
-    last_arg = cmd[-1]
-    assert "Restart-Service" in last_arg
-    assert "TermService" in last_arg
-    assert "w32tm" in last_arg
+    assert "restart" in cmd
+    assert cfg.pod.container_name in cmd
 
 
 def test_recover_rdp_returns_false_after_max_attempts(monkeypatch):

--- a/tests/test_provisioner.py
+++ b/tests/test_provisioner.py
@@ -182,7 +182,10 @@ def test_apply_max_sessions_runs_via_windows_exec(monkeypatch):
     assert "MaxInstanceCount" in payload
     assert "$desired = 25" in payload
     assert "fSingleSessionPerUser" in payload
-    assert "Restart-Service" in payload
+    # v0.1.9.5: Restart-Service intentionally removed — restarting the
+    # TermService that hosts our own RDP session kills the session
+    # before the wrapper can write its result file.
+    assert "Restart-Service" not in payload
 
 
 def test_apply_max_sessions_raises_on_nonzero_rc(monkeypatch):

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -339,39 +339,51 @@ class TestPasswordFilter:
 
 
 class TestPowerShellEscape:
-    def test_username_single_quote_escaped(self):
-        from unittest.mock import patch
+    """v0.1.9.5: _change_windows_password migrated from podman-exec to
+    windows_exec.run_in_windows. Tests now mock the new entry point and
+    inspect the payload string instead of subprocess argv."""
 
+    def test_username_single_quote_escaped(self, monkeypatch):
         from winpodx.core.config import Config
+        from winpodx.core.windows_exec import WindowsExecResult
 
         cfg = Config()
         cfg.rdp.user = "admin'; whoami; '"
+        cfg.rdp.password = "current-pw"
         cfg.pod.backend = "podman"
 
-        with patch("winpodx.core.provisioner.subprocess.run") as mock_run:
-            mock_run.return_value.returncode = 0
-            from winpodx.core.provisioner import _change_windows_password
+        captured: dict[str, str] = {}
 
-            _change_windows_password(cfg, "newpass123")
-            ps_cmd = mock_run.call_args[0][0][7]
-            assert "admin''; whoami; ''" in ps_cmd
+        def fake(cfg_inner, payload, **_kw):
+            captured["payload"] = payload
+            return WindowsExecResult(rc=0, stdout="password set", stderr="")
 
-    def test_normal_username_unchanged(self):
-        from unittest.mock import patch
+        monkeypatch.setattr("winpodx.core.windows_exec.run_in_windows", fake)
+        from winpodx.core.provisioner import _change_windows_password
 
+        assert _change_windows_password(cfg, "newpass123") is True
+        assert "admin''; whoami; ''" in captured["payload"]
+
+    def test_normal_username_unchanged(self, monkeypatch):
         from winpodx.core.config import Config
+        from winpodx.core.windows_exec import WindowsExecResult
 
         cfg = Config()
         cfg.rdp.user = "User"
+        cfg.rdp.password = "current-pw"
         cfg.pod.backend = "podman"
 
-        with patch("winpodx.core.provisioner.subprocess.run") as mock_run:
-            mock_run.return_value.returncode = 0
-            from winpodx.core.provisioner import _change_windows_password
+        captured: dict[str, str] = {}
 
-            _change_windows_password(cfg, "testpass")
-            ps_cmd = mock_run.call_args[0][0][7]
-            assert "net user 'User' 'testpass'" == ps_cmd
+        def fake(cfg_inner, payload, **_kw):
+            captured["payload"] = payload
+            return WindowsExecResult(rc=0, stdout="password set", stderr="")
+
+        monkeypatch.setattr("winpodx.core.windows_exec.run_in_windows", fake)
+        from winpodx.core.provisioner import _change_windows_password
+
+        assert _change_windows_password(cfg, "testpass") is True
+        assert "net user 'User' 'testpass'" in captured["payload"]
 
 
 class TestPasswordTimestamp:


### PR DESCRIPTION
Hotfix for kernalix7's v0.1.9.4 install output: max_sessions hit ERRINFO_RPC_INITIATED_DISCONNECT, rdp_timeouts and oem_runtime_fixes hit "Unexpected UTF-8 BOM".

## Two surgical fixes

1. **BOM in result file caused fake "fail" reports.** Wrapper used \`Out-File -Encoding utf8\` (writes BOM in WinPS 5.1); host parsed with default \`utf-8\` codec. The registry changes from rdp_timeouts and oem_runtime_fixes had actually applied successfully — only the parse step failed. Now reading with \`utf-8-sig\`.

2. **\`_apply_max_sessions\` killed its own RDP session** by calling \`Restart-Service -Force TermService\` — the very service hosting the FreeRDP RemoteApp running the script. Removed the in-script restart; registry write alone is enough.

## Full architectural cleanup

Audited every remaining host-to-Windows command path and migrated the six still on the broken \`podman exec ... powershell.exe\` channel: \`_change_windows_password\` (password rotation), \`recover_rdp_if_needed\` (now does container restart), \`sync_windows_time\`, \`updates._exec_toggle\` (Windows Update), \`_cmd_debloat\` + GUI handler, and \`discover_apps\`. All migrated to \`windows_exec.run_in_windows\`.

## Plus password-drift recovery

- New \`winpodx pod sync-password\` CLI to recover from drift
- migrate auto-detects drift, points at sync-password
- Lint test prevents future regression

## Test plan

- 380 pytest, ruff clean
- Lint test enforces single-channel rule