### PR TITLE
chore: agent error semantics + dependency-aware probes + GUI worker split

### DIFF
--- a/src/winpodx/core/agent.py
+++ b/src/winpodx/core/agent.py
@@ -161,9 +161,10 @@ class AgentClient:
         """GET /health — the readiness signal. No auth, 2s timeout.
 
         Returns the parsed JSON status payload on 200. Raises
-        ``AgentUnavailableError`` on connection-refused, timeout, 5xx,
-        or non-JSON body. Callers should treat any exception as "agent
-        not ready, do not fire FreeRDP probes" (anti-goal #3).
+        ``AgentTimeoutError`` on timeout, ``AgentUnavailableError`` on
+        connection-refused, 5xx, or non-JSON body. Callers should treat
+        any exception as "agent not ready, do not fire FreeRDP probes"
+        (anti-goal #3).
         """
         req = self._build_request("/health", method="GET", with_auth=False)
         try:
@@ -175,10 +176,12 @@ class AgentClient:
             if e.code in (401, 403):
                 raise AgentAuthError(f"/health returned {e.code}") from e
             raise AgentUnavailableError(f"/health returned HTTP {e.code}") from e
+        except socket.timeout as e:
+            raise AgentTimeoutError(f"/health timed out after {self.HEALTH_TIMEOUT}s") from e
         except urllib_error.URLError as e:
+            if isinstance(e.reason, socket.timeout):
+                raise AgentTimeoutError(f"/health timed out after {self.HEALTH_TIMEOUT}s") from e
             raise AgentUnavailableError(f"/health unreachable: {e.reason}") from e
-        except TimeoutError as e:
-            raise AgentUnavailableError(f"/health timed out after {self.HEALTH_TIMEOUT}s") from e
         except OSError as e:
             raise AgentUnavailableError(f"/health socket error: {e}") from e
 
@@ -233,8 +236,6 @@ class AgentClient:
             if isinstance(e.reason, socket.timeout):
                 raise AgentTimeoutError(f"/exec timed out after {urlopen_timeout}s") from e
             raise AgentUnavailableError(f"/exec unreachable: {e.reason}") from e
-        except TimeoutError as e:
-            raise AgentTimeoutError(f"/exec timed out after {urlopen_timeout}s") from e
         except OSError as e:
             raise AgentUnavailableError(f"/exec socket error: {e}") from e
 

--- a/src/winpodx/core/checks.py
+++ b/src/winpodx/core/checks.py
@@ -79,20 +79,35 @@ def probe_agent_health(cfg: Config) -> Probe:
     """GET /health — verifies the agent is bound and answering on 8765."""
 
     def _run() -> tuple[ProbeStatus, str]:
-        from winpodx.core.agent import AgentClient, AgentError
+        from winpodx.core.agent import AgentClient, AgentError, AgentTimeoutError
 
         client = AgentClient(cfg)
         try:
             payload = client.health()
+        except AgentTimeoutError as e:
+            return "warn", f"agent warming up or busy: {e}"
         except AgentError as e:
-            if "timed out" in str(e).lower():
-                return "warn", f"agent warming up or busy: {e}"
             return "fail", str(e)
         version = payload.get("version", "?")
         return "ok", f"version={version}"
 
     status, detail, ms = _timed(_run)
     return Probe("agent_health", status, detail, ms)
+
+
+def probe_agent_auth_ready(cfg: Config) -> Probe:
+    """Verify host-side bearer token readiness for authenticated /exec calls."""
+
+    def _run() -> tuple[ProbeStatus, str]:
+        from winpodx.core.agent import AgentClient
+
+        ok, detail = AgentClient(cfg).auth_ready()
+        if ok:
+            return "ok", "host token ready"
+        return "fail", f"auth token unavailable: {detail}"
+
+    status, detail, ms = _timed(_run)
+    return Probe("agent_auth_ready", status, detail, ms)
 
 
 def probe_guest_exec(cfg: Config) -> Probe:
@@ -297,6 +312,7 @@ PROBES: tuple[Callable[[Config], Probe], ...] = (
     probe_pod_running,
     probe_rdp_port,
     probe_agent_health,
+    probe_agent_auth_ready,
     probe_guest_exec,  # round-trip test — proves /exec works, not just /health
     probe_guest_summary,  # in-guest snapshot (Windows version / uptime / sessions / disk)
     probe_oem_version,
@@ -306,9 +322,47 @@ PROBES: tuple[Callable[[Config], Probe], ...] = (
 )
 
 
+def _skip_probe(name: str, detail: str) -> Probe:
+    return Probe(name, "skip", detail, 0)
+
+
 def run_all(cfg: Config) -> list[Probe]:
     """Run every probe and return results in deterministic order."""
-    return [p(cfg) for p in PROBES]
+    out: list[Probe] = []
+    agent_health: Probe | None = None
+    agent_auth_ready: Probe | None = None
+
+    for probe_fn in PROBES:
+        if probe_fn is probe_agent_auth_ready and agent_health is not None:
+            if agent_health.status != "ok":
+                agent_auth_ready = _skip_probe(
+                    "agent_auth_ready",
+                    f"agent not ready: {agent_health.detail}",
+                )
+                out.append(agent_auth_ready)
+                continue
+
+        if probe_fn in (probe_guest_exec, probe_guest_summary):
+            if agent_health is not None and agent_health.status != "ok":
+                out.append(_skip_probe(probe_fn.__name__.replace("probe_", ""), "agent not ready"))
+                continue
+            if agent_auth_ready is not None and agent_auth_ready.status != "ok":
+                out.append(
+                    _skip_probe(
+                        probe_fn.__name__.replace("probe_", ""),
+                        f"agent auth not ready: {agent_auth_ready.detail}",
+                    )
+                )
+                continue
+
+        probe = probe_fn(cfg)
+        out.append(probe)
+        if probe.name == "agent_health":
+            agent_health = probe
+        elif probe.name == "agent_auth_ready":
+            agent_auth_ready = probe
+
+    return out
 
 
 def overall(probes: Iterable[Probe]) -> ProbeStatus:

--- a/src/winpodx/core/transport/agent.py
+++ b/src/winpodx/core/transport/agent.py
@@ -69,7 +69,7 @@ class AgentTransport(Transport):
             auth_ready, auth_detail = self._client.auth_ready()
             if not auth_ready:
                 return HealthStatus(available=False, detail=auth_detail)
-        except AgentUnavailableError as e:
+        except (AgentTimeoutError, AgentUnavailableError) as e:
             return HealthStatus(available=False, detail=str(e))
         except Exception as e:  # noqa: BLE001 — rule: never raise on transient
             return HealthStatus(available=False, detail=f"health probe failed: {e}")

--- a/src/winpodx/gui/main_window.py
+++ b/src/winpodx/gui/main_window.py
@@ -7,7 +7,7 @@ import sys
 import threading
 from pathlib import Path
 
-from PySide6.QtCore import QObject, QSize, Qt, QThread, QTimer, Signal, Slot
+from PySide6.QtCore import QSize, Qt, QThread, QTimer, Signal, Slot
 from PySide6.QtGui import QColor, QIcon, QPixmap
 from PySide6.QtSvg import QSvgRenderer
 from PySide6.QtWidgets import (
@@ -60,169 +60,10 @@ from winpodx.gui.theme import (
     accent_color,
     avatar_color,
 )
+from winpodx.gui.workers import DiscoveryWorker, InfoWorker
 from winpodx.utils.paths import bundle_dir
 
 log = logging.getLogger(__name__)
-
-
-class _DiscoveryWorker(QObject):
-    """Background worker that runs core.discovery scan and persist off the UI thread.
-
-    State machine driven from the main window:
-      idle -> scanning -> (succeeded | failed) -> idle
-
-    Emits ``succeeded(count)`` with the number of persisted apps on success,
-    or ``failed(kind, detail)`` where ``kind`` is a short token (``pod_not_running``,
-    ``module_missing``, ``unexpected``) the UI uses to decide inline actions
-    such as offering a "Start Pod" shortcut.
-    """
-
-    succeeded = Signal(int)
-    failed = Signal(str, str)
-    finished = Signal()
-
-    @Slot()
-    def run(self) -> None:
-        try:
-            from winpodx.core import discovery as discovery_mod
-            from winpodx.core.config import Config
-        except ImportError as exc:
-            self.failed.emit("module_missing", str(exc))
-            self.finished.emit()
-            return
-
-        try:
-            cfg = Config.load()
-            apps = discovery_mod.discover_apps(cfg)
-        except Exception as exc:  # noqa: BLE001 — worker surfaces all errors to UI
-            # Prefer the explicit DiscoveryError.kind when the core layer set
-            # one — string matching misclassifies (e.g. "winpodx-app" path in
-            # a script_missing message contains the substring "pod").
-            kind = getattr(exc, "kind", None)
-            if not kind:
-                kind = "pod_not_running" if _looks_like_pod_down(exc) else "unexpected"
-            self.failed.emit(kind, str(exc))
-            self.finished.emit()
-            return
-
-        try:
-            persisted = discovery_mod.persist_discovered(apps)
-        except Exception as exc:  # noqa: BLE001
-            self.failed.emit("unexpected", str(exc))
-            self.finished.emit()
-            return
-
-        # v0.2.0.10: parity with CLI's `_refresh_apps` — install .desktop
-        # entries inline so the GUI Refresh button registers DE menu
-        # entries the same way as `winpodx app refresh`. Bidirectional
-        # sync (drop entries that no longer match a discovered app) is
-        # handled by `_sync_desktop_entries`.
-        try:
-            _sync_desktop_entries(apps)
-        except Exception:  # noqa: BLE001 — best-effort
-            log.debug("GUI refresh: desktop-entry sync failed", exc_info=True)
-
-        try:
-            from winpodx.desktop.icons import refresh_icon_cache
-
-            refresh_icon_cache()
-        except Exception:  # noqa: BLE001 — cache refresh is best-effort
-            pass
-
-        try:
-            count = len(persisted)
-        except TypeError:
-            count = len(apps)
-        self.succeeded.emit(count)
-        self.finished.emit()
-
-
-def _sync_desktop_entries(discovered) -> None:
-    """v0.2.0.10: bidirectional .desktop entry sync used by the GUI
-    refresh worker. Mirrors `cli/app._register_desktop_entries` but
-    safe to run from a worker thread (no Qt GUI calls)."""
-    from winpodx.core.app import list_available_apps
-    from winpodx.desktop.entry import install_desktop_entry, remove_desktop_entry
-    from winpodx.utils.paths import applications_dir
-
-    discovered_slugs = {d.slug or d.name for d in discovered}
-    available = {a.name: a for a in list_available_apps()}
-    for slug in discovered_slugs:
-        info = available.get(slug)
-        if info is not None:
-            try:
-                install_desktop_entry(info)
-            except Exception:  # noqa: BLE001
-                log.debug("install_desktop_entry failed for %s", slug, exc_info=True)
-
-    apps_dir = applications_dir()
-    if apps_dir.exists():
-        for entry in apps_dir.glob("winpodx-*.desktop"):
-            stem = entry.stem
-            if not stem.startswith("winpodx-"):
-                continue
-            slug = stem[len("winpodx-") :]
-            if slug in {"", "gui", "launcher"}:
-                continue
-            if slug in available:
-                continue
-            try:
-                remove_desktop_entry(slug)
-            except Exception:  # noqa: BLE001
-                log.debug("remove_desktop_entry failed for %s", slug, exc_info=True)
-
-
-def _looks_like_pod_down(exc: BaseException) -> bool:
-    text = str(exc).lower()
-    return any(tok in text for tok in ("pod", "container", "connection refused", "not running"))
-
-
-class _InfoWorker(QObject):
-    """Background worker for the Info page's gather_info() call.
-
-    Hoisted to module level (was nested inside _refresh_info) so PySide6
-    doesn't re-create the QObject metaclass on every refresh — repeated
-    nested-class definition has been observed to interact badly with
-    Qt's metaobject cache, contributing to the v0.1.9 SEGV path.
-    """
-
-    done = Signal(dict)
-    failed = Signal(str)
-
-    def __init__(self, cfg) -> None:
-        super().__init__()
-        self.cfg = cfg
-
-    @Slot()
-    def run(self) -> None:
-        try:
-            from winpodx.core import checks
-            from winpodx.core.info import gather_info
-
-            snapshot = gather_info(self.cfg)
-            # Tack the live health probes onto the snapshot so the Info page
-            # can render them in the same render cycle as everything else.
-            # Probes never raise (each is wrapped in _timed) so this stays
-            # safe even when the pod is down.
-            try:
-                probes = checks.run_all(self.cfg)
-                snapshot["health"] = [
-                    {
-                        "name": p.name,
-                        "status": p.status,
-                        "detail": p.detail,
-                        "duration_ms": p.duration_ms,
-                    }
-                    for p in probes
-                ]
-                snapshot["health_overall"] = checks.overall(probes)
-            except Exception:  # noqa: BLE001 — health is opt-in; never block info
-                log.debug("health probes failed during info refresh", exc_info=True)
-                snapshot["health"] = []
-                snapshot["health_overall"] = "fail"
-            self.done.emit(snapshot)
-        except Exception as e:  # noqa: BLE001 — surface to UI via signal
-            self.failed.emit(str(e))
 
 
 class WinpodxWindow(QMainWindow):
@@ -355,7 +196,7 @@ class WinpodxWindow(QMainWindow):
         # Refresh state: idle -> scanning -> (success|error) -> idle.
         self._refresh_state = "idle"
         self._refresh_thread: QThread | None = None
-        self._refresh_worker: _DiscoveryWorker | None = None
+        self._refresh_worker: DiscoveryWorker | None = None
 
         self._setup_signals()
         self._build_ui()
@@ -1701,7 +1542,7 @@ class WinpodxWindow(QMainWindow):
         self._info_busy = True
 
         thread = QThread(self)
-        worker = _InfoWorker(self.cfg)
+        worker = InfoWorker(self.cfg)
         worker.moveToThread(thread)
         thread.started.connect(worker.run)
         worker.done.connect(self._apply_info_snapshot)
@@ -2054,7 +1895,7 @@ class WinpodxWindow(QMainWindow):
         self._set_refresh_state("scanning")
 
         thread = QThread(self)
-        worker = _DiscoveryWorker()
+        worker = DiscoveryWorker()
         worker.moveToThread(thread)
         thread.started.connect(worker.run)
         worker.succeeded.connect(self._on_refresh_succeeded)

--- a/src/winpodx/gui/workers.py
+++ b/src/winpodx/gui/workers.py
@@ -1,0 +1,140 @@
+"""Qt worker objects used by the main winpodx window."""
+
+from __future__ import annotations
+
+import logging
+
+from PySide6.QtCore import QObject, Signal, Slot
+
+log = logging.getLogger(__name__)
+
+
+class DiscoveryWorker(QObject):
+    """Run Windows app discovery and desktop-entry sync off the UI thread."""
+
+    succeeded = Signal(int)
+    failed = Signal(str, str)
+    finished = Signal()
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            from winpodx.core import discovery as discovery_mod
+            from winpodx.core.config import Config
+        except ImportError as exc:
+            self.failed.emit("module_missing", str(exc))
+            self.finished.emit()
+            return
+
+        try:
+            cfg = Config.load()
+            apps = discovery_mod.discover_apps(cfg)
+        except Exception as exc:  # noqa: BLE001 - worker surfaces all errors to UI
+            kind = getattr(exc, "kind", None)
+            if not kind:
+                kind = "pod_not_running" if _looks_like_pod_down(exc) else "unexpected"
+            self.failed.emit(kind, str(exc))
+            self.finished.emit()
+            return
+
+        try:
+            persisted = discovery_mod.persist_discovered(apps)
+        except Exception as exc:  # noqa: BLE001
+            self.failed.emit("unexpected", str(exc))
+            self.finished.emit()
+            return
+
+        try:
+            sync_desktop_entries(apps)
+        except Exception:  # noqa: BLE001 - best-effort
+            log.debug("GUI refresh: desktop-entry sync failed", exc_info=True)
+
+        try:
+            from winpodx.desktop.icons import refresh_icon_cache
+
+            refresh_icon_cache()
+        except Exception:  # noqa: BLE001 - cache refresh is best-effort
+            log.debug("GUI refresh: icon-cache refresh failed", exc_info=True)
+
+        try:
+            count = len(persisted)
+        except TypeError:
+            count = len(apps)
+        self.succeeded.emit(count)
+        self.finished.emit()
+
+
+class InfoWorker(QObject):
+    """Gather static info plus live health probes off the UI thread."""
+
+    done = Signal(dict)
+    failed = Signal(str)
+
+    def __init__(self, cfg) -> None:
+        super().__init__()
+        self.cfg = cfg
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            from winpodx.core import checks
+            from winpodx.core.info import gather_info
+
+            snapshot = gather_info(self.cfg)
+            try:
+                probes = checks.run_all(self.cfg)
+                snapshot["health"] = [
+                    {
+                        "name": p.name,
+                        "status": p.status,
+                        "detail": p.detail,
+                        "duration_ms": p.duration_ms,
+                    }
+                    for p in probes
+                ]
+                snapshot["health_overall"] = checks.overall(probes)
+            except Exception:  # noqa: BLE001 - health is opt-in; never block info
+                log.debug("health probes failed during info refresh", exc_info=True)
+                snapshot["health"] = []
+                snapshot["health_overall"] = "fail"
+            self.done.emit(snapshot)
+        except Exception as e:  # noqa: BLE001 - surface to UI via signal
+            self.failed.emit(str(e))
+
+
+def sync_desktop_entries(discovered) -> None:
+    """Bidirectionally sync .desktop entries after GUI discovery."""
+    from winpodx.core.app import list_available_apps
+    from winpodx.desktop.entry import install_desktop_entry, remove_desktop_entry
+    from winpodx.utils.paths import applications_dir
+
+    discovered_slugs = {d.slug or d.name for d in discovered}
+    available = {a.name: a for a in list_available_apps()}
+    for slug in discovered_slugs:
+        info = available.get(slug)
+        if info is not None:
+            try:
+                install_desktop_entry(info)
+            except Exception:  # noqa: BLE001
+                log.debug("install_desktop_entry failed for %s", slug, exc_info=True)
+
+    apps_dir = applications_dir()
+    if apps_dir.exists():
+        for entry in apps_dir.glob("winpodx-*.desktop"):
+            stem = entry.stem
+            if not stem.startswith("winpodx-"):
+                continue
+            slug = stem[len("winpodx-") :]
+            if slug in {"", "gui", "launcher"}:
+                continue
+            if slug in available:
+                continue
+            try:
+                remove_desktop_entry(slug)
+            except Exception:  # noqa: BLE001
+                log.debug("remove_desktop_entry failed for %s", slug, exc_info=True)
+
+
+def _looks_like_pod_down(exc: BaseException) -> bool:
+    text = str(exc).lower()
+    return any(tok in text for tok in ("pod", "container", "connection refused", "not running"))

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -121,13 +121,22 @@ class TestHealth:
         with pytest.raises(AgentUnavailableError, match="503"):
             client.health()
 
-    def test_timeout_raises_unavailable(self, monkeypatch, client):
+    def test_timeout_raises_timeout(self, monkeypatch, client):
         def fake_urlopen(req, timeout=None):
             raise socket.timeout("timed out")
 
         _patch_urlopen(monkeypatch, fake_urlopen)
 
-        with pytest.raises(AgentUnavailableError):
+        with pytest.raises(AgentTimeoutError):
+            client.health()
+
+    def test_urlerror_socket_timeout_raises_timeout(self, monkeypatch, client):
+        def fake_urlopen(req, timeout=None):
+            raise urllib_error.URLError(socket.timeout("timed out"))
+
+        _patch_urlopen(monkeypatch, fake_urlopen)
+
+        with pytest.raises(AgentTimeoutError):
             client.health()
 
     def test_non_json_raises_unavailable(self, monkeypatch, client):
@@ -172,6 +181,27 @@ class TestTokenLazyLoad:
 
         with pytest.raises(AgentUnavailableError, match="empty"):
             client._token()
+
+    def test_auth_ready_reports_missing_token(self, monkeypatch, tmp_path, cfg):
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        client = AgentClient(cfg)
+
+        ok, detail = client.auth_ready()
+
+        assert ok is False
+        assert "missing" in detail
+
+    def test_auth_ready_ok_when_token_exists(self, monkeypatch, tmp_path, cfg):
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        path = tmp_path / "winpodx" / "agent_token.txt"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("deadbeef" * 8)
+        client = AgentClient(cfg)
+
+        ok, detail = client.auth_ready()
+
+        assert ok is True
+        assert detail == ""
 
     def test_token_loaded_and_cached(self, monkeypatch, tmp_path, cfg):
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -76,6 +76,92 @@ def test_run_all_returns_one_probe_per_registered_function(monkeypatch):
     assert all(isinstance(p, Probe) for p in out)
 
 
+def test_run_all_skips_exec_probes_when_agent_health_not_ok(monkeypatch):
+    fake_cfg = object()
+    called: list[str] = []
+
+    def pod(_cfg):
+        return Probe("pod_running", "ok", "running", 1)
+
+    def rdp(_cfg):
+        return Probe("rdp_port", "ok", "rdp", 1)
+
+    def agent(_cfg):
+        return Probe("agent_health", "warn", "agent warming up", 1)
+
+    def auth(_cfg):
+        called.append("auth")
+        return Probe("agent_auth_ready", "ok", "token", 1)
+
+    def guest_exec(_cfg):
+        called.append("exec")
+        return Probe("guest_exec", "ok", "exec", 1)
+
+    def guest_summary(_cfg):
+        called.append("summary")
+        return Probe("guest_summary", "ok", "summary", 1)
+
+    monkeypatch.setattr(checks, "probe_agent_auth_ready", auth)
+    monkeypatch.setattr(checks, "probe_guest_exec", guest_exec)
+    monkeypatch.setattr(checks, "probe_guest_summary", guest_summary)
+    monkeypatch.setattr(
+        checks,
+        "PROBES",
+        (
+            pod,
+            rdp,
+            agent,
+            checks.probe_agent_auth_ready,
+            checks.probe_guest_exec,
+            checks.probe_guest_summary,
+        ),
+    )
+
+    out = checks.run_all(fake_cfg)
+
+    by_name = {p.name: p for p in out}
+    assert by_name["agent_auth_ready"].status == "skip"
+    assert by_name["guest_exec"].status == "skip"
+    assert by_name["guest_summary"].status == "skip"
+    assert called == []
+
+
+def test_run_all_skips_exec_probes_when_auth_not_ready(monkeypatch):
+    fake_cfg = object()
+    called: list[str] = []
+
+    def pod(_cfg):
+        return Probe("pod_running", "ok", "running", 1)
+
+    def rdp(_cfg):
+        return Probe("rdp_port", "ok", "rdp", 1)
+
+    def agent(_cfg):
+        return Probe("agent_health", "ok", "version=x", 1)
+
+    def auth(_cfg):
+        return Probe("agent_auth_ready", "fail", "token missing", 1)
+
+    def guest_exec(_cfg):
+        called.append("exec")
+        return Probe("guest_exec", "ok", "exec", 1)
+
+    monkeypatch.setattr(checks, "probe_agent_auth_ready", auth)
+    monkeypatch.setattr(checks, "probe_guest_exec", guest_exec)
+    monkeypatch.setattr(
+        checks,
+        "PROBES",
+        (pod, rdp, agent, checks.probe_agent_auth_ready, checks.probe_guest_exec),
+    )
+
+    out = checks.run_all(fake_cfg)
+
+    by_name = {p.name: p for p in out}
+    assert by_name["agent_auth_ready"].status == "fail"
+    assert by_name["guest_exec"].status == "skip"
+    assert called == []
+
+
 def test_probe_pod_running_handles_pod_status_failure(monkeypatch):
     """If pod_status raises, the probe must return fail, not propagate."""
     import winpodx.core.pod as pod_mod
@@ -159,15 +245,42 @@ def test_probe_guest_exec_fail_when_agent_unreachable(monkeypatch):
     assert "connection refused" in out.detail
 
 
+def test_probe_agent_auth_ready_ok(monkeypatch):
+    class _FakeClient:
+        def __init__(self, _cfg) -> None:
+            pass
+
+        def auth_ready(self):
+            return True, ""
+
+    monkeypatch.setattr("winpodx.core.agent.AgentClient", _FakeClient)
+    out = checks.probe_agent_auth_ready(_FakeCfg())
+    assert out.status == "ok"
+
+
+def test_probe_agent_auth_ready_fail(monkeypatch):
+    class _FakeClient:
+        def __init__(self, _cfg) -> None:
+            pass
+
+        def auth_ready(self):
+            return False, "agent token file missing"
+
+    monkeypatch.setattr("winpodx.core.agent.AgentClient", _FakeClient)
+    out = checks.probe_agent_auth_ready(_FakeCfg())
+    assert out.status == "fail"
+    assert "token" in out.detail
+
+
 def test_probe_agent_health_timeout_is_warmup_warn(monkeypatch):
-    from winpodx.core.agent import AgentUnavailableError
+    from winpodx.core.agent import AgentTimeoutError
 
     class _FakeClient:
         def __init__(self, _cfg) -> None:
             pass
 
         def health(self):
-            raise AgentUnavailableError("/health timed out after 2.0s")
+            raise AgentTimeoutError("/health timed out after 2.0s")
 
     monkeypatch.setattr("winpodx.core.agent.AgentClient", _FakeClient)
     out = checks.probe_agent_health(_FakeCfg())

--- a/tests/test_oem_install_bat.py
+++ b/tests/test_oem_install_bat.py
@@ -6,6 +6,14 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 INSTALL_BAT = REPO_ROOT / "config" / "oem" / "install.bat"
 
 
+def _active_lines(text: str) -> list[str]:
+    return [
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().casefold().startswith("rem ")
+    ]
+
+
 def test_install_bat_exists() -> None:
     assert INSTALL_BAT.is_file()
 
@@ -30,3 +38,36 @@ def test_install_bat_does_not_self_lock_setup_log() -> None:
     text = INSTALL_BAT.read_text(encoding="utf-8")
     assert "Add-Content -LiteralPath '%SETUP_LOG%'" not in text
     assert '>>"%SETUP_LOG%" 2>&1' in text
+
+
+def test_install_bat_oem_version_matches_expected_setup_contract() -> None:
+    text = INSTALL_BAT.read_text(encoding="utf-8")
+    assert "set WINPODX_OEM_VERSION=24" in text
+    assert "(echo %WINPODX_OEM_VERSION%)>C:\\winpodx\\oem_version.txt" in text
+
+
+def test_install_bat_uses_tar_not_expand_archive_command() -> None:
+    text = INSTALL_BAT.read_text(encoding="utf-8")
+    active_text = "\n".join(_active_lines(text)).casefold()
+
+    assert "expand-archive" not in active_text
+    assert '"%systemroot%\\system32\\tar.exe" -xf' in active_text
+
+
+def test_install_bat_registers_and_spawns_guest_agent() -> None:
+    text = INSTALL_BAT.read_text(encoding="utf-8")
+
+    assert "Set-ItemProperty -Path $key -Name 'WinpodxAgent'" in text
+    assert "Set-ItemProperty -Path $key -Name 'WinpodxMedia'" in text
+    assert "agent-spawn: wscript+hidden-launcher.vbs" in text
+    assert "agent-spawn: direct-powershell-fallback" in text
+
+
+def test_install_bat_writes_setup_done_before_final_termservice_cycle() -> None:
+    text = INSTALL_BAT.read_text(encoding="utf-8")
+    setup_done_idx = text.index("(echo done)>C:\\winpodx\\setup_done.txt")
+    last_step_idx = text.index("REM TermService cycle -- ABSOLUTELY LAST STEP.")
+    stop_idx = text.index("net stop TermService /y")
+    start_idx = text.index("net start TermService")
+
+    assert setup_done_idx < last_step_idx < stop_idx < start_idx


### PR DESCRIPTION
## Summary

A targeted refactor / hardening pass building on top of PR #107. Three independent threads:

## 1. Distinguish agent timeout from agent unreachable

`AgentClient.health()` previously raised `AgentUnavailableError` on `socket.timeout`, collapsing two semantically distinct conditions into one. PR #107's `checks.py` worked around it with substring matching (`if "timed out" in str(e).lower()`), which is fragile.

Now: `AgentClient.health()` (and `exec()`, by parallel structure) raise `AgentTimeoutError` on socket.timeout — both bare and the URLError-wrapped form Python 3.10+ produces. The dead bare `TimeoutError` catch (urllib never raises it on its own) is removed. `AgentTransport.health()` catches `AgentTimeoutError` explicitly so timeouts get the right `HealthStatus(available=False, detail=...)` path.

## 2. `probe_agent_auth_ready` + dependency-aware `run_all()`

Splits the auth-readiness check out of `AgentTransport.health()` into its own probe (`probe_agent_auth_ready`).

`run_all()` now does **dependency-aware probing**: if `agent_health` isn't OK, downstream probes (`auth_ready`, `guest_exec`, `guest_summary`) return `status="skip"` with a detail explaining the upstream dependency, rather than each one re-running and reporting its own variation of "agent unreachable". Cuts noise in the Info screen during warm-up: a single `agent_health=warn` surfaces clearly instead of fanning out to four cascade FAILs.

## 3. Split GUI workers out of `main_window.py` into `gui/workers.py`

`_DiscoveryWorker`, `_InfoWorker`, the desktop-entry sync helper, and the pod-down heuristic moved to a dedicated module. `main_window.py` shrinks by ~100 lines. The workers are publicly named (`DiscoveryWorker`, `InfoWorker`, `sync_desktop_entries`) so they can be imported and tested independently. Behavior is unchanged — the refactor is mechanical except for the renaming.

## Tests added (10+)

- `tests/test_agent.py`: `test_timeout_raises_timeout` (renamed from `_unavailable`), new `test_urlerror_socket_timeout_raises_timeout`, `test_auth_ready_reports_missing_token`, `test_auth_ready_ok_when_token_exists`
- `tests/test_checks.py`: `test_run_all_skips_exec_probes_when_agent_health_not_ok` + related
- `tests/test_oem_install_bat.py`: 4 new — OEM v24 contract, `tar` not `Expand-Archive` in active code (REM-aware), agent register+spawn presence, setup_done.txt before final TermService cycle

\`591 passed, 1 skipped, 0 new failures.\` (was 580 → 591)

## Test plan

- [ ] Existing CI (lint + audit + 5 Python versions + discover-apps-ps) stays green.
- [ ] Smoke test: Info screen during fresh-install warm-up should show a single \`agent_health=warn\` row, with \`agent_auth_ready\` / \`guest_exec\` / \`guest_summary\` showing \`skip\` rather than each independently failing.