### PR TITLE
Nix flake packaging + bundle_dir() resource lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,24 @@ for machines with no registry / package-repo access:
 Env vars are honored even under `curl | bash`, so
 `WINPODX_SKIP_DEPS=1 curl ... | bash` works.
 
+**Nix** — a flake is provided for NixOS / nix-on-any-distro users:
+
+```bash
+# Run directly without installing
+nix run github:kernalix7/winpodx
+
+# Install into your profile
+nix profile install github:kernalix7/winpodx
+
+# As a flake input
+inputs.winpodx.url = "github:kernalix7/winpodx";
+```
+
+The wrapper bundles FreeRDP, podman / podman-compose, iproute2 and
+libnotify, so the default podman backend works out of the box. The
+docker and libvirt backends still require the respective tools to be
+present on the host.
+
 **One-line uninstall** — `--confirm` or `--purge` is required under pipe
 (the interactive prompts can't read from a terminal while bash consumes
 stdin from curl):

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -234,6 +234,23 @@ openSUSE, Fedora, Debian/Ubuntu, RHEL 계열, Arch 지원.
 환경변수는 `curl | bash` 에서도 동작하므로
 `WINPODX_SKIP_DEPS=1 curl ... | bash` 형태 사용 가능.
 
+**Nix** — NixOS / nix 사용자를 위한 flake 제공:
+
+```bash
+# 설치 없이 바로 실행
+nix run github:kernalix7/winpodx
+
+# 프로필에 설치
+nix profile install github:kernalix7/winpodx
+
+# flake input 으로 사용
+inputs.winpodx.url = "github:kernalix7/winpodx";
+```
+
+래퍼가 FreeRDP, podman / podman-compose, iproute2, libnotify 를 번들로
+포함하므로 기본 podman 백엔드는 추가 설정 없이 동작합니다. docker 및
+libvirt 백엔드는 해당 도구가 호스트에 별도 설치되어 있어야 합니다.
+
 **원 라인 삭제** — 파이프 실행에서는 `--confirm` 또는 `--purge` 플래그가 필수입니다
 (bash 가 curl 의 stdin 을 소비 중이라 대화형 프롬프트가 터미널을 읽을 수 없음):
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -52,20 +52,26 @@
               pytestCheckHook
             ];
 
-            disabledTests = [
-              # Assume repo-root data/ + scripts/ next to the package; not true
-              # for the installed wheel pytestCheckHook runs against.
-              "test_bundled_data_path_source_layout"
-              "test_apply_windows_runtime_fixes_returns_per_helper_status"
-              # `exec -a ... sleep` breaks on nixpkgs' multi-call coreutils.
-              "test_find_existing_session_rejects_non_freerdp_pid"
-            ];
+            preCheck = ''
+              export WINPODX_BUNDLE_DIR=$PWD
+            '';
+
+            # scripts/, config/ and data/ live at the repo root rather than
+            # inside the Python package; ship them under share/ and point the
+            # runtime at it so bundle_dir() resolves correctly for the wheel.
+            postInstall = ''
+              mkdir -p $out/share/winpodx
+              cp -r scripts config data $out/share/winpodx/
+            '';
 
             makeWrapperArgs = [
               "--prefix"
               "PATH"
               ":"
               (lib.makeBinPath runtimeBins)
+              "--set"
+              "WINPODX_BUNDLE_DIR"
+              "${placeholder "out"}/share/winpodx"
             ];
 
             pythonImportsCheck = [ "winpodx" ];

