### PR TITLE
fix(rdprrap): include C:\\winpodx\\rdprrap path in conf candidates

### DIFF
--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -277,6 +277,11 @@ def _multi_session(action: str) -> None:
     # rdprrap-conf paths to try, in order. Different OEM versions /
     # extraction layouts have placed it differently.
     candidates = [
+        # install.bat extracts rdprrap into C:\winpodx\rdprrap — the actual
+        # location where rdprrap-conf.exe lives on every install. The
+        # OEM / Program Files candidates stay as legacy fallbacks for
+        # users on older OEM builds that placed it differently.
+        r"C:\winpodx\rdprrap\rdprrap-conf.exe",
         r"C:\OEM\rdprrap\rdprrap-conf.exe",
         r"C:\OEM\rdprrap-conf.exe",
         r"C:\Program Files\rdprrap\rdprrap-conf.exe",

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -232,6 +232,14 @@ def _apply_multi_session(cfg: Config) -> None:
         return
 
     candidates = [
+        # install.bat extracts rdprrap into RDPRRAP_DIR=C:\winpodx\rdprrap;
+        # this is where rdprrap-conf.exe actually lives on every fresh
+        # install. Earlier candidates kept the OEM/Program Files paths in
+        # case an older OEM build dropped it elsewhere, but the C:\winpodx\
+        # path is the one that matches install.bat — without it the apply
+        # always logged "rdprrap-conf not found" and the zombie-session
+        # dialog kept reappearing because multi-session never enabled.
+        r"C:\winpodx\rdprrap\rdprrap-conf.exe",
         r"C:\OEM\rdprrap\rdprrap-conf.exe",
         r"C:\OEM\rdprrap-conf.exe",
         r"C:\Program Files\rdprrap\rdprrap-conf.exe",


### PR DESCRIPTION
Root cause for the persistent 'Select a session to reconnect to' zombie-session dialog on fresh installs. install.bat extracts rdprrap to C:\\winpodx\\rdprrap but the apply step's candidate paths only look at C:\\OEM and C:\\Program Files.