### PR TITLE
release: v0.2.0.9 — auto multi-session, bidirectional desktop sync, prominent Beta + extra README shields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,16 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
-## [0.2.0.8] - 2026-04-27
+## [0.2.0.9] - 2026-04-27
+
+### Fixed
+- **2nd app launch triggered Windows "Select a session to reconnect to" dialog instead of showing an independent app window.** Default Windows refuses concurrent FreeRDP RemoteApp sessions per user, so every app launched after the first one was either embedded in the existing session or popped a reconnect dialog. v0.2.0.9 adds `_apply_multi_session` to the self-heal apply chain — it shells out to `rdprrap-conf --enable` inside the guest so termsrv.dll allows independent per-launch sessions. Idempotent (no-op when already enabled), tolerates rdprrap-conf missing on older OEM bundles by treating it as a best-effort skip.
+- **Stale `.desktop` entries lingered in the user's DE menu after apps were removed from the Windows guest.** v0.2.0.8 added auto-install on refresh but never removed entries that no longer matched a discovered app. v0.2.0.9 makes refresh truly bidirectional: any `winpodx-*.desktop` not corresponding to an entry in `list_available_apps()` is removed (along with its icons), so uninstalling Office on the Windows side actually drops Word/Excel/PowerPoint from the launcher on next refresh. User-authored entries under `~/.local/share/winpodx/data/apps/` are preserved.
+
+### Changed
+- **README is more informative.** Big "Status: Beta" + "Latest release" badges at the top in `for-the-badge` style. Standard shields row (license, Python, backend, language, tests, CI) below. Social row (stars, forks, watchers, unique visitors). Activity row (issues, PRs, last commit, code size). EN + KO mirrored.
+
+
 
 ### Fixed
 - **`winpodx app refresh` discovered apps but never registered them in the desktop menu.** The refresh path persisted `app.toml` + icons under `~/.local/share/winpodx/discovered/` but the actual `.desktop` entries were only created by the separate `winpodx app install-all` command — so users saw "Discovered N app(s)" then had no apps in their DE menu. v0.2.0.8 has refresh auto-install entries for the discovered set inline (best-effort: failures are warned but don't abort the refresh) and refresh the icon cache afterwards.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,25 @@
 
 **Run Windows applications seamlessly on Linux**
 
+[![Status: Beta](https://img.shields.io/badge/Status-Beta-orange?style=for-the-badge)](#status-beta)
+[![Latest release](https://img.shields.io/github/v/release/kernalix7/winpodx?include_prereleases&style=for-the-badge&color=informational)](https://github.com/kernalix7/winpodx/releases)
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/Python-3.9%2B-green.svg)](https://www.python.org/)
 [![Backend: Podman](https://img.shields.io/badge/Backend-Podman-purple.svg)](https://podman.io/)
-[![Status: Beta](https://img.shields.io/badge/Status-Beta-orange.svg)](#status)
-[![Tests: 407 passed](https://img.shields.io/badge/Tests-407%20passed-brightgreen.svg)](#testing)
+[![Language: Python](https://img.shields.io/badge/Language-Python%20100%25-yellow.svg)](https://www.python.org/)
+[![Tests: 411 passed](https://img.shields.io/badge/Tests-411%20passed-brightgreen.svg)](#testing)
+[![CI](https://img.shields.io/github/actions/workflow/status/kernalix7/winpodx/ci.yml?branch=main&label=CI)](https://github.com/kernalix7/winpodx/actions/workflows/ci.yml)
+
+[![GitHub stars](https://img.shields.io/github/stars/kernalix7/winpodx?style=social)](https://github.com/kernalix7/winpodx/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/kernalix7/winpodx?style=social)](https://github.com/kernalix7/winpodx/network/members)
+[![GitHub watchers](https://img.shields.io/github/watchers/kernalix7/winpodx?style=social)](https://github.com/kernalix7/winpodx/watchers)
+[![Visitors](https://hits.dwyl.com/kernalix7/winpodx.svg?style=flat&show=unique)](https://github.com/kernalix7/winpodx)
+
+[![Issues](https://img.shields.io/github/issues/kernalix7/winpodx)](https://github.com/kernalix7/winpodx/issues)
+[![Pull requests](https://img.shields.io/github/issues-pr/kernalix7/winpodx)](https://github.com/kernalix7/winpodx/pulls)
+[![Last commit](https://img.shields.io/github/last-commit/kernalix7/winpodx)](https://github.com/kernalix7/winpodx/commits/main)
+[![Code size](https://img.shields.io/github/languages/code-size/kernalix7/winpodx)](https://github.com/kernalix7/winpodx)
 
 **English** | [한국어](docs/README.ko.md)
 
@@ -20,8 +34,8 @@
 
 ---
 
-> ### Status: Beta (v0.2.0.x)
-> winpodx is under active development. The install path, FreeRDP RemoteApp integration, Windows-side runtime applies, and discovery flow have all been hardened across the v0.1.9 → v0.2.0.x line, but you should still expect rough edges — especially on first install (Windows VM first-boot can take 5–10 minutes; see `winpodx pod wait-ready --logs` for live progress). Please file issues at <https://github.com/kernalix7/winpodx/issues> if something breaks.
+> ### Status: Beta
+> winpodx is in active development (v0.2.0.x). The install path, FreeRDP RemoteApp integration, Windows-side runtime applies, and discovery flow have all been hardened across the v0.1.9 → v0.2.0.x line, but you should still expect rough edges — especially on first install (Windows VM first-boot can take 5–10 minutes; see `winpodx pod wait-ready --logs` for live progress). Please file issues at <https://github.com/kernalix7/winpodx/issues> if something breaks.
 
 winpodx runs a Windows container (via [dockur/windows](https://github.com/dockur/windows)) in the background and presents Windows apps as native Linux applications through FreeRDP RemoteApp. No manual VM setup, no ISO downloads, no registry editing. **Near-zero external Python dependencies** (stdlib only on Python 3.11+; one pure-Python `tomli` fallback on 3.9/3.10).
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+winpodx (0.2.0.9) unstable; urgency=medium
+
+  * Fixed: 2nd app launch triggered Windows "Select a session to
+    reconnect to" dialog. Default Windows refuses concurrent
+    RemoteApp sessions per user. Self-heal apply now also runs
+    rdprrap-conf --enable so each launch gets its own session.
+    Idempotent; tolerates missing rdprrap-conf as best-effort skip.
+  * Fixed: stale .desktop entries lingered after apps removed from
+    the Windows guest. Refresh now bidirectionally syncs — any
+    winpodx-*.desktop not corresponding to an entry in
+    list_available_apps() is removed (along with its icons).
+    User-authored entries are preserved.
+  * Changed: README more informative — prominent Beta + Latest
+    release badges at top, plus social/activity shields rows.
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Mon, 27 Apr 2026 17:00:00 +0900
+
 winpodx (0.2.0.8) unstable; urgency=medium
 
   * Fixed: `winpodx app refresh` discovered apps but never registered

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,7 +9,16 @@
 
 ## [Unreleased]
 
-## [0.2.0.8] - 2026-04-27
+## [0.2.0.9] - 2026-04-27
+
+### 수정
+- **두 번째 앱 실행 시 독립 윈도 대신 Windows "Select a session to reconnect to" 다이얼로그 발생.** Windows 기본값이 사용자당 동시 FreeRDP RemoteApp 세션 거부 → 첫 앱 이후의 모든 launch 가 기존 세션에 묻히거나 reconnect 다이얼로그 띄움. v0.2.0.9 에서 self-heal apply 체인에 `_apply_multi_session` 추가 — 게스트 안에서 `rdprrap-conf --enable` 호출해 termsrv.dll 패치 활성화 → launch 마다 독립 세션. 멱등 (이미 활성화돼있으면 no-op), 구 OEM 번들에 rdprrap-conf 없으면 best-effort skip.
+- **앱이 Windows 에서 삭제됐는데 DE 메뉴에 `.desktop` 엔트리가 계속 남음.** v0.2.0.8 이 refresh 자동 설치는 추가했지만 사라진 앱의 엔트리 제거는 안 했음. v0.2.0.9 에서 refresh 진짜 양방향 동기화: `list_available_apps()` 에 없는 모든 `winpodx-*.desktop` 파일이 (해당 아이콘과 함께) 제거됨 → Windows 에서 Office 지우면 다음 refresh 때 launcher 에서도 Word/Excel/PowerPoint 사라짐. `~/.local/share/winpodx/data/apps/` 의 사용자 작성 엔트리는 보존.
+
+### 변경
+- **README 정보량 강화.** 상단에 `for-the-badge` 스타일 "Status: Beta" + "Latest release" 배지. 그 아래 표준 shields (license, Python, backend, language, tests, CI). 소셜 행 (stars, forks, watchers, unique visitors). 활동 행 (issues, PRs, last commit, code size). EN + KO 동기화.
+
+
 
 ### 수정
 - **`winpodx app refresh` 가 앱 발견은 하지만 데스크톱 메뉴에는 등록 안 함.** refresh 경로는 `app.toml` + 아이콘을 `~/.local/share/winpodx/discovered/` 에 저장만 하고, 실제 `.desktop` 엔트리는 별도 `winpodx app install-all` 명령으로만 생성됐음 → 사용자가 "Discovered N app(s)" 메시지 본 후 DE 메뉴에 앱이 안 떠서 혼란. v0.2.0.8 부터 refresh 가 발견된 앱들의 .desktop 엔트리를 자동 설치 (best-effort, 실패는 warn 만 하고 refresh 자체는 계속) + 아이콘 캐시 갱신.

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -6,11 +6,25 @@
 
 **Linux에서 Windows 앱을 심리스하게 실행**
 
+[![Status: Beta](https://img.shields.io/badge/Status-Beta-orange?style=for-the-badge)](#상태-베타)
+[![Latest release](https://img.shields.io/github/v/release/kernalix7/winpodx?include_prereleases&style=for-the-badge&color=informational)](https://github.com/kernalix7/winpodx/releases)
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/Python-3.9%2B-green.svg)](https://www.python.org/)
 [![Backend: Podman](https://img.shields.io/badge/Backend-Podman-purple.svg)](https://podman.io/)
-[![Status: Beta](https://img.shields.io/badge/Status-Beta-orange.svg)](#상태)
-[![Tests: 407 passed](https://img.shields.io/badge/Tests-407%20passed-brightgreen.svg)](#테스트)
+[![Language: Python](https://img.shields.io/badge/Language-Python%20100%25-yellow.svg)](https://www.python.org/)
+[![Tests: 411 passed](https://img.shields.io/badge/Tests-411%20passed-brightgreen.svg)](#테스트)
+[![CI](https://img.shields.io/github/actions/workflow/status/kernalix7/winpodx/ci.yml?branch=main&label=CI)](https://github.com/kernalix7/winpodx/actions/workflows/ci.yml)
+
+[![GitHub stars](https://img.shields.io/github/stars/kernalix7/winpodx?style=social)](https://github.com/kernalix7/winpodx/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/kernalix7/winpodx?style=social)](https://github.com/kernalix7/winpodx/network/members)
+[![GitHub watchers](https://img.shields.io/github/watchers/kernalix7/winpodx?style=social)](https://github.com/kernalix7/winpodx/watchers)
+[![Visitors](https://hits.dwyl.com/kernalix7/winpodx.svg?style=flat&show=unique)](https://github.com/kernalix7/winpodx)
+
+[![Issues](https://img.shields.io/github/issues/kernalix7/winpodx)](https://github.com/kernalix7/winpodx/issues)
+[![Pull requests](https://img.shields.io/github/issues-pr/kernalix7/winpodx)](https://github.com/kernalix7/winpodx/pulls)
+[![Last commit](https://img.shields.io/github/last-commit/kernalix7/winpodx)](https://github.com/kernalix7/winpodx/commits/main)
+[![Code size](https://img.shields.io/github/languages/code-size/kernalix7/winpodx)](https://github.com/kernalix7/winpodx)
 
 [English](../README.md) | **한국어**
 
@@ -20,8 +34,8 @@
 
 ---
 
-> ### 상태: 베타 (v0.2.0.x)
-> winpodx는 아직 활발히 개발 중입니다. 설치 경로, FreeRDP RemoteApp 통합, Windows-side runtime apply, discovery 흐름이 v0.1.9 → v0.2.0.x 동안 많이 개선됐지만, 여전히 거친 부분이 남아있을 수 있습니다 — 특히 첫 설치 시 (Windows VM 첫 부팅에 5~10분 소요; 진행 상황은 `winpodx pod wait-ready --logs` 로 확인). 문제 발생 시 <https://github.com/kernalix7/winpodx/issues> 에 이슈 등록해주세요.
+> ### 상태: 베타
+> winpodx는 활발히 개발 중입니다 (v0.2.0.x). 설치 경로, FreeRDP RemoteApp 통합, Windows-side runtime apply, discovery 흐름이 v0.1.9 → v0.2.0.x 동안 많이 개선됐지만, 여전히 거친 부분이 남아있을 수 있습니다 — 특히 첫 설치 시 (Windows VM 첫 부팅에 5~10분 소요; 진행 상황은 `winpodx pod wait-ready --logs` 로 확인). 문제 발생 시 <https://github.com/kernalix7/winpodx/issues> 에 이슈 등록해주세요.
 
 winpodx는 백그라운드에서 Windows 컨테이너([dockur/windows](https://github.com/dockur/windows))를 실행하고, FreeRDP RemoteApp으로 Windows 앱을 네이티브 Linux 앱처럼 표시합니다. VM 수동 설정 불필요, ISO 다운로드 불필요, 레지스트리 편집 불필요. **외부 Python 의존성 거의 없음** (Python 3.11+ 는 표준 라이브러리만; 3.9/3.10 은 순수 파이썬 `tomli` 폴백 1개).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.2.0.8"
+version = "0.2.0.9"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.2.0.8"
+__version__ = "0.2.0.9"

--- a/src/winpodx/cli/app.py
+++ b/src/winpodx/cli/app.py
@@ -141,17 +141,21 @@ def _register_desktop_entries(discovered) -> None:
     apps so they appear in the user's DE menu without a separate
     ``winpodx app install-all`` step.
 
-    Loads the merged AppInfo list (so user-authored entries survive) and
-    installs entries for any discovered slug. Keeps the legacy bundled-app
-    behavior of ``_install_all`` in setup_cmd / cli/app, but scoped to the
-    discovered set so we don't re-install unrelated entries on every refresh.
+    v0.2.0.9: bidirectional sync — also remove stale `winpodx-*.desktop`
+    entries that no longer correspond to any app on disk. Without this,
+    apps uninstalled from the Windows guest stayed in the user's DE
+    menu indefinitely (kernalix7 reported on 2026-04-27: "예전에
+    만들었다고 해서 없어졌는데 계속 남아있으면 안돼"). User-authored
+    entries (under ~/.local/share/winpodx/apps/) are preserved.
     """
     from winpodx.core.app import list_available_apps
-    from winpodx.desktop.entry import install_desktop_entry
+    from winpodx.desktop.entry import install_desktop_entry, remove_desktop_entry
     from winpodx.desktop.icons import update_icon_cache
+    from winpodx.utils.paths import applications_dir
 
     discovered_slugs = {d.slug or d.name for d in discovered}
     available = {a.name: a for a in list_available_apps()}
+    available_slugs = set(available)
     installed = 0
     for slug in discovered_slugs:
         info = available.get(slug)
@@ -166,12 +170,41 @@ def _register_desktop_entries(discovered) -> None:
                 file=sys.stderr,
             )
 
-    if installed:
+    # v0.2.0.9: prune any winpodx-*.desktop file whose slug is not in the
+    # current AppInfo set (covers both vanished discoveries and old
+    # bundled / removed entries).
+    removed = 0
+    apps_dir = applications_dir()
+    if apps_dir.exists():
+        for entry in apps_dir.glob("winpodx-*.desktop"):
+            stem = entry.stem  # winpodx-<slug>
+            if not stem.startswith("winpodx-"):
+                continue
+            slug = stem[len("winpodx-") :]
+            # Don't touch the GUI launcher itself or any winpodx-internal entry.
+            if slug in {"", "gui", "launcher"}:
+                continue
+            if slug in available_slugs:
+                continue
+            try:
+                remove_desktop_entry(slug)
+                removed += 1
+            except Exception as e:  # noqa: BLE001
+                print(
+                    f"  warning: could not remove stale entry {slug}: {e}",
+                    file=sys.stderr,
+                )
+
+    if installed or removed:
         try:
             update_icon_cache()
         except Exception as e:  # noqa: BLE001
             print(f"  warning: icon cache refresh failed: {e}", file=sys.stderr)
+    if installed:
         print(f"  Registered {installed} app(s) in your desktop menu.", file=sys.stderr)
+    if removed:
+        suffix = "y" if removed == 1 else "ies"
+        print(f"  Removed {removed} stale desktop entr{suffix}.", file=sys.stderr)
 
 
 def _run_app(name: str, file: str | None, wait: bool) -> None:

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -317,8 +317,62 @@ def _record_self_heal_done(cfg: Config) -> None:
         log.debug("could not write self-heal stamp: %s", e)
 
 
+def _apply_multi_session(cfg: Config) -> None:
+    """v0.2.0.9: enable rdprrap multi-session by default.
+
+    Without this, the 2nd FreeRDP RemoteApp launch against the same
+    Windows account triggers a "Select a session to reconnect to"
+    dialog (Windows refuses concurrent sessions per user by default)
+    instead of giving the user an independent app window. rdprrap
+    patches termsrv.dll so each connection becomes its own session.
+
+    Idempotent — rdprrap-conf --enable is a no-op when already enabled.
+    Tolerates rdprrap-conf missing (e.g. older OEM builds) by treating
+    the apply as a successful skip rather than a hard failure, since
+    the rest of the self-heal block is more important than this UX
+    nicety.
+    """
+    if cfg.pod.backend not in ("podman", "docker"):
+        return
+
+    candidates = [
+        r"C:\OEM\rdprrap\rdprrap-conf.exe",
+        r"C:\OEM\rdprrap-conf.exe",
+        r"C:\Program Files\rdprrap\rdprrap-conf.exe",
+    ]
+    payload_lines = ["$rdprrap = $null"]
+    for path in candidates:
+        payload_lines.append(
+            f"if (-not $rdprrap -and (Test-Path '{path}')) {{ $rdprrap = '{path}' }}"
+        )
+    payload_lines += [
+        "if (-not $rdprrap) {",
+        "    Write-Output 'rdprrap-conf not found; multi-session left disabled'",
+        "    exit 0",  # treat missing rdprrap as best-effort skip, not failure
+        "}",
+        "& $rdprrap --enable | Out-Null",
+        "Write-Output 'multi-session enabled'",
+        "exit 0",
+    ]
+    payload = "\n".join(payload_lines) + "\n"
+
+    from winpodx.core.windows_exec import WindowsExecError, run_in_windows
+
+    try:
+        result = run_in_windows(cfg, payload, description="apply-multi-session")
+    except WindowsExecError as e:
+        log.warning("multi_session: channel failure: %s", e)
+        raise
+    if result.rc != 0:
+        log.warning("multi_session: rc=%d stderr=%s", result.rc, result.stderr.strip())
+        # Non-fatal — log and continue. rdprrap not being patched
+        # doesn't break winpodx, just means each app share a session.
+        return
+    log.info("multi_session: %s", result.stdout.strip())
+
+
 def _self_heal_apply(cfg: Config) -> None:
-    """Run the three idempotent runtime applies in self-healing mode.
+    """Run the four idempotent runtime applies in self-healing mode.
 
     Distinct from ``apply_windows_runtime_fixes`` which is called from
     the explicit ``winpodx pod apply-fixes`` CLI / GUI button: that one
@@ -345,12 +399,14 @@ def _self_heal_apply(cfg: Config) -> None:
 
     from winpodx.core.windows_exec import WindowsExecError
 
-    succeeded = 0
-    for name, fn in (
+    applies = (
         ("max_sessions", _apply_max_sessions),
         ("rdp_timeouts", _apply_rdp_timeouts),
         ("oem_runtime_fixes", _apply_oem_runtime_fixes),
-    ):
+        ("multi_session", _apply_multi_session),
+    )
+    succeeded = 0
+    for name, fn in applies:
         try:
             fn(cfg)
             succeeded += 1
@@ -360,11 +416,11 @@ def _self_heal_apply(cfg: Config) -> None:
                 name,
                 e,
             )
-            return  # Don't waste 60s × 2 more on a still-booting guest.
+            return  # Don't waste FreeRDP retries on a still-booting guest.
         except Exception as e:  # noqa: BLE001
             log.warning("%s: self-heal apply failed: %s", name, e)
 
-    if succeeded == 3:
+    if succeeded == len(applies):
         _record_self_heal_done(cfg)
 
 
@@ -389,6 +445,7 @@ def apply_windows_runtime_fixes(cfg: Config) -> dict[str, str]:
         ("max_sessions", _apply_max_sessions),
         ("rdp_timeouts", _apply_rdp_timeouts),
         ("oem_runtime_fixes", _apply_oem_runtime_fixes),
+        ("multi_session", _apply_multi_session),
     ):
         try:
             fn(cfg)

--- a/tests/test_provisioner.py
+++ b/tests/test_provisioner.py
@@ -295,7 +295,7 @@ def test_ensure_ready_runs_apply_before_early_return_when_rdp_alive(monkeypatch)
     # RDP alive -> must trigger early return AFTER runtime apply.
     monkeypatch.setattr(provisioner, "check_rdp_port", lambda *a, **k: True)
 
-    calls = {"max_sessions": 0, "rdp_timeouts": 0, "oem_runtime_fixes": 0}
+    calls = {"max_sessions": 0, "rdp_timeouts": 0, "oem_runtime_fixes": 0, "multi_session": 0}
 
     def make_recorder(name):
         def f(c):
@@ -306,12 +306,21 @@ def test_ensure_ready_runs_apply_before_early_return_when_rdp_alive(monkeypatch)
     monkeypatch.setattr(provisioner, "_apply_max_sessions", make_recorder("max_sessions"))
     monkeypatch.setattr(provisioner, "_apply_rdp_timeouts", make_recorder("rdp_timeouts"))
     monkeypatch.setattr(provisioner, "_apply_oem_runtime_fixes", make_recorder("oem_runtime_fixes"))
+    monkeypatch.setattr(provisioner, "_apply_multi_session", make_recorder("multi_session"))
+    # Force the stamp short-circuit to be a no-op so the actual applies fire.
+    monkeypatch.setattr(provisioner, "_self_heal_already_done", lambda c: False)
+    monkeypatch.setattr(provisioner, "_record_self_heal_done", lambda c: None)
 
     result = provisioner.ensure_ready(cfg, timeout=1)
     assert result is cfg
-    # All three idempotent applies fired exactly once even though the
+    # All four idempotent applies fired exactly once even though the
     # function early-returned at the RDP-port check.
-    assert calls == {"max_sessions": 1, "rdp_timeouts": 1, "oem_runtime_fixes": 1}
+    assert calls == {
+        "max_sessions": 1,
+        "rdp_timeouts": 1,
+        "oem_runtime_fixes": 1,
+        "multi_session": 1,
+    }
 
 
 def test_ensure_ready_skips_apply_when_pod_not_running(monkeypatch):
@@ -336,6 +345,7 @@ def test_ensure_ready_skips_apply_when_pod_not_running(monkeypatch):
     monkeypatch.setattr(provisioner, "_apply_oem_runtime_fixes", recorder)
     monkeypatch.setattr(provisioner, "_apply_max_sessions", recorder)
     monkeypatch.setattr(provisioner, "_apply_rdp_timeouts", recorder)
+    monkeypatch.setattr(provisioner, "_apply_multi_session", recorder)
 
     provisioner.ensure_ready(cfg, timeout=1)
     # Stopped pod -> the early-branch `pod_status==RUNNING` guard prevents
@@ -369,7 +379,12 @@ def test_apply_windows_runtime_fixes_returns_per_helper_status(monkeypatch):
 
     monkeypatch.setattr("winpodx.core.windows_exec.run_in_windows", fake)
     result = provisioner.apply_windows_runtime_fixes(cfg)
-    assert set(result.keys()) == {"max_sessions", "rdp_timeouts", "oem_runtime_fixes"}
+    assert set(result.keys()) == {
+        "max_sessions",
+        "rdp_timeouts",
+        "oem_runtime_fixes",
+        "multi_session",
+    }
     for v in result.values():
         assert v == "ok"
 
@@ -514,9 +529,13 @@ class TestSelfHealStamp:
             "winpodx.core.provisioner._apply_oem_runtime_fixes",
             lambda cfg: called.append("oem"),
         )
+        monkeypatch.setattr(
+            "winpodx.core.provisioner._apply_multi_session",
+            lambda cfg: called.append("multi"),
+        )
 
         _self_heal_apply(self._cfg())
-        assert called == [], "stamp must short-circuit all three applies"
+        assert called == [], "stamp must short-circuit all four applies"
 
     def test_runs_apply_when_stamp_missing(self, tmp_path, monkeypatch):
         from winpodx.core.provisioner import _self_heal_apply
@@ -531,6 +550,7 @@ class TestSelfHealStamp:
             ("_apply_max_sessions", "max"),
             ("_apply_rdp_timeouts", "rdp"),
             ("_apply_oem_runtime_fixes", "oem"),
+            ("_apply_multi_session", "multi"),
         ):
 
             def make(m):
@@ -542,7 +562,7 @@ class TestSelfHealStamp:
             monkeypatch.setattr(f"winpodx.core.provisioner.{fn_name}", make(marker))
 
         _self_heal_apply(self._cfg())
-        assert called == ["max", "rdp", "oem"]
+        assert called == ["max", "rdp", "oem", "multi"]
 
     def test_runs_apply_when_pod_restarted(self, tmp_path, monkeypatch):
         """Stamp is from a previous container start; current StartedAt differs
@@ -565,6 +585,7 @@ class TestSelfHealStamp:
             ("_apply_max_sessions", "max"),
             ("_apply_rdp_timeouts", "rdp"),
             ("_apply_oem_runtime_fixes", "oem"),
+            ("_apply_multi_session", "multi"),
         ):
 
             def make(m):
@@ -576,7 +597,7 @@ class TestSelfHealStamp:
             monkeypatch.setattr(f"winpodx.core.provisioner.{fn_name}", make(marker))
 
         _self_heal_apply(self._cfg())
-        assert called == ["max", "rdp", "oem"], "pod restart must invalidate stamp"
+        assert called == ["max", "rdp", "oem", "multi"], "pod restart must invalidate stamp"
 
     def test_stamp_written_after_three_successes(self, tmp_path, monkeypatch):
         from winpodx import __version__
@@ -591,6 +612,7 @@ class TestSelfHealStamp:
             "_apply_max_sessions",
             "_apply_rdp_timeouts",
             "_apply_oem_runtime_fixes",
+            "_apply_multi_session",
         ):
             monkeypatch.setattr(f"winpodx.core.provisioner.{fn_name}", lambda cfg: None)
 


### PR DESCRIPTION
## Summary

Three user-reported issues from kernalix7 on 2026-04-27:

1. **Apps don't show up as independent windows.** Root cause: Windows refuses concurrent RemoteApp sessions per user, so the 2nd launch produced a "Select a session to reconnect to" dialog instead of a fresh window. **Fix:** self-heal apply now also runs \`rdprrap-conf --enable\` (idempotent, tolerates missing rdprrap-conf as best-effort skip) so termsrv.dll allows independent per-launch sessions.

2. **Stale .desktop entries linger after apps are removed from Windows.** Root cause: v0.2.0.8 auto-installed entries on refresh but never removed entries that no longer matched a discovered app. **Fix:** refresh is now truly bidirectional. Any \`winpodx-*.desktop\` not in \`list_available_apps()\` is removed (along with its icons). User-authored entries are preserved.

3. **Beta label and shields more prominent.** **Fix:** Big \`for-the-badge\` Status: Beta + Latest release badges at top. Standard shields row (license, Python, backend, language, tests, CI). Social shields (stars, forks, watchers, unique visitors via hits.dwyl.com). Activity shields (issues, PRs, last commit, code size). EN + KO mirrored.

### Tests
411 tests pass. Updated existing self-heal stamp tests to mock the new \`_apply_multi_session\`. Updated \`apply_windows_runtime_fixes\` test to expect \`multi_session\` key.

## Test plan
- [ ] After install + first app launch + 2nd app click: 2nd app opens as its own independent window. No Windows reconnect dialog.
- [ ] Uninstall an app inside Windows guest, run \`winpodx app refresh\`: the .desktop entry for that app is removed from the DE menu.
- [ ] README renders with prominent Beta banner + visible visitor count / star count etc.