### PR TITLE
release: v0.2.2.1 — install.sh chains pod apply-fixes after migrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
-## [0.2.2] - 2026-04-28
+## [0.2.2.1] - 2026-04-28
+
+### Changed
+- **install.sh chains `pod apply-fixes` after `migrate`.** v0.2.0.5 had removed the explicit apply-fixes call because migrate's always-apply path covers it. But when migrate itself gets deferred via the pending marker (Windows still booting, etc.) the apply never fires, leaving the user to launch the next app against an unconfigured Windows side. v0.2.2.1 re-adds it as a defensive belt-and-suspenders step. On a warm pod it's a no-op via the v0.2.0.8 stamp short-circuit; on a cold pod it now uses the v0.2.2 HTTP guest agent (~200ms) instead of the slow FreeRDP RemoteApp PowerShell channel. New `WINPODX_NO_APPLY_FIXES=1` env var to skip.
+- **`utils.pending` adds `apply_fixes` step.** Recognized by `_VALID_STEPS`, ordered between `migrate` and `discovery` in the canonical resume sequence, has its own resume handler that re-runs `apply_windows_runtime_fixes` and removes the step on success.
+
+
 
 Major: introduces a long-running **Windows guest HTTP agent** that replaces the per-call FreeRDP RemoteApp PowerShell channel for non-secret operations. Result: runtime applies are ~50× faster (50ms HTTP vs 5–10s FreeRDP) and the PowerShell window flash on every app launch is gone.
 

--- a/install.sh
+++ b/install.sh
@@ -446,10 +446,24 @@ fi
 # If an existing config is present this is an upgrade, not a fresh
 # install. Run the migrate wizard so the user sees new-version release
 # notes and can opt into app discovery. Opt out with WINPODX_NO_MIGRATE=1.
-# `|| true` keeps install.sh's exit code clean if migrate fails.
+# `|| mark_pending` records the step so the next CLI / GUI launch retries.
 if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_MIGRATE:-}" != "1" ]; then
     log "Running post-upgrade migration wizard..."
     "$HOME/.local/bin/winpodx" migrate || mark_pending "migrate"
+fi
+
+# --- Apply Windows-side runtime fixes ---
+# v0.2.2.1: explicit apply-fixes after migrate even though migrate's
+# always-apply path also runs the four applies. Reason: if migrate
+# itself was skipped or deferred via the pending marker, apply
+# wouldn't fire and the user would launch the next app against an
+# unconfigured Windows side. Calling apply-fixes here is cheap on a
+# warm pod (the v0.2.0.8 stamp short-circuit makes it a no-op when
+# already done) and now goes through the v0.2.2 HTTP guest agent
+# (~200ms total) instead of the slow FreeRDP RemoteApp channel.
+if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_APPLY_FIXES:-}" != "1" ]; then
+    log "Applying Windows-side runtime fixes (idempotent)..."
+    "$HOME/.local/bin/winpodx" pod apply-fixes 2>/dev/null || mark_pending "apply_fixes"
 fi
 
 # --- Auto-discover apps ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.2.2"
+version = "0.2.2.1"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.2.2"
+__version__ = "0.2.2.1"

--- a/src/winpodx/utils/pending.py
+++ b/src/winpodx/utils/pending.py
@@ -26,7 +26,7 @@ from winpodx.utils.paths import config_dir
 log = logging.getLogger(__name__)
 
 _PENDING_FILE = ".pending_setup"
-_VALID_STEPS = frozenset({"wait_ready", "migrate", "discovery"})
+_VALID_STEPS = frozenset({"wait_ready", "migrate", "apply_fixes", "discovery"})
 
 
 def _path() -> Path:
@@ -55,8 +55,10 @@ def list_pending() -> list[str]:
         return []
     seen = set()
     ordered = []
