### PR TITLE
fix(oem): only copy bundle OEM to user space when bundle isn't user-writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed
+- **OEM bind mount no longer copies to `~/.config/winpodx/oem/` when the bundle is already user-writable.** PR #95 (the SELinux fix for Fedora/RPM users) made `_find_oem_dir()` *always* copy the OEM tree to a user-owned path, then return that. On systems where the bundle is already user-owned (curl install, source checkout, Nix profile install -- the majority case), this introduced a regression: dockur's in-container `cp` would fail with `Permission denied` on every OEM file because `~/.config/winpodx/oem/` inherited a restrictive parent mode (e.g., 0700 from a strict default umask) that the dockur container process couldn't traverse. kernalix7 reported this on openSUSE Tumbleweed 2026-05-03: `cp: cannot stat '/oem/./install.bat': Permission denied`. Fix: branch on `os.access(bundle_oem, R_OK | W_OK)`. If the user owns the bundle, return it directly (no copy needed -- Podman's `:Z` relabel works fine on user-owned paths). Otherwise (RPM/wheel root-owned bundle), fall back to the user-space copy with explicit `chmod 0644` on files + `0755` on directories so dockur can traverse + read regardless of the host user's umask.
+
 ## [0.4.0] - 2026-05-03
 
 A significant stability + UX release focused on the install / migrate paths. Container recreates are no longer triggered by dockur's `:latest` push cadence (image is SHA-pinned), every PowerShell console flash on app launch and agent autostart has been eliminated, fresh installs honestly wait for Windows to be ready, and multi-session activation is now hands-free via `apply-fixes` / `migrate`. SELinux-enforcing systems (Fedora) work out of the box. RTM-suffixed pods (`0.3.0-RTM1`) migrate cleanly. The `winpodx app refresh` discovery race is closed in three layers. Contributing policy + lifecycle docs added.

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,9 @@
 
 ## [Unreleased]
 
+### 수정
+- **OEM bind mount 가 bundle 이 이미 user-writable 이면 `~/.config/winpodx/oem/` 으로 복사 안 함.** PR #95 (Fedora/RPM SELinux fix) 가 `_find_oem_dir()` 를 *항상* user-owned path 로 OEM 트리 복사 + 반환하게 만듦. Bundle 이 이미 user-owned 인 시스템 (curl install, source checkout, Nix profile install — 대다수 케이스) 에서 regression: dockur 의 in-container `cp` 가 모든 OEM 파일에 `Permission denied` 로 실패 (`~/.config/winpodx/oem/` 이 상위 디렉터리의 빡빡한 mode (예: 엄격한 default umask 의 0700) 를 상속받아서 dockur 컨테이너 process 가 traverse 못함). kernalix7 가 openSUSE Tumbleweed 2026-05-03 에 보고: `cp: cannot stat '/oem/./install.bat': Permission denied`. 수정: `os.access(bundle_oem, R_OK | W_OK)` 분기. 사용자가 bundle 소유하면 그대로 반환 (복사 불필요 — Podman 의 `:Z` relabel 은 user-owned path 에 정상 동작). 그 외 (RPM/wheel root-owned bundle) 인 경우 user-space 복사로 폴백 + 파일 명시적 `chmod 0644` + 디렉터리 `0755` 해서 host user 의 umask 와 무관하게 dockur 가 traverse + read 가능.
+
 ## [0.4.0] - 2026-05-03
 
 설치 / 마이그레이션 경로의 안정성 + UX 에 집중한 주요 릴리스. dockur 의 `:latest` push cadence 가 더 이상 컨테이너 재생성을 트리거하지 않음 (이미지 SHA pinned). 앱 launch 와 agent autostart 에서 PowerShell 콘솔 깜빡임이 모두 제거됨. fresh install 이 Windows 준비될 때까지 정직하게 대기. multi-session 활성화가 `apply-fixes` / `migrate` 로 hands-free. SELinux-enforcing 시스템 (Fedora) 가 out of the box 동작. RTM-suffix pod (`0.3.0-RTM1`) 정상 마이그레이션. `winpodx app refresh` discovery race 가 3계층으로 차단. Contributing 정책 + 라이프사이클 문서 추가.

