### PR TITLE
fix(test): include vbs_launchers in apply_windows_runtime_fixes set

### DIFF
--- a/tests/test_provisioner.py
+++ b/tests/test_provisioner.py
@@ -281,6 +281,7 @@ def test_apply_windows_runtime_fixes_returns_per_helper_status(monkeypatch):
         "rdp_timeouts",
         "oem_runtime_fixes",
         "multi_session",
+        "vbs_launchers",
     }
     for v in result.values():
         assert v == "ok"


### PR DESCRIPTION
Updates hardcoded 4-step set assertion to match the new 5-step chain (vbs_launchers landed in #58).