### PR TITLE
release: v0.2.0.5 — pod wait-ready CLI + install.sh single-shot UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,20 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
-## [0.2.0.4] - 2026-04-27
+## [0.2.0.5] - 2026-04-27
+
+### Added
+- **`winpodx pod wait-ready [--timeout SEC] [--logs]`** — multi-phase wait gate for Windows VM first-boot. Polls three checkpoints with elapsed-time stamps so the user actually sees progress instead of a silent multi-minute hang:
+  - `[1/3] Container running` (~5s)
+  - `[2/3] RDP port open` (typically 30-90s)
+  - `[3/3] Windows ready (RemoteApp probes OK)` (typically 2-8 min on first boot)
+  With `--logs`, container stdout is tailed in a background thread and surfaced as `[container] ...` lines so the user can see Windows actually doing work (Sysprep, OEM apply, etc.) instead of a black box.
+
+### Changed
+- **`install.sh` is now single-shot — install.sh exits when the install is actually finished, not when the container started.** The flow is now `setup` → `pod wait-ready --logs` (up to 10 min with progress + container logs) → `migrate` (apply runs cleanly since guest is now ready) → `app refresh` (discovery runs cleanly). Previously the user saw `Installation complete!` while Windows was still silently booting and had to wait again on first app launch. Skip the wait with `WINPODX_NO_WAIT=1` for CI / non-interactive setups; skip discovery with `WINPODX_NO_DISCOVERY=1`.
+- Removed the redundant `winpodx pod apply-fixes` call from install.sh — `migrate`'s "always-apply" path (since v0.1.9.3) already runs the apply, so calling it again just doubled the wait.
+
+
 
 ### Fixed
 - **Bogus "cfg.password does not match Windows" warning on every fresh `--purge` install.** v0.1.9.5 added `_probe_password_sync` to detect cfg/Windows password drift before apply, but its error classifier matched on `"no result file"` OR `"auth"` in the FreeRDP error string. On a still-booting guest (which is exactly what every fresh install hits), FreeRDP returns rc=147 `ERRCONNECT_CONNECT_TRANSPORT_FAILED` (connection reset by peer) wrapped in the host's `"No result file written"` envelope — and the classifier saw `"no result file"` and yelled drift. v0.2.0.4 fixes this two ways:

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ winpodx pod apply-fixes           # Re-apply Windows-side runtime fixes (idempot
 winpodx pod sync-password         # Recover from password drift (cfg ↔ Windows)
 winpodx pod multi-session on      # Toggle bundled rdprrap multi-session RDP
 winpodx pod multi-session status
+winpodx pod wait-ready --logs     # Wait for Windows first-boot with progress + container logs
 
 # Power management
 winpodx power --suspend           # Pause container (free CPU, keep memory)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,22 @@
