### PR TITLE
fix(discovery): Add-Result was dropping description from JSON

### DIFF
--- a/scripts/windows/discover_apps.ps1
+++ b/scripts/windows/discover_apps.ps1
@@ -186,6 +186,7 @@ function Add-Result {
     $seen[$key] = $true
     $results.Add([ordered]@{
         name          = $name
+        description   = [string]$Entry.description
         path          = $path
         args          = [string]$Entry.args
         source        = [string]$Entry.source


### PR DESCRIPTION
Three-line fix — Add-Result rebuilt entries into an [ordered]@{} with explicit fields and never forwarded the new description. Result: app.toml never got description, .desktop never got the per-app Comment, even after the agent-transport refresh succeeded.