### PR TITLE
release: v0.2.2.2 — emergency revert of USER_PORTS + GUI block + diagnostic surfacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
-## [0.2.2.1] - 2026-04-28
+## [0.2.2.2] - 2026-04-28
+
+### Fixed
+- **`USER_PORTS=8765` (v0.2.2 compose change) suspected of breaking dockur's default RDP port forward.** Multiple users reported FreeRDP rc=147 `ERRCONNECT_CONNECT_TRANSPORT_FAILED` (Connection reset by peer) on previously-working setups after the v0.2.2 install. Removed the `USER_PORTS` line from the compose template; the guest agent loses host reachability (its only port-forward mechanism) and the existing `AgentUnavailableError` → FreeRDP RemoteApp fallback path takes over for all apply / discovery operations. Net effect: revert to the v0.2.1 RDP behavior. Re-introducing the agent port will require confirming dockur's USER_PORTS parsing isn't interfering with the 3389/8006 default forwards.
+- **`winpodx gui` blocked for up to 5 minutes on CLI startup.** v0.2.1's `_maybe_resume_pending` hook fired synchronously before the GUI process started, calling `wait_for_windows_responsive(timeout=300)` — when the agent / RDP wasn't ready it just sat there. Added `gui` and `tray` (and `migrate`, since migrate is the canonical resume) to the skip list. The GUI runs its own non-blocking resume on `QTimer.singleShot` after the window paints.
+- **`wait_for_windows_responsive` surfaces the last FreeRDP error on timeout.** Previously it returned bare `False` after up to 60 minutes of silent retries; the user just saw `[3/3] FAIL Timeout` with no clue why every probe failed. Now logs the last `WindowsExecError` / non-zero rc + stderr at WARNING level so the install.sh / GUI can show actionable info (auth fail vs RemoteApp not published vs TLS handshake fail).
+
+### Added
+- **`pod wait-ready` heartbeat.** Phases 2 and 3 emit a `still waiting...` line every 30 / 60 seconds with elapsed time. During the silent Windows-installer phase (container stdout goes quiet for 5–15 min while OOBE / Sysprep run) the user no longer thinks the script hung.
+- **VNC URL hint at the start of phase 2.** `Tip: see Windows install progress at http://127.0.0.1:8006/`. Lets users watch the actual installer in parallel instead of staring at a stuck-looking terminal.
+
+
 
 ### Changed
 - **install.sh chains `pod apply-fixes` after `migrate`.** v0.2.0.5 had removed the explicit apply-fixes call because migrate's always-apply path covers it. But when migrate itself gets deferred via the pending marker (Windows still booting, etc.) the apply never fires, leaving the user to launch the next app against an unconfigured Windows side. v0.2.2.1 re-adds it as a defensive belt-and-suspenders step. On a warm pod it's a no-op via the v0.2.0.8 stamp short-circuit; on a cold pod it now uses the v0.2.2 HTTP guest agent (~200ms) instead of the slow FreeRDP RemoteApp PowerShell channel. New `WINPODX_NO_APPLY_FIXES=1` env var to skip.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.2.2.1"
+version = "0.2.2.2"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.2.2.1"
+__version__ = "0.2.2.2"

--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -463,14 +463,27 @@ def _maybe_resume_pending(argv: list[str] | None) -> None:
     """v0.2.1: detect a partial install (`.pending_setup` marker present)
     and resume the missing steps before the user's command runs.
 
-    Skipped when the user is invoking `uninstall` / `--version` / `--help`
-    so basic introspection and recovery aren't blocked behind a network
-    probe. Best-effort; never raises.
+    v0.2.2.2: skip on commands that have their own async resume path
+    (gui / tray / migrate) or that are read-only / recovery (version /
+    help / uninstall / config / info / status) — running the resume
+    synchronously here would block the user's command for up to 5 min
+    on `wait_for_windows_responsive`, defeating the point of GUI's
+    own non-blocking startup. The GUI fires its own resume on
+    QTimer.singleShot in a background thread.
     """
     args = argv if argv is not None else sys.argv[1:]
     if not args:
         return
