### PR TITLE
release: v0.2.0.8 — refresh registers .desktop entries + self-heal stamp stops PS flash on every launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
-## [0.2.0.7] - 2026-04-27
+## [0.2.0.8] - 2026-04-27
+
+### Fixed
+- **`winpodx app refresh` discovered apps but never registered them in the desktop menu.** The refresh path persisted `app.toml` + icons under `~/.local/share/winpodx/discovered/` but the actual `.desktop` entries were only created by the separate `winpodx app install-all` command — so users saw "Discovered N app(s)" then had no apps in their DE menu. v0.2.0.8 has refresh auto-install entries for the discovered set inline (best-effort: failures are warned but don't abort the refresh) and refresh the icon cache afterwards.
+- **PowerShell window flashed on every app launch.** `ensure_ready`'s self-heal apply path fired three FreeRDP RemoteApp PowerShell payloads on every single app launch — even though `-WindowStyle Hidden` makes them tiny, they still flashed visibly each time, which got annoying fast. The applies are idempotent on the registry side, so re-running them on warm pods accomplished nothing visible. v0.2.0.8 stamps `~/.config/winpodx/.applies_stamp` with `<winpodx_version>:<container_StartedAt>` after a successful self-heal — subsequent launches short-circuit until the pod restarts (so TermService / NIC settings re-apply after a Windows reboot) or winpodx upgrades.
+
+
 
 ### Fixed
 - **`pod wait-ready --logs` showed no `[container]` lines on a fast container.** Two issues: (1) the tail was started with `--tail 0` which means "show only logs emitted from now onwards", but dockur often prints Windows ISO download progress + boot stage transitions *before* wait-ready runs — so the user saw nothing. (2) Only `stdout` was being drained; dockur splits progress across stdout (download bytes/sec) and stderr (boot phase), so half the messages were silently dropped. v0.2.0.7 bumps `--tail 100` so the user sees recent context immediately, and drains both streams in parallel threads.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+winpodx (0.2.0.8) unstable; urgency=medium
+
+  * Fixed: `winpodx app refresh` discovered apps but never registered
+    them in the desktop menu. Refresh now auto-installs .desktop
+    entries for discovered apps (best-effort) + refreshes the icon
+    cache.
+  * Fixed: PowerShell window flashed on every app launch because
+    ensure_ready's self-heal apply re-fired three FreeRDP RemoteApp
+    PowerShell payloads on every click. Self-heal now stamps
+    .applies_stamp with <winpodx_version>:<container_StartedAt>
+    and short-circuits on subsequent launches until pod restart or
+    winpodx upgrade.
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Mon, 27 Apr 2026 16:00:00 +0900
+
 winpodx (0.2.0.7) unstable; urgency=medium
 
   * Fixed: pod wait-ready --logs showed no [container] lines.

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,7 +9,13 @@
 
 ## [Unreleased]
 
-## [0.2.0.7] - 2026-04-27
+## [0.2.0.8] - 2026-04-27
+
+### 수정
+- **`winpodx app refresh` 가 앱 발견은 하지만 데스크톱 메뉴에는 등록 안 함.** refresh 경로는 `app.toml` + 아이콘을 `~/.local/share/winpodx/discovered/` 에 저장만 하고, 실제 `.desktop` 엔트리는 별도 `winpodx app install-all` 명령으로만 생성됐음 → 사용자가 "Discovered N app(s)" 메시지 본 후 DE 메뉴에 앱이 안 떠서 혼란. v0.2.0.8 부터 refresh 가 발견된 앱들의 .desktop 엔트리를 자동 설치 (best-effort, 실패는 warn 만 하고 refresh 자체는 계속) + 아이콘 캐시 갱신.
+- **앱 실행할 때마다 PowerShell 창 깜빡임.** `ensure_ready` 의 self-heal apply 경로가 매 앱 실행마다 FreeRDP RemoteApp PowerShell payload 3개 발화. `-WindowStyle Hidden` 으로 작아져도 여전히 매번 눈에 띄게 깜빡임. apply 자체는 레지스트리 멱등이라 warm pod 에서 재실행해도 가시적 효과 없음 — 순수 노이즈. v0.2.0.8 부터 self-heal 성공 후 `~/.config/winpodx/.applies_stamp` 에 `<winpodx_version>:<container_StartedAt>` 기록 → 이후 launch 는 단축 회귀, pod 재시작 (TermService / NIC 설정 재적용 필요) 또는 winpodx 업그레이드 시에만 다시 발화.
+
+
 
 ### 수정
 - **빠른 컨테이너에서 `pod wait-ready --logs` 가 `[container]` 라인 하나도 안 띄움.** 두 가지 문제: (1) tail 을 `--tail 0` 으로 시작했는데 이건 "지금부터의 로그만 표시" 의미. 하지만 dockur 는 Windows ISO 다운로드 / 부팅 단계 메시지를 wait-ready 실행 *전에* 이미 출력 → 사용자에게 아무것도 안 보임. (2) `stdout` 만 drain. dockur 는 진행 메시지를 stdout (다운로드 byte/s) 과 stderr (부팅 단계) 로 나눠 출력해서 절반이 사라짐. v0.2.0.7 에서 `--tail 100` 으로 최근 컨텍스트 즉시 표시 + stdout/stderr 둘 다 병렬 스레드로 drain.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.2.0.7"
+version = "0.2.0.8"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.2.0.7"
+__version__ = "0.2.0.8"

--- a/src/winpodx/cli/app.py
+++ b/src/winpodx/cli/app.py
@@ -100,6 +100,14 @@ def _refresh_apps(as_json: bool, timeout: int) -> None:
 
     persist_discovered(apps)
 
+    # v0.2.0.8: auto-register .desktop entries so discovered apps land in
+    # the DE menu without a separate `winpodx app install-all` step.
+    # Previous releases persisted app.toml + icons but never created the
+    # XDG entries, so users saw "Discovered N apps" then no apps in the
+    # menu. Best-effort — failures are logged but don't abort refresh.
+    if apps:
+        _register_desktop_entries(apps)
+
     if as_json:
         import json
 
@@ -126,6 +134,44 @@ def _refresh_apps(as_json: bool, timeout: int) -> None:
                 print(f"  {a.name:<20} {a.full_name}")
         else:
             print("No apps discovered.")
+
+
+def _register_desktop_entries(discovered) -> None:
+    """v0.2.0.8: install .desktop + icon-cache entries for freshly-discovered
+    apps so they appear in the user's DE menu without a separate
+    ``winpodx app install-all`` step.
+
+    Loads the merged AppInfo list (so user-authored entries survive) and
+    installs entries for any discovered slug. Keeps the legacy bundled-app
+    behavior of ``_install_all`` in setup_cmd / cli/app, but scoped to the
+    discovered set so we don't re-install unrelated entries on every refresh.
+    """
+    from winpodx.core.app import list_available_apps
+    from winpodx.desktop.entry import install_desktop_entry
+    from winpodx.desktop.icons import update_icon_cache
+
+    discovered_slugs = {d.slug or d.name for d in discovered}
+    available = {a.name: a for a in list_available_apps()}
+    installed = 0
+    for slug in discovered_slugs:
+        info = available.get(slug)
+        if info is None:
+            continue
+        try:
+            install_desktop_entry(info)
+            installed += 1
+        except Exception as e:  # noqa: BLE001
+            print(
+                f"  warning: could not install desktop entry for {slug}: {e}",
+                file=sys.stderr,
+            )
+
+    if installed:
+        try:
+            update_icon_cache()
+        except Exception as e:  # noqa: BLE001
+            print(f"  warning: icon cache refresh failed: {e}", file=sys.stderr)
+        print(f"  Registered {installed} app(s) in your desktop menu.", file=sys.stderr)
 
 
 def _run_app(name: str, file: str | None, wait: bool) -> None:

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -242,6 +242,81 @@ def wait_for_windows_responsive(cfg: Config, timeout: int = 90) -> bool:
     return False
 
 
+_APPLIES_STAMP_FILENAME = ".applies_stamp"
+
+
+def _container_started_at(cfg: Config) -> str:
+    """Read the container's StartedAt timestamp via {runtime} inspect.
+
+    Used as part of the self-heal stamp so a pod restart invalidates
+    the previous apply (TermService / NIC settings need to land again
+    after a reboot of the Windows VM). Returns an empty string when the
+    backend isn't podman/docker or inspect fails — caller treats empty
+    as "no stamp" and runs the apply.
+    """
+    if cfg.pod.backend not in ("podman", "docker"):
+        return ""
+    try:
+        proc = subprocess.run(  # noqa: S603
+            [
+                cfg.pod.backend,
+                "inspect",
+                "--format",
+                "{{.State.StartedAt}}",
+                cfg.pod.container_name,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout.strip()
+
+
+def _applies_stamp_path() -> Path:
+    return Path(config_dir()) / _APPLIES_STAMP_FILENAME
+
+
+def _self_heal_already_done(cfg: Config) -> bool:
+    """Return True when the self-heal apply has already succeeded for this
+    (winpodx version, pod start instance). Avoids a 3-FreeRDP-RemoteApp
+    PowerShell flash on every single app launch — the apply payloads are
+    idempotent on the registry side, but their visible effect (briefly
+    appearing PS windows) was hitting users every time they clicked an app.
+    """
+    from winpodx import __version__
+
+    started = _container_started_at(cfg)
+    if not started:
+        return False
+    expected = f"{__version__}:{started}"
+    try:
+        return _applies_stamp_path().read_text(encoding="utf-8").strip() == expected
+    except (FileNotFoundError, OSError):
+        return False
+
+
+def _record_self_heal_done(cfg: Config) -> None:
+    """Stamp ``<winpodx_version>:<container_started_at>`` once all three
+    self-heal applies have succeeded. The next ensure_ready short-circuits
+    until either the pod is restarted (started_at changes) or winpodx is
+    upgraded (__version__ changes)."""
+    from winpodx import __version__
+
+    started = _container_started_at(cfg)
+    if not started:
+        return
+    try:
+        path = _applies_stamp_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"{__version__}:{started}\n", encoding="utf-8")
+    except OSError as e:
+        log.debug("could not write self-heal stamp: %s", e)
+
+
 def _self_heal_apply(cfg: Config) -> None:
     """Run the three idempotent runtime applies in self-healing mode.
 
@@ -253,9 +328,24 @@ def _self_heal_apply(cfg: Config) -> None:
     and a transient ERRCONNECT_ACTIVATION_TIMEOUT (Windows still
     booting) must not cascade into a Launch Error dialog. The next
     ensure_ready call picks up wherever this one left off.
+
+    v0.2.0.8: short-circuit when a stamp already records that all three
+    applies succeeded for the current (winpodx version, container
+    StartedAt) tuple. Without this, every single app launch fires three
+    FreeRDP RemoteApp PowerShell windows — even though `-WindowStyle
+    Hidden` makes them tiny, they still flash visibly on every click,
+    which kernalix7 reported as "powershell 계속 깜빡깜빡 뜬다" on
+    2026-04-27. The stamp invalidates on pod restart (so TermService /
+    NIC settings re-apply after a Windows reboot) and on winpodx
+    upgrade (so a patch-version bump still gets a chance to apply
+    new payloads).
     """
+    if _self_heal_already_done(cfg):
+        return
+
     from winpodx.core.windows_exec import WindowsExecError
 
+    succeeded = 0
     for name, fn in (
         ("max_sessions", _apply_max_sessions),
         ("rdp_timeouts", _apply_rdp_timeouts),
@@ -263,6 +353,7 @@ def _self_heal_apply(cfg: Config) -> None:
     ):
         try:
             fn(cfg)
+            succeeded += 1
         except WindowsExecError as e:
             log.warning(
                 "%s: channel failure during self-heal (will retry next ensure_ready): %s",
@@ -272,6 +363,9 @@ def _self_heal_apply(cfg: Config) -> None:
             return  # Don't waste 60s × 2 more on a still-booting guest.
         except Exception as e:  # noqa: BLE001
             log.warning("%s: self-heal apply failed: %s", name, e)
+
+    if succeeded == 3:
+        _record_self_heal_done(cfg)
 
 
 def apply_windows_runtime_fixes(cfg: Config) -> dict[str, str]:

--- a/tests/test_provisioner.py
+++ b/tests/test_provisioner.py
@@ -472,3 +472,128 @@ class TestWaitForWindowsResponsiveRetries:
         result = wait_for_windows_responsive(cfg, timeout=30)
         assert result is False
         assert len(attempts) >= 2, "must retry rather than bail on first failure"
+
+
+# --- v0.2.0.8: self-heal stamp prevents PS flash on every launch ---
+
+
+class TestSelfHealStamp:
+    """v0.2.0.8: _self_heal_apply must short-circuit when a stamp records the
+    same (winpodx version, container StartedAt) tuple already succeeded."""
+
+    def _cfg(self):
+        from winpodx.core.config import Config
+
+        cfg = Config()
+        cfg.pod.backend = "podman"
+        cfg.pod.container_name = "winpodx-windows"
+        return cfg
+
+    def test_skips_apply_when_stamp_matches(self, tmp_path, monkeypatch):
+        from winpodx import __version__
+        from winpodx.core.provisioner import _self_heal_apply
+
+        monkeypatch.setattr("winpodx.core.provisioner.config_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "winpodx.core.provisioner._container_started_at", lambda cfg: "2026-04-27T10:00Z"
+        )
+        (tmp_path / ".applies_stamp").write_text(
+            f"{__version__}:2026-04-27T10:00Z\n", encoding="utf-8"
+        )
+
+        called: list[str] = []
+        monkeypatch.setattr(
+            "winpodx.core.provisioner._apply_max_sessions",
+            lambda cfg: called.append("max"),
+        )
+        monkeypatch.setattr(
+            "winpodx.core.provisioner._apply_rdp_timeouts",
+            lambda cfg: called.append("rdp"),
+        )
+        monkeypatch.setattr(
+            "winpodx.core.provisioner._apply_oem_runtime_fixes",
+            lambda cfg: called.append("oem"),
+        )
+
+        _self_heal_apply(self._cfg())
+        assert called == [], "stamp must short-circuit all three applies"
+
+    def test_runs_apply_when_stamp_missing(self, tmp_path, monkeypatch):
+        from winpodx.core.provisioner import _self_heal_apply
+
+        monkeypatch.setattr("winpodx.core.provisioner.config_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "winpodx.core.provisioner._container_started_at", lambda cfg: "2026-04-27T10:00Z"
+        )
+
+        called: list[str] = []
+        for fn_name, marker in (
+            ("_apply_max_sessions", "max"),
+            ("_apply_rdp_timeouts", "rdp"),
+            ("_apply_oem_runtime_fixes", "oem"),
+        ):
+
+            def make(m):
+                def _stub(cfg, _m=m):
+                    called.append(_m)
+
+                return _stub
+
+            monkeypatch.setattr(f"winpodx.core.provisioner.{fn_name}", make(marker))
+
+        _self_heal_apply(self._cfg())
+        assert called == ["max", "rdp", "oem"]
+
+    def test_runs_apply_when_pod_restarted(self, tmp_path, monkeypatch):
+        """Stamp is from a previous container start; current StartedAt differs
+        → must re-run apply (TermService settings need to relaunch on
+        every Windows reboot)."""
+        from winpodx import __version__
+        from winpodx.core.provisioner import _self_heal_apply
+
+        monkeypatch.setattr("winpodx.core.provisioner.config_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "winpodx.core.provisioner._container_started_at",
+            lambda cfg: "2026-04-27T11:00Z",  # different time
+        )
+        (tmp_path / ".applies_stamp").write_text(
+            f"{__version__}:2026-04-27T10:00Z\n", encoding="utf-8"
+        )
+
+        called: list[str] = []
+        for fn_name, marker in (
+            ("_apply_max_sessions", "max"),
+            ("_apply_rdp_timeouts", "rdp"),
+            ("_apply_oem_runtime_fixes", "oem"),
+        ):
+
+            def make(m):
+                def _stub(cfg, _m=m):
+                    called.append(_m)
+
+                return _stub
+
+            monkeypatch.setattr(f"winpodx.core.provisioner.{fn_name}", make(marker))
+
+        _self_heal_apply(self._cfg())
+        assert called == ["max", "rdp", "oem"], "pod restart must invalidate stamp"
+
+    def test_stamp_written_after_three_successes(self, tmp_path, monkeypatch):
+        from winpodx import __version__
+        from winpodx.core.provisioner import _self_heal_apply
+
+        monkeypatch.setattr("winpodx.core.provisioner.config_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "winpodx.core.provisioner._container_started_at",
+            lambda cfg: "2026-04-27T12:00Z",
+        )
+        for fn_name in (
+            "_apply_max_sessions",
+            "_apply_rdp_timeouts",
+            "_apply_oem_runtime_fixes",
+        ):
+            monkeypatch.setattr(f"winpodx.core.provisioner.{fn_name}", lambda cfg: None)
+
+        _self_heal_apply(self._cfg())
+        stamp = (tmp_path / ".applies_stamp").read_text(encoding="utf-8").strip()
+        assert stamp == f"{__version__}:2026-04-27T12:00Z"


### PR DESCRIPTION
## Summary

Two user-reported UX bugs:

1. **\`winpodx app refresh\` discovered apps but didn't put them in the menu.** Refresh persisted \`app.toml\` + icons but the \`.desktop\` entries were a separate \`app install-all\` step. Fixed: refresh now auto-installs entries inline + refreshes the icon cache.

2. **PowerShell window flashed every time the user launched an app.** \`ensure_ready\`'s self-heal apply re-fired three FreeRDP RemoteApp PowerShell payloads on every single launch. Even with \`-WindowStyle Hidden\` they flashed visibly each time. Fixed: stamp \`~/.config/winpodx/.applies_stamp\` with \`<version>:<container_StartedAt>\` once all three applies succeed; subsequent launches short-circuit until pod restart or winpodx upgrade.

### Tests
4 new tests cover stamp match (skip), missing (run), pod-restart-invalidate (re-run), and success-writes-stamp. 411 tests pass; ruff clean.

## Test plan
- [ ] \`winpodx app refresh\`: discovered apps appear in DE menu without a separate \`app install-all\` step.
- [ ] Click an app twice in a row: PS window flashes ONCE on first launch (apply runs), then no flashes on subsequent launches in the same pod lifetime.
- [ ] \`winpodx pod restart\` then click an app: PS window flashes again (stamp invalidated, applies re-run), then quiet on subsequent clicks.