### PR TITLE
feat(checks): guest-side probes + live GUI transport indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 ## [Unreleased]
 
 ### Added
-- **`winpodx check` health probes.** New CLI command runs a fast multi-source health audit (pod running, RDP port, agent /health, OEM bundle version, password rotation age, discovered apps count, host disk free) and prints one line per probe with `OK` / `WARN` / `FAIL` / `SKIP` and per-probe duration. `--json` emits machine-readable output for scripting. Exit code is `0` unless any probe is `FAIL`.
-- **GUI Info page Health card.** The Info page gains a top "Health" section that runs the same probes as `winpodx check` and renders each with a coloured status badge plus the overall verdict. Refreshes whenever the user clicks Refresh Info.
+- **`winpodx check` health probes.** New CLI command runs a fast multi-source health audit and prints one line per probe with `OK` / `WARN` / `FAIL` / `SKIP` and per-probe duration. `--json` emits machine-readable output for scripting. Exit code is `0` unless any probe is `FAIL`. Probes:
+  - `pod_running`, `rdp_port`, `agent_health` — surface bring-up state
+  - `guest_exec` — POSTs `/exec` with a trivial `Write-Output ok` and verifies rc=0 + stdout="ok". Proves the host→guest channel actually round-trips, not just that `/health` answers
+  - `guest_summary` — single `/exec` returning Windows version + uptime + current user + active session count + C: free space
+  - `oem_version`, `password_age`, `apps_discovered`, `disk_free` — host-side state
+- **GUI Info page Health card with auto-refresh.** The Info page gains a top "Health" section that renders each probe with a coloured status badge plus the overall verdict. While the page is visible the card auto-refreshes every 30 s; off-page the timer is paused so the guest isn't polled while idle.
+- **Sidebar transport indicators.** The pod chip in the top bar now shows two extra letter dots — `A` (guest agent) and `R` (RDP port) — that turn green when reachable and red when not. Hover surfaces "agent OK (version)" / "host→guest commands fall back to FreeRDP RemoteApp" tooltips so the user sees at a glance which channel will service the next launch. Updated by the existing 15 s pod-status timer.
 
 ### Fixed
 - **Discovery script path off by one.** `_ps_script_path` walked four `.parent`s and resolved to `<root>/src/scripts/windows/discover_apps.ps1`, which never exists in any layout. Walked five now so the resolution lands on the actual `<root>/scripts/windows/` directory; clicking GUI Refresh stops popping the "Pod Not Running" dialog when the pod is fine.

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -10,8 +10,13 @@
 ## [Unreleased]
 
 ### 추가
-- **`winpodx check` 헬스 프로브.** 새 CLI 명령어가 멀티 소스 헬스 점검 (pod 동작 / RDP 포트 / agent /health / OEM 번들 버전 / 비밀번호 회전 만료 / 디스커버리된 앱 수 / 호스트 디스크 여유) 을 한 번에 실행하고 각 프로브를 `OK` / `WARN` / `FAIL` / `SKIP` 와 측정 시간으로 출력. `--json` 로 머신 판독용 출력. exit code 는 어떤 프로브든 `FAIL` 일 때만 `1`.
-- **GUI Info 페이지에 Health 카드 추가.** Info 페이지 최상단에 새 "Health" 섹션이 `winpodx check` 와 동일한 프로브를 실행하고 각각 색깔 있는 상태 배지 + 전체 verdict 으로 렌더링. Refresh Info 클릭 시 갱신.
+- **`winpodx check` 헬스 프로브.** 새 CLI 명령어가 멀티 소스 헬스 점검을 한 번에 실행하고 각 프로브를 `OK` / `WARN` / `FAIL` / `SKIP` 와 측정 시간으로 출력. `--json` 로 머신 판독용 출력. exit code 는 어떤 프로브든 `FAIL` 일 때만 `1`. 프로브:
+  - `pod_running`, `rdp_port`, `agent_health` — bring-up 상태
+  - `guest_exec` — `Write-Output ok` 페이로드를 `/exec` 로 보내 rc=0 + stdout="ok" 검증. host→guest 채널이 실제로 round-trip 하는지 (단순히 `/health` 응답만이 아니라) 증명
+  - `guest_summary` — `/exec` 한 번으로 Windows 버전 / uptime / 현재 사용자 / 활성 세션 수 / C: 여유 공간 가져옴
+  - `oem_version`, `password_age`, `apps_discovered`, `disk_free` — 호스트 측 상태
+- **GUI Info 페이지 Health 카드 자동 갱신.** Info 페이지 최상단의 새 "Health" 섹션이 각 프로브를 색 배지 + 전체 verdict 로 렌더. 페이지가 보이는 동안 30초마다 자동 갱신, 페이지 떠나면 타이머 일시정지 (idle 시 guest poll 안 함).
+- **사이드바 트랜스포트 표시기.** 상단 pod chip 에 글자 점 2개 추가 — `A` (guest agent) 와 `R` (RDP 포트) — 도달 가능하면 녹색, 안 되면 빨강. tooltip 으로 "agent OK (version)" / "host→guest 명령어가 FreeRDP RemoteApp 으로 폴백됨" 표시 — 다음 launch 가 어느 채널로 갈지 한눈에 보임. 기존 15초 pod-status 타이머가 같이 갱신.
 
 ### 수정
 - **discovery 스크립트 경로 한 단계 어긋남.** `_ps_script_path` 가 `.parent` 를 4번 거슬러 `<root>/src/scripts/windows/discover_apps.ps1` 를 만들었는데 어떤 layout 에도 없는 경로. 5번 거슬러 실제 `<root>/scripts/windows/` 로 resolve 되게 수정 — 이제 GUI Refresh 가 pod 정상일 때 "Pod Not Running" dialog 를 띄우지 않음.

