### PR TITLE
fix(pod): rewrite dockur's VNC URL in wait-ready logs to the host port

### DIFF
--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -537,6 +537,23 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
                 bufsize=1,
             )
 
+            # Rewrite dockur's container-internal VNC web URL to the host
+            # port the user can actually reach. dockur prints
+            # `visit http://127.0.0.1:8006/ to view the screen` from inside
+            # its container, where 8006 IS the listening port; from the
+            # host that port is mapped to cfg.pod.vnc_port (8007 by default
+            # — see core/pod/compose.py). Without this rewrite, the line
+            # streamed via `--logs` told the user to visit a port that's
+            # only reachable inside the container, and copy-pasting the
+            # URL into a browser silently failed (xiyeming reported this
+            # 2026-05-05 in #118).
+            vnc_port = cfg.pod.vnc_port
+
+            def _rewrite_vnc_url(line: str) -> str:
+                if vnc_port == 8006:
+                    return line
+                return line.replace("127.0.0.1:8006", f"127.0.0.1:{vnc_port}")
+
             def _drain(stream) -> None:  # type: ignore[no-untyped-def]
                 if stream is None:
                     return
@@ -545,7 +562,7 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
                         break
                     line = line.rstrip()
                     if line:
-                        print(f"       [container] {line}")
+                        print(f"       [container] {_rewrite_vnc_url(line)}")
 
             threading.Thread(target=_drain, args=(log_proc.stdout,), daemon=True).start()
             threading.Thread(target=_drain, args=(log_proc.stderr,), daemon=True).start()


### PR DESCRIPTION
Closes #118.

## Summary

dockur prints `visit http://127.0.0.1:8006/ to view the screen` from inside its container, where `8006` IS the listening port. From the host that internal port is mapped to `cfg.pod.vnc_port` (default `8007`, see `core/pod/compose.py`'s `127.0.0.1:{vnc_port}:8006` spec). The `--logs` tail in install.sh's wait-ready output streamed the container line as-is, so users were told to open a port only reachable inside the container.

## Fix

`_drain` in `_wait_ready` now substitutes `127.0.0.1:8006` with `127.0.0.1:{cfg.pod.vnc_port}` per streamed line. Uses the **user's actual configured port** (whatever's in `winpodx.toml`), not a hardcoded value. No-ops when `vnc_port` happens to equal `8006`.

## Test plan

- [x] Inline replacement logic verified against the dockur banner + custom port + matching-port noop cases.
- [ ] Re-run `winpodx pod wait-ready --logs` after the next pod start: `[container] ❯ Windows started successfully, visit http://127.0.0.1:<actual-port>/ ...` instead of `:8006`.