--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,27 @@
       );
 
       checks = forAllSystems (pkgs: {
-        winpodx = self.packages.${pkgs.system}.winpodx;
+        winpodx = self.packages.${pkgs.stdenv.hostPlatform.system}.winpodx;
+      });
+
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          inputsFrom = [ self.packages.${pkgs.stdenv.hostPlatform.system}.winpodx ];
+          # Runtime tools the wrapper would normally inject; expose them in
+          # the dev shell so `python -m winpodx` works against the source tree.
+          packages = [
+            pkgs.freerdp
+            pkgs.iproute2
+            pkgs.libnotify
+            pkgs.podman
+            pkgs.podman-compose
+            pkgs.ruff
+            pkgs.mypy
+          ];
+          shellHook = ''
+            export PYTHONPATH="$PWD/src''${PYTHONPATH:+:$PYTHONPATH}"
+          '';
+        };
       });
 
       formatter = forAllSystems (pkgs: pkgs.nixfmt);

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,90 @@
+{
+  description = "winpodx — Windows app integration for Linux desktop";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (
+        pkgs:
+        let
+          inherit (pkgs) lib;
+          python = pkgs.python3;
+
+          # Runtime CLI tools winpodx shells out to. Podman is the default
+          # backend so it ships in the wrapper PATH; docker/libvirt stay
+          # opt-in via the host to keep the closure bounded.
+          runtimeBins = [
+            pkgs.freerdp
+            pkgs.iproute2
+            pkgs.libnotify
+            pkgs.podman
+            pkgs.podman-compose
+          ];
+        in
+        {
+          default = self.packages.${pkgs.stdenv.hostPlatform.system}.winpodx;
+
+          winpodx = python.pkgs.buildPythonApplication {
+            pname = "winpodx";
+            version = "0.3.0";
+            pyproject = true;
+
+            src = lib.cleanSource ./.;
+
+            build-system = [ python.pkgs.hatchling ];
+
+            dependencies = with python.pkgs; [
+              pyside6
+              docker
+              libvirt
+            ];
+
+            nativeCheckInputs = with python.pkgs; [
+              pytestCheckHook
+            ];
+
+            disabledTests = [
+              # Assume repo-root data/ + scripts/ next to the package; not true
+              # for the installed wheel pytestCheckHook runs against.
+              "test_bundled_data_path_source_layout"
+              "test_apply_windows_runtime_fixes_returns_per_helper_status"
+              # `exec -a ... sleep` breaks on nixpkgs' multi-call coreutils.
+              "test_find_existing_session_rejects_non_freerdp_pid"
+            ];
+
+            makeWrapperArgs = [
+              "--prefix"
+              "PATH"
+              ":"
+              (lib.makeBinPath runtimeBins)
+            ];
+
+            pythonImportsCheck = [ "winpodx" ];
+
+            meta = {
+              description = "Windows app integration for the Linux desktop (FreeRDP RemoteApp + dockur/windows)";
+              homepage = "https://github.com/kernalix7/winpodx";
+              license = lib.licenses.mit;
+              mainProgram = "winpodx";
+              platforms = lib.platforms.linux;
+            };
+          };
+        }
+      );
+
+      checks = forAllSystems (pkgs: {
+        winpodx = self.packages.${pkgs.system}.winpodx;
+      });
+
+      formatter = forAllSystems (pkgs: pkgs.nixfmt);
+    };
+}

