### PR TITLE
fix(migrate): retry _attempt_refresh up to 3x on discovery channel failure

### DIFF
--- a/src/winpodx/cli/migrate.py
+++ b/src/winpodx/cli/migrate.py
@@ -853,14 +853,36 @@ def _attempt_refresh() -> None:
         )
         return
 
-    try:
-        print("\n  Scanning Windows pod for installed apps...")
-        apps = discover_apps(cfg)
-        written = persist_discovered(apps)
-        print(f"  Discovered {len(apps)} app(s); wrote {len(written)} profile(s).")
-    except DiscoveryError as exc:
-        print(f"\n  Discovery failed: {exc}")
-        print("  Retry later with: winpodx app refresh")
+    # v0.4.0 (post-rc1): retry up to 3 times with 10s spacing.
+    # `_apply_vbs_launchers` (which runs as part of the apply chain just
+    # before this prompt) ends by spawning agent-respawn.ps1 detached.
+    # The respawn waits ~3s, kills the running agent, then starts a new
+    # one. If the user accepts the discovery prompt fast enough, the
+    # /exec hits the agent during that kill-then-restart window and gets
+    # "Remote end closed connection without response". Three attempts at
+    # 10s spacing covers the respawn cycle plus any HKCU\Run-driven
+    # restart race; final failure still prints the retry-later hint so
+    # the user knows pending-resume isn't silently kicking in here.
+    print("\n  Scanning Windows pod for installed apps...")
+    last_exc: DiscoveryError | None = None
+    for attempt in (1, 2, 3):
+        try:
+            apps = discover_apps(cfg)
+            written = persist_discovered(apps)
+            print(f"  Discovered {len(apps)} app(s); wrote {len(written)} profile(s).")
+            return
+        except DiscoveryError as exc:
+            last_exc = exc
+            if attempt < 3:
+                print(
+                    f"  attempt {attempt} deferred ({exc}); "
+                    "retrying in 10s (agent may be respawning)..."
+                )
+                import time as _time
+
+                _time.sleep(10)
+    print(f"\n  Discovery failed: {last_exc}")
+    print("  Retry later with: winpodx app refresh")
 
 
 def _pod_is_running(cfg) -> bool:


### PR DESCRIPTION
## Summary

kernalix7's 2026-05-05 v0.3.0 → v0.4.0rc1 upgrade smoke saw discovery fail in migrate's interactive "Run app discovery now?" path with `Remote end closed connection without response`.

## Cause

`_apply_vbs_launchers` (part of the apply chain that runs just before the discovery prompt) ends by spawning `agent-respawn.ps1` detached. The respawn waits ~3 s, kills the running agent, then starts a new one. If the user accepts the discovery prompt fast enough, the `/exec` hits the agent during that kill-then-restart window.

`install.sh`'s non-interactive path already had retry-with-delay (PR #111); the interactive `_attempt_refresh` in migrate did not.

## Fix

Same 3-attempt loop with 10 s spacing as install.sh. Final failure still prints "Retry later with: winpodx app refresh" so the user knows pending-resume isn't silently kicking in here.

## Test plan

- [ ] v0.3.0 → v0.4.0rc1 upgrade: discovery prompt completes inline (`Discovered N app(s)`), or shows `attempt 1 deferred ... retrying in 10s` then succeeds.