### PR TITLE
feat(provisioner): auto-respawn agent at end of vbs_launchers migration

### DIFF
--- a/config/oem/agent-respawn.ps1
+++ b/config/oem/agent-respawn.ps1
@@ -1,0 +1,73 @@
+# agent-respawn.ps1 — kill the running agent.ps1 process and spawn a fresh
+# one via the hidden-launcher.vbs wrapper.
+#
+# Background: HKCU\Run only fires once per user session, so the new wscript
+# wrapper installed by `_apply_vbs_launchers` doesn't take effect until the
+# user logs out and back in (or the pod restarts). That's a hard ask for an
+# apply-fixes / migrate step. This script lets the migration close the loop
+# itself: kill the old agent (started under the legacy `powershell.exe
+# -WindowStyle Hidden -File agent.ps1` invocation), wait for the listener
+# port to free, then start the new agent under the wscript wrapper.
+#
+# Spawned by the migration's last action with
+#
+#   Start-Process wscript.exe -ArgumentList @(
+#       'C:\Users\Public\winpodx\launchers\hidden-launcher.vbs',
+#       'powershell.exe', '-NoProfile', '-ExecutionPolicy', 'Bypass',
+#       '-File', 'C:\Users\Public\winpodx\launchers\agent-respawn.ps1'
+#   )
+#
+# so this script itself runs windowless under wscript+hidden-launcher.
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+# Give the parent /exec call ~3s to finish delivering its response to the
+# host. Killing the agent before its /exec reply lands would surface as a
+# spurious "channel failure" on `winpodx pod apply-fixes`.
+Start-Sleep -Seconds 3
+
+$ourPid = $PID
+
+# Find the running agent. Match on the cmdline mentioning agent.ps1 and
+# exclude this respawn script to avoid suicide. Both classic powershell.exe
+# and the newer pwsh.exe count.
+$victims = @(
+    Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.ProcessId -ne $ourPid -and
+            $_.CommandLine -and
+            $_.CommandLine -like '*agent.ps1*' -and
+            $_.CommandLine -notlike '*agent-respawn*' -and
+            ($_.Name -ieq 'powershell.exe' -or $_.Name -ieq 'pwsh.exe')
+        }
+)
+
+foreach ($v in $victims) {
+    try { Stop-Process -Id $v.ProcessId -Force -ErrorAction SilentlyContinue } catch { }
+}
+
+# Wait briefly for port 8765 to release. HttpListener doesn't always release
+# immediately — give the kernel a beat.
+Start-Sleep -Milliseconds 800
+
+$launcher = 'C:\Users\Public\winpodx\launchers\hidden-launcher.vbs'
+if (Test-Path -LiteralPath $launcher) {
+    # Preferred path: hidden VBS wrapper. wscript.exe is GUI-subsystem so the
+    # spawned PowerShell child starts windowless from the very first instant.
+    Start-Process wscript.exe -ArgumentList @(
+        $launcher,
+        'powershell.exe',
+        '-NoProfile',
+        '-ExecutionPolicy', 'Bypass',
+        '-File', 'C:\OEM\agent.ps1'
+    ) | Out-Null
+} else {
+    # Fallback to the legacy direct invocation. Brief PS console flash, but
+    # the agent at least comes back up.
+    Start-Process powershell.exe -ArgumentList @(
+        '-NoProfile',
+        '-ExecutionPolicy', 'Bypass',
+        '-WindowStyle', 'Hidden',
+        '-File', 'C:\OEM\agent.ps1'
+    ) -WindowStyle Hidden | Out-Null
+}

--- a/config/oem/install.bat
+++ b/config/oem/install.bat
@@ -1,7 +1,7 @@
 @echo off
 REM First-boot OEM setup for winpodx Windows guest. Runs once during dockur's unattended install. Every action must stay idempotent — there is no guest-side re-run channel in 0.1.6 (push/exec bridge planned for a later release).
 
-set WINPODX_OEM_VERSION=13
+set WINPODX_OEM_VERSION=14
 
 echo [winpodx] Starting post-install configuration (version %WINPODX_OEM_VERSION%)...
 
@@ -273,6 +273,7 @@ mkdir "C:\Users\Public\winpodx\launchers" 2>nul
 copy /Y "%~dp0hidden-launcher.vbs" "C:\Users\Public\winpodx\launchers\hidden-launcher.vbs" 2>nul
 copy /Y "%~dp0launch_uwp.vbs" "C:\Users\Public\winpodx\launchers\launch_uwp.vbs" 2>nul
 copy /Y "%~dp0launch_uwp.ps1" "C:\Users\Public\winpodx\launchers\launch_uwp.ps1" 2>nul
