### PR TITLE
release: v0.2.0.7 — wait-ready --logs shows download progress + drains stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
-## [0.2.0.6] - 2026-04-27
+## [0.2.0.7] - 2026-04-27
+
+### Fixed
+- **`pod wait-ready --logs` showed no `[container]` lines on a fast container.** Two issues: (1) the tail was started with `--tail 0` which means "show only logs emitted from now onwards", but dockur often prints Windows ISO download progress + boot stage transitions *before* wait-ready runs — so the user saw nothing. (2) Only `stdout` was being drained; dockur splits progress across stdout (download bytes/sec) and stderr (boot phase), so half the messages were silently dropped. v0.2.0.7 bumps `--tail 100` so the user sees recent context immediately, and drains both streams in parallel threads.
+
+
 
 ### Fixed
 - **`wait_for_windows_responsive` collapsed in <1s on a still-booting guest, defeating the entire `pod wait-ready` UX.** The helper waited correctly for the RDP TCP port to open, then fired exactly **one** FreeRDP RemoteApp probe — a single failure (which is what every still-booting guest produces, rc=147 connection-reset) returned False immediately and the caller's 600s timeout was effectively ignored. v0.2.0.6 turns the probe into a retry loop that fires repeated 5-20s probes until either one succeeds or the overall `timeout` expires (paced 3s between attempts so we don't pin a CPU spinning FreeRDP). Now `pod wait-ready --timeout 600` actually waits up to 10 minutes — observable in the elapsed-time stamp incrementing during phase 3.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+winpodx (0.2.0.7) unstable; urgency=medium
+
+  * Fixed: pod wait-ready --logs showed no [container] lines.
+    The tail was started with --tail 0 (only logs from "now" onward,
+    so Windows ISO download + boot stage messages already printed
+    before wait-ready ran were invisible) AND only stdout was drained
+    while dockur splits progress between stdout and stderr.
+    v0.2.0.7 uses --tail 100 + drains both streams in parallel
+    threads, so the user actually sees what Windows is doing.
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Mon, 27 Apr 2026 15:00:00 +0900
+
 winpodx (0.2.0.6) unstable; urgency=high
 
   * Fixed: wait_for_windows_responsive collapsed in <1s on a still-

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,7 +9,12 @@
 
 ## [Unreleased]
 
-## [0.2.0.6] - 2026-04-27
+## [0.2.0.7] - 2026-04-27
+
+### 수정
+- **빠른 컨테이너에서 `pod wait-ready --logs` 가 `[container]` 라인 하나도 안 띄움.** 두 가지 문제: (1) tail 을 `--tail 0` 으로 시작했는데 이건 "지금부터의 로그만 표시" 의미. 하지만 dockur 는 Windows ISO 다운로드 / 부팅 단계 메시지를 wait-ready 실행 *전에* 이미 출력 → 사용자에게 아무것도 안 보임. (2) `stdout` 만 drain. dockur 는 진행 메시지를 stdout (다운로드 byte/s) 과 stderr (부팅 단계) 로 나눠 출력해서 절반이 사라짐. v0.2.0.7 에서 `--tail 100` 으로 최근 컨텍스트 즉시 표시 + stdout/stderr 둘 다 병렬 스레드로 drain.
+
+
 
 ### 수정
 - **`wait_for_windows_responsive` 가 부팅 중 게스트에서 1초도 안 되어 무너져 `pod wait-ready` UX 가 통째로 망가짐.** 헬퍼가 RDP TCP 포트 열림은 제대로 대기했지만, 그 다음 FreeRDP RemoteApp probe 를 **단 한 번만** 발화. 한 번 실패하면 (부팅 중 게스트는 항상 rc=147 connection-reset 반환) 즉시 False return → 호출자가 넘긴 600초 timeout 이 무시됨. v0.2.0.6 에서 probe 를 retry loop 로 변경: 5-20초짜리 probe 를 deadline 까지 반복 (FreeRDP 프로세스 CPU 점유 막기 위해 3초 간격). 이제 `pod wait-ready --timeout 600` 이 진짜 10분까지 기다림 — phase 3 의 elapsed time 이 증가하는 게 보임.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.2.0.6"
+version = "0.2.0.7"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.2.0.6"
+__version__ = "0.2.0.7"

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -385,24 +385,32 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
     log_stop = threading.Event()
     if show_logs:
         try:
+            # v0.2.0.7: --tail 100 so the user sees recent context (Windows
+            # ISO download, current boot stage) instead of nothing — dockur
+            # may have already printed minutes of progress before wait-ready
+            # runs. Both stdout and stderr are drained because dockur's
+            # progress output is split across both streams (download
+            # bytes/sec on one, boot phase on the other).
             log_proc = Popen(
-                [cfg.pod.backend, "logs", "-f", "--tail", "0", cfg.pod.container_name],
+                [cfg.pod.backend, "logs", "-f", "--tail", "100", cfg.pod.container_name],
                 stdout=PIPE,
                 stderr=PIPE,
                 text=True,
                 bufsize=1,
             )
 
-            def _drain() -> None:
-                assert log_proc is not None and log_proc.stdout is not None
-                for line in log_proc.stdout:
+            def _drain(stream) -> None:  # type: ignore[no-untyped-def]
+                if stream is None:
+                    return
+                for line in stream:
                     if log_stop.is_set():
                         break
                     line = line.rstrip()
                     if line:
                         print(f"       [container] {line}")
 
-            threading.Thread(target=_drain, daemon=True).start()
+            threading.Thread(target=_drain, args=(log_proc.stdout,), daemon=True).start()
+            threading.Thread(target=_drain, args=(log_proc.stderr,), daemon=True).start()
         except (FileNotFoundError, OSError) as e:
             print(f"       (could not tail container logs: {e})")
             log_proc = None


### PR DESCRIPTION
## Summary

User reported \`pod wait-ready --logs\` showed zero \`[container]\` lines while Windows VM was booting (and downloading the Windows ISO from dockur). Two root causes:

1. **\`--tail 0\`** = "only show logs emitted from now onward". But dockur prints the ISO download + boot progress *before* \`wait-ready\` runs, so the user saw silence.
2. **stderr never drained**. dockur splits its progress across stdout (download bytes/sec) and stderr (boot phase transitions). Half the messages were silently dropped.

### Fix
- \`--tail 100\` so the user sees recent context immediately when wait-ready starts.
- Drain stdout AND stderr in parallel daemon threads.

### Tests
407 tests pass; ruff clean. (No new test — the change is in container-log subprocess plumbing which is hard to mock without integration env; the fix is small and the manual repro path is clear.)

## Test plan
- [ ] Fresh \`uninstall --purge\` then \`curl install.sh | bash\`: \`[3/3] Waiting for Windows activation...\` now shows \`[container]\` lines (download progress, boot stages, sysprep messages) while waiting.