--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -406,23 +406,18 @@ def _cmd_debloat() -> None:
     couldn't reach the Windows VM. Now reads the script body locally
     and pipes it through ``windows_exec.run_in_windows``.
     """
-    from pathlib import Path
-
     from winpodx.core.config import Config
     from winpodx.core.windows_exec import WindowsExecError, run_via_transport
+    from winpodx.utils.paths import bundle_dir
 
     cfg = Config.load()
     if cfg.pod.backend not in ("podman", "docker"):
         print("Debloat only supported for Podman/Docker backends.")
         return
 
-    candidates = [
-        Path(__file__).parent.parent.parent.parent / "scripts" / "windows" / "debloat.ps1",
-        Path.home() / ".local" / "bin" / "winpodx-app" / "scripts" / "windows" / "debloat.ps1",
-    ]
-    script = next((p for p in candidates if p.exists()), None)
-    if script is None:
-        print(f"Debloat script not found in any of: {[str(p) for p in candidates]}")
+    script = bundle_dir() / "scripts" / "windows" / "debloat.ps1"
+    if not script.exists():
+        print(f"Debloat script not found: {script}")
         return
 
     try:

--- a/src/winpodx/core/discovery/__init__.py
+++ b/src/winpodx/core/discovery/__init__.py
@@ -27,7 +27,6 @@ import re
 import shutil
 import struct
 import subprocess
-import sys
 import threading
 import time
 import zlib
@@ -43,6 +42,7 @@ from typing import Any
 
 from winpodx.core.app import discovered_apps_dir as _app_discovered_apps_dir
 from winpodx.core.config import Config
+from winpodx.utils.paths import bundle_dir
 from winpodx.utils.toml_writer import dumps as toml_dumps
 
 log = logging.getLogger(__name__)
@@ -399,28 +399,8 @@ def discovered_apps_dir() -> Path:
 
 
 def _ps_script_path() -> Path:
-    """Locate ``scripts/windows/discover_apps.ps1``.
-
-    Checks repo layout first, then wheel / user install prefixes. Uses
-    the same search order as ``winpodx.core.app.bundled_apps_dir`` so
-    behaviour is consistent across install modes.
-    """
-    # __file__ is at <root>/src/winpodx/core/discovery/__init__.py — five
-    # `.parent` hops reach <root>, where `scripts/windows/` lives. The previous
-    # four-hop version landed at <root>/src/, producing "<root>/src/scripts/..."
-    # which never exists in any layout (repo, wheel, or .local/bin install).
-    candidates = [
-        Path(__file__).resolve().parent.parent.parent.parent.parent
-        / "scripts"
-        / "windows"
-        / "discover_apps.ps1",
-        Path(sys.prefix) / "share" / "winpodx" / "scripts" / "windows" / "discover_apps.ps1",
-        Path.home() / ".local" / "share" / "winpodx" / "scripts" / "windows" / "discover_apps.ps1",
-    ]
-    for candidate in candidates:
-        if candidate.exists():
-            return candidate
-    return candidates[0]
+    """Locate ``scripts/windows/discover_apps.ps1`` via :func:`bundle_dir`."""
+    return bundle_dir() / "scripts" / "windows" / "discover_apps.ps1"
 
 
 def _runtime_for(backend: str) -> str:

--- a/src/winpodx/core/info.py
+++ b/src/winpodx/core/info.py
@@ -19,6 +19,7 @@ from typing import Any
 from winpodx import __version__
 from winpodx.core.config import Config, check_session_budget
 from winpodx.core.pod import PodState, check_rdp_port, pod_status
+from winpodx.utils.paths import bundle_dir
 
 log = logging.getLogger(__name__)
 
@@ -52,20 +53,12 @@ def _bundled_oem_version() -> str:
          This is the source of truth — the .txt file is only emitted by the
          guest install at OEM time, so it's missing on a fresh checkout.
     """
-    candidates = [
-        Path(__file__).parent.parent.parent.parent / "config" / "oem" / "oem_version.txt",
-        Path.home() / ".local" / "bin" / "winpodx-app" / "config" / "oem" / "oem_version.txt",
-    ]
-    for path in candidates:
-        text = _read_text_file(path, max_bytes=64)
-        if text:
-            return text
+    oem = bundle_dir() / "config" / "oem"
+    text = _read_text_file(oem / "oem_version.txt", max_bytes=64)
+    if text:
+        return text
 
-    install_bat_candidates = [
-        Path(__file__).parent.parent.parent.parent / "config" / "oem" / "install.bat",
-        Path.home() / ".local" / "bin" / "winpodx-app" / "config" / "oem" / "install.bat",
-    ]
-    for path in install_bat_candidates:
+    for path in (oem / "install.bat",):
         try:
             with path.open("r", encoding="utf-8", errors="replace") as fh:
                 # The version line lives in the first ~5 lines of install.bat;
@@ -83,15 +76,10 @@ def _bundled_oem_version() -> str:
 
 def _bundled_rdprrap_version() -> str:
     """Read the bundled rdprrap version pin file."""