+winpodx (0.2.0.5) unstable; urgency=medium
+
+  * Added: `winpodx pod wait-ready [--timeout SEC] [--logs]` —
+    multi-phase wait gate for Windows VM first-boot. Three checkpoints
+    with elapsed-time stamps: container running, RDP port open,
+    Windows ready (RemoteApp probes OK). With --logs, container
+    stdout is tailed in a background thread so the user sees Windows
+    Sysprep / OEM apply progress instead of a silent multi-minute
+    hang.
+  * Changed: install.sh is now single-shot. Flow: setup -> pod
+    wait-ready --logs -> migrate -> app refresh. install.sh exits
+    when the install is actually finished, not when the container
+    started. WINPODX_NO_WAIT=1 / WINPODX_NO_DISCOVERY=1 skip the
+    waits in CI / non-interactive setups.
+  * Removed redundant `winpodx pod apply-fixes` call from install.sh
+    (migrate's always-apply path already runs the apply).
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Mon, 27 Apr 2026 13:00:00 +0900
+
 winpodx (0.2.0.4) unstable; urgency=high
 
   * Fixed: bogus "cfg.password does not match Windows" warning on

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,7 +9,20 @@
 
 ## [Unreleased]
 
-## [0.2.0.4] - 2026-04-27
+## [0.2.0.5] - 2026-04-27
+
+### 추가
+- **`winpodx pod wait-ready [--timeout SEC] [--logs]`** — Windows VM 첫 부팅 다단계 wait gate. 세 체크포인트를 elapsed time 과 함께 표시해서 사용자가 침묵 속 몇 분간 hang 대신 실제 진행 상황을 봄:
+  - `[1/3] Container running` (~5초)
+  - `[2/3] RDP port open` (보통 30-90초)
+  - `[3/3] Windows ready (RemoteApp probes OK)` (첫 부팅 시 보통 2-8분)
+  `--logs` 옵션 시 컨테이너 stdout 을 백그라운드 스레드로 tail 해서 `[container] ...` 라인으로 surfacing — Windows 가 실제로 뭐 하는지 (Sysprep, OEM apply 등) 보임. 블랙박스 → 가시성.
+
+### 변경
+- **`install.sh` 가 진짜 single-shot 으로 바뀜 — 설치 정말 끝났을 때 exit, 컨테이너 시작했다고 거짓말 안 함.** 새 흐름: `setup` → `pod wait-ready --logs` (최대 10분, progress + 컨테이너 로그) → `migrate` (게스트 ready 라 apply 깔끔히 통과) → `app refresh` (디스커버리 즉시 통과). 기존에는 Windows 가 아직 부팅 중인데 `Installation complete!` 표시 후, 사용자가 첫 앱 실행 시 또 기다리는 구조였음. CI / 비대화형 환경에서는 `WINPODX_NO_WAIT=1` 로 wait 우회, `WINPODX_NO_DISCOVERY=1` 로 디스커버리 우회.
+- install.sh 의 중복 `winpodx pod apply-fixes` 호출 제거 — v0.1.9.3 이후 `migrate` 의 "always-apply" 경로가 이미 apply 를 돌리므로 한 번 더 부르면 wait 만 두 배가 됨.
+
+
 
 ### 수정
 - **신규 `--purge` 설치마다 가짜 "cfg.password does not match Windows" 경고.** v0.1.9.5 가 추가한 `_probe_password_sync` (cfg/Windows 비밀번호 drift 사전 감지) 의 에러 분류기가 FreeRDP 에러 문자열에 `"no result file"` 또는 `"auth"` 가 들어있으면 drift 로 판정. 하지만 부팅 중 게스트 (모든 신규 설치가 거치는 상태) 는 FreeRDP 가 rc=147 `ERRCONNECT_CONNECT_TRANSPORT_FAILED` (connection reset) 반환 → host wrapper 가 `"No result file written"` 으로 감쌈 → 분류기가 `"no result file"` 매칭 → 가짜 drift 경고 발화. v0.2.0.4 가 두 방향으로 수정:

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -308,6 +308,7 @@ winpodx pod apply-fixes           # Windows 런타임 수정 재적용 (멱등)
 winpodx pod sync-password         # 비밀번호 drift 복구 (cfg ↔ Windows)
 winpodx pod multi-session on      # 번들 rdprrap 다중 세션 RDP 토글
 winpodx pod multi-session status
+winpodx pod wait-ready --logs     # Windows 첫 부팅 대기 (진행 + 컨테이너 로그)
 
 # 전원 관리
 winpodx power --suspend           # 일시정지 (CPU 해제, 메모리 유지)

--- a/install.sh
+++ b/install.sh
@@ -410,21 +410,48 @@ log "Installed winpodx GUI launcher and icon"
 # discovered apps + their real Windows-extracted icons land in the menu.
 # Manual trigger any time: `winpodx app refresh`.
 
+# --- Wait for Windows VM to finish first-boot setup ---
+# v0.2.0.5: dockur Windows first-boot can take 5-10 minutes (Sysprep,
+# OEM apply, account password set, RDP listener up). Without this gate
+# the user just saw "Installation complete!" while Windows was still
+# silently booting in the background, then had to wait again the first
+# time they tried to launch an app. wait-ready surfaces the same wait
+# up-front with [1/3] container → [2/3] RDP port → [3/3] activation
+# progress + tailed container logs so the user can see what's happening.
+# Skip with WINPODX_NO_WAIT=1 (CI / non-interactive setups).
+if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_WAIT:-}" != "1" ]; then
+    log "Waiting for Windows VM to finish first-boot (up to 10 min)..."
+    "$HOME/.local/bin/winpodx" pod wait-ready --timeout 600 --logs || {
+        warn "Windows first-boot didn't complete in 10 minutes."
+        warn "You can re-run \`winpodx pod wait-ready --logs\` to keep waiting,"
+        warn "or just launch any app from the menu — the apply / discovery will fire automatically."
+    }
+fi
+
 # --- Post-upgrade migration wizard ---
 # If an existing config is present this is an upgrade, not a fresh
 # install. Run the migrate wizard so the user sees new-version release
 # notes and can opt into app discovery. Opt out with WINPODX_NO_MIGRATE=1.
 # `|| true` keeps install.sh's exit code clean if migrate fails.