-    skip_first = args[0].lstrip("-") in {"version", "help", "uninstall", "config", "info"}
+    skip_first = args[0].lstrip("-") in {
+        "version",
+        "help",
+        "uninstall",
+        "config",
+        "info",
+        "gui",  # GUI has its own async resume in _maybe_run_first_launch_checks
+        "tray",  # Same
+        "migrate",  # migrate is the canonical resume; let it own its flow
+    }
     if skip_first:
         return
     try:

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -433,10 +433,27 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
 
         # --- [2/3] RDP port open ---
         print(f"[2/3] Waiting for Windows RDP service...     ({elapsed()})")
+        print(
+            "      Tip: see Windows install progress at "
+            f"http://{cfg.rdp.ip}:{cfg.pod.vnc_port}/"
+        )
+        # v0.2.2.2: heartbeat every 30s during the silent Windows-installer
+        # phase. Once QEMU starts the OS, container stdout goes quiet for
+        # 5-15 min while OOBE / Sysprep run. Without periodic feedback the
+        # user thinks the install hung. The heartbeat surfaces elapsed
+        # time + a "still waiting" reassurance.
+        last_beat = _time.monotonic()
         while _time.monotonic() < deadline:
             if check_rdp_port(cfg.rdp.ip, cfg.rdp.port, timeout=1.0):
                 print(f"      OK RDP port {cfg.rdp.port} open                  ({elapsed()})")
                 break
+            now = _time.monotonic()
+            if now - last_beat >= 30:
+                print(
+                    f"      ... still waiting for Windows installer / Sysprep "
+                    f"({elapsed()})"
+                )
+                last_beat = now
             _time.sleep(3)
         else:
             print(f"      FAIL Timeout waiting for RDP port        ({elapsed()})")
@@ -445,7 +462,30 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
         # --- [3/3] FreeRDP RemoteApp activation ---
         print(f"[3/3] Waiting for Windows activation...      ({elapsed()})")
         remaining = max(60, int(deadline - _time.monotonic()))
-        if wait_for_windows_responsive(cfg, timeout=remaining):
+        # Phase 3 calls wait_for_windows_responsive which has its own
+        # tight 3s polling loop; pass a per-callback heartbeat through
+        # the existing `progress_callback` plumbing isn't straightforward,
+        # so we just emit one mid-phase reminder if it stays silent for
+        # 60s+.
+        beat_thread_stop = threading.Event()
+
+        def _phase3_heartbeat() -> None:
+            t0 = _time.monotonic()
+            while not beat_thread_stop.wait(60):
+                el_s = int(_time.monotonic() - t0)
+                print(
+                    f"      ... still waiting for FreeRDP activation "
+                    f"(phase 3 elapsed: {el_s // 60:02d}:{el_s % 60:02d})"
+                )
+
+        beat = threading.Thread(target=_phase3_heartbeat, daemon=True)
+        beat.start()
+        try:
+            ok = wait_for_windows_responsive(cfg, timeout=remaining)
+        finally:
+            beat_thread_stop.set()
+
+        if ok:
             print(f"      OK Windows ready                         ({elapsed()})")
         else:
             print(

--- a/src/winpodx/core/compose.py
+++ b/src/winpodx/core/compose.py
@@ -31,7 +31,14 @@ services:
       REGION: "en-001"
       KEYBOARD: "en-US"
       ARGUMENTS: "-cpu host,arch_capabilities=off"
-      USER_PORTS: "8765"
+      # v0.2.2.2: USER_PORTS removed pending root-cause investigation —
+      # v0.2.2 added USER_PORTS=8765 for the guest agent, but multiple
+      # users reported FreeRDP rc=147 (transport reset) on what had
+      # been a working setup. Until we confirm dockur's USER_PORTS
+      # parsing isn't interfering with the default 3389/8006 hostfwds,
+      # the agent runs without the QEMU NAT publish (so it's
+      # unreachable from host — agent code falls back to FreeRDP
+      # RemoteApp via the existing AgentUnavailableError path).
     volumes:
       - winpodx-data:/storage:Z
       - {oem_dir}:/oem:Z

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -224,6 +224,10 @@ def wait_for_windows_responsive(cfg: Config, timeout: int = 90) -> bool:
             break
         time.sleep(2)
     else:
+        log.warning(
+            "wait_for_windows_responsive: timed out before RDP port "
+            "%s:%d came up", cfg.rdp.ip, cfg.rdp.port,
+        )
         return False
 
     # Port is open — keep firing the activation probe until one succeeds
@@ -232,6 +236,10 @@ def wait_for_windows_responsive(cfg: Config, timeout: int = 90) -> bool:
     # though the RDP listener answers TCP, so a one-shot probe here is
     # the wrong primitive — the user already passed `timeout` to express
     # "try this hard, for this long".
+    last_error: str | None = None
+    last_rc: int | None = None
+    last_stderr: str | None = None
+    probes = 0
     while time.monotonic() < deadline:
         per_probe_budget = max(5, min(20, int(deadline - time.monotonic())))
         try:
@@ -241,16 +249,40 @@ def wait_for_windows_responsive(cfg: Config, timeout: int = 90) -> bool:
                 description="responsive-probe",
                 timeout=per_probe_budget,
             )
