### PR TITLE
release: v0.2.0.10 — fix GUI refresh SEGV + 1800s install timeout + auto-discovery + live logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
-## [0.2.0.9] - 2026-04-27
+## [0.2.0.10] - 2026-04-27
+
+### Fixed
+- **GUI Refresh button SEGV.** `_DiscoveryWorker.run()` (Qt worker thread) calls `persist_discovered` which calls `_validate_png_bytes`, which used `QImage.loadFromData` — but Qt + libgallium / Mesa state on Wayland race when `QImage` is touched off the main thread, dropping a `Signal: 11 (SEGV)` core. v0.2.0.10 has `_validate_png_bytes` short-circuit to the stdlib chunk walker when `threading.current_thread() is not threading.main_thread()`. The walker still enforces CRC + dimension caps + IEND terminator, so off-main-thread callers get a slightly slower but crash-free path.
+- **install.sh wait-ready 600s → 1800s.** A fresh install (`uninstall --purge` then re-install) downloads the ~7.5 GB Windows ISO + extracts + Sysprep + OEM apply + final reboot — that's 15–30 min on first run, way past 600s. The previous timeout fired before the Windows VM had even booted, leaving the user with `[FAIL] Timeout waiting for Windows ready (09:56)`. The 1800s budget covers a fresh install on typical hardware; subsequent installs reuse the cached ISO and finish in 2–5 min.
+- **GUI Refresh now installs `.desktop` entries** (parity with `winpodx app refresh` CLI). Previously only the CLI path inline-registered entries — clicking Refresh in the GUI updated the discovered tree but left `~/.local/share/applications/` untouched. v0.2.0.10's `_DiscoveryWorker` runs `_sync_desktop_entries` which is the worker-thread-safe sibling of `cli/app._register_desktop_entries`.
+
+### Added
+- **GUI auto-discovery on first boot.** When the pod transitions to `running` AND the app list is empty, the main window auto-fires the Refresh worker after a 2s settle. Solves the case where install.sh's wait-ready timed out before Sysprep finished — the user opens the GUI later, sees the pod running, and discovery just happens.
+- **GUI live log streaming.** The Tools/Terminal page gained four new buttons: `Live (pod)` and `Live (app)` start a `tail -F` against the container or `~/.config/winpodx/winpodx.log` and stream new lines into the panel as they appear; `App log` shows the last 200 lines of winpodx's own application log; `Stop tail` kills the active streamer. Previously the page only showed the last 100 pod logs as a one-shot snapshot.
+
+
 
 ### Fixed
 - **2nd app launch triggered Windows "Select a session to reconnect to" dialog instead of showing an independent app window.** Default Windows refuses concurrent FreeRDP RemoteApp sessions per user, so every app launched after the first one was either embedded in the existing session or popped a reconnect dialog. v0.2.0.9 adds `_apply_multi_session` to the self-heal apply chain — it shells out to `rdprrap-conf --enable` inside the guest so termsrv.dll allows independent per-launch sessions. Idempotent (no-op when already enabled), tolerates rdprrap-conf missing on older OEM bundles by treating it as a best-effort skip.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,27 @@
+winpodx (0.2.0.10) unstable; urgency=high
+
+  * Fixed: GUI Refresh button SEGV. _DiscoveryWorker.run() called
+    persist_discovered -> _validate_png_bytes which used QImage on a
+    Qt worker thread; Mesa/libgallium state owned by the main GUI
+    thread raced and dropped a Signal 11 core. _validate_png_bytes
+    now short-circuits to the stdlib chunk walker when off the main
+    thread.
+  * Fixed: install.sh wait-ready timeout 600s -> 1800s. A fresh
+    install downloads the ~7.5GB Windows ISO + Sysprep + OEM apply,
+    which takes 15-30 minutes on first run. The previous 600s timeout
+    fired before the Windows VM had even booted.
+  * Added: GUI Refresh now installs .desktop entries (parity with
+    CLI). Bidirectional sync via worker-thread-safe
+    _sync_desktop_entries.
+  * Added: GUI auto-fires discovery when the pod transitions to
+    running and the app list is empty (covers the case where install
+    timeout hit before Sysprep finished).
+  * Added: GUI live log streaming. New buttons on Tools/Terminal:
+    `Live (pod)`, `Live (app)`, `App log`, `Stop tail` — tail -F the
+    container or ~/.config/winpodx/winpodx.log into the panel.
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Mon, 27 Apr 2026 18:00:00 +0900
+
 winpodx (0.2.0.9) unstable; urgency=medium
 
   * Fixed: 2nd app launch triggered Windows "Select a session to

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,7 +9,18 @@
 
 ## [Unreleased]
 