+#
+# v0.2.0.5: now that wait-ready ran first, migrate's apply step
+# completes quickly (the wait gate inside migrate is a no-op since the
+# guest is already responsive) instead of blocking 180s only to skip.
 if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_MIGRATE:-}" != "1" ]; then
     log "Running post-upgrade migration wizard..."
     "$HOME/.local/bin/winpodx" migrate || true
-    # v0.1.9.3: also fire the standalone apply-fixes command. migrate's
-    # version-comparison can short-circuit ("already current") if the
-    # marker matches — but the Windows-side apply still needs to run,
-    # because patch-version bumps collapse to the same (X,Y,Z) tuple.
-    # `pod apply-fixes` is idempotent and self-skips when the pod is
-    # stopped, so this is safe to call unconditionally.
-    "$HOME/.local/bin/winpodx" pod apply-fixes 2>/dev/null || true
+fi
+
+# --- Auto-discover apps ---
+# v0.2.0.5: trigger discovery so the menu populates before install.sh
+# exits. Same logic as auto_discover_if_empty in ensure_ready, but on
+# the install path so the user gets a populated app menu the first
+# time they look. Best-effort — if discovery fails (channel error,
+# Windows still warming up), the next ensure_ready picks it up.
+if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_DISCOVERY:-}" != "1" ]; then
+    log "Discovering installed Windows apps..."
+    "$HOME/.local/bin/winpodx" app refresh 2>/dev/null || \
+        warn "Discovery did not complete; run \`winpodx app refresh\` later."
 fi
 
 # --- Done ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.2.0.4"
+version = "0.2.0.5"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.2.0.4"
+__version__ = "0.2.0.5"

--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -112,6 +112,25 @@ def cli(argv: list[str] | None = None) -> None:
         choices=("on", "off", "status"),
         help="on = enable multi-session, off = disable, status = report current state",
     )
+    wait_p = pod_sub.add_parser(
+        "wait-ready",
+        help=(
+            "Wait until the Windows VM has finished first-boot setup and "
+            "the FreeRDP RemoteApp channel is responsive. Used by install.sh "
+            "and useful after a cold `pod start`."
+        ),
+    )
+    wait_p.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="Maximum seconds to wait (default 600 = 10 minutes).",
+    )
+    wait_p.add_argument(
+        "--logs",
+        action="store_true",
+        help="Tail container logs while waiting so the user sees Windows boot progress.",
+    )
 
     # --- config ---
     cfg_parser = sub.add_parser("config", help="Manage configuration")

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -23,9 +23,12 @@ def handle_pod(args: argparse.Namespace) -> None:
         _sync_password(getattr(args, "non_interactive", False))
     elif cmd == "multi-session":
         _multi_session(args.action)
+    elif cmd == "wait-ready":
+        _wait_ready(args.timeout, getattr(args, "logs", False))
     else:
         print(
-            "Usage: winpodx pod {start|stop|status|restart|apply-fixes|sync-password|multi-session}"
+            "Usage: winpodx pod {start|stop|status|restart|apply-fixes|"
+            "sync-password|multi-session|wait-ready}"
         )
         sys.exit(1)
 
@@ -341,3 +344,116 @@ def _restart() -> None:
     else:
         print(f"Failed to restart: {status.error}", file=sys.stderr)
         sys.exit(1)