--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -85,30 +85,80 @@ def _yaml_escape(val: str) -> str:
 def _find_oem_dir() -> str:
     """Return a user-writable OEM directory for the compose bind mount.
 
-    Copies the bundle OEM tree into ``~/.config/winpodx/oem/`` so that
-    Podman's ``:Z`` SELinux relabeling works regardless of install method.
-    RPM/wheel installs place the bundle under root-owned ``/usr/share/``,
-    which rootless Podman cannot relabel on SELinux-enforcing systems.
+    Two regimes:
 
-    Falls back to the bundle path when the bundle OEM dir is missing
-    (broken install), so callers still get a path for error messages.
+    1. **Bundle dir is user-writable** (curl install, source checkout,
+       Nix profile install -- anything where the user owns the bundle
+       tree). Return bundle path directly. No copy needed: Podman's
+       ``:Z`` relabel works fine because the user owns the source.
+       This is the common case and matches the pre-PR-#95 behavior.
+
+    2. **Bundle dir is read-only to current user** (RPM/wheel install
+       under ``/usr/share/winpodx/`` -- root-owned, world-readable
+       only). Copy the OEM tree into ``~/.config/winpodx/oem/`` and
+       return that. Necessary because rootless Podman can't lsetxattr
+       root-owned files for ``:Z`` -- pgarciaq's GH-93. Files are
+       chmod'd 0644 + dirs 0755 after copy so the dockur container
+       process can read them regardless of the user's umask.
+
+    Pre-this-fix (PR #95) the function *always* copied -- and dockur's
+    cp inside the container then hit ``Permission denied`` on the
+    user-OEM files when ``~/.config/winpodx/`` had a 0700 default
+    parent mode. Branching on user-writability lets us keep the
+    SELinux fix for Fedora/RPM users while not running the copy on
+    systems where it isn't needed (the curl-install majority).
+
+    Falls back to the user OEM path string when the bundle OEM dir is
+    missing (broken install), so callers still get a path for error
+    messages.
     """
     bundle_oem = bundle_dir() / "config" / "oem"
+
+    # Case 1 -- user owns the bundle. Use it directly. No copy.
+    # Compose's ``:Z`` relabel is a no-op or in-place relabel on
+    # user-owned files; rootless Podman handles it fine.
+    if bundle_oem.is_dir() and os.access(bundle_oem, os.R_OK | os.W_OK):
+        return str(bundle_oem)
+
+    # Case 2 -- bundle is read-only (or missing). Copy into user space
+    # so ``:Z`` can relabel. Permissions explicitly set to 0644 / 0755
+    # so dockur's in-container cp can read regardless of umask.
     user_oem = config_dir() / "oem"
-
-    if bundle_oem.is_dir():
-        user_oem.mkdir(parents=True, exist_ok=True)
-        for item in bundle_oem.iterdir():
-            dest = user_oem / item.name
-            if item.is_dir():
-                shutil.copytree(item, dest, dirs_exist_ok=True)
-            else:
-                shutil.copy2(item, dest)
-
-    if user_oem.is_dir():
+    if not bundle_oem.is_dir():
+        # Broken install: bundle dir doesn't exist at all. Nothing to
+        # copy; return the user_oem path for the caller's error
+        # message but don't create the dir.
         return str(user_oem)
 
