### PR TITLE
release: v0.2.0.11 — fix second SEGV path on GUI Refresh (Python ref / Qt deleteLater race)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
-## [0.2.0.10] - 2026-04-27
+## [0.2.0.11] - 2026-04-28
+
+### Fixed
+- **Second SEGV path on GUI Refresh — Python ref / Qt deleteLater race.** v0.2.0.10 fixed the QImage-on-worker-thread crash, but a second SEGV remained: `_on_refresh_succeeded` and `_on_refresh_failed` slots both did `self._refresh_worker = None` immediately. Python's reference drop raced with Qt's queued `worker.deleteLater()` event — whichever ran second hit a freed/being-freed `QObject` and crashed in `~QObject()` on the worker thread. Coredump on 2026-04-28 confirmed: top frame `QObject::~QObject` on worker thread 2282062, while main thread 2281803 was inside the slot's PySide6 `callPythonMetaMethod` dispatch. Fix: drop `_refresh_worker` / `_refresh_thread` Python refs only via `_cleanup_refresh_worker`, bound to `thread.finished` which fires after both Qt objects are fully torn down. Worker `deleteLater` keeps running on the worker thread's own event loop as Qt intends — no Python GC interference.
+
+
 
 ### Fixed
 - **GUI Refresh button SEGV.** `_DiscoveryWorker.run()` (Qt worker thread) calls `persist_discovered` which calls `_validate_png_bytes`, which used `QImage.loadFromData` — but Qt + libgallium / Mesa state on Wayland race when `QImage` is touched off the main thread, dropping a `Signal: 11 (SEGV)` core. v0.2.0.10 has `_validate_png_bytes` short-circuit to the stdlib chunk walker when `threading.current_thread() is not threading.main_thread()`. The walker still enforces CRC + dimension caps + IEND terminator, so off-main-thread callers get a slightly slower but crash-free path.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+winpodx (0.2.0.11) unstable; urgency=high
+
+  * Fixed: second SEGV path on GUI Refresh. v0.2.0.10 fixed the
+    QImage-on-worker-thread race, but the success/failure slots
+    immediately nulled out self._refresh_worker. Python's ref drop
+    raced Qt's queued worker.deleteLater event -> ~QObject() on a
+    half-freed pointer -> Signal 11. Now Python refs are dropped
+    only via thread.finished after both Qt objects have been torn
+    down properly.
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Tue, 28 Apr 2026 08:00:00 +0900
+
 winpodx (0.2.0.10) unstable; urgency=high
 
   * Fixed: GUI Refresh button SEGV. _DiscoveryWorker.run() called

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,7 +9,12 @@
 
 ## [Unreleased]
 
-## [0.2.0.10] - 2026-04-27
+## [0.2.0.11] - 2026-04-28
+
+### 수정
+- **GUI Refresh 두 번째 SEGV 경로 — Python ref / Qt deleteLater race.** v0.2.0.10 이 QImage-워커스레드 크래시는 잡았지만 두 번째 SEGV 가 남아있었음: `_on_refresh_succeeded` 와 `_on_refresh_failed` 슬롯이 즉시 `self._refresh_worker = None` 실행. Python 의 ref drop 이 Qt 의 queued `worker.deleteLater()` 이벤트와 race — 둘 중 나중에 실행되는 쪽이 free 된 `QObject` 만나서 worker 스레드의 `~QObject()` 에서 크래시. 2026-04-28 코어덤프로 확인: 워커 스레드 2282062 의 top frame 이 `QObject::~QObject`, 메인 스레드 2281803 은 슬롯의 PySide6 `callPythonMetaMethod` 디스패치 중. 수정: `_refresh_worker` / `_refresh_thread` Python ref drop 을 `_cleanup_refresh_worker` 로만 옮김, `thread.finished` 에 바인딩되어 Qt 객체 둘 다 완전 해제된 후 실행. Worker `deleteLater` 는 워커 스레드 자체 이벤트 루프에서 정상 처리 — Python GC 간섭 없음.
+
+
 
 ### 수정
 - **GUI Refresh 버튼 SEGV.** `_DiscoveryWorker.run()` (Qt 워커 스레드) 가 `persist_discovered` → `_validate_png_bytes` → `QImage.loadFromData` 호출. Wayland 의 Qt + libgallium / Mesa state 가 메인 스레드 외에서 QImage 만지면 race → `Signal: 11 (SEGV)` 코어 덤프. v0.2.0.10 에서 `_validate_png_bytes` 가 `threading.current_thread() is not threading.main_thread()` 일 때 stdlib 청크 워커로 단축 회귀. 워커도 여전히 CRC + 크기 캡 + IEND terminator 강제하므로 off-main-thread 호출자는 약간 느리지만 크래시 없는 경로.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.2.0.10"
