### PR TITLE
chore(oem): track dockur/windows v5.14 in VERSIONS.txt

### DIFF
--- a/config/oem/VERSIONS.txt
+++ b/config/oem/VERSIONS.txt
@@ -1,0 +1,6 @@
+# Last-known-good versions of bundled / pulled dependencies.
+# The check-windows-updates GitHub workflow reads this file weekly and
+# opens an issue when an upstream release differs.
+#
+# Format: <key>=<version>
+dockur=v5.14


### PR DESCRIPTION
Closes #1. Compose already uses :latest tag, container runs v5.14. Just record it so the weekly check workflow stops opening tracking issues.