+            probes += 1
             if result.rc == 0:
                 return True
-        except WindowsExecError:
-            # Transient — Windows likely still booting / Sysprep running.
-            pass
+            last_rc = result.rc
+            last_stderr = (result.stderr or "")[-400:]
+        except WindowsExecError as e:
+            probes += 1
+            last_error = str(e)[-400:]
         # Pace retries so we don't pin a CPU spinning FreeRDP processes.
         if time.monotonic() < deadline - 3:
             time.sleep(3)
         else:
             break
+    # v0.2.2.2: surface diagnostic context on timeout. Without this, the
+    # caller (winpodx pod wait-ready or _self_heal_apply) just sees False
+    # and the user is left with "FAIL Timeout" after 60 minutes with no
+    # idea why every probe failed. Now the last channel error makes it
+    # into the host log so we can distinguish auth mismatch from
+    # RemoteApp-not-published from TLS-handshake-failed.
+    if last_error is not None:
+        log.warning(
+            "wait_for_windows_responsive: %d probes failed, last channel "
+            "error: %s", probes, last_error,
+        )
+    elif last_rc is not None:
+        log.warning(
+            "wait_for_windows_responsive: %d probes returned rc=%d, "
+            "last stderr: %s", probes, last_rc, last_stderr,
+        )
+    else:
+        log.warning(
+            "wait_for_windows_responsive: %d probes ran but produced no "
+            "diagnostic — check FreeRDP binary on PATH", probes,
+        )
     return False
 
 


### PR DESCRIPTION
## Summary

Emergency hotfix: v0.2.2's \`USER_PORTS=8765\` compose change broke RDP on previously-working setups (FreeRDP rc=147 / Connection reset by peer). Plus three other regressions surfaced during user testing.

### Fixed
- **USER_PORTS removed from compose template.** Guest agent loses host reachability — the existing AgentUnavailableError → FreeRDP RemoteApp fallback handles all operations. Net: RDP behavior reverts to v0.2.1. Re-enabling the agent port requires confirming dockur's USER_PORTS parsing.
- **\`winpodx gui\` no longer blocks 5 min on CLI startup.** v0.2.1's pending-resume hook was synchronous; gui/tray/migrate now skip it (GUI has its own non-blocking resume).
- **wait_for_windows_responsive surfaces the last FreeRDP error on timeout.** No more silent 60-minute fails.

### Added
- \`pod wait-ready\` heartbeat (30/60 sec) during silent Windows-installer phase.
- VNC URL tip in phase 2.

### Tests
449 passed + 1 skipped. Ruff clean.

## Test plan
- [ ] \`winpodx gui\` opens immediately, doesn't block on resume.
- [ ] \`winpodx app run desktop\` works without rc=147.
- [ ] \`pod wait-ready\` shows heartbeat lines while Windows installer is running silently.