### PR TITLE
fix(discovery): File Explorer description from real metadata

### DIFF
--- a/scripts/windows/discover_apps.ps1
+++ b/scripts/windows/discover_apps.ps1
@@ -459,9 +459,14 @@ Write-WinpodxProgress 'Emitting essential apps (File Explorer / Calculator / Set
 try {
     $explorer = Join-Path $env:WINDIR 'explorer.exe'
     if (Test-Path -LiteralPath $explorer) {
+        # Pull the real description from explorer.exe's VersionInfo via the
+        # same Get-AppDescription helper Source 1-4 use — no hardcoded
+        # string. Stock Win11 returns "Microsoft® Windows® Operating
+        # System" (ProductName, since it differs from FileDescription
+        # "Windows Explorer").
         Add-Result @{
             name          = 'File Explorer'
-            description   = 'Browse files and folders on the Windows guest'
+            description   = Get-AppDescription $explorer
             path          = $explorer
             args          = 'shell:MyComputerFolder'
             source        = 'win32'


### PR DESCRIPTION
Source 5's File Explorer entry was hardcoding 'Browse files and folders on the Windows guest' as its description. Use Get-AppDescription on explorer.exe instead — the same helper Sources 1-4 use — so the .desktop Comment matches what stock Windows actually says ('Microsoft® Windows® Operating System').