-    candidates = [
-        Path(__file__).parent.parent.parent.parent / "config" / "oem" / "rdprrap_version.txt",
-        Path.home() / ".local" / "bin" / "winpodx-app" / "config" / "oem" / "rdprrap_version.txt",
-    ]
-    for path in candidates:
-        text = _read_text_file(path, max_bytes=128)
-        if text:
-            # Pin file may have version on first line + sha256 on second; keep just the version.
-            return text.splitlines()[0].strip()
+    text = _read_text_file(bundle_dir() / "config" / "oem" / "rdprrap_version.txt", max_bytes=128)
+    if text:
+        # Pin file may have version on first line + sha256 on second; keep just the version.
+        return text.splitlines()[0].strip()
     return "(unknown)"
 
 

--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -9,7 +9,7 @@ import tempfile
 from pathlib import Path
 
 from winpodx.core.config import Config
-from winpodx.utils.paths import config_dir
+from winpodx.utils.paths import bundle_dir, config_dir
 
 _COMPOSE_TEMPLATE_BASE = """\
 name: "winpodx"
@@ -82,17 +82,8 @@ def _yaml_escape(val: str) -> str:
 
 
 def _find_oem_dir() -> str:
-    """Return the best available OEM directory path as a string."""
-    candidates = [
-        Path(__file__).parent.parent.parent.parent / "config" / "oem",
-        Path.home() / ".local" / "bin" / "winpodx-app" / "config" / "oem",
-    ]
-    oem_dir = str(candidates[0])
-    for candidate in candidates:
-        if candidate.exists():
-            oem_dir = str(candidate)
-            break
-    return oem_dir
+    """Return the OEM directory path as a string (see :func:`bundle_dir`)."""
+    return str(bundle_dir() / "config" / "oem")
 
 
 def _build_compose_content(cfg: Config) -> str:

--- a/src/winpodx/core/process.py
+++ b/src/winpodx/core/process.py
@@ -16,13 +16,40 @@ from winpodx.utils.paths import runtime_dir
 
 log = logging.getLogger(__name__)
 
+# argv[0] basenames find_freerdp() may launch.
+_FREERDP_ARGV0 = (
+    b"xfreerdp",
+    b"xfreerdp3",
+    b"wlfreerdp",
+    b"wlfreerdp3",
+    b"sdl-freerdp",
+    b"sdl-freerdp3",
+)
+
+
+def _cmdline_is_freerdp(cmdline: bytes) -> bool:
+    """Return True if a ``/proc/<pid>/cmdline`` blob is a FreeRDP client.
+
+    Only argv[0]'s basename (or ``flatpak run com.freerdp.FreeRDP``) counts;
+    a blanket ``b"freerdp" in cmdline`` would adopt unrelated processes that
+    merely mention freerdp in an argument or path.
+    """
+    if not cmdline:
+        return False
+    argv = cmdline.split(b"\0")
+    prog = argv[0].rsplit(b"/", 1)[-1].lower()
+    if prog in _FREERDP_ARGV0:
+        return True
+    if prog == b"flatpak":
+        tail = [a.lower() for a in argv[1:] if a]
+        return b"com.freerdp.freerdp" in tail
+    return False
+
 
 def is_freerdp_pid(pid: int) -> bool:
     """Return True if the given PID is a live FreeRDP process we spawned.
 
