### PR TITLE
release: v0.2.0.3 — gate discovery on Windows VM boot + bump timeout to 180s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
-## [0.2.0.2] - 2026-04-26
+## [0.2.0.3] - 2026-04-27
+
+### Fixed
+- **Discovery hit the same boot race the apply path used to.** v0.2.0.1 gated `_apply_*` and `pod apply-fixes` on `wait_for_windows_responsive`, but `winpodx migrate`'s "Run app discovery now?" prompt and `provisioner._auto_discover_if_empty` (fired by ensure_ready on first pod boot) still launched the FreeRDP RemoteApp channel without a probe. On a fresh `--purge` reinstall the Windows VM was still booting inside QEMU when discovery fired, so the scan collapsed with `ERRCONNECT_CONNECT_TRANSPORT_FAILED [0x0002000D]` (rc=147, connection reset by peer) and the user ended up with an empty app menu. v0.2.0.3 wires the same probe into both discovery call sites — discovery now waits, then either scans or skips with a "Re-run later with: winpodx app refresh" pointer.
+- **First-boot timeout 90s → 180s.** Real-world fresh installs on slower hardware can take more than 90s for Windows + RDP + activation handshake. Bumped the wait budget on all three apply / discovery probes to 180s so a one-shot install actually completes the apply round on first try.
+
+
 
 ### Fixed
 - **Fresh `--purge` reinstall reported a bogus "0.1.7 -> X detected" upgrade.** `winpodx setup` saved `winpodx.toml` but never stamped `installed_version.txt`, so the follow-up `winpodx migrate` (which `install.sh` chains automatically) saw the config + missing marker and hit the pre-tracker fallback that assumes baseline 0.1.7. The fallback is correct for genuine upgrades from before the marker existed, but for a fresh install it ran every migration step needlessly and printed a confusing "What's new in 0.1.8 / 0.1.9 / …" wall. v0.2.0.2 has setup write the current version to `installed_version.txt` if it doesn't already exist, so a fresh install reports as the current version (no migration steps fire) while a real upgrade flow still works as before.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+winpodx (0.2.0.3) unstable; urgency=high
+
+  * Fixed: discovery hit the same boot race the apply path used to.
+    v0.2.0.1 gated _apply_* and pod apply-fixes on
+    wait_for_windows_responsive, but migrate's "Run app discovery now?"
+    prompt and provisioner._auto_discover_if_empty still launched the
+    FreeRDP RemoteApp channel without a probe. On fresh --purge
+    reinstalls the scan collapsed with rc=147 connection reset.
+    v0.2.0.3 wires the same probe into both discovery call sites.
+  * Bumped first-boot timeout 90s -> 180s on all three apply /
+    discovery probes so slower hardware completes the install on
+    the first try.
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Mon, 27 Apr 2026 10:00:00 +0900
+
 winpodx (0.2.0.2) unstable; urgency=medium
 
   * Fixed: fresh --purge reinstall reported a bogus "0.1.7 -> X

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,7 +9,13 @@
 
 ## [Unreleased]
 
-## [0.2.0.2] - 2026-04-26
+## [0.2.0.3] - 2026-04-27
+
+### 수정
+- **Discovery 가 apply path 와 동일한 부팅 race 에 노출.** v0.2.0.1 이 `_apply_*` 와 `pod apply-fixes` 만 `wait_for_windows_responsive` 로 게이팅하고, `winpodx migrate` 의 "Run app discovery now?" 프롬프트와 `provisioner._auto_discover_if_empty` (첫 부팅 시 ensure_ready 가 발화) 는 probe 없이 FreeRDP RemoteApp 채널 호출. 신규 `--purge` 설치 시 QEMU 안 Windows VM 이 여전히 부팅 중인데 discovery 가 떠서 `ERRCONNECT_CONNECT_TRANSPORT_FAILED [0x0002000D]` (rc=147, connection reset) 으로 무너지고 사용자는 빈 앱 메뉴로 끝남. v0.2.0.3 이 두 discovery 호출 지점 모두에 동일 probe 적용 — wait 후 scan 또는 "Re-run later with: winpodx app refresh" 안내로 skip.
+- **첫 부팅 timeout 90s → 180s.** 실제 환경의 신규 설치는 느린 하드웨어에서 Windows + RDP + activation 핸드셰이크에 90초 초과 가능. 세 개의 apply / discovery probe 의 wait 예산을 180초로 상향 — one-shot install 이 첫 시도에 apply round 까지 완료할 수 있게 함.
+
+
 
 ### 수정
 - **`--purge` 신규 설치가 가짜 "0.1.7 -> X detected" 업그레이드 메시지 표시.** `winpodx setup` 이 `winpodx.toml` 만 저장하고 `installed_version.txt` 마커는 안 써서, `install.sh` 가 자동으로 이어 호출하는 `winpodx migrate` 가 "config 있고 marker 없음" 상태 보고 pre-tracker fallback (baseline 0.1.7 가정) 발동. 실제 마커 도입 전 업그레이드에서는 맞는 동작이지만, 신규 설치에서는 모든 마이그레이션 스텝을 불필요하게 재실행하면서 "What's new in 0.1.8 / 0.1.9 / ..." 안내까지 띄움. v0.2.0.2 에서 setup 이 마커가 없을 때만 현재 버전을 `installed_version.txt` 에 기록하도록 수정 — 신규 설치는 현재 버전으로 보고되어 마이그레이션 스텝 발화 안 함, 실제 업그레이드 흐름은 그대로 동작.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.2.0.2"
