### PR TITLE
fix(ps): ASCII-only in PS scripts; em-dash in string literal broke parser

### DIFF
--- a/config/oem/agent-respawn.ps1
+++ b/config/oem/agent-respawn.ps1
@@ -1,4 +1,4 @@
-# agent-respawn.ps1 — kill the running agent.ps1 process and spawn a fresh
+# agent-respawn.ps1 -- kill the running agent.ps1 process and spawn a fresh
 # one via the hidden-launcher.vbs wrapper.
 #
 # Background: HKCU\Run only fires once per user session, so the new wscript
@@ -47,7 +47,7 @@ foreach ($v in $victims) {
 }
 
 # Wait briefly for port 8765 to release. HttpListener doesn't always release
-# immediately — give the kernel a beat.
+# immediately -- give the kernel a beat.
 Start-Sleep -Milliseconds 800
 
 $launcher = 'C:\Users\Public\winpodx\launchers\hidden-launcher.vbs'

--- a/config/oem/agent/agent.ps1
+++ b/config/oem/agent/agent.ps1
@@ -1,12 +1,12 @@
 # =====================================================================
-# winpodx guest agent (Phase 2) — /health + bearer-auth /exec
+# winpodx guest agent (Phase 2) -- /health + bearer-auth /exec
 # =====================================================================
 #
 # Purpose
 # -------
 # HTTP server inside the Windows guest. Phase 1 shipped the bare
 # /health readiness probe. Phase 2 adds bearer-auth and a POST /exec
-# endpoint that runs base64-encoded PowerShell snippets — replacing
+# endpoint that runs base64-encoded PowerShell snippets -- replacing
 # FreeRDP RemoteApp PowerShell calls for non-sensitive host -> guest
 # traffic so the host can stop emitting visible PS-window flashes for
 # every registry tweak / discovery roundtrip.
@@ -15,10 +15,10 @@
 # ----------
 #   * Bind: ``http://+:8765/`` (all interfaces inside the Windows VM).
 #     QEMU's user-mode NAT forwards from the container to the VM's
-#     slirp interface (10.0.2.15:8765, NOT 127.0.0.1:8765 — slirp
+#     slirp interface (10.0.2.15:8765, NOT 127.0.0.1:8765 -- slirp
 #     hostfwd targets the VM's main NIC, not loopback). Binding only
 #     to 127.0.0.1 inside Windows would mean slirp's forwarded packets
-#     hit a closed port — kernalix7 saw "Connection reset by peer" on
+#     hit a closed port -- kernalix7 saw "Connection reset by peer" on
 #     2026-04-30 from exactly this. Binding to ``+`` covers all
 #     interfaces. The agent is still externally unreachable: compose's
 #     ``127.0.0.1:8765:8765/tcp`` mapping is loopback-only on the host,
@@ -33,7 +33,7 @@
 #     process and HKCU\Run does not auto-restart.
 #   * The token is never logged or echoed back. /exec script content
 #     lands in C:\OEM\agent.log only as a SHA256 hash, never the raw
-#     payload — sensitive payloads (registry keys, credentials touched
+#     payload -- sensitive payloads (registry keys, credentials touched
 #     by self-heal) must not survive in the log.
 # =====================================================================
 
