### PR TITLE
docs(readme): add Star History section above License

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,16 @@ Maintainer setup for each channel lives under [`packaging/`](packaging/):
 
 For security issues, follow the process in [SECURITY.md](SECURITY.md).
 
+## Star History
+
+<a href="https://star-history.com/#kernalix7/winpodx&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date" />
+  </picture>
+</a>
+
 ## License
 
 [MIT](LICENSE) - Kim DaeHyun (kernalix7@kodenet.io)

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -627,6 +627,16 @@ ruff check src/ tests/         # 린트
 
 보안 이슈는 [SECURITY.ko.md](SECURITY.ko.md)의 절차를 따라 주세요.
 
+## Star History
+
+<a href="https://star-history.com/#kernalix7/winpodx&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date" />
+  </picture>
+</a>
+
 ## 라이선스
 
 [MIT](LICENSE) - Kim DaeHyun (kernalix7@kodenet.io)


### PR DESCRIPTION
## Summary

Embeds the `api.star-history.com` SVG with light/dark variants via the HTML `<picture>` element (so GitHub's dark-theme rendering uses the dark chart). Click takes the visitor to the interactive chart at `https://star-history.com/#kernalix7/winpodx&Date`.

Mirror change in `docs/README.ko.md` so the Korean README stays in sync with the English one.

## Test plan

- [ ] Open README.md on github.com — Star History section renders between Security and License with a live chart embed.
- [ ] Switch GitHub UI to dark mode — chart variant switches.