### PR TITLE
release: v0.2.0.4 — password probe no longer false-positives on cold boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
-## [0.2.0.3] - 2026-04-27
+## [0.2.0.4] - 2026-04-27
+
+### Fixed
+- **Bogus "cfg.password does not match Windows" warning on every fresh `--purge` install.** v0.1.9.5 added `_probe_password_sync` to detect cfg/Windows password drift before apply, but its error classifier matched on `"no result file"` OR `"auth"` in the FreeRDP error string. On a still-booting guest (which is exactly what every fresh install hits), FreeRDP returns rc=147 `ERRCONNECT_CONNECT_TRANSPORT_FAILED` (connection reset by peer) wrapped in the host's `"No result file written"` envelope — and the classifier saw `"no result file"` and yelled drift. v0.2.0.4 fixes this two ways:
+  1. The probe now waits on `wait_for_windows_responsive(timeout=180)` first; if the guest isn't ready, it skips with `(probe deferred — guest still booting; will retry on next ensure_ready)` instead of misfiring.
+  2. The classifier now distinguishes transport-level failures (`rc=131`, `rc=147`, `transport_failed`, `connection reset`) from genuine auth failures (`logon_failure`, `STATUS_LOGON_FAILURE`, etc.) — only the latter trigger the "run sync-password" warning.
+
+
 
 ### Fixed
 - **Discovery hit the same boot race the apply path used to.** v0.2.0.1 gated `_apply_*` and `pod apply-fixes` on `wait_for_windows_responsive`, but `winpodx migrate`'s "Run app discovery now?" prompt and `provisioner._auto_discover_if_empty` (fired by ensure_ready on first pod boot) still launched the FreeRDP RemoteApp channel without a probe. On a fresh `--purge` reinstall the Windows VM was still booting inside QEMU when discovery fired, so the scan collapsed with `ERRCONNECT_CONNECT_TRANSPORT_FAILED [0x0002000D]` (rc=147, connection reset by peer) and the user ended up with an empty app menu. v0.2.0.3 wires the same probe into both discovery call sites — discovery now waits, then either scans or skips with a "Re-run later with: winpodx app refresh" pointer.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+winpodx (0.2.0.4) unstable; urgency=high