--- a/src/winpodx/core/checks.py
+++ b/src/winpodx/core/checks.py
@@ -76,6 +76,8 @@ def probe_rdp_port(cfg: Config) -> Probe:
 
 
 def probe_agent_health(cfg: Config) -> Probe:
+    """GET /health — verifies the agent is bound and answering on 8765."""
+
     def _run() -> tuple[ProbeStatus, str]:
         from winpodx.core.agent import AgentClient, AgentError
 
@@ -89,6 +91,125 @@ def probe_agent_health(cfg: Config) -> Probe:
 
     status, detail, ms = _timed(_run)
     return Probe("agent_health", status, detail, ms)
+
+
+def probe_guest_exec(cfg: Config) -> Probe:
+    """POST /exec round-trip — proves the host→guest command channel works.
+
+    Sends a trivial PowerShell payload (``Write-Output ok``) through
+    ``AgentClient.exec`` and verifies rc==0 and stdout=="ok". A passing
+    /health doesn't tell you the bearer auth, base64 decode, child spawn,
+    stdio capture, and JSON serialization all work — this probe does.
+
+    Skipped when the pod isn't running (no point running it just to fail);
+    fails loudly when /health is fine but /exec isn't (the symptom that
+    the rc:null bug from 2026-04-30 created).
+    """
+
+    def _run() -> tuple[ProbeStatus, str]:
+        from winpodx.core.agent import AgentClient, AgentError
+        from winpodx.core.pod import PodState, pod_status
+
+        # Skip rather than fail when the pod itself is down — keeps the
+        # report readable in the "pod stopped" state where every guest
+        # probe would otherwise red-X.
+        try:
+            if pod_status(cfg).state != PodState.RUNNING:
+                return "skip", "pod not running"
+        except Exception:  # noqa: BLE001
+            return "skip", "pod state unknown"
+
+        client = AgentClient(cfg)
+        try:
+            result = client.exec("Write-Output ok\n", timeout=10.0)
+        except AgentError as e:
+            return "fail", f"exec failed: {e}"
+        if result.rc != 0:
+            return "fail", f"rc={result.rc} stderr={result.stderr.strip()[:80]!r}"
+        out = (result.stdout or "").strip()
+        if out != "ok":
+            return "warn", f"unexpected stdout: {out[:80]!r}"
+        return "ok", "round-trip OK (rc=0, stdout='ok')"
+
+    status, detail, ms = _timed(_run)
+    return Probe("guest_exec", status, detail, ms)
+
+
+def probe_guest_summary(cfg: Config) -> Probe:
+    """Single /exec call that returns a JSON snapshot of guest state.
+
+    Reports Windows version, uptime, current RDP user, active session
+    count, and C: free space in one row. Cheap enough to include in the
+    default check (~150ms typical) and answers the most common
+    "what's going on inside Windows" question without requiring the
+    user to open a remote desktop.
+    """
+
+    def _run() -> tuple[ProbeStatus, str]:
+        import json
+
+        from winpodx.core.agent import AgentClient, AgentError
+        from winpodx.core.pod import PodState, pod_status
+
+        try:
+            if pod_status(cfg).state != PodState.RUNNING:
+                return "skip", "pod not running"
+        except Exception:  # noqa: BLE001
+            return "skip", "pod state unknown"
+
+        # Single PowerShell payload — emit one JSON object so the host
+        # parses it in one shot. Keep the script short; agent.ps1 logs
+        # the payload hash for forensics, and longer scripts inflate
+        # /exec latency.
+        script = (
+            "$os = Get-CimInstance Win32_OperatingSystem -ErrorAction SilentlyContinue;"
+            "$cs = Get-CimInstance Win32_ComputerSystem -ErrorAction SilentlyContinue;"
+            "$disk = Get-CimInstance Win32_LogicalDisk -Filter \"DeviceID='C:'\""
+            " -ErrorAction SilentlyContinue;"
+            "$sessions = (query session 2>$null | Where-Object { $_ -match 'rdp' }"
+            " | Measure-Object).Count;"
+            "$obj = @{"
+            "  os = if ($os) { $os.Caption.Trim() } else { '?' };"
+            "  build = if ($os) { $os.BuildNumber } else { '?' };"
+            "  uptime_h = if ($os) {"
+            "    [math]::Round((New-TimeSpan -Start $os.LastBootUpTime"
+            " -End (Get-Date)).TotalHours, 1)"
+            "  } else { 0 };"
+            "  user = if ($cs) { $cs.UserName } else { '' };"
+            "  c_free_gb = if ($disk) {"
+            "    [math]::Round($disk.FreeSpace / 1GB, 1)"
+            "  } else { 0 };"
+            "  sessions = [int]$sessions;"
+            "};"
+            "$obj | ConvertTo-Json -Compress"
+        )
+
+        client = AgentClient(cfg)
+        try:
+            result = client.exec(script, timeout=15.0)
+        except AgentError as e:
+            return "fail", f"exec failed: {e}"
+        if result.rc != 0:
+            return "warn", f"rc={result.rc} stderr={result.stderr.strip()[:80]!r}"
+        try:
+            payload = json.loads(result.stdout.strip().splitlines()[-1])
+        except (ValueError, IndexError) as e:
+            return "warn", f"non-JSON stdout: {e}"
+
+        os_name = payload.get("os", "?")
+        build = payload.get("build", "?")
+        uptime_h = payload.get("uptime_h", 0)
+        user = payload.get("user") or "(no user)"
+        sessions = payload.get("sessions", 0)
+        c_free = payload.get("c_free_gb", 0)
+        detail = (
+            f"{os_name} build={build} up={uptime_h}h user={user!r} "
+            f"sessions={sessions} C:={c_free}GiB free"
+        )
+        return "ok", detail
+
+    status, detail, ms = _timed(_run)
+    return Probe("guest_summary", status, detail, ms)
 
 
 def probe_oem_version(cfg: Config) -> Probe:
@@ -170,6 +291,8 @@ PROBES: tuple[Callable[[Config], Probe], ...] = (
     probe_pod_running,
     probe_rdp_port,
     probe_agent_health,
+    probe_guest_exec,  # round-trip test — proves /exec works, not just /health
+    probe_guest_summary,  # in-guest snapshot (Windows version / uptime / sessions / disk)
     probe_oem_version,
     probe_password_age,
     probe_apps_discovered,

--- a/src/winpodx/gui/main_window.py
+++ b/src/winpodx/gui/main_window.py
@@ -229,6 +229,7 @@ class WinpodxWindow(QMainWindow):
 
     # Thread-safe signals
     pod_status_updated = Signal(str, str)
+    transport_status_updated = Signal(bool, bool, str)  # agent_ok, rdp_ok, agent_version
     app_launched = Signal(str)
     app_launch_failed = Signal(str)
     log_signal = Signal(str, str)
@@ -366,6 +367,7 @@ class WinpodxWindow(QMainWindow):
 
     def _setup_signals(self) -> None:
         self.pod_status_updated.connect(self._on_pod_status)
+        self.transport_status_updated.connect(self._on_transport_status)
         self.app_launched.connect(self._on_app_launched)
         self.app_launch_failed.connect(self._on_app_launch_failed)
         self.log_signal.connect(self._log_append)
@@ -464,6 +466,7 @@ class WinpodxWindow(QMainWindow):
         self.pod_dot.setStyleSheet(
             f"background: transparent; color: {C.SUBTEXT0}; font-size: 10px;"
         )
+        self.pod_dot.setToolTip("Pod state")
         chip_l.addWidget(self.pod_dot)
 
         self.pod_label = QLabel("checking")
@@ -471,6 +474,25 @@ class WinpodxWindow(QMainWindow):
             f"background: transparent; color: {C.SUBTEXT0}; font-size: 12px;"
         )
         chip_l.addWidget(self.pod_label)