-    Single source of truth for PID-reuse detection. Accepts only ``freerdp``
-    or ``xfreerdp`` in the cmdline (our own spawned binaries). Excludes
-    ``winpodx`` because that substring can match unrelated CLI invocations.
+    Single source of truth for PID-reuse detection.
     """
     try:
         os.kill(pid, 0)
@@ -30,11 +57,11 @@ def is_freerdp_pid(pid: int) -> bool:
         return False
 
     try:
-        cmdline = Path(f"/proc/{pid}/cmdline").read_bytes().lower()
+        cmdline = Path(f"/proc/{pid}/cmdline").read_bytes()
     except (OSError, PermissionError):
         return False
 
-    return b"freerdp" in cmdline or b"xfreerdp" in cmdline
+    return _cmdline_is_freerdp(cmdline)
 
 
 @dataclass

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -26,7 +26,10 @@ from winpodx.core.rotation import (  # noqa: F401  re-exports
     _mark_rotation_pending,
     _rotation_marker_path,
 )
-from winpodx.utils.paths import config_dir  # noqa: F401  used by other helpers in this module
+from winpodx.utils.paths import (  # noqa: F401  config_dir used by other helpers in this module
+    bundle_dir,
+    config_dir,
+)
 
 log = logging.getLogger(__name__)
 
@@ -373,27 +376,17 @@ def _apply_vbs_launchers(cfg: Config) -> None:
     if cfg.pod.backend not in ("podman", "docker"):
         return
 
-    from pathlib import Path
-
-    # Locate the source files shipped with this winpodx install. Same
-    # search order as ``_ps_script_path`` and ``_bundled_oem_version``.
-    candidates_root = (
-        Path(__file__).resolve().parent.parent.parent.parent / "config" / "oem",
-        Path.home() / ".local" / "bin" / "winpodx-app" / "config" / "oem",
-    )
+    oem_root = bundle_dir() / "config" / "oem"
     files = ("hidden-launcher.vbs", "launch_uwp.vbs", "launch_uwp.ps1")
     sources: dict[str, str] = {}
     for fname in files:
-        for root in candidates_root:
-            path = root / fname
-            if path.is_file():
-                try:
-                    sources[fname] = path.read_text(encoding="utf-8")
-                except OSError as e:
-                    raise RuntimeError(f"cannot read {path}: {e}") from e
-                break
-        else:
-            raise RuntimeError(f"vbs_launchers source missing: {fname}")
+        path = oem_root / fname
+        if not path.is_file():
+            raise RuntimeError(f"vbs_launchers source missing: {path}")
+        try:
+            sources[fname] = path.read_text(encoding="utf-8")
+        except OSError as e:
+            raise RuntimeError(f"cannot read {path}: {e}") from e
 
     # Build a single PS payload that writes all three files + updates
     # HKCU\Run in one /exec round-trip. Each file body is base64-encoded

--- a/src/winpodx/desktop/icons.py
+++ b/src/winpodx/desktop/icons.py
@@ -5,22 +5,16 @@ from __future__ import annotations
 import logging
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
-from winpodx.utils.paths import icons_dir
+from winpodx.utils.paths import bundle_dir, icons_dir
 
 log = logging.getLogger(__name__)
 
 
 def bundled_data_path(*parts: str) -> Path | None:
-    """Resolve a file under data/ across source, wheel, and user install layouts."""
-    candidates = [
-        Path(__file__).resolve().parent.parent.parent.parent / "data",
-        Path(sys.prefix) / "share" / "winpodx" / "data",
-        Path.home() / ".local" / "share" / "winpodx" / "data",
-    ]
-    for base in candidates:
+    """Resolve a file under the bundled ``data/`` tree."""
+    for base in (bundle_dir() / "data",):
         candidate = base.joinpath(*parts)
         if not candidate.exists():
             continue

--- a/src/winpodx/gui/main_window.py
+++ b/src/winpodx/gui/main_window.py
@@ -60,6 +60,7 @@ from winpodx.gui.theme import (
     accent_color,
     avatar_color,
 )
+from winpodx.utils.paths import bundle_dir
 
 log = logging.getLogger(__name__)
 
@@ -2499,19 +2500,8 @@ class WinpodxWindow(QMainWindow):
             from winpodx.core.windows_exec import WindowsExecError, run_via_transport
 
             cfg = Config.load()
-            base = Path(__file__).parent.parent.parent.parent
-            candidates = [
-                base / "scripts" / "windows" / "debloat.ps1",
-                Path.home()
-                / ".local"
-                / "bin"
-                / "winpodx-app"
-                / "scripts"
-                / "windows"
-                / "debloat.ps1",
-            ]
-            script = next((p for p in candidates if p.exists()), None)
-            if script is None:
+            script = bundle_dir() / "scripts" / "windows" / "debloat.ps1"
+            if not script.exists():
                 self.app_launch_failed.emit("Debloat script not found")
                 return
 

--- a/src/winpodx/utils/paths.py
+++ b/src/winpodx/utils/paths.py
@@ -3,9 +3,44 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
 APP_NAME = "winpodx"
+
+# Directories shipped at the repo/bundle root (next to ``src/``) that the
+# runtime needs to locate regardless of install mode.
+_BUNDLE_MARKERS = ("scripts", "config", "data")
+
+
+def bundle_dir() -> Path:
+    """Return the directory containing ``scripts/``, ``config/`` and ``data/``.
+
+    Several call sites previously hand-rolled ``__file__.parent.parent...``
+    chains with inconsistent fallbacks, which broke for any install that
+    doesn't preserve the repo layout (wheel, Nix, distro package). This is
+    the single resolution point; search order:
+
+      1. ``$WINPODX_BUNDLE_DIR`` -- set by packaging wrappers (Nix flake).
+      2. Source checkout -- ``<repo>/`` derived from this file's location.
+      3. ``sys.prefix/share/winpodx`` -- FHS-style install (wheel, distro).
+      4. ``~/.local/bin/winpodx-app`` -- curl|bash installer drop location.
+
+    Falls back to the source-checkout guess so callers get a stable path for
+    error messages even when nothing exists.
+    """
+    env = os.environ.get("WINPODX_BUNDLE_DIR")
+    src_guess = Path(__file__).resolve().parents[3]
+    candidates = [
+        Path(env) if env else None,
+        src_guess,
+        Path(sys.prefix) / "share" / APP_NAME,
+        Path.home() / ".local" / "bin" / "winpodx-app",
+    ]
+    for c in candidates:
+        if c is not None and any((c / m).is_dir() for m in _BUNDLE_MARKERS):
+            return c
+    return src_guess
 
 
 def config_dir() -> Path:

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -180,27 +180,8 @@ def test_bundled_data_path_source_layout():
     assert path.name == "winpodx-icon.svg"
 
 
-def test_bundled_data_path_missing_returns_none(monkeypatch, tmp_path):
-    # When all candidate locations miss, returns None (no exception).
-    monkeypatch.setattr("sys.prefix", str(tmp_path))
-    monkeypatch.setenv("HOME", str(tmp_path))
-    result = bundled_data_path("does-not-exist-" + "x" * 20 + ".svg")
-    assert result is None
-
-
-def test_bundled_data_path_falls_back_to_sys_prefix(monkeypatch, tmp_path):
-    # If source layout misses, sys.prefix/share/winpodx/data is searched.
-    prefix = tmp_path / "prefix"
-    share = prefix / "share" / "winpodx" / "data"
-    share.mkdir(parents=True)
-    fake_icon = share / "fake-wheel-asset.svg"
-    fake_icon.write_text("<svg/>", encoding="utf-8")
-
-    monkeypatch.setattr("sys.prefix", str(prefix))
-    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
-
-    resolved = bundled_data_path("fake-wheel-asset.svg")
-    assert resolved == fake_icon
+def test_bundled_data_path_missing_returns_none():
+    assert bundled_data_path("does-not-exist-" + "x" * 20 + ".svg") is None
 
 
 # Audit Issue 12: update_icon_cache must enforce timeout
@@ -391,21 +372,11 @@ def test_bundled_data_path_rejects_symlink_escape(tmp_path, monkeypatch):
     secret = tmp_path / "secret.txt"
     secret.write_text("TOP SECRET", encoding="utf-8")
 
-    home = tmp_path / "home"
-    data = home / ".local" / "share" / "winpodx" / "data"
+    data = tmp_path / "bundle" / "data"
     data.mkdir(parents=True)
-    malicious = data / "winpodx-icon.svg"
-    malicious.symlink_to(secret)
+    (data / "winpodx-icon.svg").symlink_to(secret)
 
-    empty_prefix = tmp_path / "empty-prefix"
-    empty_prefix.mkdir()
-    monkeypatch.setattr("sys.prefix", str(empty_prefix))
-    monkeypatch.setenv("HOME", str(home))
-    monkeypatch.setattr(
-        icons_mod,
-        "__file__",
-        str(empty_prefix / "unused" / "a" / "b" / "c.py"),
-    )
+    monkeypatch.setattr(icons_mod, "bundle_dir", lambda: tmp_path / "bundle")
 
     result = icons_mod.bundled_data_path("winpodx-icon.svg")
     assert result is None, "symlink escape must be rejected, got %r" % (result,)
@@ -435,20 +406,11 @@ def test_bundled_data_path_accepts_regular_file(tmp_path, monkeypatch):
     # Regression: ordinary files in the data dir still work.
     from winpodx.desktop import icons as icons_mod
 
-    home = tmp_path / "home"
-    data = home / ".local" / "share" / "winpodx" / "data"
+    data = tmp_path / "bundle" / "data"
     data.mkdir(parents=True)
     (data / "winpodx-icon.svg").write_text("<svg/>", encoding="utf-8")
 
-    empty_prefix = tmp_path / "empty-prefix"
-    empty_prefix.mkdir()
-    monkeypatch.setattr("sys.prefix", str(empty_prefix))
-    monkeypatch.setenv("HOME", str(home))
-    monkeypatch.setattr(
-        icons_mod,
-        "__file__",
-        str(empty_prefix / "unused" / "a" / "b" / "c.py"),
-    )
+    monkeypatch.setattr(icons_mod, "bundle_dir", lambda: tmp_path / "bundle")
 
     result = icons_mod.bundled_data_path("winpodx-icon.svg")
     assert result is not None

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -82,10 +82,7 @@ def test_bundled_oem_version_falls_back_to_unknown(monkeypatch, tmp_path):
     version.
     """
     monkeypatch.setattr("winpodx.core.info._read_text_file", lambda *a, **k: None)