@@ -95,7 +95,7 @@ function Compare-Constant([string]$a, [string]$b) {
 
 # Read the Authorization header off an HttpListener request, strip the
 # "Bearer " prefix, and constant-time compare against $script:Token.
-# Returns $true / $false — never throws, never logs the supplied value.
+# Returns $true / $false -- never throws, never logs the supplied value.
 function Test-Auth($req) {
     $h = $req.Headers['Authorization']
     if (-not $h) { return $false }
@@ -109,7 +109,7 @@ function Read-Body($req) {
     try { return $sr.ReadToEnd() } finally { $sr.Dispose() }
 }
 
-# SHA256 hex of arbitrary bytes — used to log a fingerprint of /exec
+# SHA256 hex of arbitrary bytes -- used to log a fingerprint of /exec
 # script payloads without spilling the script itself into agent.log.
 function Get-BytesHash([byte[]]$bytes) {
     $sha = [System.Security.Cryptography.SHA256]::Create()
@@ -161,7 +161,7 @@ function Invoke-ExecScript([string]$scriptB64, [int]$timeoutSec) {
         # Spawn the child via [Diagnostics.Process] + ProcessStartInfo with
         # CreateNoWindow=$true. Start-Process -NoNewWindow re-opens a console
         # for the child when the parent (agent.ps1) was launched with
-        # -WindowStyle Hidden — kernalix7 saw flashing PS windows on every
+        # -WindowStyle Hidden -- kernalix7 saw flashing PS windows on every
         # /exec call on 2026-04-30. CreateNoWindow + UseShellExecute=$false
         # is the canonical "run windowless and capture stdio" combination.
         $proc = $null
@@ -195,7 +195,7 @@ function Invoke-ExecScript([string]$scriptB64, [int]$timeoutSec) {
             # Start-Process -PassThru can leave ExitCode as $null even after
             # WaitForExit() returns true (Windows quirk: handle isn't kept open
             # for fast-exiting children unless the StartInfo enables it). The
-            # process did terminate cleanly, so treat null as 0 — and never
+            # process did terminate cleanly, so treat null as 0 -- and never
             # emit a non-int rc, since the host AgentClient parses it as int.
             $exitCode = $proc.ExitCode
             if ($null -eq $exitCode) { $rc = 0 } else { $rc = [int]$exitCode }
@@ -235,7 +235,7 @@ try {
     # because it conflicts with an existing registration on the machine"
     # when the URL ACL is owned by a different user (stale registration
     # from a previous install / different SDDL). install.bat pre-registers
-    # the URL ACL with user=Everyone for exactly this reason — but if
+    # the URL ACL with user=Everyone for exactly this reason -- but if
     # someone deleted that or the install.bat block didn't run, we want
     # the failure visible in agent.log instead of a silent process exit.
     $err = "HttpListener.Start() failed: $($_.Exception.Message)"

--- a/config/oem/launch_uwp.ps1
+++ b/config/oem/launch_uwp.ps1
@@ -1,8 +1,8 @@
-# launch_uwp.ps1 — activate a UWP/MSIX app by AUMID via COM, no explorer.exe
+# launch_uwp.ps1 -- activate a UWP/MSIX app by AUMID via COM, no explorer.exe
 #
 # The default RemoteApp UWP launch (`explorer.exe shell:AppsFolder\<AUMID>`)
 # briefly shows an explorer.exe RemoteApp window before dispatching to the
-# UWP frame — that's the "PowerShell-looking flash" users see when launching
+# UWP frame -- that's the "PowerShell-looking flash" users see when launching
 # Calculator / Settings / Terminal et al. Calling IApplicationActivationManager
 # directly skips the explorer transition: the UWP frame appears immediately
 # without an intermediate window.
@@ -19,7 +19,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# IApplicationActivationManager — Windows shell COM interface for launching
+# IApplicationActivationManager -- Windows shell COM interface for launching
 # packaged apps by AUMID. Documented in MSDN; available since Windows 8.
 #
 # Why a C# helper instead of calling the COM object directly from PowerShell:
@@ -77,7 +77,7 @@ try {
     [void][WinpodxUwpLauncher]::Activate($Aumid)
     exit 0
 } catch {
-    # Don't surface to the user with a console — write to a log the agent can
+    # Don't surface to the user with a console -- write to a log the agent can
     # tail. Swallowing keeps RemoteApp's "session ended" return code clean
     # rather than dumping an uncaught .NET stack on the silent path.
     try {

--- a/config/oem/rdprrap-activate.ps1
+++ b/config/oem/rdprrap-activate.ps1
@@ -1,4 +1,4 @@
-# rdprrap-activate.ps1 — single source of truth for rdprrap activation,
+# rdprrap-activate.ps1 -- single source of truth for rdprrap activation,
 # usable both at OEM Sysprep time (synchronous from install.bat) and at
 # runtime (detached from `winpodx pod multi-session on`).
 #
@@ -12,19 +12,19 @@
 #
 # 1) OEM time (install.bat, console session):
 #    powershell -NoProfile -ExecutionPolicy Bypass -File rdprrap-activate.ps1
-#    → no -Detached: skips the 2s parent-response wait, runs
+#    -> no -Detached: skips the 2s parent-response wait, runs
 #      synchronously, exits with the activation rc so install.bat can
-#      branch on it. TermService cycle is safe — install.bat runs from
+#      branch on it. TermService cycle is safe -- install.bat runs from
 #      FirstLogonCommands in the local console session and TermService
 #      only manages RDP sessions, so the cycle doesn't tear down our
 #      cmd.exe parent.
 #
 # 2) Runtime (cli.pod multi-session on, agent's user session):
 #    wscript.exe hidden-launcher.vbs powershell.exe ... -Detached
-#    → -Detached: sleeps 2s before any work so the parent /exec
+#    -> -Detached: sleeps 2s before any work so the parent /exec
 #      response can land at the host before TermService restart kills
 #      the agent's RDP session. Subsequent run via HKCU\Run reads the
-#      .activation_status marker — same marker install.bat writes — so
+#      .activation_status marker -- same marker install.bat writes -- so
 #      `winpodx pod multi-session status` and `apply-fixes` report
 #      OEM-time and runtime activations through one surface.
 #
@@ -37,7 +37,7 @@ param(
     [switch]$Detached
 )
 
-# Default ErrorActionPreference ('Continue') — errors surface to the
+# Default ErrorActionPreference ('Continue') -- errors surface to the
 # log instead of being silently swallowed. The few calls that genuinely
 # tolerate failure (registry probes, log writes) opt in to
 # -ErrorAction SilentlyContinue locally.
@@ -62,7 +62,7 @@ function Set-Status([string]$value) {
 # Detached mode (runtime via /exec): give the parent call ~2s to land
 # its response at the host before we trigger TermService cycle that
 # kills the agent's session. Synchronous mode (OEM install.bat): no
-# such caller — skip the wait.
+# such caller -- skip the wait.
 if ($Detached) {
     Start-Sleep -Seconds 2
     Append-Log '=== runtime rdprrap activation triggered (detached) ==='
@@ -72,14 +72,14 @@ if ($Detached) {
 
 # Extract the bundled zip if rdprrap-installer.exe isn't staged. Covers
 # the case where install.bat's extract step failed at OEM time
-# (extract-failed marker) — we don't want activation to be impossible
+# (extract-failed marker) -- we don't want activation to be impossible
 # without container recreate.
 if (-not (Test-Path -LiteralPath $installer)) {
     Append-Log 'rdprrap-installer.exe missing; attempting to extract from C:\OEM bundle'
     $zip = Get-ChildItem -LiteralPath 'C:\OEM' -Filter 'rdprrap-*.zip' -ErrorAction SilentlyContinue |
         Select-Object -First 1
     if (-not $zip) {
-        Append-Log 'FAIL: no rdprrap-*.zip found under C:\OEM — cannot proceed'
+        Append-Log 'FAIL: no rdprrap-*.zip found under C:\OEM -- cannot proceed'
         Set-Status 'extract-failed'
         exit 1
     }
@@ -129,7 +129,7 @@ if (-not $installOk) {
 }
 
 # Cycle TermService so the running TermService picks up the new
-# ServiceDll. This will kill the agent's user session — but we're
+# ServiceDll. This will kill the agent's user session -- but we're
 # detached, so the host's caller already returned. The agent will
 # auto-respawn on the next user logon (HKCU\Run, via wscript wrapper).
 Append-Log 'restarting TermService to load termwrap.dll'

--- a/scripts/windows/discover_apps.ps1
+++ b/scripts/windows/discover_apps.ps1
@@ -1,4 +1,4 @@
-# discover_apps.ps1 — enumerate installed Windows apps and emit JSON on stdout
+# discover_apps.ps1 -- enumerate installed Windows apps and emit JSON on stdout
 #
 # Consumed by winpodx.core.discovery. Four sources are scanned inside the
 # running guest and unioned, deduping by lowercase executable path or UWP
@@ -17,7 +17,7 @@
 #
 # Semantic contract for `launch_uri`:
 #   - source == "uwp"   : bare AUMID of the form `PackageFamilyName!AppId`
-#                         (NO `shell:AppsFolder\` prefix — the host prepends
+#                         (NO `shell:AppsFolder\` prefix -- the host prepends
 #                         that when building the FreeRDP `/app-cmd`). The
 #                         host-side regex `_AUMID_RE` in
 #                         `src/winpodx/core/rdp.py` rejects any value that
@@ -107,15 +107,15 @@ function Get-AppDescription {
     # Win32 binaries rarely fill Comments; ProductName + CompanyName are the
     # only fields we can rely on. The output lands in the Linux .desktop
     # Comment= key (a tooltip), so identical-to-the-name strings are still
-    # useful — better to surface "Microsoft Edge" than the project-wide
+    # useful -- better to surface "Microsoft Edge" than the project-wide
     # "Windows application via winpodx" generic stamp.
     #
     # Order:
-    #   1. Comments — most authored field; trust it when set.
+    #   1. Comments -- most authored field; trust it when set.
     #   2. ProductName when distinct from FileDescription (gives e.g.
     #      "Microsoft Windows Operating System" for inbox tools where the
     #      FileDescription is just "Notepad").
-    #   3. CompanyName when present — "by Microsoft Corporation" is a
+    #   3. CompanyName when present -- "by Microsoft Corporation" is a
     #      meaningful tooltip even when ProductName duplicates the name.
     #   4. Bare ProductName as a last resort (still better than nothing).
     param([string]$ExePath)
@@ -170,12 +170,12 @@ if ($DryRun) {
 # At Sysprep first-boot the user session has just started: AppX deployment
 # is still finishing, Start Menu indexer hasn't propagated all .lnk files
 # yet, AppXSvc may still be queueing work. discovery firing in this 30-60 s
-# window returns partial / empty results — kernalix7 reported the menu
+# window returns partial / empty results -- kernalix7 reported the menu
 # populating one install, missing UWP entries the next, despite identical
 # config. Both symptoms collapse to "we ran too early".
 #
 # Gate: wait until BOTH conditions hold or until the bounded budget
-# expires (we proceed regardless after timeout — a partial discovery is
+# expires (we proceed regardless after timeout -- a partial discovery is
 # better than none, and the host's retry-on-empty layer covers the
 # all-empty case).
 #
@@ -188,7 +188,7 @@ if ($DryRun) {
 # Quiescence: poll every 1 s; require 3 consecutive samples where
 # AppXSvc is Running + .lnk count is non-zero before declaring ready.
 # This catches the case where AppXSvc flips Running briefly during
-# StartPending → Running → restart cycles.
+# StartPending -> Running -> restart cycles.
 
 $readyBudgetSec = 60
 $pollIntervalSec = 1
@@ -216,7 +216,7 @@ while ((Get-Date) -lt $readyDeadline) {
     if ($appxRunning -and $lnkCount -gt 0) {
         $stableSamples++
         if ($stableSamples -ge $stableSamplesNeeded) {
-            [Console]::Error.WriteLine("[discover] stable (AppXSvc=Running, .lnk=$lnkCount, samples=$stableSamples) — proceeding")
+            [Console]::Error.WriteLine("[discover] stable (AppXSvc=Running, .lnk=$lnkCount, samples=$stableSamples) -- proceeding")
             break
         }
     } else {
@@ -262,7 +262,7 @@ function Add-Result {
 # windows_exec.run_in_windows with a progress_callback, the wrapper
 # defines `Write-WinpodxProgress`. When run standalone (or via a wrapper
 # that doesn't define it) the function is missing and the calls would
-# error — define a no-op shim that yields when the real one isn't
+# error -- define a no-op shim that yields when the real one isn't
 # available.
 if (-not (Get-Command 'Write-WinpodxProgress' -ErrorAction SilentlyContinue)) {
     function Write-WinpodxProgress($msg) { }
@@ -403,7 +403,7 @@ try {
                             $displayName = $dn
                         }
                         # AppxManifest's <VisualElements Description="..."> is the
-                        # Start-menu tooltip — exactly what we want for the
+                        # Start-menu tooltip -- exactly what we want for the
                         # Linux .desktop Comment field. Skip ms-resource:
                         # indirections that PowerShell can't resolve in a
                         # non-interactive session.
@@ -507,7 +507,7 @@ foreach ($d in $shimDirs) {
 # --- Source 5: Essentials (always emit) ------------------------------------
 #
 # OS staples (File Explorer, Calculator, Settings) sometimes fall through
-# the previous sources — File Explorer has no Start Menu .lnk, and UWP apps
+# the previous sources -- File Explorer has no Start Menu .lnk, and UWP apps
 # whose DisplayName is an unresolved ms-resource: lookup get filtered as
 # junk by the host because their fallback name is a dotted package id.
 # Emit them explicitly here with proper icons + launch args so the host
@@ -515,15 +515,15 @@ foreach ($d in $shimDirs) {
 
 Write-WinpodxProgress 'Emitting essential apps (File Explorer / Calculator / Settings)...'
 
-# File Explorer — must launch with a shell: argument so RemoteApp opens a
+# File Explorer -- must launch with a shell: argument so RemoteApp opens a
 # window instead of trying to take over as the user shell. ``shell:MyComputerFolder``
 # opens the "This PC" view; the cmd: side propagates as explorer.exe args.
 try {
     $explorer = Join-Path $env:WINDIR 'explorer.exe'
     if (Test-Path -LiteralPath $explorer) {
         # Pull the real description from explorer.exe's VersionInfo via the
-        # same Get-AppDescription helper Source 1-4 use — no hardcoded
-        # string. Stock Win11 returns "Microsoft® Windows® Operating
+        # same Get-AppDescription helper Source 1-4 use -- no hardcoded
+        # string. Stock Win11 returns "Microsoft(R) Windows(R) Operating
         # System" (ProductName, since it differs from FileDescription
         # "Windows Explorer").
         Add-Result @{


### PR DESCRIPTION
## Summary

PR #86 added an em-dash inside a string literal in `discover_apps.ps1`. The host pipeline UTF-8 → base64 → /exec → \`[IO.File]::WriteAllBytes\` (no BOM) → \`powershell.exe -File\` (PS 5.1 ANSI default) miscodes the bytes. The 0x94 byte from UTF-8 em-dash maps to right-double-quote in CP-1252, ending the string literal early → cascade of \"Missing ')'\" / \"Unexpected token\" parse errors → discovery rc=1 → FreeRDP times out after 120s waiting for a result file that never appears.

User hit this on `install.sh --main` and got the GUI dialog: \"Discovery channel failure: FreeRDP timed out after 120s waiting for the script to complete\".

## What

ASCII-ify all PS files. Em-dashes in **string literals** were the live bug; em-dashes in **comments** happened to be tolerated (PS tokenizer skips to EOL). Replaced both for consistency — makes future grep / lint catch any reintroduction.

Files touched:

- `scripts/windows/discover_apps.ps1` (the live bug)
- `config/oem/agent-respawn.ps1`
- `config/oem/launch_uwp.ps1`
- `config/oem/rdprrap-activate.ps1`
- `config/oem/agent/agent.ps1`

Substitutions:

| was | now |
|---|---|
| em-dash `—` | `--` |
| en-dash `–` | `-` |
| right arrow `→` | `->` |
| `®` / `©` / `™` | `(R)` / `(C)` / `(TM)` |
| ellipsis `…` | `...` |
| curly quotes `' ' \" \"` | straight `' \"` |

## Why this slipped past CI

Our `discover-apps-ps` job runs `pwsh -NoProfile -Command \"[System.Management.Automation.Language.Parser]::ParseFile(...)\"` on Linux. PowerShell Core (pwsh) on Linux defaults to UTF-8, so it parses the em-dash correctly and the test passes. Only PS 5.1 on Windows with default ANSI codepage trips on it. We could add a Windows-PS-5.1 parse step or a pre-commit hook that flags non-ASCII in PS files; for now the ASCII-only convention is the cheap fix.

## Test plan

- [x] No non-ASCII bytes anywhere in `config/oem/*.ps1`, `config/oem/agent/*.ps1`, `scripts/windows/*.ps1`
- [ ] User: re-run `install.sh --main` → discovery completes successfully, app menu populates
- [ ] User: GUI Tools page \"Refresh Apps\" → no FreeRDP timeout