### PR TITLE
rdp: don't silently spawn doomed FreeRDP clients

### DIFF
--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -102,25 +102,31 @@ _FREERDP_CACHE: tuple[str, str] | None = None
 
 
 def find_freerdp() -> tuple[str, str] | None:
-    """Locate a FreeRDP 3+ binary on the system."""
+    """Locate a FreeRDP 3+ binary on the system.
+
+    ``xfreerdp`` first: it is the only client with working RAIL.
+    ``sdl-freerdp`` has none (FreeRDP #9078) and ``wlfreerdp`` is
+    deprecated with broken RAIL repaint, so neither is a Wayland
+    substitute -- pure-Wayland needs XWayland. SDL stays as a
+    full-desktop-only fallback.
+    """
     global _FREERDP_CACHE
     if _FREERDP_CACHE is not None:
         return _FREERDP_CACHE
 
+    probes: tuple[tuple[tuple[str, ...], str], ...] = (
+        (("xfreerdp3", "xfreerdp"), "xfreerdp"),
+        (("sdl-freerdp3", "sdl-freerdp"), "sdl"),
+    )
     found: tuple[str, str] | None = None
-
-    for name in ("xfreerdp3", "xfreerdp"):
-        path = shutil.which(name)
-        if path:
-            found = (path, "xfreerdp")
-            break
-
-    if found is None:
-        for name in ("sdl-freerdp3", "sdl-freerdp"):
+    for names, kind in probes:
+        for name in names:
             path = shutil.which(name)
             if path:
-                found = (path, "sdl")
+                found = (path, kind)
                 break
+        if found is not None:
+            break
 
     if found is None:
         try:
@@ -482,6 +488,18 @@ def launch_app(
         wm_class_hint=wm_class_hint,
         default_args=default_args,
     )
+
+    # See find_freerdp(): only xfreerdp has working RAIL, and it needs $DISPLAY.
+    is_remoteapp = launch_uri is not None or app_executable is not None
+    found = find_freerdp()
+    kind = found[1] if found else ""
+    if is_remoteapp and kind == "xfreerdp" and not os.environ.get("DISPLAY"):
+        raise RuntimeError(
+            "RemoteApp requires xfreerdp, which needs an X display. "
+            "On Wayland, enable XWayland (e.g. your compositor's built-in "
+            "support, or xwayland-satellite for niri/river) and ensure "
+            "$DISPLAY is set."
+        )
 
     log.info("Launching RDP: %s", " ".join(cmd))
 

--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -73,11 +73,22 @@ def _uwp_fallback_wm_class(aumid: str) -> str:
 class RDPSession:
     app_name: str
     process: subprocess.Popen | None = None
-    stderr_tail: bytes = b""
 
     @property
     def pid_file(self) -> Path:
         return runtime_dir() / f"{self.app_name}.cproc"
+
+    @property
+    def stderr_log(self) -> Path:
+        return runtime_dir() / f"{self.app_name}.stderr"
+
+    @property
+    def stderr_tail(self) -> bytes:
+        try:
+            data = self.stderr_log.read_bytes()
+        except OSError:
+            return b""
+        return data[-2048:]
 
     @property
     def is_running(self) -> bool:
@@ -427,14 +438,12 @@ def _find_existing_session(app_name: str) -> RDPSession | None:
 
 
 def _reaper_thread(session: RDPSession) -> None:
-    """Wait for process exit, drain stderr, and clean up the PID file."""
+    """Wait for process exit and clean up the PID file."""
     proc = session.process
     if proc is None:
         return
     try:
-        _out, err = proc.communicate()
-        if err:
-            session.stderr_tail = err[-2048:]
+        proc.wait()
     except (OSError, ValueError):
         pass
     finally:
@@ -518,13 +527,17 @@ def launch_app(
             return existing
         raise RuntimeError(f"Could not acquire lock for {app_name}")
 
+    # stderr=PIPE would SIGPIPE-kill the detached client once the CLI
+    # parent exits; log to a file so the session outlives us.
+    err_log = session.stderr_log.open("wb")
     try:
         proc = subprocess.Popen(
             cmd,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
+            stderr=err_log,
         )
+        err_log.close()
 
         session.process = proc
 

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -39,6 +39,19 @@ def test_linux_to_unc_media_path(monkeypatch, tmp_path):
     assert result == "\\\\tsclient\\media\\USB\\report.docx"
 
 
+def test_launch_app_remoteapp_without_display_raises(monkeypatch, tmp_path):
+    # No $DISPLAY -> xfreerdp would die post-detach; launch_app must raise.
+    from winpodx.core import rdp as rdp_mod
+
+    monkeypatch.setattr(rdp_mod, "find_freerdp", lambda: ("/usr/bin/xfreerdp", "xfreerdp"))
+    monkeypatch.setattr(rdp_mod, "runtime_dir", lambda: tmp_path)
+    monkeypatch.setattr("winpodx.core.process.runtime_dir", lambda: tmp_path)
+    monkeypatch.delenv("DISPLAY", raising=False)
+
+    with pytest.raises(RuntimeError, match="XWayland"):
+        rdp_mod.launch_app(Config(), app_executable="notepad.exe")
+
+
 def test_find_freerdp_returns_tuple_or_none():
     from winpodx.core.rdp import find_freerdp
 


### PR DESCRIPTION
## Summary

Two ways `winpodx app run` could spawn a FreeRDP that dies invisibly:

- stderr was a subprocess PIPE, so when the CLI parent exits the read end closes and the next stderr write SIGPIPE-kills the detached client. Log to a per-app file under XDG_RUNTIME_DIR instead so the session outlives the parent and the tail stays inspectable.
- On a pure Wayland session xfreerdp (the only client with working RAIL — sdl-freerdp has none per FreeRDP #9078, wlfreerdp is deprecated with broken RAIL repaint) dies post-detach with "failed to open display". Raise an actionable error pointing at XWayland instead.

## Checklist

- [x] pytest: all tests pass
- [x] ruff check: zero errors
- [x] ruff format: formatted
- [ ] Documentation updated (CHANGELOG, docs: both ko & en)
- [x] No hardcoded paths, credentials, or personal info