### PR TITLE
chore: PR #65 follow-ups — dynamic flake version + flatten info.py loop

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,12 @@
         "aarch64-linux"
       ];
       forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+
+      # Single source of truth for the package version. Reading from
+      # pyproject.toml at evaluation time keeps the Nix store path
+      # (winpodx-<version>) in sync with the Python distribution version
+      # automatically — no need to bump two files at release time.
+      pyprojectVersion = (builtins.fromTOML (builtins.readFile ./pyproject.toml)).project.version;
     in
     {
       packages = forAllSystems (
@@ -35,7 +41,7 @@
 
           winpodx = python.pkgs.buildPythonApplication {
             pname = "winpodx";
-            version = "0.3.0";
+            version = pyprojectVersion;
             pyproject = true;
 
             src = lib.cleanSource ./.;

--- a/src/winpodx/core/info.py
+++ b/src/winpodx/core/info.py
@@ -58,19 +58,19 @@ def _bundled_oem_version() -> str:
     if text:
         return text
 
-    for path in (oem / "install.bat",):
-        try:
-            with path.open("r", encoding="utf-8", errors="replace") as fh:
-                # The version line lives in the first ~5 lines of install.bat;
-                # cap iteration so we never scan the whole file.
-                for _, line in zip(range(20), fh):
-                    stripped = line.strip()
-                    if stripped.lower().startswith("set winpodx_oem_version="):
-                        value = stripped.split("=", 1)[1].strip()
-                        if value:
-                            return value
-        except (FileNotFoundError, OSError):
-            continue
+    install_bat = oem / "install.bat"
+    try:
+        with install_bat.open("r", encoding="utf-8", errors="replace") as fh:
+            # The version line lives in the first ~5 lines of install.bat;
+            # cap iteration so we never scan the whole file.
+            for _, line in zip(range(20), fh):
+                stripped = line.strip()
+                if stripped.lower().startswith("set winpodx_oem_version="):
+                    value = stripped.split("=", 1)[1].strip()
+                    if value:
+                        return value
+    except (FileNotFoundError, OSError):
+        pass
     return "(unknown)"
 
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -110,6 +110,15 @@ def test_sync_windows_time_uses_windows_exec_channel(monkeypatch):
         captured["description"] = description
         return WindowsExecResult(rc=0, stdout="time synced", stderr="")
 
+    # Force the FreeRDP fallback path so the run_in_windows stub is reachable.
+    # On a dev box where a real winpodx agent is listening on 127.0.0.1:8765,
+    # transport.dispatch picks AgentTransport and bypasses run_in_windows;
+    # making dispatch raise routes the call through the FreeRDP branch
+    # exactly as run_via_transport's contract documents.
+    def _no_agent(_cfg, **_kw):
+        raise RuntimeError("agent transport disabled for tests")
+
+    monkeypatch.setattr("winpodx.core.transport.dispatch", _no_agent)
     monkeypatch.setattr("winpodx.core.windows_exec.run_in_windows", fake)
     assert sync_windows_time(cfg) is True
     assert "w32tm" in captured["payload"]


### PR DESCRIPTION
Closes the two open items from the PR #65 review (memory: project_pr65_followups.md):

1. flake.nix version reads from pyproject.toml via builtins.fromTOML — no more dual-bump at release time.
2. core/info.py drops the vestigial single-element tuple loop in _bundled_oem_version.

Bonus: test_daemon's sync-time test was also failing on dev boxes because the daemon migrated to run_via_transport and the test only mocks run_in_windows; same dispatch-disable monkeypatch fix used for the discovery + migrate paths.