+
+
+def _wait_ready(timeout: int, show_logs: bool) -> None:
+    """v0.2.0.5: multi-phase wait for the Windows VM to finish first-boot.
+
+    Polls three checkpoints with elapsed-time stamps so the user sees
+    progress instead of a silent multi-minute hang on `curl install.sh`:
+
+      [1/3] Container running                  (e.g. 5s)
+      [2/3] RDP port open                      (typically 30-90s)
+      [3/3] Windows ready (RemoteApp probes OK) (typically 2-8min on first boot)
+
+    With ``--logs``, container stdout is tailed in a background thread
+    and surfaced as ``[container] ...`` lines so the user can see Windows
+    actually doing work (Sysprep, OEM apply, etc.) instead of a black
+    box.
+    """
+    import threading
+    import time as _time
+    from subprocess import PIPE, Popen
+
+    from winpodx.core.config import Config
+    from winpodx.core.pod import PodState, check_rdp_port, pod_status
+    from winpodx.core.provisioner import wait_for_windows_responsive
+
+    cfg = Config.load()
+    if cfg.pod.backend not in ("podman", "docker"):
+        print(f"wait-ready not supported for backend {cfg.pod.backend!r} (podman/docker only).")
+        sys.exit(2)
+
+    timeout = max(60, min(7200, int(timeout)))
+    start = _time.monotonic()
+
+    def elapsed() -> str:
+        s = int(_time.monotonic() - start)
+        return f"{s // 60:02d}:{s % 60:02d}"
+
+    log_proc: Popen | None = None
+    log_stop = threading.Event()
+    if show_logs:
+        try:
+            log_proc = Popen(
+                [cfg.pod.backend, "logs", "-f", "--tail", "0", cfg.pod.container_name],
+                stdout=PIPE,
+                stderr=PIPE,
+                text=True,
+                bufsize=1,
+            )
+
+            def _drain() -> None:
+                assert log_proc is not None and log_proc.stdout is not None
+                for line in log_proc.stdout:
+                    if log_stop.is_set():
+                        break
+                    line = line.rstrip()
+                    if line:
+                        print(f"       [container] {line}")
+
+            threading.Thread(target=_drain, daemon=True).start()
+        except (FileNotFoundError, OSError) as e:
+            print(f"       (could not tail container logs: {e})")
+            log_proc = None
+
+    try:
+        # --- [1/3] Container running ---
+        print(f"[1/3] Waiting for container to start...      ({elapsed()})")
+        deadline = start + timeout
+        while _time.monotonic() < deadline:
+            try:
+                if pod_status(cfg).state == PodState.RUNNING:
+                    print(f"      OK Container running                   ({elapsed()})")
+                    break
+            except Exception:  # noqa: BLE001
+                pass
+            _time.sleep(2)
+        else:
+            print(f"      FAIL Timeout waiting for container       ({elapsed()})")
+            sys.exit(3)
+
+        # --- [2/3] RDP port open ---
+        print(f"[2/3] Waiting for Windows RDP service...     ({elapsed()})")
+        while _time.monotonic() < deadline:
+            if check_rdp_port(cfg.rdp.ip, cfg.rdp.port, timeout=1.0):
+                print(f"      OK RDP port {cfg.rdp.port} open                  ({elapsed()})")
+                break
+            _time.sleep(3)
+        else:
+            print(f"      FAIL Timeout waiting for RDP port        ({elapsed()})")
+            sys.exit(3)
+
+        # --- [3/3] FreeRDP RemoteApp activation ---
+        print(f"[3/3] Waiting for Windows activation...      ({elapsed()})")
+        remaining = max(60, int(deadline - _time.monotonic()))
+        if wait_for_windows_responsive(cfg, timeout=remaining):
+            print(f"      OK Windows ready                         ({elapsed()})")
+        else:
+            print(
+                f"      FAIL Timeout waiting for Windows ready   ({elapsed()})\n"
+                "      Run `winpodx pod status` later and re-run "
+                "`winpodx pod wait-ready` once the container is fully up."
+            )
+            sys.exit(3)
+    finally:
+        log_stop.set()
+        if log_proc is not None:
+            try:
+                log_proc.terminate()
+                log_proc.wait(timeout=3)
+            except Exception:  # noqa: BLE001
+                try:
+                    log_proc.kill()
+                except Exception:  # noqa: BLE001
+                    pass

--- a/tests/test_pod.py
+++ b/tests/test_pod.py
@@ -154,3 +154,66 @@ def test_recover_rdp_succeeds_even_when_exec_returns_nonzero(monkeypatch):
         lambda cmd, **kw: subprocess.CompletedProcess(cmd, 1, "", "service stuck"),
     )
     assert recover_rdp_if_needed(cfg) is True