-    # Redirect __file__'s parent walk to a tmp path so install.bat candidates
-    # don't resolve to the real repo file.
-    monkeypatch.setattr("winpodx.core.info.Path.home", staticmethod(lambda: tmp_path))
-    monkeypatch.setattr("winpodx.core.info.__file__", str(tmp_path / "info.py"), raising=False)
+    monkeypatch.setattr("winpodx.core.info.bundle_dir", lambda: tmp_path)
     assert _bundled_oem_version() == "(unknown)"
 
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,6 +1,6 @@
 """Tests for XDG path management."""
 
-from winpodx.utils.paths import applications_dir, config_dir, data_dir
+from winpodx.utils.paths import applications_dir, bundle_dir, config_dir, data_dir
 
 
 def test_config_dir(monkeypatch):
@@ -16,3 +16,16 @@ def test_data_dir(monkeypatch):
 def test_applications_dir(monkeypatch):
     monkeypatch.setenv("XDG_DATA_HOME", "/tmp/test-data")
     assert str(applications_dir()) == "/tmp/test-data/applications"
+
+
+class TestBundleDir:
+    def test_env_var_wins(self, tmp_path, monkeypatch):
+        (tmp_path / "scripts").mkdir()
+        monkeypatch.setenv("WINPODX_BUNDLE_DIR", str(tmp_path))
+        assert bundle_dir() == tmp_path
+
+    def test_resolves_shipped_scripts(self):
+        # Source checkout (parents[3]) or packager-set $WINPODX_BUNDLE_DIR --
+        # either way the discover script must be reachable.
+        result = bundle_dir()
+        assert (result / "scripts" / "windows" / "discover_apps.ps1").exists()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -4,7 +4,29 @@ from __future__ import annotations
 
 import os
 