+
+        # Mini transport indicators \u2014 small colored dots next to the pod
+        # chip showing agent + RDP reachability so the user can see at a
+        # glance whether host\u2192guest commands will succeed (agent dot) or
+        # fall back to FreeRDP RemoteApp (RDP dot). Updated by the same
+        # 15s status_timer that drives pod_dot, plus a quick agent probe.
+        self.agent_dot = QLabel("A")
+        self.agent_dot.setStyleSheet(
+            f"background: transparent; color: {C.OVERLAY0}; font-size: 10px; font-weight: bold;"
+        )
+        self.agent_dot.setToolTip("Guest agent (HTTP /health) \u2014 probing\u2026")
+        chip_l.addWidget(self.agent_dot)
+
+        self.rdp_dot = QLabel("R")
+        self.rdp_dot.setStyleSheet(
+            f"background: transparent; color: {C.OVERLAY0}; font-size: 10px; font-weight: bold;"
+        )
+        self.rdp_dot.setToolTip("RDP port (3390) \u2014 probing\u2026")
+        chip_l.addWidget(self.rdp_dot)
 
         ctrl_w = QWidget()
         ctrl_w.setStyleSheet(POD_CTRL)
@@ -2101,6 +2123,31 @@ class WinpodxWindow(QMainWindow):
         else:
             self._on_stop_tail()
 
+        # Auto-refresh the Info page Health card when the user is looking
+        # at it. The probes hit /exec which spawns a child PS, so we keep
+        # the cadence at 30s (cheap on a healthy install — ~2s for the
+        # full sweep, dominated by guest_exec + guest_summary). Off-page,
+        # the timer is paused so we don't poll the guest while idle.
+        info_index = 4
+        if index == info_index:
+            self._start_info_auto_refresh()
+        else:
+            self._stop_info_auto_refresh()
+
+    def _start_info_auto_refresh(self) -> None:
+        """Begin polling Info-page probes every 30s; runs immediately once."""
+        if getattr(self, "_info_auto_timer", None) is None:
+            self._info_auto_timer = QTimer(self)
+            self._info_auto_timer.timeout.connect(self._refresh_info)
+        self._info_auto_timer.start(30000)
+        # Kick the first refresh now so the user doesn't sit on stale data.
+        self._refresh_info()
+
+    def _stop_info_auto_refresh(self) -> None:
+        timer = getattr(self, "_info_auto_timer", None)
+        if timer is not None:
+            timer.stop()
+
     # Serializes ensure_ready + Popen spawn so concurrent launches don't race.
     _launch_lock = threading.Lock()
 
@@ -2580,8 +2627,62 @@ class WinpodxWindow(QMainWindow):
                 self.pod_status_updated.emit(s.state.value, s.ip)
             except Exception:
                 self.pod_status_updated.emit("error", "")
+                self.transport_status_updated.emit(False, False, "")
+                return
+
+            # Probe transports in the same worker tick so the chip dots
+            # stay synced with the pod state. Both probes are bounded
+            # (~2s each); together they finish well inside the 15s timer.
+            agent_ok = False
+            agent_version = ""
+            rdp_ok = False
+            try:
+                from winpodx.core.agent import AgentClient, AgentError
+
+                client = AgentClient(cfg)
+                try:
+                    payload = client.health()
+                    agent_ok = True
+                    agent_version = str(payload.get("version", ""))
+                except AgentError:
+                    agent_ok = False
+            except Exception:  # noqa: BLE001 — never break the timer
+                log.debug("agent probe in status_timer failed", exc_info=True)
+            try:
+                from winpodx.core.pod import check_rdp_port
+
+                rdp_ok = check_rdp_port(cfg.rdp.ip, cfg.rdp.port, timeout=1.0)
+            except Exception:  # noqa: BLE001
+                log.debug("rdp probe in status_timer failed", exc_info=True)
+            self.transport_status_updated.emit(agent_ok, rdp_ok, agent_version)
 
         threading.Thread(target=_do, daemon=True).start()
