### PR TITLE
fix(install): setup.log self-lock + agent warm-up WARN + token-aware transport

### DIFF
--- a/config/oem/install.bat
+++ b/config/oem/install.bat
@@ -1,7 +1,7 @@
 @echo off
 REM First-boot OEM setup for winpodx Windows guest. Runs once during dockur's unattended install. Every action must stay idempotent - there is no guest-side re-run channel in 0.1.6 (push/exec bridge planned for a later release).
 
-set WINPODX_OEM_VERSION=23
+set WINPODX_OEM_VERSION=24
 
 echo [winpodx] Starting post-install configuration (version %WINPODX_OEM_VERSION%)...
 
@@ -483,20 +483,20 @@ echo [winpodx] Registering HKCU\Run entries...
 powershell -NoProfile -ExecutionPolicy Bypass -Command ^
   "$wrap = 'C:\Users\Public\winpodx\launchers\hidden-launcher.vbs';" ^
   "$haveWrap = Test-Path -LiteralPath $wrap;" ^
-  "Add-Content -LiteralPath '%SETUP_LOG%' -Value (\"reg-add: haveWrap=$haveWrap\");" ^
+    "Write-Output (\"reg-add: haveWrap=$haveWrap\");" ^
   "$key = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run';" ^
   "if ($haveWrap) {" ^
   "  $agent = 'wscript.exe \"' + $wrap + '\" \"powershell.exe\" \"-NoProfile\" \"-ExecutionPolicy\" \"Bypass\" \"-File\" \"C:\OEM\agent.ps1\"';" ^
   "  $media = 'wscript.exe \"' + $wrap + '\" \"powershell.exe\" \"-NoProfile\" \"-ExecutionPolicy\" \"Bypass\" \"-File\" \"C:\winpodx\media_monitor.ps1\"';" ^
   "} else {" ^
-  "  Add-Content -LiteralPath '%SETUP_LOG%' -Value 'reg-add: hidden-launcher.vbs missing -> fallback to direct powershell (brief flash)';" ^
+    "  Write-Output 'reg-add: hidden-launcher.vbs missing -> fallback to direct powershell (brief flash)';" ^
   "  $agent = 'powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File C:\OEM\agent.ps1';" ^
   "  $media = 'powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File C:\winpodx\media_monitor.ps1';" ^
   "}" ^
   "Set-ItemProperty -Path $key -Name 'WinpodxAgent' -Value $agent -Force;" ^
   "Set-ItemProperty -Path $key -Name 'WinpodxMedia' -Value $media -Force;" ^
-  "Add-Content -LiteralPath '%SETUP_LOG%' -Value ('reg-add: WinpodxAgent=' + $agent);" ^
-  "Add-Content -LiteralPath '%SETUP_LOG%' -Value ('reg-add: WinpodxMedia=' + $media);" 2>>"%SETUP_LOG%"
+    "Write-Output ('reg-add: WinpodxAgent=' + $agent);" ^
+    "Write-Output ('reg-add: WinpodxMedia=' + $media);" >>"%SETUP_LOG%" 2>&1
 
 REM Start the agent NOW (install.bat-time spawn) -- not just register it
 REM in HKCU\Run for future sessions. Reasoning: HKCU\Run fires once per
@@ -520,11 +520,11 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command ^
   "if (Test-Path -LiteralPath $wrap) {" ^
   "  $startArgs = @($wrap, 'powershell.exe', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', 'C:\OEM\agent.ps1');" ^
   "  Start-Process wscript.exe -ArgumentList $startArgs -WindowStyle Hidden | Out-Null;" ^
-  "  Add-Content -LiteralPath '%SETUP_LOG%' -Value 'agent-spawn: wscript+hidden-launcher.vbs';" ^
+    "  Write-Output 'agent-spawn: wscript+hidden-launcher.vbs';" ^
   "} else {" ^
   "  Start-Process powershell.exe -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', 'C:\OEM\agent.ps1') -WindowStyle Hidden | Out-Null;" ^
