### PR TITLE
hotfix: strip RTM in publish workflows + sync v0.3.0 docs

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -44,8 +44,13 @@ jobs:
           else
             tag="${{ inputs.tag }}"
           fi
+          # AUR pkgver disallows '-' (reserved for the pkgrel delimiter),
+          # so strip the RTM gate suffix before stamping PKGBUILD. Tag
+          # name itself is preserved for the source URL.
+          version="${tag#v}"
+          version="${version%%-RTM*}"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Render PKGBUILD (stamp version + sha256)
         if: steps.check.outputs.skip == 'false'

--- a/.github/workflows/obs-publish.yml
+++ b/.github/workflows/obs-publish.yml
@@ -36,8 +36,13 @@ jobs:
           else
             tag="${{ inputs.tag }}"
           fi
+          # OBS feeds the version into both deb and rpm specs; rpm forbids
+          # '-' in Version: (Version/Release delimiter). Strip the RTM
+          # gate suffix so `0.3.0-RTM1` lands as `0.3.0`.
+          version="${tag#v}"
+          version="${version%%-RTM*}"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Install curl + jq
         run: sudo apt-get update && sudo apt-get install -y curl jq

--- a/.github/workflows/rhel-publish.yml
+++ b/.github/workflows/rhel-publish.yml
@@ -63,8 +63,16 @@ jobs:
           else
             tag="${{ inputs.tag }}"
           fi
+          # Strip the RTM gate suffix when computing the package version —
+          # RPM's Version: field forbids '-' (it's the Version/Release
+          # delimiter), so 'v0.3.0-RTM1' would land as the illegal
+          # 'Version: 0.3.0-RTM1'. The tag itself is preserved for the
+          # release upload + asset naming; only the on-disk Version is
+          # stripped to a plain '0.3.0'.
+          version="${tag#v}"
+          version="${version%%-RTM*}"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Install RPM build deps
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 Major release — modular core, HTTP guest agent, and a comprehensive health-check surface. Replaces the FreeRDP RemoteApp pipeline as the default host→guest command channel.
 
+### Background
+
+v0.2.2 / v0.2.2.1 were an earlier attempt at these features that landed broken on real installs (PS-window storms, "Another user is signed in" dialogs, install timeouts, RST from `/exec` because compose was missing the `8765` port mapping). main was rolled back to v0.2.1 on 2026-04-29 and the agent + transport feature redesigned from scratch with explicit anti-goals (see `docs/AGENT_V2_DESIGN.md`). v0.3.0 is that redesigned implementation; the `0.2.2.x` tags exist on the timeline but should not be used.
+
 ### Added
 - **HTTP guest agent (rev4).** `agent.ps1` runs inside Windows on `127.0.0.1:8765`, bound via `+:8765` so QEMU's user-mode NAT can reach it. Bearer-authed `/exec` (base64-encoded PowerShell payloads) replaces FreeRDP RemoteApp as the default host→guest command channel; `/health` stays unauthenticated for the readiness probe. Child PS spawned via `[Diagnostics.Process]` + `CreateNoWindow=$true` + async `ReadToEndAsync` — no PS-window flashes, no pipe-buffer deadlocks. Token delivered via the OEM bind mount (mode `0600` on host, gitignored).
 - **Transport ABC v1** (`core/transport/{base,agent,freerdp,dispatch}`). `dispatch()` prefers the agent and falls back to FreeRDP when `/health` doesn't answer. Password rotation explicitly **never** routes through Transport (rule #6 in `docs/TRANSPORT_ABC.md`) — rotation owns its own credentials and calls `run_in_windows` directly to avoid a bootstrap loop on stale-password recovery.
@@ -23,6 +27,7 @@ Major release — modular core, HTTP guest agent, and a comprehensive health-che
   - `oem_version`, `password_age`, `apps_discovered`, `disk_free` — host-side state
 - **GUI Info page Health card with auto-refresh.** The Info page gains a top "Health" section that renders each probe with a coloured status badge plus the overall verdict. While the page is visible the card auto-refreshes every 30 s; off-page the timer is paused so the guest isn't polled while idle.
 - **Sidebar transport indicators.** The pod chip in the top bar now shows two extra letter dots — `A` (guest agent) and `R` (RDP port) — that turn green when reachable and red when not. Hover surfaces "agent OK (version)" / "host→guest commands fall back to FreeRDP RemoteApp" tooltips so the user sees at a glance which channel will service the next launch. Updated by the existing 15 s pod-status timer.