-    return str(bundle_oem)
+    user_oem.mkdir(parents=True, exist_ok=True, mode=0o755)
+    try:
+        os.chmod(user_oem, 0o755)
+    except OSError:
+        pass
+
+    for item in bundle_oem.iterdir():
+        dest = user_oem / item.name
+        if item.is_dir():
+            shutil.copytree(item, dest, dirs_exist_ok=True)
+            for root_dir, _dirs, files in os.walk(dest):
+                root_path = Path(root_dir)
+                try:
+                    os.chmod(root_path, 0o755)
+                except OSError:
+                    pass
+                for f in files:
+                    try:
+                        os.chmod(root_path / f, 0o644)
+                    except OSError:
+                        pass
+        else:
+            shutil.copy2(item, dest)
+            try:
+                os.chmod(dest, 0o644)
+            except OSError:
+                pass
+
+    return str(user_oem)
 
 
 def _build_compose_content(cfg: Config) -> str:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -53,27 +53,83 @@ class TestBundleDir:
 
 
 class TestFindOemDir:
-    """_find_oem_dir() must return a user-writable copy, not the bundle path."""
+    """_find_oem_dir() returns the bundle path directly when user-owned,
+    otherwise copies the OEM tree into ~/.config/winpodx/oem/ and returns
+    that. Two regimes; both regression-tested."""
 
-    def test_copies_bundle_oem_to_user_config(self, tmp_path, monkeypatch):
+    def test_returns_bundle_path_when_user_writable(self, tmp_path, monkeypatch):
+        """Common case (curl install / source checkout / Nix profile):
+        the user owns the bundle dir, so we use it directly without
+        copying. Pre-PR this always copied -- the unconditional copy
+        on opensuse with restrictive ~/.config/winpodx/ parent perms
+        triggered ``cp: cannot stat '/oem/./install.bat': Permission
+        denied`` from dockur's in-container OEM-copy step."""
         from winpodx.core.pod.compose import _find_oem_dir
 
+        # Real bundle dir on the source checkout is user-writable
+        # (test runner owns the worktree). Set XDG_CONFIG_HOME just
+        # so any fallback would be visible if it fired.
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-
         result = Path(_find_oem_dir())
 
-        assert result == tmp_path / "winpodx" / "oem"
+        # Returned path must NOT be under tmp_path/winpodx/oem -- the
+        # user_oem fallback shouldn't fire when the bundle is writable.
+        user_oem = tmp_path / "winpodx" / "oem"
+        assert result != user_oem, "user_oem fallback fired despite bundle being user-writable"
+        # Returned path must be the actual bundle OEM dir on disk.
+        assert (result / "install.bat").exists(), "bundle OEM not at returned path"
+
+    def test_copies_to_user_dir_when_bundle_readonly(self, tmp_path, monkeypatch):
+        """Fedora/RPM case: bundle dir is root-owned + read-only to
+        the current user. Fall back to a copy under
+        ``~/.config/winpodx/oem/`` so Podman's ``:Z`` relabel can land.
+        Regression test for GH-93 (pgarciaq's lsetxattr fail).
+        """
+        import os as _os
+
+        from winpodx.core.pod import compose as compose_mod
+
+        # Build a fake "bundle" dir we can mark as read-only-only.
+        fake_bundle = tmp_path / "fake-bundle"
+        (fake_bundle / "config" / "oem").mkdir(parents=True)
+        (fake_bundle / "scripts").mkdir()
+        (fake_bundle / "data").mkdir()
+        (fake_bundle / "config" / "oem" / "install.bat").write_text("rem fake")
+
+        # bundle_dir() is module-level, monkeypatch the import site.
+        monkeypatch.setattr(compose_mod, "bundle_dir", lambda: fake_bundle)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "user-config"))
+
+        # Force the writability check to report False even though the
+        # test process technically owns the dir. Mocking os.access is
+        # cleaner than juggling sticky chmod bits in a tmp tree.
+        real_access = _os.access
+
+        def fake_access(path, mode):
+            if str(path).startswith(str(fake_bundle)):
+                return False
+            return real_access(path, mode)
+
+        monkeypatch.setattr(compose_mod.os, "access", fake_access)
+
+        result = Path(compose_mod._find_oem_dir())
+        user_oem = tmp_path / "user-config" / "winpodx" / "oem"
+
+        assert result == user_oem, "expected fallback to user_oem when bundle is read-only"
         assert result.is_dir()
         assert (result / "install.bat").exists(), "bundle OEM files should be copied"