-from winpodx.core.process import TrackedProcess, kill_session, list_active_sessions
+from winpodx.core.process import (
+    TrackedProcess,
+    _cmdline_is_freerdp,
+    kill_session,
+    list_active_sessions,
+)
+
+
+class TestCmdlineIsFreerdp:
+    def test_argv0_xfreerdp(self):
+        assert _cmdline_is_freerdp(b"/usr/bin/xfreerdp3\0/v:host\0")
+
+    def test_argv0_flatpak_freerdp(self):
+        assert _cmdline_is_freerdp(b"flatpak\0run\0com.freerdp.FreeRDP\0/v:host\0")
+
+    def test_freerdp_only_in_later_argv_rejected(self):
+        # Regression: "freerdp" in a later arg must not match.
+        assert not _cmdline_is_freerdp(
+            b"/usr/bin/python3\0-m\0pytest\0--deselect=test_freerdp_pid\0"
+        )
+
+    def test_freerdp_only_in_argv0_path_component_rejected(self):
+        assert not _cmdline_is_freerdp(b"/home/user/freerdp-notes/run.sh\0")
 
 
 class TestTrackedProcess:

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -50,33 +50,20 @@ def test_find_existing_session_rejects_non_freerdp_pid(tmp_path, monkeypatch):
     # A non-freerdp process with 'winpodx' in its cmdline must not look like a live RDP session.
     import shutil
     import subprocess