+
+
+# --- v0.2.0.5: pod wait-ready ---
+
+
+class TestWaitReady:
+    """Multi-phase wait gate: container -> RDP port -> activation."""
+
+    def _patch_cfg(self, monkeypatch):
+        from winpodx.core.config import Config
+
+        cfg = Config()
+        cfg.pod.backend = "podman"
+        cfg.pod.container_name = "winpodx-windows"
+        cfg.rdp.ip = "127.0.0.1"
+        cfg.rdp.port = 3389
+        monkeypatch.setattr("winpodx.core.config.Config.load", classmethod(lambda cls: cfg))
+        return cfg
+
+    def test_rejects_unsupported_backend(self, monkeypatch, capsys):
+        import pytest
+
+        from winpodx.cli.pod import _wait_ready
+        from winpodx.core.config import Config
+
+        cfg = Config()
+        cfg.pod.backend = "libvirt"
+        monkeypatch.setattr("winpodx.core.config.Config.load", classmethod(lambda cls: cfg))
+
+        with pytest.raises(SystemExit) as excinfo:
+            _wait_ready(timeout=10, show_logs=False)
+        assert excinfo.value.code == 2
+        assert "wait-ready not supported" in capsys.readouterr().out
+
+    def test_happy_path_traverses_three_phases(self, monkeypatch, capsys):
+        from unittest.mock import MagicMock
+
+        from winpodx.cli.pod import _wait_ready
+        from winpodx.core.pod import PodState
+
+        self._patch_cfg(monkeypatch)
+        # Phase 1: container running immediately.
+        monkeypatch.setattr(
+            "winpodx.core.pod.pod_status",
+            lambda cfg: MagicMock(state=PodState.RUNNING),
+        )
+        # Phase 2: RDP port immediately reachable.
+        monkeypatch.setattr(
+            "winpodx.core.pod.check_rdp_port",
+            lambda ip, port, timeout=1.0: True,
+        )
+        # Phase 3: activation probe succeeds.
+        monkeypatch.setattr(
+            "winpodx.core.provisioner.wait_for_windows_responsive",
+            lambda cfg, timeout=180: True,
+        )
+
+        _wait_ready(timeout=30, show_logs=False)
+        out = capsys.readouterr().out
+        assert "[1/3]" in out
+        assert "[2/3]" in out
+        assert "[3/3]" in out
+        assert "Windows ready" in out


### PR DESCRIPTION
## Summary

Make \`curl install.sh | bash\` actually finish when it claims to. Previously the user saw \`Installation complete!\` while Windows was still booting in the background, then had to wait again the first time they launched an app.

### Added
- \`winpodx pod wait-ready [--timeout SEC] [--logs]\` — multi-phase wait gate showing real progress:
  ```
  [1/3] Waiting for container to start...      (00:00)
        OK Container running                   (00:05)
  [2/3] Waiting for Windows RDP service...     (00:05)
        [container] Boot Manager: loading kernel
        [container] Setup is starting services
        OK RDP port 3389 open                  (01:48)
  [3/3] Waiting for Windows activation...      (01:48)
        [container] Sysprep: applying OEM specialization
        OK Windows ready                       (04:35)
  ```

### Changed
- \`install.sh\` flow: \`setup\` → \`pod wait-ready --logs\` (up to 10 min with progress + container logs) → \`migrate\` (apply runs cleanly since guest is ready) → \`app refresh\` (discovery runs cleanly).
- Removed redundant \`pod apply-fixes\` call. \`migrate\`'s always-apply path (since v0.1.9.3) already covers it; the extra call just doubled the wait.
- Skip with \`WINPODX_NO_WAIT=1\` / \`WINPODX_NO_DISCOVERY=1\` for CI / non-interactive setups.

### Tests
- \`test_rejects_unsupported_backend\` — libvirt/manual exits 2 with clear message.
- \`test_happy_path_traverses_three_phases\` — all three checkpoints printed when each phase passes.
- 405 tests pass; ruff clean.

## Test plan
- [ ] Fresh \`uninstall --purge\` then \`curl install.sh | bash\`: install pauses with [1/3]/[2/3]/[3/3] progress + tailed container logs, completes with apps already discovered, and \`winpodx app run desktop\` works immediately afterward without further waiting.