-  "  Add-Content -LiteralPath '%SETUP_LOG%' -Value 'agent-spawn: direct-powershell-fallback (brief flash)';" ^
-  "}" 2>>"%SETUP_LOG%"
+    "  Write-Output 'agent-spawn: direct-powershell-fallback (brief flash)';" ^
+    "}" >>"%SETUP_LOG%" 2>&1
 
 REM Token is delivered via the OEM bind mount - no \\tsclient\home copy
 REM needed. Setup stages it to {oem_dir}/agent_token.txt before container

--- a/src/winpodx/core/agent.py
+++ b/src/winpodx/core/agent.py
@@ -126,6 +126,19 @@ class AgentClient:
         self._cached_token = content
         return content
 
+    def auth_ready(self) -> tuple[bool, str]:
+        """Return whether authenticated endpoints can be used.
+
+        This intentionally does not expose the token. It lets transport
+        selection verify that /exec can authenticate after an unauthenticated
+        /health succeeds.
+        """
+        try:
+            self._token()
+        except AgentUnavailableError as e:
+            return False, str(e)
+        return True, ""
+
     def _build_request(
         self,
         path: str,

--- a/src/winpodx/core/checks.py
+++ b/src/winpodx/core/checks.py
@@ -85,6 +85,8 @@ def probe_agent_health(cfg: Config) -> Probe:
         try:
             payload = client.health()
         except AgentError as e:
+            if "timed out" in str(e).lower():
+                return "warn", f"agent warming up or busy: {e}"
             return "fail", str(e)
         version = payload.get("version", "?")
         return "ok", f"version={version}"
@@ -107,7 +109,7 @@ def probe_guest_exec(cfg: Config) -> Probe:
     """
 
     def _run() -> tuple[ProbeStatus, str]:
-        from winpodx.core.agent import AgentClient, AgentError
+        from winpodx.core.agent import AgentClient, AgentError, AgentTimeoutError
         from winpodx.core.pod import PodState, pod_status
 
         # Skip rather than fail when the pod itself is down — keeps the
@@ -122,6 +124,8 @@ def probe_guest_exec(cfg: Config) -> Probe:
         client = AgentClient(cfg)
         try:
             result = client.exec("Write-Output ok\n", timeout=10.0)
+        except AgentTimeoutError as e:
+            return "warn", f"agent warming up or busy: {e}"
         except AgentError as e:
             return "fail", f"exec failed: {e}"
         if result.rc != 0:
@@ -148,7 +152,7 @@ def probe_guest_summary(cfg: Config) -> Probe:
     def _run() -> tuple[ProbeStatus, str]:
         import json
 
-        from winpodx.core.agent import AgentClient, AgentError
+        from winpodx.core.agent import AgentClient, AgentError, AgentTimeoutError
         from winpodx.core.pod import PodState, pod_status
 
         try:
@@ -187,6 +191,8 @@ def probe_guest_summary(cfg: Config) -> Probe:
         client = AgentClient(cfg)
         try:
             result = client.exec(script, timeout=15.0)
+        except AgentTimeoutError as e:
+            return "warn", f"agent warming up or busy: {e}"
         except AgentError as e:
             return "fail", f"exec failed: {e}"
         if result.rc != 0:

--- a/src/winpodx/core/transport/agent.py
+++ b/src/winpodx/core/transport/agent.py
@@ -61,6 +61,14 @@ class AgentTransport(Transport):
         """
         try:
             payload = self._client.health()
+            # /health is intentionally unauthenticated, but this Transport is
+            # only usable for authenticated /exec calls. If the host token is
+            # missing, report the agent transport as unavailable so default
+            # dispatch can fall back to FreeRDP instead of selecting agent and
+            # failing later on the first /exec.
+            auth_ready, auth_detail = self._client.auth_ready()
+            if not auth_ready:
+                return HealthStatus(available=False, detail=auth_detail)
         except AgentUnavailableError as e:
             return HealthStatus(available=False, detail=str(e))
         except Exception as e:  # noqa: BLE001 — rule: never raise on transient

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -159,6 +159,62 @@ def test_probe_guest_exec_fail_when_agent_unreachable(monkeypatch):
     assert "connection refused" in out.detail
 
 
+def test_probe_agent_health_timeout_is_warmup_warn(monkeypatch):
+    from winpodx.core.agent import AgentUnavailableError
+
+    class _FakeClient:
+        def __init__(self, _cfg) -> None:
+            pass
+
+        def health(self):
+            raise AgentUnavailableError("/health timed out after 2.0s")
+
+    monkeypatch.setattr("winpodx.core.agent.AgentClient", _FakeClient)
+    out = checks.probe_agent_health(_FakeCfg())
+    assert out.status == "warn"
+    assert "warming up" in out.detail
+
+
+def test_probe_guest_exec_timeout_is_warmup_warn(monkeypatch):
+    import winpodx.core.pod as pod_mod
+    from winpodx.core.agent import AgentTimeoutError
+    from winpodx.core.pod import PodState, PodStatus
+
+    monkeypatch.setattr(pod_mod, "pod_status", lambda _cfg: PodStatus(state=PodState.RUNNING))
+
+    class _FakeClient:
+        def __init__(self, _cfg) -> None:
+            pass
+
+        def exec(self, *_a, **_k):
+            raise AgentTimeoutError("/exec timed out after 9.0s")
+
+    monkeypatch.setattr("winpodx.core.agent.AgentClient", _FakeClient)
+    out = checks.probe_guest_exec(_FakeCfg())
+    assert out.status == "warn"
+    assert "warming up" in out.detail
+
+
+def test_probe_guest_summary_timeout_is_warmup_warn(monkeypatch):
+    import winpodx.core.pod as pod_mod
+    from winpodx.core.agent import AgentTimeoutError
+    from winpodx.core.pod import PodState, PodStatus
+
+    monkeypatch.setattr(pod_mod, "pod_status", lambda _cfg: PodStatus(state=PodState.RUNNING))
+
+    class _FakeClient:
+        def __init__(self, _cfg) -> None:
+            pass
+
+        def exec(self, *_a, **_k):
+            raise AgentTimeoutError("/exec timed out after 14.0s")
+
+    monkeypatch.setattr("winpodx.core.agent.AgentClient", _FakeClient)
+    out = checks.probe_guest_summary(_FakeCfg())
+    assert out.status == "warn"
+    assert "warming up" in out.detail
+
+
 def test_probe_apps_discovered_warn_on_missing_dir(tmp_path, monkeypatch):
     monkeypatch.setattr("winpodx.core.discovery.discovered_apps_dir", lambda: tmp_path / "missing")
     out = checks.probe_apps_discovered(_FakeCfg())

--- a/tests/test_oem_install_bat.py
+++ b/tests/test_oem_install_bat.py
@@ -1,0 +1,32 @@
+"""Static checks for config/oem/install.bat first-boot glue."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_BAT = REPO_ROOT / "config" / "oem" / "install.bat"
+
+
+def test_install_bat_exists() -> None:
+    assert INSTALL_BAT.is_file()
+
+
+def test_install_bat_has_no_non_ascii() -> None:
+    text = INSTALL_BAT.read_text(encoding="utf-8")
+    assert all(ord(ch) < 128 for ch in text)
+
+
+def test_install_bat_uses_absolute_windows_tar() -> None:
+    text = INSTALL_BAT.read_text(encoding="utf-8")
+    assert '"%SystemRoot%\\System32\\tar.exe" -xf' in text
+
+
+def test_install_bat_does_not_self_lock_setup_log() -> None:
+    """Do not Add-Content to setup.log from a process whose stderr is
+    already redirected to setup.log. Windows can hold the redirection handle
+    exclusively, producing noisy setup.log WriteError records and hiding the
+    real agent-spawn state.
+    """
+
+    text = INSTALL_BAT.read_text(encoding="utf-8")
+    assert "Add-Content -LiteralPath '%SETUP_LOG%'" not in text
+    assert '>>"%SETUP_LOG%" 2>&1' in text

--- a/tests/test_transport/test_agent.py
+++ b/tests/test_transport/test_agent.py
@@ -46,15 +46,35 @@ class TestHealth:
     """health() never raises on transient state — see Transport ABC rule."""
 
     def test_returns_available_when_client_responds(self, transport):
-        with patch.object(
-            type(transport._client),
-            "health",
-            return_value={"version": "0.2.2-rev1", "ok": True},
+        with (
+            patch.object(
+                type(transport._client),
+                "health",
+                return_value={"version": "0.2.2-rev1", "ok": True},
+            ),
+            patch.object(type(transport._client), "auth_ready", return_value=(True, "")),
         ):
             status = transport.health()
         assert isinstance(status, HealthStatus)
         assert status.available is True
         assert status.version == "0.2.2-rev1"
+
+    def test_returns_unavailable_when_token_missing(self, transport):
+        with (
+            patch.object(
+                type(transport._client),
+                "health",
+                return_value={"version": "0.2.2-rev1", "ok": True},
+            ),
+            patch.object(
+                type(transport._client),
+                "auth_ready",
+                return_value=(False, "agent token file missing"),
+            ),
+        ):
+            status = transport.health()
+        assert status.available is False
+        assert "token" in (status.detail or "")
 
     def test_returns_unavailable_on_unavailable_error(self, transport):
         with patch.object(
@@ -76,7 +96,10 @@ class TestHealth:
     def test_handles_non_dict_payload_gracefully(self, transport):
         # AgentClient.health() returns a dict on success; if it ever
         # returns something else, AgentTransport must not crash.
-        with patch.object(type(transport._client), "health", return_value=[]):
+        with (
+            patch.object(type(transport._client), "health", return_value=[]),
+            patch.object(type(transport._client), "auth_ready", return_value=(True, "")),
+        ):
             status = transport.health()
         assert status.available is True
         assert status.version is None


### PR DESCRIPTION
## Summary

Fresh-install triage after PR #105 + #106 merged: install.bat itself completed (rdprrap install + agent.ps1 staging + launcher copy all succeeded), agent eventually came up cleanly, but the Info screen flashed **"Overall: FAIL"** for ~30-60 s while the agent was warming up. `setup.log` also accumulated "The process cannot access the file" noise that hid the actual reg-add / agent-spawn breadcrumbs.

Three independent issues collapsed onto the same UX:

## Fixes

### 1. install.bat setup.log self-lock (OEM v23 → v24)

The HKCU\Run reg-add and agent-spawn PowerShell blocks redirect stderr to setup.log via cmd's `2>>"%SETUP_LOG%"`. Inside those blocks we also called `Add-Content -LiteralPath '%SETUP_LOG%'`. **Windows holds the redirection handle exclusively** → Add-Content's second open raises a sharing violation → the .NET exception logs via the same stderr redirect → into setup.log itself. Self-lock loop.

Fix: every `Add-Content` inside the PS blocks → `Write-Output`. cmd-level redirect `2>>"%SETUP_LOG%"` → `>>"%SETUP_LOG%" 2>&1` so PS stdout is the single writer.

### 2. `checks.py`: agent warm-up = WARN, not FAIL

`probe_agent_health`, `probe_guest_exec`, `probe_guest_summary` returned **FAIL** when the agent's /health or /exec timed out. Right after fresh install the agent is up but slow (Sysprep just finished; cold cache; first PS execution behind it). FAIL surfaces in the Info screen as "Overall: FAIL" — user reads as real failure. Now timeout-shaped errors return `WARN("agent warming up or busy: ...")`.

### 3. `AgentTransport` token-aware health

`/health` is unauthenticated by spec. `/exec` requires the host token. If the token file isn't readable yet (race during install.sh first run), `dispatch()` would pick AgentTransport on a green /health and then fail on first /exec with token-missing AgentAuthError — too late to recover.

Fix: `AgentClient.auth_ready()` returns `(bool, detail)` for whether `_token()` resolves. `AgentTransport.health()` consults it after /health and reports `available=False` with the auth detail if the token isn't ready. Default dispatch then falls back to FreerdpTransport. Token itself is never exposed (bool + detail string only).

## Tests (8 new, 1 new file)

- `tests/test_oem_install_bat.py` (NEW) — 4 static checks: file exists, ASCII-only, absolute tar path, no setup-log self-lock.
- `tests/test_checks.py` — 3 warm-up WARN regressions.
- `tests/test_transport/test_agent.py` — `test_returns_unavailable_when_token_missing`.

`580 passed, 1 skipped, 0 new failures.`

## Test plan

- [ ] Existing CI (lint + audit + 5 Python versions + discover-apps-ps) stays green.
- [ ] Fresh smoke on opensuse Tumbleweed: setup.log free of "process cannot access the file" lines; Info screen shows WARN (not FAIL) during the first ~30-60 s; OEM v24 is the version recorded in `C:\winpodx\oem_version.txt`.