### PR TITLE
config: switch default image to docker.io/dockurr/windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ vnc_port = 8007
 auto_start = true                                # Start pod automatically when launching an app
 idle_timeout = 0                                 # Seconds before auto-suspend (0 = disabled)
 boot_timeout = 300                               # Seconds to wait for first-boot unattended install
-image = "ghcr.io/dockur/windows:latest"          # Container image (override for air-gapped mirror)
+image = "docker.io/dockurr/windows:latest"          # Container image (override for air-gapped mirror)
 disk_size = "64G"                                # Virtual disk size passed to dockur
 ```
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -446,7 +446,7 @@ vnc_port = 8007
 auto_start = true                                # 앱 실행 시 자동 팟 시작
 idle_timeout = 0                                 # 자동 일시정지 (초, 0 = 비활성화)
 boot_timeout = 300                               # 최초 부팅 무인 설치 대기 시간 (초)
-image = "ghcr.io/dockur/windows:latest"          # 컨테이너 이미지 (에어갭 미러 지정 가능)
+image = "docker.io/dockurr/windows:latest"          # 컨테이너 이미지 (에어갭 미러 지정 가능)
 disk_size = "64G"                                # dockur 에 전달되는 가상 디스크 크기
 ```
 

--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -61,7 +61,7 @@ class PodConfig:
     boot_timeout: int = 300  # seconds, max wait for RDP after start_pod
     # Container image for dockur/windows. Expose as config so users can
     # pin a known-good tag or switch to a mirror.
-    image: str = "ghcr.io/dockur/windows:latest"
+    image: str = "docker.io/dockurr/windows:latest"
     # Virtual disk size exposed in the compose template (e.g. "64G", "128G").
     disk_size: str = "64G"
     # Maximum concurrent RemoteApp sessions. Writes
@@ -89,7 +89,7 @@ class PodConfig:
             # Fall back silently so a hand-edited config does not brick setup.
             self.container_name = _DEFAULT_CONTAINER_NAME
         if not isinstance(self.image, str) or not self.image.strip():
-            self.image = "ghcr.io/dockur/windows:latest"
+            self.image = "docker.io/dockurr/windows:latest"
         if not isinstance(self.disk_size, str) or not self.disk_size.strip():
             self.disk_size = "64G"
 

--- a/tests/test_audit5_core.py
+++ b/tests/test_audit5_core.py
@@ -275,13 +275,13 @@ def test_check_freerdp_reports_missing(monkeypatch):
 
 def test_pod_config_image_and_disk_size_defaults():
     pod = PodConfig()
-    assert pod.image == "ghcr.io/dockur/windows:latest"
+    assert pod.image == "docker.io/dockurr/windows:latest"
     assert pod.disk_size == "64G"
 
 
 def test_pod_config_image_and_disk_size_fallback_on_empty():
     pod = PodConfig(image="", disk_size="   ")
-    assert pod.image == "ghcr.io/dockur/windows:latest"
+    assert pod.image == "docker.io/dockurr/windows:latest"
     assert pod.disk_size == "64G"
 
 


### PR DESCRIPTION
## Summary

ghcr.io/dockur/windows now returns HTTP 403 on token request, breaking fresh installs. Upstream publishes the same image on Docker Hub as dockurr/windows (note the double r). Existing users with a generated compose.yaml need to regenerate or edit it.

## Checklist

- [x] pytest: all tests pass
- [x] ruff check: zero errors
- [x] ruff format: formatted
- [ ] Documentation updated (CHANGELOG, docs: both ko & en)
- [x] No hardcoded paths, credentials, or personal info