-    # Canonical order: wait_ready first, then migrate, then discovery.
-    for step in ("wait_ready", "migrate", "discovery"):
+    # Canonical order: wait_ready first, then migrate, then apply_fixes,
+    # then discovery. apply_fixes added in v0.2.2.1 — install.sh now
+    # explicitly invokes `pod apply-fixes` after migrate.
+    for step in ("wait_ready", "migrate", "apply_fixes", "discovery"):
         if step in raw and step in _VALID_STEPS and step not in seen:
             ordered.append(step)
             seen.add(step)
@@ -140,6 +142,24 @@ def resume(printer=print) -> None:
                 printer(f"[winpodx] Apply partial: {results} — leaving pending.")
         except Exception as e:  # noqa: BLE001
             printer(f"[winpodx] migrate resume failed: {e}")
+
+    if "apply_fixes" in pending:
+        # v0.2.2.1: install.sh explicitly invokes `pod apply-fixes` so it
+        # can be marked pending separately from migrate. Resume runs the
+        # same apply path; the v0.2.0.8 stamp short-circuits if migrate
+        # already covered it on this pod lifetime.
+        try:
+            from winpodx.core.provisioner import apply_windows_runtime_fixes
+
+            printer("[winpodx] Re-running explicit apply-fixes...")
+            results = apply_windows_runtime_fixes(cfg)
+            if all(v == "ok" for v in results.values()):
+                remove_step("apply_fixes")
+                printer("[winpodx] apply-fixes complete.")
+            else:
+                printer(f"[winpodx] apply-fixes partial: {results} — leaving pending.")
+        except Exception as e:  # noqa: BLE001
+            printer(f"[winpodx] apply_fixes resume failed: {e}")
 
     if "discovery" in pending:
         try:

--- a/tests/test_pending.py
+++ b/tests/test_pending.py
@@ -33,11 +33,18 @@ class TestHasPending:
 class TestListPending:
     def test_returns_canonical_order(self, patched_config_dir):
         # Even if the file has them in random order, list_pending returns
-        # them in the canonical (wait_ready, migrate, discovery) order.
+        # them in the canonical (wait_ready, migrate, apply_fixes,
+        # discovery) order. v0.2.2.1 added apply_fixes between migrate
+        # and discovery.
         (patched_config_dir / ".pending_setup").write_text(
-            "discovery\nwait_ready\nmigrate\n", encoding="utf-8"
+            "discovery\napply_fixes\nwait_ready\nmigrate\n", encoding="utf-8"
         )
-        assert pending.list_pending() == ["wait_ready", "migrate", "discovery"]
+        assert pending.list_pending() == [
+            "wait_ready",
+            "migrate",
+            "apply_fixes",
+            "discovery",
+        ]
 
     def test_filters_unknown_steps(self, patched_config_dir):
         (patched_config_dir / ".pending_setup").write_text(


### PR DESCRIPTION
## Summary

Re-add explicit \`pod apply-fixes\` step to install.sh between migrate and discovery.

v0.2.0.5 had removed it because migrate's always-apply path already covers it. But when migrate itself gets deferred via the pending marker (Windows still booting), the apply never fires and the user lands on an unconfigured Windows side.

### Changes
- \`install.sh\`: explicit \`winpodx pod apply-fixes\` call between migrate and \`app refresh\`. On warm pod = no-op via v0.2.0.8 stamp short-circuit. On cold pod = v0.2.2 HTTP guest agent (~200ms total). Failure → marks \`apply_fixes\` pending. \`WINPODX_NO_APPLY_FIXES=1\` to skip.
- \`utils/pending.py\`: adds \`apply_fixes\` step ID, canonical order \`wait_ready → migrate → apply_fixes → discovery\`, dedicated resume handler.
- \`tests/test_pending.py\`: updates canonical-order test for the new step.

### Tests
449 passed + 1 skipped. Ruff clean.

## Test plan
- [ ] Fresh \`uninstall --purge\` → \`curl install.sh\`: install log shows \`Applying Windows-side runtime fixes (idempotent)...\` after \`Running post-upgrade migration wizard...\` and before \`Discovering installed Windows apps...\`.
- [ ] If apply-fixes fails (Windows still booting): \`.pending_setup\` includes \`apply_fixes\`; next \`winpodx\` invocation auto-resumes.