### PR TITLE
fix(release): include unreleased intermediate sections in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,9 +102,36 @@ jobs:
           # REL-v0.4.0 -> 0.4.0; REL-v0.4.0rc1 -> 0.4.0rc1.
           tag="${GITHUB_REF_NAME#REL-}"
           tag="${tag#v}"
-          notes=$(awk -v ver="$tag" '
-            $0 ~ "^## \\[" ver "\\]" { flag=1; next }
-            flag && /^## \[/ { exit }
+          # Determine the previous published version so we can include
+          # any intermediate unreleased sections in the notes (sections
+          # the user wrote in CHANGELOG but never tagged & released).
+          # On 2026-05-05, v0.3.1 was such an unreleased section: it
+          # collected Mic92's PRs #62-#65 but no v0.3.1 tag was ever
+          # pushed; v0.4.0rc1's release page would have lost those
+          # contributor credits if it only matched ## [0.4.0].
+          # Strategy: find the most recent CHANGELOG section that
+          # corresponds to a published GitHub Release (i.e., has its own
+          # tag). Capture from the current section back to (but not
+          # including) that already-published one.
+          prev=""
+          while IFS= read -r section; do
+            sver="${section#\#\# \[}"
+            sver="${sver%%\] *}"
+            # Skip the in-flight version itself and the unreleased header.
+            [ "$sver" = "$tag" ] && continue
+            [ "$sver" = "Unreleased" ] && continue
+            # First section we hit that has a corresponding tag is the
+            # previous published release. CHANGELOG is in newest-first
+            # order so this is correct on the first match.
+            if git rev-parse --verify "v${sver}^{commit}" >/dev/null 2>&1; then
+              prev="$sver"
+              break
+            fi
+          done < <(grep -E '^## \[' CHANGELOG.md)
+          notes=$(awk -v ver="$tag" -v prev="$prev" '
+            $0 ~ "^## \\[" ver "\\]" { flag=1 }
+            prev != "" && $0 ~ "^## \\[" prev "\\]" { exit }
+            prev == "" && flag && /^## \[/ && $0 !~ "^## \\[" ver "\\]" { exit }
             flag { print }
           ' CHANGELOG.md)
           # PEP 440 prereleases (0.4.0rc1) usually share notes with the
@@ -113,9 +140,10 @@ jobs:
           if [ -z "$(echo "$notes" | tr -d '[:space:]')" ]; then
             base=$(echo "$tag" | sed -E 's/(rc|alpha|beta)[0-9]*$//')
             if [ "$base" != "$tag" ]; then
-              notes=$(awk -v ver="$base" '
-                $0 ~ "^## \\[" ver "\\]" { flag=1; next }
-                flag && /^## \[/ { exit }
+              notes=$(awk -v ver="$base" -v prev="$prev" '
+                $0 ~ "^## \\[" ver "\\]" { flag=1 }
+                prev != "" && $0 ~ "^## \\[" prev "\\]" { exit }
+                prev == "" && flag && /^## \[/ && $0 !~ "^## \\[" ver "\\]" { exit }
                 flag { print }
               ' CHANGELOG.md)
             fi


### PR DESCRIPTION
## Summary

`v0.4.0rc1`'s release page only contained the `## [0.4.0]` section, missing all of Mic92's contributions (PRs #62-#65) which were credited under the `## [0.3.1]` header. v0.3.1 was a CHANGELOG section that I wrote but never tagged and released, so the awk extractor (which matched exactly one `## [<ver>]` section and stopped at the next `## [`) skipped it entirely.

## Fix

Find the most recent CHANGELOG section that corresponds to a real git tag (= a published release), and emit everything from the current section down to but **not including** that previous-published one. CHANGELOG is in newest-first order so the first matching section is correct.

If no previous published version exists (very early project state), fall back to the original behaviour of stopping at the next `## [` header.

The v0.4.0rc1 release page itself was already updated manually via `gh release edit --notes-file` to include the missing v0.3.1 content; this commit prevents the same scenario from happening on the next release.

## Test plan

- [ ] Local awk run with `tag=0.4.0`, simulated `git rev-parse v0.3.0-RTM1^{commit}` succeeding and `v0.3.1^{commit}` failing → produces v0.4.0 + v0.3.1 sections, stops at v0.3.0.