### PR TITLE
release: v0.2.0.2 — setup stamps install marker (fixes bogus 0.1.7 upgrade on fresh --purge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
-## [0.2.0.1] - 2026-04-26
+## [0.2.0.2] - 2026-04-26
+
+### Fixed
+- **Fresh `--purge` reinstall reported a bogus "0.1.7 -> X detected" upgrade.** `winpodx setup` saved `winpodx.toml` but never stamped `installed_version.txt`, so the follow-up `winpodx migrate` (which `install.sh` chains automatically) saw the config + missing marker and hit the pre-tracker fallback that assumes baseline 0.1.7. The fallback is correct for genuine upgrades from before the marker existed, but for a fresh install it ran every migration step needlessly and printed a confusing "What's new in 0.1.8 / 0.1.9 / …" wall. v0.2.0.2 has setup write the current version to `installed_version.txt` if it doesn't already exist, so a fresh install reports as the current version (no migration steps fire) while a real upgrade flow still works as before.
+
+
 
 ### Fixed
 - **Apply cascade collapsed on cold container.** v0.2.0 fired the three idempotent runtime applies (`max_sessions`, `rdp_timeouts`, `oem_runtime_fixes`) the moment `pod_status` reported `RUNNING`. The dockur Linux container reaches `RUNNING` in seconds, but the Windows VM inside QEMU needs another 30–90s before its RDP listener can accept FreeRDP RemoteApp activation. Within that window every apply collapsed with either `ERRCONNECT_CONNECT_TRANSPORT_FAILED [0x0002000D]` (rc=147, RDP socket open but server not initialized — connection reset by peer) on a fresh install, or `ERRCONNECT_ACTIVATION_TIMEOUT [0x0002001C]` (rc=131, FreeRDP connected but activation phase didn't complete) on `winpodx pod restart`. Each apply waited the full 60s timeout, so the cascade ran 3min before surfacing as a Launch Error dialog or "3 of 3 applies failed" panic message during `winpodx setup` → `winpodx migrate`.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+winpodx (0.2.0.2) unstable; urgency=medium
+
+  * Fixed: fresh --purge reinstall reported a bogus "0.1.7 -> X
+    detected" upgrade. winpodx setup saved winpodx.toml but never
+    stamped installed_version.txt, so the follow-up `winpodx migrate`
+    chained by install.sh saw the config + missing marker and fell
+    through to the pre-tracker fallback that assumes baseline 0.1.7.
+    Setup now writes the current version to installed_version.txt
+    when absent, so a fresh install reports as the current version
+    (no migration steps fire) while real upgrades still work.
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Sun, 26 Apr 2026 23:00:00 +0900
+
 winpodx (0.2.0.1) unstable; urgency=high
 
   * Fixed: apply cascade collapsed on cold container. v0.2.0 fired the

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,7 +9,12 @@
 
 ## [Unreleased]
 
-## [0.2.0.1] - 2026-04-26
+## [0.2.0.2] - 2026-04-26
+
+### 수정
+- **`--purge` 신규 설치가 가짜 "0.1.7 -> X detected" 업그레이드 메시지 표시.** `winpodx setup` 이 `winpodx.toml` 만 저장하고 `installed_version.txt` 마커는 안 써서, `install.sh` 가 자동으로 이어 호출하는 `winpodx migrate` 가 "config 있고 marker 없음" 상태 보고 pre-tracker fallback (baseline 0.1.7 가정) 발동. 실제 마커 도입 전 업그레이드에서는 맞는 동작이지만, 신규 설치에서는 모든 마이그레이션 스텝을 불필요하게 재실행하면서 "What's new in 0.1.8 / 0.1.9 / ..." 안내까지 띄움. v0.2.0.2 에서 setup 이 마커가 없을 때만 현재 버전을 `installed_version.txt` 에 기록하도록 수정 — 신규 설치는 현재 버전으로 보고되어 마이그레이션 스텝 발화 안 함, 실제 업그레이드 흐름은 그대로 동작.
+
+
 
 ### 수정
 - **차가운 컨테이너에서 apply cascade 가 무너짐.** v0.2.0 은 `pod_status` 가 `RUNNING` 이 되는 즉시 세 개 idempotent runtime apply (`max_sessions`, `rdp_timeouts`, `oem_runtime_fixes`) 를 발화. dockur Linux 컨테이너는 몇 초 안에 `RUNNING` 도달하지만, QEMU 안 Windows VM 은 RDP 리스너가 FreeRDP RemoteApp activation 받기까지 30~90초 더 필요. 그 윈도우 안에서 모든 apply 는:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.2.0.1"
+version = "0.2.0.2"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.2.0.1"
+__version__ = "0.2.0.2"

--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -170,6 +170,24 @@ def handle_setup(args: argparse.Namespace) -> None:
     cfg.save()
     print(f"\nConfig saved to {Config.path()}")
 
+    # v0.2.0.2: stamp installed_version.txt so a follow-up `winpodx migrate`
+    # doesn't misclassify this fresh install as a "pre-tracker upgrade from
+    # 0.1.7". Migrate's pre-tracker fallback (config exists but no marker
+    # → assume baseline 0.1.7) is only correct for actual upgrades from
+    # before the marker existed; for fresh `--purge` reinstalls it produces
+    # a bogus "0.1.7 -> X detected" run that re-applies all the migration
+    # steps unnecessarily. Only write if absent so an actual upgrade flow
+    # (where the user manually ran setup over an existing install) isn't
+    # downgraded.
+    from winpodx import __version__ as _winpodx_version
+
+    marker_path = config_dir() / "installed_version.txt"
+    if not marker_path.exists():
+        try:
+            marker_path.write_text(_winpodx_version + "\n", encoding="utf-8")
+        except OSError as e:
+            print(f"  warning: could not stamp install marker ({e})")
+
     # v0.1.9: bundled profiles were removed. Desktop entries are now created
     # by `winpodx app refresh` (auto-fired on first pod boot via
     # provisioner.ensure_ready). Until the user's first launch, only the

--- a/tests/test_cli_issues.py
+++ b/tests/test_cli_issues.py
@@ -111,6 +111,77 @@ class TestAskHelper:
 
             handle_setup(args)
 
+    def test_setup_stamps_install_marker_on_fresh_run(self, tmp_path, monkeypatch):
+        """v0.2.0.2: setup must write installed_version.txt so a follow-up
+        `winpodx migrate` doesn't misclassify a fresh --purge install as a
+        pre-tracker upgrade from 0.1.7."""
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr("sys.stdin", MagicMock(isatty=lambda: False))
+
+        args = argparse.Namespace(backend="manual", non_interactive=True)
+
+        freerdp_dep = MagicMock()
+        freerdp_dep.found = True
+        freerdp_dep.note = ""
+
+        with (
+            patch(
+                "winpodx.cli.setup_cmd.check_all",
+                return_value={"freerdp": freerdp_dep},
+            ),
+            patch("winpodx.cli.setup_cmd.import_winapps_config", return_value=None),
+            patch("winpodx.cli.setup_cmd._generate_compose"),
+            patch("winpodx.cli.setup_cmd._recreate_container"),
+            patch("winpodx.cli.setup_cmd._register_all_desktop_entries"),
+            patch("winpodx.display.scaling.detect_scale_factor", return_value=100),
+            patch("winpodx.display.scaling.detect_raw_scale", return_value=1.0),
+        ):
+            from winpodx.cli.setup_cmd import handle_setup
+
+            handle_setup(args)
+
+        from winpodx import __version__
+
+        marker = tmp_path / "winpodx" / "installed_version.txt"
+        assert marker.exists(), "setup must stamp installed_version.txt"
+        assert marker.read_text(encoding="utf-8").strip() == __version__
+
+    def test_setup_does_not_overwrite_existing_marker(self, tmp_path, monkeypatch):
+        """An older marker (e.g. mid-upgrade) must not be silently bumped to
+        the current version by re-running setup. Migrate is the only thing
+        that should advance the marker."""
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr("sys.stdin", MagicMock(isatty=lambda: False))
+
+        cfg_dir = tmp_path / "winpodx"
+        cfg_dir.mkdir(parents=True)
+        marker = cfg_dir / "installed_version.txt"
+        marker.write_text("0.1.8\n", encoding="utf-8")
+
+        args = argparse.Namespace(backend="manual", non_interactive=True)
+
+        freerdp_dep = MagicMock()
+        freerdp_dep.found = True
+        freerdp_dep.note = ""
+
+        with (
+            patch(
+                "winpodx.cli.setup_cmd.check_all",
+                return_value={"freerdp": freerdp_dep},
+            ),
+            patch("winpodx.cli.setup_cmd.import_winapps_config", return_value=None),
+            patch("winpodx.cli.setup_cmd._generate_compose"),
+            patch("winpodx.cli.setup_cmd._recreate_container"),
+            patch("winpodx.cli.setup_cmd._register_all_desktop_entries"),
+            patch("winpodx.display.scaling.detect_scale_factor", return_value=100),
+            patch("winpodx.display.scaling.detect_raw_scale", return_value=1.0),
+        ):
+            from winpodx.cli.setup_cmd import handle_setup
+
+            handle_setup(args)
+
+        assert marker.read_text(encoding="utf-8").strip() == "0.1.8"
+
 
 # Issue 8: password rotation split-brain
 


### PR DESCRIPTION
## Summary

Fresh `--purge` reinstall reported a bogus \`0.1.7 -> X detected\` upgrade because \`winpodx setup\` saved \`winpodx.toml\` but never stamped \`installed_version.txt\`. The follow-up \`winpodx migrate\` (chained by \`install.sh\`) saw the config + missing marker and fell through to the pre-tracker fallback that assumes baseline \`0.1.7\`.

### Fix
\`handle_setup\` now writes \`__version__\` to \`installed_version.txt\` only when the file is absent — fresh installs report as the current version (no migration steps fire) while real upgrade flows still advance the marker through \`migrate\` as designed.

### Tests
- \`test_setup_stamps_install_marker_on_fresh_run\` — fresh setup writes marker matching \`__version__\`.
- \`test_setup_does_not_overwrite_existing_marker\` — pre-existing 0.1.8 marker survives a setup re-run so mid-upgrade state isn't silently bumped.
- 400 tests pass; ruff check + format clean.

## Test plan
- [ ] \`winpodx uninstall --purge\` then \`curl install.sh | bash\`: migrate prints something like \`winpodx is up-to-date (current: 0.2.0.2)\` instead of \`0.1.7 -> 0.2.0.2 detected\` followed by the "What's new" wall.
- [ ] Real upgrade from older 0.1.x: still shows the upgrade banner and runs migration steps.