+- **`install.sh` ref selection.** `--main` installs from `origin/main` (development), `--ref TAG` installs from a specific git ref / release tag. Default with no flag uses the latest GitHub Release. Added together with the RTM-only release gate so rapid-iteration tags between RTM points don't trigger AUR / OBS / Debian publishes that overwrite working installs.
 
 ### Fixed
 - **Discovery script path off by one.** `_ps_script_path` walked four `.parent`s and resolved to `<root>/src/scripts/windows/discover_apps.ps1`, which never exists in any layout. Walked five now so the resolution lands on the actual `<root>/scripts/windows/` directory; clicking GUI Refresh stops popping the "Pod Not Running" dialog when the pod is fine.

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh |
 ---
 
 > ### Status: Beta
-> winpodx is in active development (v0.2.0.x). The install path, FreeRDP RemoteApp integration, Windows-side runtime applies, and discovery flow have all been hardened across the v0.1.9 → v0.2.0.x line, but you should still expect rough edges — especially on first install (Windows VM first-boot can take 5–10 minutes; see `winpodx pod wait-ready --logs` for live progress). Please file issues at <https://github.com/kernalix7/winpodx/issues> if something breaks.
+> winpodx is in active development (v0.3.0). v0.3.0 ships a redesigned host→guest pipeline — bearer-authed HTTP agent on `127.0.0.1:8765` is now the default command channel, with FreeRDP RemoteApp kept as fallback. App launches no longer flash a PowerShell window. New `winpodx check` CLI + GUI Health card surface live pod / RDP / agent / round-trip / disk state. First install still takes ~5-10 minutes (Windows VM ISO download + Sysprep + OEM apply); `winpodx pod wait-ready --logs` shows live progress. Please file issues at <https://github.com/kernalix7/winpodx/issues> if something breaks.
 
 **No full-screen RDP.** Each Windows app becomes its own Linux window with its real icon — pinnable, alt-tabbable, file-associated. Drop into a full Windows desktop only when you actually want one (`winpodx app run desktop`).
 