+version = "0.2.0.3"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.2.0.2"
+__version__ = "0.2.0.3"

--- a/src/winpodx/cli/migrate.py
+++ b/src/winpodx/cli/migrate.py
@@ -457,10 +457,10 @@ def _apply_runtime_fixes_to_existing_guest(non_interactive: bool) -> None:
     # FreeRDP RemoteApp before firing applies.
     from winpodx.core.provisioner import wait_for_windows_responsive
 
-    print("  Waiting for Windows guest to finish booting (up to 90s)...")
-    if not wait_for_windows_responsive(cfg, timeout=90):
+    print("  Waiting for Windows guest to finish booting (up to 180s)...")
+    if not wait_for_windows_responsive(cfg, timeout=180):
         print(
-            "  Windows guest still booting after 90s — skipping runtime apply.\n"
+            "  Windows guest still booting after 180s — skipping runtime apply.\n"
             "  Run `winpodx pod apply-fixes` once `winpodx pod status` reports "
             "the pod is fully up, or just launch any app and the apply will "
             "fire automatically."
@@ -526,6 +526,21 @@ def _attempt_refresh() -> None:
         except Exception as exc:  # noqa: BLE001 — surface any startup failure
             print(f"\n  Could not start pod: {exc}")
             return
+
+    # v0.2.0.3: discovery hits the same FreeRDP RemoteApp channel as the
+    # apply path, so it suffers the same race when Windows VM inside QEMU
+    # is still booting. Wait until the guest is responsive (or skip with
+    # a useful message) before running the scan; otherwise the user just
+    # sees rc=147 connection-reset right after a fresh install.
+    from winpodx.core.provisioner import wait_for_windows_responsive
+
+    print("\n  Waiting for Windows guest to be ready (up to 180s)...")
+    if not wait_for_windows_responsive(cfg, timeout=180):
+        print(
+            "  Windows guest still booting — skipping discovery for now.\n"
+            "  Re-run later with: winpodx app refresh"
+        )
+        return
 
     try:
         print("\n  Scanning Windows pod for installed apps...")

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -142,10 +142,10 @@ def _apply_fixes() -> None:
     # doesn't see 3×60s of timeout cascades.
     from winpodx.core.provisioner import wait_for_windows_responsive
 
-    print("Waiting for Windows guest to finish booting (up to 90s)...")
-    if not wait_for_windows_responsive(cfg, timeout=90):
+    print("Waiting for Windows guest to finish booting (up to 180s)...")
+    if not wait_for_windows_responsive(cfg, timeout=180):
         print(
-            "Windows guest still booting after 90s. Wait a bit longer, "
+            "Windows guest still booting after 180s. Wait a bit longer, "
             "then re-run `winpodx pod apply-fixes`."
         )
         sys.exit(2)

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -628,6 +628,15 @@ def _auto_discover_if_empty(cfg: Config) -> None:
             return  # already discovered before; user-triggered refresh stays in their hands.
 
         log.info("First boot detected; auto-running discovery to populate the app menu...")
+        # v0.2.0.3: discovery uses the same FreeRDP RemoteApp channel as
+        # the apply path; on first pod boot Windows VM may still be
+        # booting inside QEMU even though ensure_ready already passed
+        # check_rdp_port (port open != activation-ready). Wait for a
+        # responsive guest before scanning, otherwise rc=147 connection
+        # reset and the user's first install ends with an empty menu.
+        if not wait_for_windows_responsive(cfg, timeout=180):
+            log.info("Windows guest still booting; deferring auto-discovery to a later run.")
+            return
         apps = discover_apps(cfg)
         persist_discovered(apps)
         log.info("Auto-discovery wrote %d app(s) to %s", len(apps), discovered_dir)


### PR DESCRIPTION
## Summary

v0.2.0.1 added `wait_for_windows_responsive` on the apply path, but two discovery call sites slipped through and still hit FreeRDP RemoteApp without a probe — so on a fresh `--purge` reinstall, after the apply path gracefully skipped, discovery still fired and collapsed with `rc=147 ERRCONNECT_CONNECT_TRANSPORT_FAILED` (connection reset by peer). Result: user ended up with an empty app menu.

### Fix
- `_attempt_refresh()` (migrate's "Run app discovery now?" prompt) — wait for guest, skip with "Re-run later with: winpodx app refresh" pointer.
- `_auto_discover_if_empty()` (ensure_ready first-boot auto-discovery) — same wait gate; defers silently if guest still booting.
- All three probes (apply path, apply-fixes CLI, discovery) bumped from 90s → 180s. Real-world slower hardware needs more than 90s for Windows + RDP + activation handshake on first boot.

### Tests
400 tests pass; ruff check + format clean.

## Test plan
- [ ] `winpodx uninstall --purge` then `curl install.sh | bash`: install completes with apply round + discovery both succeeding on first try (no rc=147 cascade).
- [ ] If install still hits the 180s timeout on very slow hardware: graceful skip with "Re-run later with: winpodx app refresh" message, no crash dialog.