### PR TITLE
process: match FreeRDP by argv[0] instead of cmdline substring

### DIFF
--- a/src/winpodx/core/process.py
+++ b/src/winpodx/core/process.py
@@ -16,13 +16,40 @@ from winpodx.utils.paths import runtime_dir
 
 log = logging.getLogger(__name__)
 
+# argv[0] basenames find_freerdp() may launch.
+_FREERDP_ARGV0 = (
+    b"xfreerdp",
+    b"xfreerdp3",
+    b"wlfreerdp",
+    b"wlfreerdp3",
+    b"sdl-freerdp",
+    b"sdl-freerdp3",
+)
+
+
+def _cmdline_is_freerdp(cmdline: bytes) -> bool:
+    """Return True if a ``/proc/<pid>/cmdline`` blob is a FreeRDP client.
+
+    Only argv[0]'s basename (or ``flatpak run com.freerdp.FreeRDP``) counts;
+    a blanket ``b"freerdp" in cmdline`` would adopt unrelated processes that
+    merely mention freerdp in an argument or path.
+    """
+    if not cmdline:
+        return False
+    argv = cmdline.split(b"\0")
+    prog = argv[0].rsplit(b"/", 1)[-1].lower()
+    if prog in _FREERDP_ARGV0:
+        return True
+    if prog == b"flatpak":
+        tail = [a.lower() for a in argv[1:] if a]
+        return b"com.freerdp.freerdp" in tail
+    return False
+
 
 def is_freerdp_pid(pid: int) -> bool:
     """Return True if the given PID is a live FreeRDP process we spawned.
 
-    Single source of truth for PID-reuse detection. Accepts only ``freerdp``
-    or ``xfreerdp`` in the cmdline (our own spawned binaries). Excludes
-    ``winpodx`` because that substring can match unrelated CLI invocations.
+    Single source of truth for PID-reuse detection.
     """
     try:
         os.kill(pid, 0)
@@ -30,11 +57,11 @@ def is_freerdp_pid(pid: int) -> bool:
         return False
 
     try:
-        cmdline = Path(f"/proc/{pid}/cmdline").read_bytes().lower()
+        cmdline = Path(f"/proc/{pid}/cmdline").read_bytes()
     except (OSError, PermissionError):
         return False
 
-    return b"freerdp" in cmdline or b"xfreerdp" in cmdline
+    return _cmdline_is_freerdp(cmdline)
 
 
 @dataclass

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -4,7 +4,29 @@ from __future__ import annotations
 
 import os
 
-from winpodx.core.process import TrackedProcess, kill_session, list_active_sessions
+from winpodx.core.process import (
+    TrackedProcess,
+    _cmdline_is_freerdp,
+    kill_session,
+    list_active_sessions,
+)
+
+
+class TestCmdlineIsFreerdp:
+    def test_argv0_xfreerdp(self):
+        assert _cmdline_is_freerdp(b"/usr/bin/xfreerdp3\0/v:host\0")
+
+    def test_argv0_flatpak_freerdp(self):
+        assert _cmdline_is_freerdp(b"flatpak\0run\0com.freerdp.FreeRDP\0/v:host\0")
+
+    def test_freerdp_only_in_later_argv_rejected(self):
+        # Regression: "freerdp" in a later arg must not match.
+        assert not _cmdline_is_freerdp(
+            b"/usr/bin/python3\0-m\0pytest\0--deselect=test_freerdp_pid\0"
+        )
+
+    def test_freerdp_only_in_argv0_path_component_rejected(self):
+        assert not _cmdline_is_freerdp(b"/home/user/freerdp-notes/run.sh\0")
 
 
 class TestTrackedProcess:

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -50,33 +50,20 @@ def test_find_existing_session_rejects_non_freerdp_pid(tmp_path, monkeypatch):
     # A non-freerdp process with 'winpodx' in its cmdline must not look like a live RDP session.
     import shutil
     import subprocess
-    import time
-    from pathlib import Path
 
     from winpodx.core.rdp import _find_existing_session
 
     monkeypatch.setattr("winpodx.core.rdp.runtime_dir", lambda: tmp_path)
     monkeypatch.setattr("winpodx.core.process.runtime_dir", lambda: tmp_path)
 
-    bash = shutil.which("bash")
-    if bash is None:  # pragma: no cover - bash is standard on target distros
-        pytest.skip("bash not available for argv0 spoofing")
+    sleep = shutil.which("sleep")
+    if sleep is None:  # pragma: no cover
+        pytest.skip("sleep not available")
 
-    child = subprocess.Popen(  # noqa: S603
-        [bash, "-c", "exec -a winpodx-app-list sleep 30"],
-    )
+    # Any live process whose argv[0] is not a FreeRDP binary must be rejected
+    # and its stale .cproc marker reaped (PID-reuse guard).
+    child = subprocess.Popen([sleep, "30"])  # noqa: S603
     try:
-        proc_cmdline = Path(f"/proc/{child.pid}/cmdline")
-        for _ in range(40):
-            try:
-                if b"winpodx" in proc_cmdline.read_bytes().lower():
-                    break
-            except OSError:
-                pass
-            time.sleep(0.05)
-        else:
-            pytest.fail("child process did not expose 'winpodx' in cmdline")
-
         pidfile = tmp_path / "notepad.cproc"
         pidfile.write_text(str(child.pid))
 

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -121,7 +121,8 @@ def test_is_freerdp_pid_helper_accepts_freerdp_only():
     with (
         patch("winpodx.core.process.os.kill", return_value=None),
         patch(
-            "winpodx.core.process.Path", side_effect=fake_path_factory(b"/usr/bin/winpodx app list")
+            "winpodx.core.process.Path",
+            side_effect=fake_path_factory(b"/usr/bin/winpodx\0app\0list\0"),
         ),
     ):
         assert proc_mod.is_freerdp_pid(12345) is False
@@ -130,7 +131,7 @@ def test_is_freerdp_pid_helper_accepts_freerdp_only():
         patch("winpodx.core.process.os.kill", return_value=None),
         patch(
             "winpodx.core.process.Path",
-            side_effect=fake_path_factory(b"/usr/bin/xfreerdp3 /v:127.0.0.1"),
+            side_effect=fake_path_factory(b"/usr/bin/xfreerdp3\0/v:127.0.0.1\0"),
         ),
     ):
         assert proc_mod.is_freerdp_pid(12345) is True


### PR DESCRIPTION
## Summary

is_freerdp_pid() accepted any process whose /proc cmdline contained the bytes "freerdp" anywhere, adopting unrelated processes (scripts under ~/freerdp-*/, tools passed a freerdp-mentioning argument) as live RDP sessions so their .cproc markers never reap. Restrict the check to the argv[0] basename against the binaries find_freerdp() actually launches. The PID-reuse regression test is rewritten without `exec -a … sleep`, which fails on multi-call coreutils.

## Checklist

- [x] pytest: all tests pass
- [x] ruff check: zero errors
- [x] ruff format: formatted
- [ ] Documentation updated (CHANGELOG, docs: both ko & en)
- [x] No hardcoded paths, credentials, or personal info