-winpodx runs a Windows container (via [dockur/windows](https://github.com/dockur/windows)) in the background and presents Windows apps as native Linux applications through FreeRDP RemoteApp. No manual VM setup, no ISO downloads, no registry editing. **Near-zero external Python dependencies** (stdlib only on Python 3.11+; one pure-Python `tomli` fallback on 3.9/3.10).
+winpodx runs a Windows container (via [dockur/windows](https://github.com/dockur/windows)) in the background and presents Windows apps as native Linux applications through FreeRDP RemoteApp, while a bearer-authed HTTP agent inside the guest handles the host→guest command channel without flashing a PowerShell window. No manual VM setup, no ISO downloads, no registry editing. **Near-zero external Python dependencies** (stdlib only on Python 3.11+; one pure-Python `tomli` fallback on 3.9/3.10).
 
 ## Why winpodx?
 
@@ -213,6 +213,7 @@ Status legend: `OK` (green) / `WARN` (yellow — informational, exit 0) / `FAIL`
 | GUI (optional) | PySide6 (Qt6) |
 | Config | TOML (stdlib `tomllib` on 3.11+ / `tomli` on 3.9/3.10; built-in writer) |
 | RDP | FreeRDP 3+ (xfreerdp, RemoteApp/RAIL) |
+| Guest agent | PowerShell `HttpListener` on `127.0.0.1:8765` (bearer auth, base64-encoded `/exec` payloads) |
 | Container | Podman / Docker ([dockur/windows](https://github.com/dockur/windows)) |
 | VM | libvirt / KVM |
 | CI | GitHub Actions (lint + test on 3.9-3.13 + pip-audit) |

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -13,6 +13,10 @@
 
 메이저 릴리스 — 모듈형 core 재구조, HTTP guest agent, 통합 헬스체크 surface. FreeRDP RemoteApp 파이프라인을 기본 host→guest 채널에서 대체.
 
+### 배경
+
+v0.2.2 / v0.2.2.1 가 같은 기능들의 첫 시도였지만 실설치에서 깨짐 (PS창 폭주, "Another user is signed in" 다이얼로그, install timeout, compose 의 `8765` 포트 매핑 누락으로 `/exec` RST). 2026-04-29 main 을 v0.2.1 로 롤백하고 명시적 anti-goal 와 함께 agent + transport 처음부터 재설계 (`docs/AGENT_V2_DESIGN.md` 참고). v0.3.0 이 그 재설계 구현; `0.2.2.x` 태그는 timeline 에 남아있지만 사용하지 말 것.
+
 ### 추가
 - **HTTP guest agent (rev4).** `agent.ps1` 가 Windows 안 `127.0.0.1:8765` 에서 동작, `+:8765` 로 바인드해서 QEMU user-mode NAT 통과. Bearer-authed `/exec` (base64 인코딩 PowerShell 페이로드) 가 FreeRDP RemoteApp 을 기본 host→guest 채널에서 대체; `/health` 는 readiness probe 위해 unauthenticated 유지. child PS 는 `[Diagnostics.Process]` + `CreateNoWindow=$true` + 비동기 `ReadToEndAsync` 로 spawn — PS창 깜빡임 없음, pipe buffer deadlock 없음. 토큰은 OEM bind mount 로 전달 (호스트 mode `0600`, gitignored).
 - **Transport ABC v1** (`core/transport/{base,agent,freerdp,dispatch}`). `dispatch()` 가 agent 우선, `/health` 응답 없으면 FreeRDP 폴백. Password rotation 은 명시적으로 Transport 통하지 **않음** (`docs/TRANSPORT_ABC.md` 규칙 #6) — rotation 은 자체 credential 소유 + `run_in_windows` 직접 호출 (stale-password 복구 시 bootstrap loop 회피).
@@ -23,6 +27,7 @@
   - `oem_version`, `password_age`, `apps_discovered`, `disk_free` — 호스트 측 상태
 - **GUI Info 페이지 Health 카드 자동 갱신.** Info 페이지 최상단의 새 "Health" 섹션이 각 프로브를 색 배지 + 전체 verdict 로 렌더. 페이지가 보이는 동안 30초마다 자동 갱신, 페이지 떠나면 타이머 일시정지 (idle 시 guest poll 안 함).
 - **사이드바 트랜스포트 표시기.** 상단 pod chip 에 글자 점 2개 추가 — `A` (guest agent) 와 `R` (RDP 포트) — 도달 가능하면 녹색, 안 되면 빨강. tooltip 으로 "agent OK (version)" / "host→guest 명령어가 FreeRDP RemoteApp 으로 폴백됨" 표시 — 다음 launch 가 어느 채널로 갈지 한눈에 보임. 기존 15초 pod-status 타이머가 같이 갱신.
+- **`install.sh` ref 선택.** `--main` 은 `origin/main` 에서 설치 (개발용), `--ref TAG` 는 특정 git ref / 릴리스 태그에서 설치. 플래그 없으면 최신 GitHub Release 사용. RTM-only 릴리스 게이트와 같이 추가 — RTM 사이의 rapid iteration 태그가 AUR / OBS / Debian publish 를 트리거해서 동작하는 install 을 덮어쓰지 않게 함.
 
 ### 수정
 - **discovery 스크립트 경로 한 단계 어긋남.** `_ps_script_path` 가 `.parent` 를 4번 거슬러 `<root>/src/scripts/windows/discover_apps.ps1` 를 만들었는데 어떤 layout 에도 없는 경로. 5번 거슬러 실제 `<root>/scripts/windows/` 로 resolve 되게 수정 — 이제 GUI Refresh 가 pod 정상일 때 "Pod Not Running" dialog 를 띄우지 않음.

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -35,11 +35,11 @@
 ---
 
 > ### 상태: 베타
-> winpodx는 활발히 개발 중입니다 (v0.2.0.x). 설치 경로, FreeRDP RemoteApp 통합, Windows-side runtime apply, discovery 흐름이 v0.1.9 → v0.2.0.x 동안 많이 개선됐지만, 여전히 거친 부분이 남아있을 수 있습니다 — 특히 첫 설치 시 (Windows VM 첫 부팅에 5~10분 소요; 진행 상황은 `winpodx pod wait-ready --logs` 로 확인). 문제 발생 시 <https://github.com/kernalix7/winpodx/issues> 에 이슈 등록해주세요.
+> winpodx는 활발히 개발 중입니다 (v0.3.0). v0.3.0 은 host→guest 파이프라인을 새로 설계 — bearer-authed HTTP agent (`127.0.0.1:8765`) 가 기본 명령 채널, FreeRDP RemoteApp 은 폴백. 앱 launch 마다 PowerShell 창 깜빡이지 않음. 새 `winpodx check` CLI + GUI Health 카드가 pod / RDP / agent / round-trip / disk 상태 실시간 표시. 첫 설치는 여전히 ~5-10분 소요 (Windows VM ISO 다운로드 + Sysprep + OEM apply); 진행 상황은 `winpodx pod wait-ready --logs` 로 확인. 문제 발생 시 <https://github.com/kernalix7/winpodx/issues> 에 이슈 등록해주세요.
 
 **Full-screen RDP 아님.** Windows 앱이 각각 네이티브 Linux 윈도 — pin 가능, alt-tab 됨, 파일 연결 동작. 진짜 Windows 데스크톱 필요할 때만 `winpodx app run desktop`.
 
-winpodx는 백그라운드에서 Windows 컨테이너([dockur/windows](https://github.com/dockur/windows))를 실행하고, FreeRDP RemoteApp으로 Windows 앱을 네이티브 Linux 앱처럼 표시합니다. VM 수동 설정 불필요, ISO 다운로드 불필요, 레지스트리 편집 불필요. **외부 Python 의존성 거의 없음** (Python 3.11+ 는 표준 라이브러리만; 3.9/3.10 은 순수 파이썬 `tomli` 폴백 1개).
+winpodx는 백그라운드에서 Windows 컨테이너([dockur/windows](https://github.com/dockur/windows))를 실행하고, FreeRDP RemoteApp으로 Windows 앱을 네이티브 Linux 앱처럼 표시합니다. 게스트 안의 bearer-authed HTTP agent 가 host→guest 명령 채널을 처리해서 PowerShell 창이 깜빡이지 않음. VM 수동 설정 불필요, ISO 다운로드 불필요, 레지스트리 편집 불필요. **외부 Python 의존성 거의 없음** (Python 3.11+ 는 표준 라이브러리만; 3.9/3.10 은 순수 파이썬 `tomli` 폴백 1개).
 
 ## 왜 winpodx인가?
 
@@ -188,6 +188,7 @@ Wine 은 속도와 GPU (DXVK/VKD3D 가 깔끔히 번역해줄 때) 에서 이깁
 | GUI (선택) | PySide6 (Qt6) |
 | 설정 | TOML (3.11+ 는 표준 라이브러리 `tomllib` / 3.9/3.10 은 `tomli`; 내장 writer) |
 | RDP | FreeRDP 3+ (xfreerdp, RemoteApp/RAIL) |
+| Guest agent | PowerShell `HttpListener` on `127.0.0.1:8765` (bearer auth, base64-encoded `/exec` payloads) |
 | 컨테이너 | Podman / Docker ([dockur/windows](https://github.com/dockur/windows)) |
 | VM | libvirt / KVM |
 | CI | GitHub Actions (lint + test on 3.9-3.13 + pip-audit) |


### PR DESCRIPTION
Strip `-RTM*` in aur/obs/rhel publish workflows so v0.3.0-RTM1 lands as plain Version: 0.3.0 in package metadata. Plus README + CHANGELOG updates so the docs match v0.3.0 (background paragraph, install.sh ref selection, agent-default-channel blurb).