+
+  * Fixed: bogus "cfg.password does not match Windows" warning on
+    every fresh --purge install. _probe_password_sync's error
+    classifier matched on "no result file" OR "auth" — but on a
+    still-booting guest FreeRDP returns rc=147 connection-reset
+    wrapped in the host's "No result file written" envelope, which
+    matched the first pattern and surfaced as a phantom drift
+    warning. v0.2.0.4 gates the probe on wait_for_windows_responsive
+    (skip if guest isn't ready) AND tightens the classifier to
+    distinguish transport-level failures (rc=131, rc=147,
+    transport_failed, connection reset) from genuine auth failures
+    (logon_failure, STATUS_LOGON_FAILURE).
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Mon, 27 Apr 2026 11:00:00 +0900
+
 winpodx (0.2.0.3) unstable; urgency=high
 
   * Fixed: discovery hit the same boot race the apply path used to.

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,7 +9,14 @@
 
 ## [Unreleased]
 
-## [0.2.0.3] - 2026-04-27
+## [0.2.0.4] - 2026-04-27
+
+### 수정
+- **신규 `--purge` 설치마다 가짜 "cfg.password does not match Windows" 경고.** v0.1.9.5 가 추가한 `_probe_password_sync` (cfg/Windows 비밀번호 drift 사전 감지) 의 에러 분류기가 FreeRDP 에러 문자열에 `"no result file"` 또는 `"auth"` 가 들어있으면 drift 로 판정. 하지만 부팅 중 게스트 (모든 신규 설치가 거치는 상태) 는 FreeRDP 가 rc=147 `ERRCONNECT_CONNECT_TRANSPORT_FAILED` (connection reset) 반환 → host wrapper 가 `"No result file written"` 으로 감쌈 → 분류기가 `"no result file"` 매칭 → 가짜 drift 경고 발화. v0.2.0.4 가 두 방향으로 수정:
+  1. probe 가 `wait_for_windows_responsive(timeout=180)` 로 먼저 대기. 게스트 미준비면 `(probe deferred — guest still booting; will retry on next ensure_ready)` 메시지로 skip.
+  2. 분류기가 transport-level 실패 (`rc=131`, `rc=147`, `transport_failed`, `connection reset`) 와 실제 auth 실패 (`logon_failure`, `STATUS_LOGON_FAILURE` 등) 를 구분. 후자만 sync-password 경고 발화.
+
+
 
 ### 수정
 - **Discovery 가 apply path 와 동일한 부팅 race 에 노출.** v0.2.0.1 이 `_apply_*` 와 `pod apply-fixes` 만 `wait_for_windows_responsive` 로 게이팅하고, `winpodx migrate` 의 "Run app discovery now?" 프롬프트와 `provisioner._auto_discover_if_empty` (첫 부팅 시 ensure_ready 가 발화) 는 probe 없이 FreeRDP RemoteApp 채널 호출. 신규 `--purge` 설치 시 QEMU 안 Windows VM 이 여전히 부팅 중인데 discovery 가 떠서 `ERRCONNECT_CONNECT_TRANSPORT_FAILED [0x0002000D]` (rc=147, connection reset) 으로 무너지고 사용자는 빈 앱 메뉴로 끝남. v0.2.0.3 이 두 discovery 호출 지점 모두에 동일 probe 적용 — wait 후 scan 또는 "Re-run later with: winpodx app refresh" 안내로 skip.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.2.0.3"
+version = "0.2.0.4"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.2.0.3"
+__version__ = "0.2.0.4"

--- a/src/winpodx/cli/migrate.py
+++ b/src/winpodx/cli/migrate.py
@@ -361,7 +361,22 @@ def _probe_password_sync(non_interactive: bool) -> None:
     except Exception:  # noqa: BLE001
         return
 
+    # v0.2.0.4: gate the probe on wait_for_windows_responsive. Without
+    # this, a fresh --purge install (where Windows VM inside QEMU is
+    # still booting in the background) makes the probe fire too early,
+    # FreeRDP returns rc=147 ERRCONNECT_CONNECT_TRANSPORT_FAILED with a
+    # "no result file written" wrapper message, the matcher saw "no
+    # result file" and falsely classified it as auth failure → surfaced
+    # a bogus "cfg.password does not match Windows" warning on every
+    # fresh install. The probe only makes sense when we can actually
+    # reach the guest; if not, skip silently and let the apply step
+    # (which has its own wait gate) decide.
+    from winpodx.core.provisioner import wait_for_windows_responsive
+
     print("\nProbing Windows-side authentication...")
+    if not wait_for_windows_responsive(cfg, timeout=180):
+        print("  (probe deferred — guest still booting; will retry on next ensure_ready)")
+        return
     try:
         run_in_windows(
             cfg,
@@ -375,7 +390,27 @@ def _probe_password_sync(non_interactive: bool) -> None:
         )
     except WindowsExecError as e:
         msg = str(e).lower()
-        if "no result file" in msg or "auth" in msg:
+        # v0.2.0.4: tighten error classification. Transport-level
+        # failures (rc=131 activation timeout, rc=147 connection reset,
+        # "transport_failed", etc.) mean the guest isn't ready — they
+        # do NOT mean the password is wrong. Only treat "auth"-flavored
+        # FreeRDP errors as drift indicators.
+        is_transport_error = (
+            "rc=131" in msg
+            or "rc=147" in msg
+            or "errconnect_connect_transport_failed" in msg
+            or "errconnect_activation_timeout" in msg
+            or "transport_read_layer" in msg
+            or "connection reset" in msg
+            or "transport failed" in msg
+        )
+        is_auth_error = (
+            "auth" in msg
+            or "logon_failure" in msg
+            or "errconnect_logon" in msg
+            or "0xc000006d" in msg  # STATUS_LOGON_FAILURE
+        )
+        if is_auth_error and not is_transport_error:
             print(
                 "  WARNING: cfg.password does not match Windows guest's account "
                 "password (FreeRDP authentication failed).\n"

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -9,7 +9,7 @@ flow through ``run_migrate`` with refresh skipped.
 from __future__ import annotations
 
 import argparse
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from winpodx.cli.migrate import (
     _VERSION_NOTES,
@@ -100,6 +100,93 @@ def test_detect_prefers_marker_over_baseline(tmp_path, monkeypatch):
     cfg_path.write_text("[rdp]\n", encoding="utf-8")
     with patch("winpodx.core.config.Config.path", return_value=cfg_path):
         assert _detect_installed_version() == "0.1.9"
+
+
+# --- _probe_password_sync (v0.2.0.4 false-positive fix) ---
+
+
+class TestProbePasswordSync:
+    """v0.2.0.4: probe must NOT classify boot-time transport errors as drift."""
+
+    def _setup_cfg(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        from winpodx.core.config import Config
+
+        cfg = Config()
+        cfg.pod.backend = "podman"
+        cfg.rdp.password = "abc123"
+        cfg.rdp.user = "User"
+        cfg.save()
+
+    def test_transport_reset_not_classified_as_drift(self, tmp_path, monkeypatch, capsys):
+        """rc=147 ERRCONNECT_CONNECT_TRANSPORT_FAILED on still-booting guest must
+        produce 'probe inconclusive', not the 'cfg.password does not match'
+        warning. Reproduces the v0.2.0.3 bogus-warning bug."""
+        self._setup_cfg(tmp_path, monkeypatch)
+        from winpodx.cli.migrate import _probe_password_sync
+        from winpodx.core.pod import PodState
+        from winpodx.core.windows_exec import WindowsExecError
+
+        with (
+            patch("winpodx.core.pod.pod_status") as mock_status,
+            patch("winpodx.core.provisioner.wait_for_windows_responsive", return_value=True),
+            patch("winpodx.core.windows_exec.run_in_windows") as mock_run,
+        ):
+            mock_status.return_value = MagicMock(state=PodState.RUNNING)
+            mock_run.side_effect = WindowsExecError(
+                "No result file written (FreeRDP rc=147). stderr tail: "
+                "'ERRCONNECT_CONNECT_TRANSPORT_FAILED [0x0002000D] ... "
+                "Connection reset by peer'"
+            )
+
+            _probe_password_sync(non_interactive=True)
+
+        out = capsys.readouterr().out
+        assert "does not match" not in out, "transport reset must not surface drift warning"
+        assert "probe inconclusive" in out
+
+    def test_genuine_auth_failure_classified_as_drift(self, tmp_path, monkeypatch, capsys):
+        """An auth-flavored failure must still trigger the sync-password warning."""
+        self._setup_cfg(tmp_path, monkeypatch)
+        from winpodx.cli.migrate import _probe_password_sync
+        from winpodx.core.pod import PodState
+        from winpodx.core.windows_exec import WindowsExecError
+
+        with (
+            patch("winpodx.core.pod.pod_status") as mock_status,
+            patch("winpodx.core.provisioner.wait_for_windows_responsive", return_value=True),
+            patch("winpodx.core.windows_exec.run_in_windows") as mock_run,
+        ):
+            mock_status.return_value = MagicMock(state=PodState.RUNNING)
+            mock_run.side_effect = WindowsExecError(
+                "FreeRDP authentication failed: STATUS_LOGON_FAILURE 0xC000006D"
+            )
+
+            _probe_password_sync(non_interactive=True)
+
+        out = capsys.readouterr().out
+        assert "does not match" in out, "real auth failure must surface drift warning"
+        assert "sync-password" in out
+
+    def test_probe_skipped_when_guest_not_responsive(self, tmp_path, monkeypatch, capsys):
+        """Guest still booting → probe deferred, no false alarm."""
+        self._setup_cfg(tmp_path, monkeypatch)
+        from winpodx.cli.migrate import _probe_password_sync
+        from winpodx.core.pod import PodState
+
+        with (
+            patch("winpodx.core.pod.pod_status") as mock_status,
+            patch("winpodx.core.provisioner.wait_for_windows_responsive", return_value=False),
+            patch("winpodx.core.windows_exec.run_in_windows") as mock_run,
+        ):
+            mock_status.return_value = MagicMock(state=PodState.RUNNING)
+
+            _probe_password_sync(non_interactive=True)
+
+        out = capsys.readouterr().out
+        assert "probe deferred" in out
+        assert "does not match" not in out
+        mock_run.assert_not_called()
 
 
 # --- _print_whats_new ---


### PR DESCRIPTION
## Summary

Every fresh \`--purge\` install on v0.2.0.3 still surfaced a phantom \`cfg.password does not match Windows guest's account password\` warning. Root cause: \`_probe_password_sync\`'s classifier matched on \`"no result file"\` OR \`"auth"\` in the FreeRDP error string, but on a still-booting guest FreeRDP returns \`rc=147 ERRCONNECT_CONNECT_TRANSPORT_FAILED\` (connection reset) wrapped in the host's \`"No result file written"\` envelope — false positive every time.

### Fix
1. Probe waits on \`wait_for_windows_responsive(timeout=180)\` first; defers if guest isn't ready.
2. Classifier distinguishes transport-level failures (\`rc=131\`, \`rc=147\`, \`transport_failed\`, \`connection reset\`) from genuine auth failures (\`logon_failure\`, \`STATUS_LOGON_FAILURE\`). Only auth triggers the sync-password warning.

### Tests
3 new tests cover transport-error → no warning, auth-error → warning, guest-not-responsive → deferred. 403 tests pass; ruff clean.

## Test plan
- [ ] \`winpodx uninstall --purge\` then \`curl install.sh | bash\`: no phantom drift warning. Probe either reports OK (if Windows ready in ≤180s) or "probe deferred" (still booting).
- [ ] If you actually have password drift (someone changed Windows pw out-of-band): \`STATUS_LOGON_FAILURE\` still surfaces the recovery instructions.