### PR TITLE
release: v0.2.0.6 — wait_for_windows_responsive retries instead of bailing on first probe failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
-## [0.2.0.5] - 2026-04-27
+## [0.2.0.6] - 2026-04-27
+
+### Fixed
+- **`wait_for_windows_responsive` collapsed in <1s on a still-booting guest, defeating the entire `pod wait-ready` UX.** The helper waited correctly for the RDP TCP port to open, then fired exactly **one** FreeRDP RemoteApp probe — a single failure (which is what every still-booting guest produces, rc=147 connection-reset) returned False immediately and the caller's 600s timeout was effectively ignored. v0.2.0.6 turns the probe into a retry loop that fires repeated 5-20s probes until either one succeeds or the overall `timeout` expires (paced 3s between attempts so we don't pin a CPU spinning FreeRDP). Now `pod wait-ready --timeout 600` actually waits up to 10 minutes — observable in the elapsed-time stamp incrementing during phase 3.
+
+
 
 ### Added
 - **`winpodx pod wait-ready [--timeout SEC] [--logs]`** — multi-phase wait gate for Windows VM first-boot. Polls three checkpoints with elapsed-time stamps so the user actually sees progress instead of a silent multi-minute hang:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+winpodx (0.2.0.6) unstable; urgency=high
+
+  * Fixed: wait_for_windows_responsive collapsed in <1s on a still-
+    booting guest. The helper fired exactly ONE FreeRDP RemoteApp
+    probe after the RDP port opened — a single failure (which is what
+    every still-booting guest produces, rc=147 connection-reset)
+    returned False immediately and the caller's 600s timeout was
+    effectively ignored. v0.2.0.6 turns the probe into a retry loop
+    that fires repeated 5-20s probes until one succeeds or the
+    overall timeout expires (3s pacing between attempts). pod
+    wait-ready --timeout 600 now actually waits up to 10 minutes
+    instead of bailing in the first second.
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Mon, 27 Apr 2026 14:00:00 +0900
+
 winpodx (0.2.0.5) unstable; urgency=medium
 
   * Added: `winpodx pod wait-ready [--timeout SEC] [--logs]` —

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,7 +9,12 @@
 
 ## [Unreleased]
 
-## [0.2.0.5] - 2026-04-27
+## [0.2.0.6] - 2026-04-27
+
+### 수정
+- **`wait_for_windows_responsive` 가 부팅 중 게스트에서 1초도 안 되어 무너져 `pod wait-ready` UX 가 통째로 망가짐.** 헬퍼가 RDP TCP 포트 열림은 제대로 대기했지만, 그 다음 FreeRDP RemoteApp probe 를 **단 한 번만** 발화. 한 번 실패하면 (부팅 중 게스트는 항상 rc=147 connection-reset 반환) 즉시 False return → 호출자가 넘긴 600초 timeout 이 무시됨. v0.2.0.6 에서 probe 를 retry loop 로 변경: 5-20초짜리 probe 를 deadline 까지 반복 (FreeRDP 프로세스 CPU 점유 막기 위해 3초 간격). 이제 `pod wait-ready --timeout 600` 이 진짜 10분까지 기다림 — phase 3 의 elapsed time 이 증가하는 게 보임.
+
+
 
 ### 추가
 - **`winpodx pod wait-ready [--timeout SEC] [--logs]`** — Windows VM 첫 부팅 다단계 wait gate. 세 체크포인트를 elapsed time 과 함께 표시해서 사용자가 침묵 속 몇 분간 hang 대신 실제 진행 상황을 봄:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.2.0.5"