+version = "0.2.0.11"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.2.0.10"
+__version__ = "0.2.0.11"

--- a/src/winpodx/gui/main_window.py
+++ b/src/winpodx/gui/main_window.py
@@ -1891,7 +1891,18 @@ class WinpodxWindow(QMainWindow):
         worker.succeeded.connect(self._on_refresh_succeeded)
         worker.failed.connect(self._on_refresh_failed)
         worker.finished.connect(thread.quit)
+        # v0.2.0.11: keep Qt's canonical cleanup chain (worker.deleteLater
+        # processed by the worker thread's event loop *before* it exits,
+        # then thread.deleteLater after the thread dies) BUT do not also
+        # null out `self._refresh_worker` from the success/failure slots.
+        # The previous code raced Python's ref drop with Qt's queued
+        # deleteLater event → QObject destructor ran on a half-freed
+        # pointer → Signal 11. Now Python refs are dropped only via
+        # `_cleanup_refresh_worker`, bound to `thread.finished` which
+        # fires after both worker and thread have been fully torn down
+        # by Qt.
         worker.finished.connect(worker.deleteLater)
+        thread.finished.connect(self._cleanup_refresh_worker)
         thread.finished.connect(thread.deleteLater)
         # Keep references so the QThread+QObject aren't garbage-collected mid-run.
         self._refresh_thread = thread
@@ -1910,19 +1921,33 @@ class WinpodxWindow(QMainWindow):
     @Slot(int)
     def _on_refresh_succeeded(self, count: int) -> None:
         self._set_refresh_state("idle")
-        self._refresh_thread = None
-        self._refresh_worker = None
+        # NOTE: don't null out _refresh_worker / _refresh_thread here —
+        # see v0.2.0.11 comment in `_on_refresh_apps`. Cleanup happens
+        # via `_cleanup_refresh_worker` once the thread.finished signal
+        # fires (i.e. after Qt has drained the event loop and processed
+        # any pending deleteLater on the worker).
         self._reload_apps()
         if count:
             self.info_label.setText(f"Discovery complete: {count} app(s) updated")
         else:
             self.info_label.setText("Discovery complete: no new apps found")
 
+    @Slot()
+    def _cleanup_refresh_worker(self) -> None:
+        """Drop Python refs to the worker + thread once Qt has finished
+        with them. Bound to ``thread.finished`` so it runs after the
+        worker's event loop has drained — racing the ref drop with Qt's
+        deleteLater is what crashed v0.2.0.10."""
+        # `worker.deleteLater()` is implicit — once we drop the last
+        # Python ref AND the thread is done, Qt collects the QObject on
+        # the next event-loop tick of its owning thread (which is now
+        # the main thread since the worker thread has exited).
+        self._refresh_worker = None
+        self._refresh_thread = None
+
     @Slot(str, str)
     def _on_refresh_failed(self, kind: str, detail: str) -> None:
         self._set_refresh_state("idle")
-        self._refresh_thread = None
-        self._refresh_worker = None
         self.info_label.setText("App discovery failed")
 
         # v0.1.9.1: defer the QMessageBox creation to a clean event-loop tick.


### PR DESCRIPTION
## Summary

User on openSUSE Tumbleweed Wayland reported another SEGV on GUI Refresh after v0.2.0.10. Coredump showed:

```
Thread 2282062 (worker):
  #0 QObject::~QObject (libQt6Core)
  #1 PySide6 SignalManager teardown
  ...

Thread 2281803 (main):
  ...
  #3 PySide6 SignalManager::callPythonMetaMethod  ← inside our slot
  ...
```

### Root cause

The `_on_refresh_succeeded` and `_on_refresh_failed` slots both ran:

```python
self._refresh_worker = None
self._refresh_thread = None
```

immediately. Python's reference drop raced Qt's queued `worker.deleteLater()` event — whichever ran second hit a half-freed `QObject` and crashed in `~QObject()` on the worker thread.

### Fix

Move Python ref cleanup into `_cleanup_refresh_worker`, bound to `thread.finished` (which fires only after Qt has fully processed `worker.deleteLater` on the worker thread and the event loop has exited). The slots themselves no longer null out refs.

### Tests
411 tests pass; ruff clean. (Crash repro is environment-specific Qt+Mesa; manual verify required.)

## Test plan
- [ ] `winpodx gui` → click Refresh repeatedly: no SEGV
- [ ] After Refresh succeeds: app list updates correctly
- [ ] After Refresh fails (pod down): error dialog displays correctly with QTimer.singleShot defer still working