-## [0.2.0.9] - 2026-04-27
+## [0.2.0.10] - 2026-04-27
+
+### 수정
+- **GUI Refresh 버튼 SEGV.** `_DiscoveryWorker.run()` (Qt 워커 스레드) 가 `persist_discovered` → `_validate_png_bytes` → `QImage.loadFromData` 호출. Wayland 의 Qt + libgallium / Mesa state 가 메인 스레드 외에서 QImage 만지면 race → `Signal: 11 (SEGV)` 코어 덤프. v0.2.0.10 에서 `_validate_png_bytes` 가 `threading.current_thread() is not threading.main_thread()` 일 때 stdlib 청크 워커로 단축 회귀. 워커도 여전히 CRC + 크기 캡 + IEND terminator 강제하므로 off-main-thread 호출자는 약간 느리지만 크래시 없는 경로.
+- **install.sh wait-ready 600s → 1800s.** 신규 설치 (`uninstall --purge` 후 재설치) 는 ~7.5GB Windows ISO 다운로드 + 추출 + Sysprep + OEM apply + 최종 재부팅 = 첫 실행 15~30분. 600초 timeout 이 Windows VM 부팅 전에 발화 → `[FAIL] Timeout waiting for Windows ready (09:56)` 로 끝남. 1800초 예산이 일반적 환경에서 신규 설치 커버; 후속 설치는 캐시된 ISO 재사용해서 2~5분.
+- **GUI Refresh 가 `.desktop` 엔트리 자동 설치** (`winpodx app refresh` CLI 와 parity). 기존엔 CLI 경로만 인라인 등록했고 GUI Refresh 는 discovered 트리만 갱신, `~/.local/share/applications/` 는 안 건드림. v0.2.0.10 의 `_DiscoveryWorker` 가 `_sync_desktop_entries` 호출 — `cli/app._register_desktop_entries` 의 워커-스레드-안전 형제 함수.
+
+### 추가
+- **첫 부팅 GUI 자동 디스커버리.** Pod 가 `running` 으로 전이 + 앱 리스트 비어있을 때, 메인 윈도가 2초 settle 후 Refresh 워커 자동 발화. install.sh 의 wait-ready 가 Sysprep 끝나기 전에 timeout 한 케이스 해결 — 사용자가 나중에 GUI 열면 pod 살아있는 거 확인 후 디스커버리가 알아서 발화.
+- **GUI 실시간 로그 스트리밍.** Tools/Terminal 페이지에 4개 버튼 추가: `Live (pod)` 와 `Live (app)` 가 컨테이너 또는 `~/.config/winpodx/winpodx.log` 에 `tail -F` 걸어 새 라인을 패널로 스트리밍; `App log` 는 winpodx 자체 앱 로그 마지막 200줄 표시; `Stop tail` 은 활성 streamer 종료. 기존엔 pod 로그 100줄 one-shot 스냅샷만 있었음.
+
+
 
 ### 수정
 - **두 번째 앱 실행 시 독립 윈도 대신 Windows "Select a session to reconnect to" 다이얼로그 발생.** Windows 기본값이 사용자당 동시 FreeRDP RemoteApp 세션 거부 → 첫 앱 이후의 모든 launch 가 기존 세션에 묻히거나 reconnect 다이얼로그 띄움. v0.2.0.9 에서 self-heal apply 체인에 `_apply_multi_session` 추가 — 게스트 안에서 `rdprrap-conf --enable` 호출해 termsrv.dll 패치 활성화 → launch 마다 독립 세션. 멱등 (이미 활성화돼있으면 no-op), 구 OEM 번들에 rdprrap-conf 없으면 best-effort skip.

--- a/install.sh
+++ b/install.sh
@@ -420,11 +420,14 @@ log "Installed winpodx GUI launcher and icon"
 # progress + tailed container logs so the user can see what's happening.
 # Skip with WINPODX_NO_WAIT=1 (CI / non-interactive setups).
 if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_WAIT:-}" != "1" ]; then