-    import time
-    from pathlib import Path
 
     from winpodx.core.rdp import _find_existing_session
 
     monkeypatch.setattr("winpodx.core.rdp.runtime_dir", lambda: tmp_path)
     monkeypatch.setattr("winpodx.core.process.runtime_dir", lambda: tmp_path)
 
-    bash = shutil.which("bash")
-    if bash is None:  # pragma: no cover - bash is standard on target distros
-        pytest.skip("bash not available for argv0 spoofing")
+    sleep = shutil.which("sleep")
+    if sleep is None:  # pragma: no cover
+        pytest.skip("sleep not available")
 
-    child = subprocess.Popen(  # noqa: S603
-        [bash, "-c", "exec -a winpodx-app-list sleep 30"],
-    )
+    # Any live process whose argv[0] is not a FreeRDP binary must be rejected
+    # and its stale .cproc marker reaped (PID-reuse guard).
+    child = subprocess.Popen([sleep, "30"])  # noqa: S603
     try:
-        proc_cmdline = Path(f"/proc/{child.pid}/cmdline")
-        for _ in range(40):
-            try:
-                if b"winpodx" in proc_cmdline.read_bytes().lower():
-                    break
-            except OSError:
-                pass
-            time.sleep(0.05)
-        else:
-            pytest.fail("child process did not expose 'winpodx' in cmdline")
-
         pidfile = tmp_path / "notepad.cproc"
         pidfile.write_text(str(child.pid))
 

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -121,7 +121,8 @@ def test_is_freerdp_pid_helper_accepts_freerdp_only():
     with (
         patch("winpodx.core.process.os.kill", return_value=None),
         patch(
-            "winpodx.core.process.Path", side_effect=fake_path_factory(b"/usr/bin/winpodx app list")
+            "winpodx.core.process.Path",
+            side_effect=fake_path_factory(b"/usr/bin/winpodx\0app\0list\0"),
         ),
     ):
         assert proc_mod.is_freerdp_pid(12345) is False
@@ -130,7 +131,7 @@ def test_is_freerdp_pid_helper_accepts_freerdp_only():
         patch("winpodx.core.process.os.kill", return_value=None),
         patch(
             "winpodx.core.process.Path",
-            side_effect=fake_path_factory(b"/usr/bin/xfreerdp3 /v:127.0.0.1"),
+            side_effect=fake_path_factory(b"/usr/bin/xfreerdp3\0/v:127.0.0.1\0"),
         ),
     ):
         assert proc_mod.is_freerdp_pid(12345) is True


### PR DESCRIPTION
> **Stacked on #63** — review only the last 3 commits. Diff shrinks once #63 merges.

## Summary

Nix packaging plus the resource-lookup refactor it requires.

## Changes

- flake.nix: `nix run github:kernalix7/winpodx`; the wrapper bundles FreeRDP, iproute2, libnotify and podman. A devShell exposes the same runtime tools with src/ on PYTHONPATH. README (en/ko) gains a Nix install section.
- paths.bundle_dir(): single resolver for the shipped scripts/, config/oem/ and data/ trees (env var > source tree > sys.prefix/share/winpodx > ~/.local/bin/winpodx-app). Seven call sites previously hand-rolled __file__.parent… walks that break for any installed wheel — discovery script not found, compose bind-mounts an empty /oem, icons missing. The flake ships those trees under share/winpodx and points the wrapper at them.

## Checklist

- [x] pytest: all tests pass
- [x] ruff check: zero errors
- [x] ruff format: formatted
- [ ] Documentation updated (CHANGELOG, docs: both ko & en)
- [x] No hardcoded paths, credentials, or personal info