+        # Files must end up world-readable so dockur's in-container
+        # cp succeeds regardless of the host user's umask.
+        copied_mode = (result / "install.bat").stat().st_mode & 0o777
+        assert copied_mode & 0o044, f"copied file mode {oct(copied_mode)} not world-readable"
 
     def test_user_oem_not_under_usr_share(self, tmp_path, monkeypatch):
-        """Regression test for GH-93: compose mount path must be user-owned."""
+        """Regression test for GH-93: even when the fallback fires,
+        the returned path never points at the system bundle path."""
         from winpodx.core.pod.compose import _find_oem_dir
 
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-
         result = _find_oem_dir()
-
         assert "/usr/share/" not in result, (
             "OEM dir must not point to system paths (SELinux :Z relabeling fails)"
         )


### PR DESCRIPTION
## Summary

PR #95 made `_find_oem_dir()` *always* copy the OEM tree to `~/.config/winpodx/oem/` to fix Podman's `:Z` relabel failure on root-owned RPM bundle paths (issue #93, Fedora). That was the right fix for the Fedora case but introduced a regression for everyone else: when the bundle is already user-owned (curl install, source checkout, Nix profile install -- the majority case), the unconditional copy lands the OEM tree under `~/.config/winpodx/oem/`. If that path inherits a restrictive parent mode (e.g., 0700 from a strict default umask), dockur's in-container `cp` can't traverse it.

User report 2026-05-03 on openSUSE Tumbleweed:

```
[container] cp: cannot stat '/oem/./install.bat': Permission denied
[container] cp: cannot stat '/oem/./agent-respawn.ps1': Permission denied
[container] cp: cannot stat '/oem/./hidden-launcher.vbs': Permission denied
...
[container] ❯ ERROR: Failed to add OEM folder to image!
```

## Fix

Branch on `os.access(bundle_oem, R_OK | W_OK)`:

```python
def _find_oem_dir() -> str:
    bundle_oem = bundle_dir() / "config" / "oem"

    # Case 1 -- user owns the bundle. Return directly. No copy.
    if bundle_oem.is_dir() and os.access(bundle_oem, os.R_OK | os.W_OK):
        return str(bundle_oem)

    # Case 2 -- bundle is read-only (RPM/wheel). Copy to user space
    # with explicit chmod 0644 / 0755 so dockur's cp can traverse + read.
    user_oem = config_dir() / "oem"
    ...
```

Two regimes both regression-tested:

- **`test_returns_bundle_path_when_user_writable`**: common case (curl install / source / Nix). The user owns the bundle, so we return the bundle path directly. The user-space fallback shouldn't fire.
- **`test_copies_to_user_dir_when_bundle_readonly`**: Fedora/RPM fallback. `os.access` is monkeypatched to report False; the function falls back to copying into a user-owned dir and chmods every file 0644 + every dir 0755 (verified by reading back the resulting mode).

## Compatibility

- **Fedora SELinux** (issue #93, pgarciaq's case): bundle is root-owned, `os.access` returns False, falls through to copy path → SELinux `:Z` relabel works on the user-owned copy. Same outcome as PR #95.
- **openSUSE / curl install** (kernalix7's case): bundle is user-owned, returns bundle path directly → no copy, no permission issue with dockur's in-container `cp`.
- **Nix profile install**: typically user-owned (~/.local etc.) → fast path.
- **Source checkout**: user-owned → fast path.

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] `pytest tests/`: 562 passed, 1 skipped (3 path tests including 2 new regression tests)
- [ ] User: re-run `winpodx pod start` on openSUSE Tumbleweed → no more `cp: cannot stat` errors → Sysprep proceeds end-to-end
- [ ] Fedora SELinux user (pgarciaq): regression test that issue #93 stays fixed (the copy fallback path still fires on root-owned bundle)