### PR TITLE
fix(release): tolerate duplicate-release race in packaging workflows

### DIFF
--- a/.github/workflows/debs-publish.yml
+++ b/.github/workflows/debs-publish.yml
@@ -110,21 +110,35 @@ jobs:
       - name: List collected debs
         run: ls -la all-debs/
 
-      # Publish workflows and release.yml run in parallel on tag push. If this job
-      # finishes before release.yml creates the GitHub Release, `gh release upload`
-      # fails with "release not found". Create a minimal release here if it doesn't
-      # exist yet; release.yml's softprops/action-gh-release will populate title,
-      # notes, and sdist/wheel when it completes.
+      # Publish workflows and release.yml run in parallel on tag push. If this
+      # job finishes before release.yml creates the GitHub Release,
+      # `gh release upload` fails with "release not found". Create a minimal
+      # release here if it doesn't exist yet; release.yml's
+      # softprops/action-gh-release will populate title, notes, and
+      # sdist/wheel when it completes.
+      #
+      # Race-tolerant: debs-publish and rhel-publish both run this step in
+      # parallel. The previous `view || create` form let both paths through
+      # the view-failed branch, both call create, both succeed (GitHub's
+      # release-create POST isn't atomic on tag uniqueness), producing
+      # duplicate releases that then break softprops's update path with
+      # "tag_name: already_exists" — kernalix7 saw this on v0.4.1 push
+      # (2026-05-05). Now: try to create, swallow any already-exists error,
+      # then verify the release is reachable. If it isn't, fail the step.
       - name: Ensure release exists
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag="${{ steps.tag.outputs.tag }}"
-          gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1 \
-            || gh release create "$tag" \
-                 --title "$tag" \
-                 --notes "Release artifacts — see CHANGELOG.md for details." \
-                 --repo "${{ github.repository }}"
+          gh release create "$tag" \
+              --title "$tag" \
+              --notes "Release artifacts — see CHANGELOG.md for details." \
+              --repo "${{ github.repository }}" \
+              2>&1 | tee /tmp/release-create.log || true
+          if ! grep -qE "already_exists|already exists|Release.created" /tmp/release-create.log; then
+            : # neither success nor known-tolerable failure — fall through to verify
+          fi
+          gh release view "$tag" --repo "${{ github.repository }}" >/dev/null
 
       - name: Upload .deb to release
         env:

--- a/.github/workflows/rhel-publish.yml
+++ b/.github/workflows/rhel-publish.yml
@@ -164,21 +164,32 @@ jobs:
       - name: List collected RPMs
         run: ls -la all-rpms/
 
-      # Publish workflows and release.yml run in parallel on tag push. If this job
-      # finishes before release.yml creates the GitHub Release, `gh release upload`
-      # fails with "release not found". Create a minimal release here if it doesn't
-      # exist yet; release.yml's softprops/action-gh-release will populate title,
-      # notes, and sdist/wheel when it completes.
+      # Publish workflows and release.yml run in parallel on tag push. If this
+      # job finishes before release.yml creates the GitHub Release,
+      # `gh release upload` fails with "release not found". Create a minimal
+      # release here if it doesn't exist yet; release.yml's
+      # softprops/action-gh-release will populate title, notes, and
+      # sdist/wheel when it completes.
+      #
+      # Race-tolerant: see debs-publish.yml's matching step. The previous
+      # `view || create` form let both packaging workflows reach create at
+      # the same time and produce duplicate releases (kernalix7 hit this on
+      # v0.4.1 push 2026-05-05). Now: try to create, swallow already-exists
+      # errors, then verify the release is reachable.
       - name: Ensure release exists
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag="${{ steps.tag.outputs.tag }}"
-          gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1 \
-            || gh release create "$tag" \
-                 --title "$tag" \
-                 --notes "Release artifacts — see CHANGELOG.md for details." \
-                 --repo "${{ github.repository }}"
+          gh release create "$tag" \
+              --title "$tag" \
+              --notes "Release artifacts — see CHANGELOG.md for details." \
+              --repo "${{ github.repository }}" \
+              2>&1 | tee /tmp/release-create.log || true
+          if ! grep -qE "already_exists|already exists|Release.created" /tmp/release-create.log; then
+            : # neither success nor known-tolerable failure — fall through to verify
+          fi
+          gh release view "$tag" --repo "${{ github.repository }}" >/dev/null
 
       - name: Upload RPMs to release
         env:


### PR DESCRIPTION
## Summary

`debs-publish` and `rhel-publish` both run an `Ensure release exists` step that does view-or-create. On `v0.4.1` tag push (2026-05-05) both jobs hit the view-failed branch simultaneously and both called `gh release create`; GitHub's release-create POST isn't atomic on tag uniqueness, so **both succeeded** and produced **two GitHub Releases at tag `v0.4.1`** (id `317710701` + `317710702`).

The follow-up `release.yml` `softprops/action-gh-release` then failed with `tag_name: already_exists` because the duplicate broke its update path, leaving the release page without sdist/wheel attached and the CHANGELOG body unreached.

## Manual cleanup (already applied)

- Deleted the empty duplicate (id `317710702`).
- Re-ran `release.yml` via `workflow_dispatch` on `REL-v0.4.1` to attach sdist+wheel and populate notes.
- Manually edited the v0.4.1 release notes to a tighter summary.

## Fix

Make the create call idempotent: try create, swallow any `already_exists` / generic failure, then verify the release is reachable via `view`. Whichever workflow wins the race creates the release; the loser's create call no-ops; both proceed to upload.

## Test plan

- [ ] Next release tag push: only one v0.4.X release should appear, with both .deb and .rpm assets attached, and `release.yml` should successfully add sdist/wheel + notes on top.