### PR TITLE
release: v0.2.0.1 — gate runtime applies on Windows VM boot completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,17 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-04-26
+## [0.2.0.1] - 2026-04-26
+
+### Fixed
+- **Apply cascade collapsed on cold container.** v0.2.0 fired the three idempotent runtime applies (`max_sessions`, `rdp_timeouts`, `oem_runtime_fixes`) the moment `pod_status` reported `RUNNING`. The dockur Linux container reaches `RUNNING` in seconds, but the Windows VM inside QEMU needs another 30–90s before its RDP listener can accept FreeRDP RemoteApp activation. Within that window every apply collapsed with either `ERRCONNECT_CONNECT_TRANSPORT_FAILED [0x0002000D]` (rc=147, RDP socket open but server not initialized — connection reset by peer) on a fresh install, or `ERRCONNECT_ACTIVATION_TIMEOUT [0x0002001C]` (rc=131, FreeRDP connected but activation phase didn't complete) on `winpodx pod restart`. Each apply waited the full 60s timeout, so the cascade ran 3min before surfacing as a Launch Error dialog or "3 of 3 applies failed" panic message during `winpodx setup` → `winpodx migrate`.
+- New `wait_for_windows_responsive(cfg, timeout=90)` helper: polls `check_rdp_port`, then fires a 20s no-op `Write-Output 'ping'` probe to confirm the FreeRDP RemoteApp channel is actually live. Used as a precondition by:
+  - `ensure_ready()` warm-pod path — skips the self-heal apply block entirely if the guest isn't responsive yet.
+  - `winpodx pod apply-fixes` CLI — explicit "Waiting for Windows guest to finish booting (up to 90s)…" message so users know it's not hung.
+  - `winpodx migrate` apply step — same wait, with a clear "guest still booting; run apply-fixes later, or just launch any app" message instead of three channel-failure stack traces.
+- `_self_heal_apply()` (new) — wraps the warm-pod ensure_ready apply block in `WindowsExecError` swallow so a transient channel failure logs a warning and stops further attempts in the same call instead of cascading. The next ensure_ready picks up where this one left off.
+
+
 
 ### Fixed
 - **`oem_runtime_fixes` failed on first apply with `AllowComputerToTurnOffDevice` parameter error.** v0.1.9.5 shipped the runtime apply through FreeRDP RemoteApp PowerShell, but the payload still passed `Set-NetAdapterPowerManagement -AllowComputerToTurnOffDevice $false`. The cmdlet expects the enum string `'Disabled'` / `'Enabled'`, and on virtual NICs (virtio inside QEMU) the parameter often isn't exposed at all. v0.2.0 wraps the call in `try/catch`, switches to the enum form, and skips adapters that don't support it — apply now passes regardless of NIC topology.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+winpodx (0.2.0.1) unstable; urgency=high
+
+  * Fixed: apply cascade collapsed on cold container. v0.2.0 fired the
+    three runtime applies (max_sessions, rdp_timeouts, oem_runtime_fixes)
+    the moment the container reached RUNNING, but the Windows VM inside
+    QEMU needed another 30-90s before its RDP listener could accept
+    FreeRDP RemoteApp activation. Within that window every apply
+    collapsed: ERRCONNECT_CONNECT_TRANSPORT_FAILED (rc=147) on fresh
+    install, or ERRCONNECT_ACTIVATION_TIMEOUT (rc=131) on pod restart.
+    3min cascade surfaced as a Launch Error dialog or "3 of 3 applies
+    failed" panic during setup -> migrate.
+  * Added: wait_for_windows_responsive() helper polls check_rdp_port,
+    then fires a 20s no-op probe to confirm FreeRDP RemoteApp is live.
+    Used by ensure_ready warm path, winpodx pod apply-fixes, and
+    winpodx migrate apply step.
+  * Added: _self_heal_apply() wraps warm-pod ensure_ready applies in
+    WindowsExecError swallow so transient channel failures log a
+    warning and abort further attempts in the same call.
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Sun, 26 Apr 2026 22:30:00 +0900
+
 winpodx (0.2.0) unstable; urgency=medium
 
   * Fixed: oem_runtime_fixes failed on first apply with

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,7 +9,20 @@
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-04-26
+## [0.2.0.1] - 2026-04-26
+
+### 수정
+- **차가운 컨테이너에서 apply cascade 가 무너짐.** v0.2.0 은 `pod_status` 가 `RUNNING` 이 되는 즉시 세 개 idempotent runtime apply (`max_sessions`, `rdp_timeouts`, `oem_runtime_fixes`) 를 발화. dockur Linux 컨테이너는 몇 초 안에 `RUNNING` 도달하지만, QEMU 안 Windows VM 은 RDP 리스너가 FreeRDP RemoteApp activation 받기까지 30~90초 더 필요. 그 윈도우 안에서 모든 apply 는:
+  - 신규 설치 시: `ERRCONNECT_CONNECT_TRANSPORT_FAILED [0x0002000D]` (rc=147, RDP 소켓은 열렸지만 서버 미초기화 — connection reset by peer)
+  - `winpodx pod restart` 시: `ERRCONNECT_ACTIVATION_TIMEOUT [0x0002001C]` (rc=131, FreeRDP 연결됐지만 activation 단계 미완료)
+  로 무너짐. 각 apply 가 60초 timeout 풀로 대기 → cascade 3분 → 사용자가 앱 실행 시 Launch Error 다이얼로그 또는 `winpodx setup` → `winpodx migrate` 도중 "3 of 3 applies failed" 패닉 메시지로 표면화.
+- 새 헬퍼 `wait_for_windows_responsive(cfg, timeout=90)`: `check_rdp_port` 폴링 후 20초 no-op `Write-Output 'ping'` 프로브로 FreeRDP RemoteApp 채널이 실제로 살아있는지 확인. 다음 경로의 precondition 으로 사용:
+  - `ensure_ready()` warm-pod 경로 — 게스트가 미응답이면 self-heal apply 블록 통째로 skip.
+  - `winpodx pod apply-fixes` CLI — 명시적 "Waiting for Windows guest to finish booting (up to 90s)…" 메시지로 hang 아님을 표시.
+  - `winpodx migrate` apply 단계 — 같은 wait + 채널 실패 스택트레이스 3개 대신 "게스트 부팅 중; 나중에 apply-fixes 실행하거나 그냥 앱 실행해도 됨" 명확한 메시지.
+- `_self_heal_apply()` (신규) — warm-pod ensure_ready apply 블록을 `WindowsExecError` swallow 로 감싸서 transient 채널 실패가 cascade 안 되고 warning 만 로그 후 같은 호출 내 추가 시도 중단. 다음 ensure_ready 가 이어받음.
+
+
 
 ### 수정
 - **`oem_runtime_fixes` 가 `AllowComputerToTurnOffDevice` 파라미터 오류로 첫 적용 실패.** v0.1.9.5 가 runtime apply 를 FreeRDP RemoteApp PowerShell 로 넘겼지만 payload 는 여전히 `Set-NetAdapterPowerManagement -AllowComputerToTurnOffDevice $false` 호출. 이 cmdlet 은 enum 문자열 `'Disabled'` / `'Enabled'` 를 요구하고, QEMU 안 가상 NIC (virtio) 는 이 파라미터 자체가 노출 안 되는 경우 잦음. v0.2.0 은 `try/catch` 로 감싸고 enum 형태로 전환, 미지원 어댑터는 건너뜀 — NIC 토폴로지 무관 apply 성공.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.2.0"
+version = "0.2.0.1"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.0.1"

--- a/src/winpodx/cli/migrate.py
+++ b/src/winpodx/cli/migrate.py
@@ -449,6 +449,24 @@ def _apply_runtime_fixes_to_existing_guest(non_interactive: bool) -> None:
             print(f"  warning: pod start failed ({e}). Try `winpodx pod start --wait`.")
         return
 
+    # v0.2.0.1: container can be RUNNING while the Windows VM inside
+    # QEMU is still booting — that's the fresh-install scenario where
+    # `setup` recreates the container then `migrate` runs immediately
+    # and every apply collapses with rc=147 connection-reset / rc=131
+    # activation-timeout. Wait for the RDP listener to actually accept
+    # FreeRDP RemoteApp before firing applies.
+    from winpodx.core.provisioner import wait_for_windows_responsive
+
+    print("  Waiting for Windows guest to finish booting (up to 90s)...")
+    if not wait_for_windows_responsive(cfg, timeout=90):
+        print(
+            "  Windows guest still booting after 90s — skipping runtime apply.\n"
+            "  Run `winpodx pod apply-fixes` once `winpodx pod status` reports "
+            "the pod is fully up, or just launch any app and the apply will "
+            "fire automatically."
+        )
+        return
+
     # Pod is running — three idempotent applies.
     failures: list[str] = []
     for name, fn in (

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -136,6 +136,20 @@ def _apply_fixes() -> None:
         print("Start the pod first with: winpodx pod start --wait")
         sys.exit(2)
 
+    # v0.2.0.1: container RUNNING != Windows VM accepting FreeRDP yet.
+    # Wait for the guest to finish booting before firing applies, so a
+    # user running `winpodx pod apply-fixes` right after a fresh start
+    # doesn't see 3×60s of timeout cascades.
+    from winpodx.core.provisioner import wait_for_windows_responsive
+
+    print("Waiting for Windows guest to finish booting (up to 90s)...")
+    if not wait_for_windows_responsive(cfg, timeout=90):
+        print(
+            "Windows guest still booting after 90s. Wait a bit longer, "
+            "then re-run `winpodx pod apply-fixes`."
+        )
+        sys.exit(2)
+
     print("Applying Windows-side runtime fixes...")
     results = apply_windows_runtime_fixes(cfg)
 

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -45,10 +45,20 @@ def ensure_ready(cfg: Config | None = None, timeout: int = 300) -> Config:
     # container. Each apply is idempotent — `Set-ItemProperty -Force` is a
     # no-op when the value already matches — so running them on every
     # ensure_ready is cheap (~1.5s overhead) and self-healing.
-    if cfg.pod.backend in ("podman", "docker") and pod_status(cfg).state == PodState.RUNNING:
-        _apply_max_sessions(cfg)
-        _apply_rdp_timeouts(cfg)
-        _apply_oem_runtime_fixes(cfg)
+    #
+    # v0.2.0.1: gate the warm-pod path on `check_rdp_port` so we don't
+    # fire FreeRDP RemoteApp at a container that's `RUNNING` but whose
+    # Windows VM is still booting. Without the gate, each apply hits
+    # ERRCONNECT_ACTIVATION_TIMEOUT (rc=131) or ERRCONNECT_CONNECT_TRANSPORT_FAILED
+    # (rc=147, connection reset) after up to 60s, and the cascade
+    # (3×60s) surfaces as a Launch Error dialog when the user tries
+    # to start an app right after `winpodx pod restart`.
+    if (
+        cfg.pod.backend in ("podman", "docker")
+        and pod_status(cfg).state == PodState.RUNNING
+        and check_rdp_port(cfg.rdp.ip, cfg.rdp.port, timeout=1.0)
+    ):
+        _self_heal_apply(cfg)
 
     if check_rdp_port(cfg.rdp.ip, cfg.rdp.port, timeout=0.3):
         return cfg
@@ -66,9 +76,7 @@ def ensure_ready(cfg: Config | None = None, timeout: int = 300) -> Config:
     # Re-apply once more after starting (cold-pod path); same idempotency
     # guarantees mean this only does work the first time after a fresh
     # start. The earlier branch handles the warm-pod case.
-    _apply_max_sessions(cfg)
-    _apply_rdp_timeouts(cfg)
-    _apply_oem_runtime_fixes(cfg)
+    _self_heal_apply(cfg)
     # Bug B: after host suspend / long idle the pod can be running but RDP
     # itself is dead while VNC is fine. Probe and try to revive TermService
     # before handing the cfg to the caller — the alternative is the FreeRDP
@@ -171,6 +179,80 @@ def _apply_max_sessions(cfg: Config) -> None:
         log.warning("max_sessions: rc=%d stderr=%s", result.rc, result.stderr.strip())
         raise RuntimeError(f"max_sessions apply failed (rc={result.rc}): {result.stderr.strip()}")
     log.info("max_sessions: %s", result.stdout.strip())
+
+
+def wait_for_windows_responsive(cfg: Config, timeout: int = 90) -> bool:
+    """Poll until the Windows guest can actually accept FreeRDP RemoteApp.
+
+    Container ``RUNNING`` state is not enough — dockur boots the Linux
+    container in seconds but the Windows VM inside QEMU needs another
+    30-90s before its RDP listener accepts activation. Firing an apply
+    inside that window means every call hits one of:
+
+    - ``ERRCONNECT_CONNECT_TRANSPORT_FAILED`` (rc=147, connection reset
+      by peer — RDP socket open but server not initialized)
+    - ``ERRCONNECT_ACTIVATION_TIMEOUT`` (rc=131, FreeRDP connected but
+      activation phase didn't complete in time)
+
+    This helper waits for the RDP port first, then fires a tiny
+    no-op probe (`Write-Output 'ping'`) with a 15s budget to confirm
+    the FreeRDP RemoteApp channel is actually live. Returns True on
+    success, False if the guest is still booting after ``timeout``
+    seconds — caller decides whether to skip / retry / surface to user.
+    """
+    from winpodx.core.windows_exec import WindowsExecError, run_in_windows
+
+    deadline = time.monotonic() + max(1, int(timeout))
+    while time.monotonic() < deadline:
+        if check_rdp_port(cfg.rdp.ip, cfg.rdp.port, timeout=1.0):
+            break
+        time.sleep(2)
+    else:
+        return False
+
+    # Port is open — confirm activation works with a short probe.
+    try:
+        result = run_in_windows(
+            cfg,
+            "Write-Output 'ping'\n",
+            description="responsive-probe",
+            timeout=20,
+        )
+        return result.rc == 0
+    except WindowsExecError:
+        return False
+
+
+def _self_heal_apply(cfg: Config) -> None:
+    """Run the three idempotent runtime applies in self-healing mode.
+
+    Distinct from ``apply_windows_runtime_fixes`` which is called from
+    the explicit ``winpodx pod apply-fixes`` CLI / GUI button: that one
+    must surface failures in its result map. Self-healing mode is fired
+    from ``ensure_ready`` on every app launch, so any failure must be
+    swallowed — the user is trying to launch an app, not run an apply,
+    and a transient ERRCONNECT_ACTIVATION_TIMEOUT (Windows still
+    booting) must not cascade into a Launch Error dialog. The next
+    ensure_ready call picks up wherever this one left off.
+    """
+    from winpodx.core.windows_exec import WindowsExecError
+
+    for name, fn in (
+        ("max_sessions", _apply_max_sessions),
+        ("rdp_timeouts", _apply_rdp_timeouts),
+        ("oem_runtime_fixes", _apply_oem_runtime_fixes),
+    ):
+        try:
+            fn(cfg)
+        except WindowsExecError as e:
+            log.warning(
+                "%s: channel failure during self-heal (will retry next ensure_ready): %s",
+                name,
+                e,
+            )
+            return  # Don't waste 60s × 2 more on a still-booting guest.
+        except Exception as e:  # noqa: BLE001
+            log.warning("%s: self-heal apply failed: %s", name, e)
 
 
 def apply_windows_runtime_fixes(cfg: Config) -> dict[str, str]:


### PR DESCRIPTION
## Summary

v0.2.0.1 is an emergency hotfix for an apply-cascade collapse that turned `winpodx setup` (fresh install) and `winpodx pod restart` (existing install) into 3-minute hangs ending in error dialogs.

### Root cause
v0.2.0 fired the three idempotent runtime applies (`max_sessions`, `rdp_timeouts`, `oem_runtime_fixes`) the moment `pod_status` reported `RUNNING`. The dockur Linux container reaches `RUNNING` in seconds, but the Windows VM inside QEMU needs another 30–90s before its RDP listener can accept FreeRDP RemoteApp activation. Within that window every apply collapsed — `ERRCONNECT_CONNECT_TRANSPORT_FAILED [0x0002000D]` (rc=147, fresh install) or `ERRCONNECT_ACTIVATION_TIMEOUT [0x0002001C]` (rc=131, pod restart) — and the 3×60s cascade surfaced as a Launch Error dialog or "3 of 3 applies failed" panic.

### Fix
- `wait_for_windows_responsive(cfg, timeout=90)` — polls `check_rdp_port` then fires a 20s no-op `Write-Output 'ping'` probe via `run_in_windows` to confirm the FreeRDP RemoteApp channel is actually live.
- `_self_heal_apply()` — wraps the warm-pod ensure_ready applies in a `WindowsExecError` swallow so a transient channel failure logs and aborts the in-call cascade. Next ensure_ready picks up.
- Gated three call sites on the new probe: `ensure_ready()` warm path, `winpodx pod apply-fixes`, and `winpodx migrate`'s apply step. Each prints a clear "Waiting for Windows guest to finish booting (up to 90s)..." then either proceeds or skips with a useful message.

### Tests
398 tests pass; ruff check + format clean.

## Test plan
- [ ] `winpodx pod restart` then immediately `winpodx app run desktop`: no Launch Error dialog, app launches once Windows is ready.
- [ ] Fresh `curl install.sh | bash`: migrate prints the wait message and either applies cleanly or skips with the new helpful message — no 3-failure cascade.
- [ ] `winpodx pod apply-fixes` after `pod start --wait`: prints wait line, then succeeds.