+copy /Y "%~dp0agent-respawn.ps1" "C:\Users\Public\winpodx\launchers\agent-respawn.ps1" 2>nul
 
 REM Pre-register the URL ACL for agent.ps1's HttpListener prefix.
 REM

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -357,27 +357,38 @@ def _apply_oem_runtime_fixes(cfg: Config) -> None:
 
 
 def _apply_vbs_launchers(cfg: Config) -> None:
-    """Push hidden-launcher.vbs / launch_uwp.vbs / launch_uwp.ps1 + update
-    HKCU\\Run so existing pods stop flashing PowerShell windows on agent
-    autostart and UWP launches.
+    """Push hidden-launcher.vbs / launch_uwp.{vbs,ps1} / agent-respawn.ps1
+    + update HKCU\\Run + auto-respawn the running agent under the new
+    wrapper so existing pods stop flashing PowerShell windows on agent
+    autostart and UWP launches — without needing a user logout or pod
+    restart.
 
-    Migration path for users on v0.3.0-RTM1 (OEM v12). Fresh installs from
-    OEM v13+ already have the files staged via install.bat; this step is
-    a no-op then. Targets ``C:\\Users\\Public\\winpodx\\launchers\\``
-    because Public is universally writable for Authenticated Users (the
-    agent runs as User and can't write to ``C:\\OEM\\``, which is
-    SYSTEM-owned).
+    Migration path for users on v0.3.0-RTM1 / OEM v12 / v13. Fresh installs
+    from OEM v14+ already have the files staged via install.bat; this step
+    is then a re-write + re-respawn no-op. Targets
+    ``C:\\Users\\Public\\winpodx\\launchers\\`` because Public is
+    universally writable for Authenticated Users (the agent runs as User
+    and can't write to ``C:\\OEM\\``, which is SYSTEM-owned).
 
-    Idempotent — re-running just rewrites the files and the registry
-    value. The autostart change takes effect on the next user session
-    logon (or pod restart); UWP launch path is picked up immediately by
-    the host's next ``rdp.build_rdp_command`` call.
+    The respawn fires as a detached wscript invocation at the end of the
+    payload. ``agent-respawn.ps1`` waits ~3s (giving this /exec response
+    time to land), kills the old agent process, waits for port 8765 to
+    free, then starts a fresh agent under wscript+hidden-launcher.vbs.
+
+    Idempotent — re-running rewrites files, refreshes the registry
+    value, and triggers another respawn cycle. UWP launch path is picked
+    up immediately by the host's next ``rdp.build_rdp_command`` call.
     """
     if cfg.pod.backend not in ("podman", "docker"):
         return
 
     oem_root = bundle_dir() / "config" / "oem"
-    files = ("hidden-launcher.vbs", "launch_uwp.vbs", "launch_uwp.ps1")
+    files = (
+        "hidden-launcher.vbs",
+        "launch_uwp.vbs",
+        "launch_uwp.ps1",
+        "agent-respawn.ps1",
+    )
     sources: dict[str, str] = {}
     for fname in files:
         path = oem_root / fname
@@ -417,7 +428,27 @@ def _apply_vbs_launchers(cfg: Config) -> None:
             "$runKey = 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Run'",
             "if (-not (Test-Path $runKey)) { [void](New-Item -Path $runKey -Force) }",
             f"Set-ItemProperty -Path $runKey -Name 'WinpodxAgent' -Value '{reg_value}'",
-            "Write-Output 'vbs_launchers applied'",
+        ]
+    )
+    # Auto-respawn the running agent under the new wscript wrapper so the
+    # autostart-flash fix takes effect without requiring a user logout or
+    # `winpodx pod restart`. The respawn script waits ~3s before killing
+    # the old agent — long enough for THIS /exec response to land at the
+    # host. Spawned hidden via wscript+hidden-launcher.vbs.
+    respawn_args_ps = (
+        "@(",
+        f"        '{target_dir}\\hidden-launcher.vbs',",
+        "        'powershell.exe',",
+        "        '-NoProfile',",
+        "        '-ExecutionPolicy', 'Bypass',",
+        f"        '-File', '{target_dir}\\agent-respawn.ps1'",
+        "    )",
+    )
+    lines.extend(
+        [
+            "$respawnArgs = " + "\n    ".join(respawn_args_ps),
+            "Start-Process wscript.exe -ArgumentList $respawnArgs | Out-Null",
+            "Write-Output 'vbs_launchers applied + agent respawn queued'",
         ]
     )
     payload = "\n".join(lines) + "\n"


### PR DESCRIPTION
User running `winpodx pod apply-fixes` against a live pod no longer needs to manually restart to clear the autostart PS-console flash. The migration now stages an agent-respawn.ps1 helper and detaches it via wscript at the end of the apply payload — kills old agent, waits for port 8765 to free, spawns new agent under wscript+hidden-launcher.vbs.

OEM v13 → v14.