-    log "Waiting for Windows VM to finish first-boot (up to 10 min)..."
-    "$HOME/.local/bin/winpodx" pod wait-ready --timeout 600 --logs || {
-        warn "Windows first-boot didn't complete in 10 minutes."
+    log "Waiting for Windows VM to finish first-boot (up to 30 min)..."
+    log "  Fresh install downloads ~7.5GB Windows ISO + runs Sysprep + OEM apply."
+    log "  Subsequent installs reuse the cached ISO and finish in 2-5 min."
+    "$HOME/.local/bin/winpodx" pod wait-ready --timeout 1800 --logs || {
+        warn "Windows first-boot didn't complete in 30 minutes."
         warn "You can re-run \`winpodx pod wait-ready --logs\` to keep waiting,"
-        warn "or just launch any app from the menu — the apply / discovery will fire automatically."
+        warn "or just launch any app from the menu once \`winpodx pod status\`"
+        warn "reports the pod is fully up — the apply / discovery will fire automatically."
     }
 fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.2.0.9"
+version = "0.2.0.10"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.2.0.9"
+__version__ = "0.2.0.10"

--- a/src/winpodx/core/discovery.py
+++ b/src/winpodx/core/discovery.py
@@ -702,6 +702,17 @@ def _validate_png_bytes(data: bytes) -> bool:
     if not data or not data.startswith(b"\x89PNG\r\n\x1a\n"):
         return False
 
+    # v0.2.0.10: only use QImage on the main thread. From a Qt worker
+    # thread (e.g. the GUI Refresh button's _DiscoveryWorker), creating
+    # a QImage races with libgallium / Mesa state owned by the main
+    # GUI thread and segfaults the whole process — observed on
+    # openSUSE Tumbleweed Wayland 2026-04-27. The stdlib walker is
+    # strict enough on its own (CRC + dimension caps + IEND
+    # terminator), so off-main-thread callers get a slightly slower
+    # but crash-free path.
+    if threading.current_thread() is not threading.main_thread():
+        return _validate_png_stdlib(data)
+
     # Fast path: PySide6 is already a GUI-team dependency, and QImage
     # is strict about truncated/corrupt streams.
     try:

--- a/src/winpodx/gui/main_window.py
+++ b/src/winpodx/gui/main_window.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 import threading
 from pathlib import Path
@@ -60,6 +61,8 @@ from winpodx.gui.theme import (
     avatar_color,
 )
 
+log = logging.getLogger(__name__)
+
 
 class _DiscoveryWorker(QObject):
     """Background worker that runs core.discovery scan and persist off the UI thread.
@@ -103,6 +106,16 @@ class _DiscoveryWorker(QObject):
             self.finished.emit()
             return
 
+        # v0.2.0.10: parity with CLI's `_refresh_apps` — install .desktop
+        # entries inline so the GUI Refresh button registers DE menu
+        # entries the same way as `winpodx app refresh`. Bidirectional
+        # sync (drop entries that no longer match a discovered app) is
+        # handled by `_sync_desktop_entries`.
+        try:
+            _sync_desktop_entries(apps)
+        except Exception:  # noqa: BLE001 — best-effort
+            log.debug("GUI refresh: desktop-entry sync failed", exc_info=True)
+
         try:
             from winpodx.desktop.icons import refresh_icon_cache
 
@@ -116,6 +129,41 @@ class _DiscoveryWorker(QObject):
             count = len(apps)
         self.succeeded.emit(count)
         self.finished.emit()
+
+
+def _sync_desktop_entries(discovered) -> None:
+    """v0.2.0.10: bidirectional .desktop entry sync used by the GUI
+    refresh worker. Mirrors `cli/app._register_desktop_entries` but
+    safe to run from a worker thread (no Qt GUI calls)."""
+    from winpodx.core.app import list_available_apps
+    from winpodx.desktop.entry import install_desktop_entry, remove_desktop_entry
+    from winpodx.utils.paths import applications_dir
+
+    discovered_slugs = {d.slug or d.name for d in discovered}
+    available = {a.name: a for a in list_available_apps()}
+    for slug in discovered_slugs:
+        info = available.get(slug)
+        if info is not None:
+            try:
+                install_desktop_entry(info)
+            except Exception:  # noqa: BLE001
+                log.debug("install_desktop_entry failed for %s", slug, exc_info=True)
+
+    apps_dir = applications_dir()
+    if apps_dir.exists():
+        for entry in apps_dir.glob("winpodx-*.desktop"):
+            stem = entry.stem
+            if not stem.startswith("winpodx-"):
+                continue
+            slug = stem[len("winpodx-") :]
+            if slug in {"", "gui", "launcher"}:
+                continue
+            if slug in available:
+                continue
+            try:
+                remove_desktop_entry(slug)
+            except Exception:  # noqa: BLE001
+                log.debug("remove_desktop_entry failed for %s", slug, exc_info=True)
 
 
 def _looks_like_pod_down(exc: BaseException) -> bool:
@@ -1275,9 +1323,13 @@ class WinpodxWindow(QMainWindow):
         container = self.cfg.pod.container_name
         quick = [
             ("Status", ["podman", "ps", "-a", "--filter", f"name={container}"]),
-            ("Logs", ["podman", "logs", "--tail", "50", container]),
+            ("Pod logs", ["podman", "logs", "--tail", "100", container]),
+            ("Live (pod)", "follow_pod"),
+            ("App log", "tail_app_log"),
+            ("Live (app)", "follow_app_log"),
             ("Inspect", ["podman", "inspect", container]),
             ("RDP Test", None),
+            ("Stop tail", "stop_tail"),
             ("Clear", None),
         ]
         for label, cmd in quick:
@@ -1287,6 +1339,14 @@ class WinpodxWindow(QMainWindow):
                 btn.clicked.connect(lambda: self.log_output.clear())
             elif label == "RDP Test":
                 btn.clicked.connect(self._on_rdp_test)
+            elif cmd == "follow_pod":
+                btn.clicked.connect(self._on_follow_pod_log)
+            elif cmd == "tail_app_log":
+                btn.clicked.connect(self._on_tail_app_log)
+            elif cmd == "follow_app_log":
+                btn.clicked.connect(self._on_follow_app_log)
+            elif cmd == "stop_tail":
+                btn.clicked.connect(self._on_stop_tail)
             else:
                 btn.clicked.connect(lambda _, c=cmd: self._run_log_cmd(c))
             header.addWidget(btn)
@@ -1593,6 +1653,123 @@ class WinpodxWindow(QMainWindow):
                 self.log_signal.emit(f"Command not found: {cmd[0]}", C.RED)
 
         threading.Thread(target=_do, daemon=True).start()
+
+    # v0.2.0.10: live log streaming. The Pod logs button shows the last
+    # 100 lines, but for first-install / debug the user wants to watch
+    # the container output as Windows downloads / Sysprep / boots, and
+    # also see winpodx's own application log (under XDG state) so they
+    # can correlate guest events with host actions.
+    def _on_follow_pod_log(self) -> None:
+        import subprocess
+
+        self._on_stop_tail()
+        self._log_append(
+            f"$ podman logs -f --tail 50 {self.cfg.pod.container_name} (Stop tail to end)",
+            C.BLUE,
+        )
+        try:
+            self._tail_proc = subprocess.Popen(
+                [
+                    self.cfg.pod.backend,
+                    "logs",
+                    "-f",
+                    "--tail",
+                    "50",
+                    self.cfg.pod.container_name,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+            )
+        except (FileNotFoundError, OSError) as e:
+            self._log_append(f"Could not start tail: {e}", C.RED)
+            return
+        self._tail_stop = threading.Event()
+        threading.Thread(target=self._drain_tail, args=(self._tail_proc,), daemon=True).start()
+
+    def _on_tail_app_log(self) -> None:
+        from winpodx.utils.paths import config_dir
+
+        log_path = config_dir() / "winpodx.log"
+        self._log_append(f"$ tail {log_path}", C.BLUE)
+        if not log_path.exists():
+            self._log_append(
+                "(no app log file yet — winpodx writes to it after the next CLI / GUI action)",
+                C.OVERLAY0,
+            )
+            return
+        try:
+            content = log_path.read_text(encoding="utf-8", errors="replace")
+        except OSError as e:
+            self._log_append(f"Could not read app log: {e}", C.RED)
+            return
+        # Show only the last ~200 lines so we don't drown the view.
+        lines = content.splitlines()[-200:]
+        for line in lines:
+            self._log_append(line, C.SUBTEXT1)
+
+    def _on_follow_app_log(self) -> None:
+        import subprocess
+
+        from winpodx.utils.paths import config_dir
+
+        log_path = config_dir() / "winpodx.log"
+        self._on_stop_tail()
+        self._log_append(f"$ tail -F {log_path} (Stop tail to end)", C.BLUE)
+        # Pre-create the file so `tail -F` doesn't loop on FileNotFoundError.
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.touch(exist_ok=True)
+        try:
+            self._tail_proc = subprocess.Popen(
+                ["tail", "-F", "-n", "50", str(log_path)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+            )
+        except (FileNotFoundError, OSError) as e:
+            self._log_append(f"Could not start tail: {e}", C.RED)
+            return
+        self._tail_stop = threading.Event()
+        threading.Thread(target=self._drain_tail, args=(self._tail_proc,), daemon=True).start()
+
+    def _drain_tail(self, proc) -> None:  # type: ignore[no-untyped-def]
+        try:
+            for line in iter(proc.stdout.readline, ""):
+                if self._tail_stop.is_set():
+                    break
+                line = line.rstrip()
+                if line:
+                    self.log_signal.emit(line, C.SUBTEXT1)
+        except Exception:  # noqa: BLE001
+            log.debug("tail drain crashed", exc_info=True)
+        try:
+            proc.terminate()
+            proc.wait(timeout=2)
+        except Exception:  # noqa: BLE001
+            try:
+                proc.kill()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def _on_stop_tail(self) -> None:
+        proc = getattr(self, "_tail_proc", None)
+        stop = getattr(self, "_tail_stop", None)
+        if proc is None:
+            return
+        if stop is not None:
+            stop.set()
+        try:
+            proc.terminate()
+            proc.wait(timeout=2)
+        except Exception:  # noqa: BLE001
+            try:
+                proc.kill()
+            except Exception:  # noqa: BLE001
+                pass
+        self._log_append("(tail stopped)", C.OVERLAY0)
+        self._tail_proc = None
 
     _ALLOWED_COMMANDS = {
         "podman",
@@ -2207,6 +2384,20 @@ class WinpodxWindow(QMainWindow):
 
     @Slot(str, str)
     def _on_pod_status(self, state: str, ip: str) -> None:
+        # v0.2.0.10: trigger auto-discovery once when pod transitions
+        # to running AND the app list is empty. Solves the
+        # fresh-install case where install.sh's wait-ready timed out
+        # before Windows finished Sysprep — once GUI sees the pod
+        # come up, kick off a scan in the background.
+        if (
+            state == "running"
+            and self._pod_state != "running"
+            and not self.apps
+            and self._refresh_state == "idle"
+        ):
+            log.info("pod is now running and app list is empty — auto-firing discovery")
+            QTimer.singleShot(2000, self._on_refresh_apps)
+
         self._pod_state = state
         colors = {
             "running": C.GREEN,


### PR DESCRIPTION
## Summary

User on openSUSE Tumbleweed Wayland reported three issues from a fresh `uninstall --purge` + re-install run:

1. **GUI Refresh crashed with SEGV** (Signal 11) — coredump showed Qt worker thread fault with libgallium frames.
2. **install.sh timed out at 09:56** while Windows ISO download had just completed and Sysprep hadn't started.
3. **GUI showed "no apps found"** because discovery didn't get a chance to run.

### Critical fix
`_validate_png_bytes` was calling `QImage.loadFromData` on the worker thread. Qt's QImage off the main thread races with Mesa/libgallium state owned by the main GUI thread → SEGV. Now short-circuits to the stdlib chunk walker when not on main thread.

### Other fixes
- install.sh wait-ready timeout 600s → 1800s (covers ISO download + Sysprep + OEM apply on a true first install)
- GUI Refresh button now installs `.desktop` entries (CLI parity)
- GUI auto-fires discovery when pod becomes running + app list empty
- GUI live log streaming (Live pod / Live app / App log / Stop tail buttons)

### Tests
411 tests pass; ruff clean. (Crash repro is environment-specific Qt+Mesa; manual verification required.)

## Test plan
- [ ] `winpodx gui` → click Refresh on a fresh install → does NOT segfault
- [ ] On a true first install, install.sh waits up to 30 min and either succeeds or surfaces the new clearer message
- [ ] After install timeout, opening GUI later auto-fires discovery once pod becomes running
- [ ] Tools/Terminal page → Live (pod) / Live (app) buttons stream new lines as they appear