+
+    @Slot(bool, bool, str)
+    def _on_transport_status(self, agent_ok: bool, rdp_ok: bool, agent_version: str) -> None:
+        """Paint the agent + RDP mini dots on the sidebar pod chip."""
+        green = C.GREEN
+        red = C.RED
+
+        self.agent_dot.setStyleSheet(
+            f"background: transparent; color: {green if agent_ok else red}; "
+            f"font-size: 10px; font-weight: bold;"
+        )
+        if agent_ok:
+            tip = f"Guest agent OK ({agent_version})" if agent_version else "Guest agent OK"
+        else:
+            tip = "Guest agent unreachable — host→guest commands fall back to FreeRDP RemoteApp"
+        self.agent_dot.setToolTip(tip)
+
+        self.rdp_dot.setStyleSheet(
+            f"background: transparent; color: {green if rdp_ok else red}; "
+            f"font-size: 10px; font-weight: bold;"
+        )
+        self.rdp_dot.setToolTip(
+            "RDP port 3390 reachable"
+            if rdp_ok
+            else "RDP port 3390 unreachable — apps cannot launch"
+        )
 
     @Slot(str, str)
     def _on_pod_status(self, state: str, ip: str) -> None:

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -114,6 +114,51 @@ def test_probe_password_age_warn_when_overdue():
     assert "overdue" in out.detail
 
 
+def test_probe_guest_exec_skip_when_pod_not_running(monkeypatch):
+    """When the pod isn't running, the round-trip probe must skip rather than
+    fail — every guest probe would red-X otherwise and drown out the actual
+    "pod is down" signal."""
+    import winpodx.core.pod as pod_mod
+    from winpodx.core.pod import PodState, PodStatus
+
+    monkeypatch.setattr(pod_mod, "pod_status", lambda _cfg: PodStatus(state=PodState.STOPPED))
+    out = checks.probe_guest_exec(_FakeCfg())
+    assert out.status == "skip"
+    assert "pod" in out.detail.lower()
+
+
+def test_probe_guest_summary_skip_when_pod_not_running(monkeypatch):
+    import winpodx.core.pod as pod_mod
+    from winpodx.core.pod import PodState, PodStatus
+
+    monkeypatch.setattr(pod_mod, "pod_status", lambda _cfg: PodStatus(state=PodState.STOPPED))
+    out = checks.probe_guest_summary(_FakeCfg())
+    assert out.status == "skip"
+
+
+def test_probe_guest_exec_fail_when_agent_unreachable(monkeypatch):
+    """When the pod IS running but agent is down, the probe must fail with
+    a useful detail — proves the round-trip channel is broken even though
+    the container is up."""
+    import winpodx.core.pod as pod_mod
+    from winpodx.core.agent import AgentUnavailableError
+    from winpodx.core.pod import PodState, PodStatus
+
+    monkeypatch.setattr(pod_mod, "pod_status", lambda _cfg: PodStatus(state=PodState.RUNNING))
+
+    class _FakeClient:
+        def __init__(self, _cfg) -> None:
+            pass
+
+        def exec(self, *_a, **_k):
+            raise AgentUnavailableError("connection refused")
+
+    monkeypatch.setattr("winpodx.core.agent.AgentClient", _FakeClient)
+    out = checks.probe_guest_exec(_FakeCfg())
+    assert out.status == "fail"
+    assert "connection refused" in out.detail
+
+
 def test_probe_apps_discovered_warn_on_missing_dir(tmp_path, monkeypatch):
     monkeypatch.setattr("winpodx.core.discovery.discovered_apps_dir", lambda: tmp_path / "missing")
     out = checks.probe_apps_discovered(_FakeCfg())


### PR DESCRIPTION
## Summary
- Two new probes that exercise the host→guest channel end-to-end (not just /health):
  - `guest_exec` — verifies /exec round-trip (rc=0, stdout='ok')
  - `guest_summary` — single /exec returning Windows version, uptime, user, sessions, C: free
- GUI Info Health card auto-refreshes every 30s while visible (paused off-page)
- Sidebar pod chip gains `A` (agent) + `R` (RDP) dots that turn green/red live, with tooltips explaining which transport the next launch will use

## Test plan
- [x] `pytest tests/test_checks.py` — 18 pass
- [x] `winpodx check` shows 9 probes, all OK on healthy install
- [x] Lint + format clean