+version = "0.2.0.6"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.2.0.5"
+__version__ = "0.2.0.6"

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -194,11 +194,15 @@ def wait_for_windows_responsive(cfg: Config, timeout: int = 90) -> bool:
     - ``ERRCONNECT_ACTIVATION_TIMEOUT`` (rc=131, FreeRDP connected but
       activation phase didn't complete in time)
 
-    This helper waits for the RDP port first, then fires a tiny
-    no-op probe (`Write-Output 'ping'`) with a 15s budget to confirm
-    the FreeRDP RemoteApp channel is actually live. Returns True on
-    success, False if the guest is still booting after ``timeout``
-    seconds — caller decides whether to skip / retry / surface to user.
+    This helper waits for the RDP port first, then fires repeated tiny
+    no-op probes (`Write-Output 'ping'`) until either one succeeds or
+    the overall timeout expires. v0.2.0.6 added the retry loop after
+    v0.2.0.5 shipped a one-shot probe — on a still-booting guest the
+    first probe always hits rc=147 connection-reset and the entire
+    wait collapsed in <1s regardless of the timeout the caller passed.
+    Returns True once a probe succeeds, False if the guest is still
+    booting at ``timeout`` seconds — caller decides whether to skip /
+    retry / surface to user.
     """
     from winpodx.core.windows_exec import WindowsExecError, run_in_windows
 
@@ -210,17 +214,32 @@ def wait_for_windows_responsive(cfg: Config, timeout: int = 90) -> bool:
     else:
         return False
 
-    # Port is open — confirm activation works with a short probe.
-    try:
-        result = run_in_windows(
-            cfg,
-            "Write-Output 'ping'\n",
-            description="responsive-probe",
-            timeout=20,
-        )
-        return result.rc == 0
-    except WindowsExecError:
-        return False
+    # Port is open — keep firing the activation probe until one succeeds
+    # or the deadline expires. On first boot the guest can refuse FreeRDP
+    # for several minutes (Windows still in mid-Sysprep / OEM apply) even
+    # though the RDP listener answers TCP, so a one-shot probe here is
+    # the wrong primitive — the user already passed `timeout` to express
+    # "try this hard, for this long".
+    while time.monotonic() < deadline:
+        per_probe_budget = max(5, min(20, int(deadline - time.monotonic())))
+        try:
+            result = run_in_windows(
+                cfg,
+                "Write-Output 'ping'\n",
+                description="responsive-probe",
+                timeout=per_probe_budget,
+            )
+            if result.rc == 0:
+                return True
+        except WindowsExecError:
+            # Transient — Windows likely still booting / Sysprep running.
+            pass
+        # Pace retries so we don't pin a CPU spinning FreeRDP processes.
+        if time.monotonic() < deadline - 3:
+            time.sleep(3)
+        else:
+            break
+    return False
 
 
 def _self_heal_apply(cfg: Config) -> None:

--- a/tests/test_provisioner.py
+++ b/tests/test_provisioner.py
@@ -390,3 +390,85 @@ def test_apply_windows_runtime_fixes_records_individual_failures(monkeypatch):
     assert result["max_sessions"].startswith("failed: ")
     assert result["rdp_timeouts"] == "ok"
     assert result["oem_runtime_fixes"] == "ok"
+
+
+# --- v0.2.0.6: wait_for_windows_responsive retry loop ---
+
+
+class TestWaitForWindowsResponsiveRetries:
+    """v0.2.0.6: probe must retry until deadline, not bail on first failure.
+
+    Reproduces the v0.2.0.5 bug where _wait_ready phase 3 returned FAIL at
+    elapsed=00:00 because wait_for_windows_responsive ran exactly one
+    FreeRDP probe and returned False on the first WindowsExecError.
+    """
+
+    def _cfg(self):
+        from winpodx.core.config import Config
+
+        cfg = Config()
+        cfg.pod.backend = "podman"
+        cfg.rdp.ip = "127.0.0.1"
+        cfg.rdp.port = 3389
+        cfg.rdp.password = "abc123"
+        return cfg
+
+    def test_returns_true_when_probe_eventually_succeeds(self, monkeypatch):
+        """First N probes raise WindowsExecError; eventually one returns rc=0
+        and the helper must return True instead of bailing on probe #1."""
+        from winpodx.core.provisioner import wait_for_windows_responsive
+        from winpodx.core.windows_exec import WindowsExecError, WindowsExecResult
+
+        cfg = self._cfg()
+        monkeypatch.setattr(
+            "winpodx.core.provisioner.check_rdp_port",
+            lambda ip, port, timeout=1.0: True,
+        )
+        # Compress the inter-probe sleep so the test is fast.
+        monkeypatch.setattr("winpodx.core.provisioner.time.sleep", lambda _: None)
+
+        attempts: list[int] = []
+
+        def fake_run(cfg_inner, payload, *, description, timeout):
+            attempts.append(len(attempts))
+            if len(attempts) < 4:
+                raise WindowsExecError("FreeRDP rc=147 connection reset by peer")
+            return WindowsExecResult(rc=0, stdout="ping\n", stderr="")
+
+        monkeypatch.setattr("winpodx.core.windows_exec.run_in_windows", fake_run)
+        assert wait_for_windows_responsive(cfg, timeout=60) is True
+        assert len(attempts) >= 4, "must keep probing past first failure"
+
+    def test_returns_false_only_after_deadline(self, monkeypatch):
+        """If every probe fails for the full timeout, helper must take roughly
+        `timeout` seconds — not return False after the first attempt."""
+
+        from winpodx.core.provisioner import wait_for_windows_responsive
+        from winpodx.core.windows_exec import WindowsExecError
+
+        cfg = self._cfg()
+        monkeypatch.setattr(
+            "winpodx.core.provisioner.check_rdp_port",
+            lambda ip, port, timeout=1.0: True,
+        )
+        # Use a virtual clock so we don't really wait.
+        clock = {"t": 0.0}
+        monkeypatch.setattr("winpodx.core.provisioner.time.monotonic", lambda: clock["t"])
+        monkeypatch.setattr(
+            "winpodx.core.provisioner.time.sleep",
+            lambda s: clock.update(t=clock["t"] + s),
+        )
+
+        attempts: list[int] = []
+
+        def fake_run(cfg_inner, payload, *, description, timeout):
+            attempts.append(timeout)
+            # Each probe consumes ~5s of virtual time.
+            clock["t"] += 5
+            raise WindowsExecError("FreeRDP rc=147 connection reset")
+
+        monkeypatch.setattr("winpodx.core.windows_exec.run_in_windows", fake_run)
+
+        result = wait_for_windows_responsive(cfg, timeout=30)
+        assert result is False
+        assert len(attempts) >= 2, "must retry rather than bail on first failure"


### PR DESCRIPTION
## Summary

v0.2.0.5 shipped \`pod wait-ready\` but the user's first run showed:

\`\`\`
[3/3] Waiting for Windows activation...      (00:00)
      FAIL Timeout waiting for Windows ready   (00:00)
\`\`\`

Phase 3 returned FAIL at 00:00 — the entire 600s timeout was ignored.

### Root cause
\`wait_for_windows_responsive\` waited correctly for the RDP TCP port to open, then fired exactly ONE FreeRDP RemoteApp probe afterwards. A single failure (which is what every still-booting guest produces, rc=147 connection-reset) returned False immediately. The caller's 600s timeout never had a chance to apply to the probe phase.

### Fix
Turned the probe into a retry loop: 5-20s probes paced 3s apart, repeating until one succeeds or the overall \`timeout\` expires. The TCP-port wait is unchanged.

### Tests
- \`test_returns_true_when_probe_eventually_succeeds\` — first 3 probes raise WindowsExecError, 4th returns rc=0 → helper returns True (would have returned False on probe #1 before this fix).
- \`test_returns_false_only_after_deadline\` — virtual clock, every probe fails, helper keeps retrying until deadline reached.
- 407 tests pass; ruff clean.

## Test plan
- [ ] Fresh \`uninstall --purge\` then \`curl install.sh | bash\`: \`[3/3] Waiting for Windows activation...\` now actually waits with elapsed-time incrementing during the wait, finishing with \`OK Windows ready (NN:NN)\` once the guest is up — instead of the v0.2.0.5 \`FAIL Timeout (00:00)\` that bailed in <1s.