### PR TITLE
release: v0.4.2 — VNC URL rewrite + packaging-race fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-05-05
+
+Patch release. Two small fixes on top of 0.4.1.
+
+### Fixed
+- **`wait-ready --logs` rewrites dockur's container-internal VNC URL to the host's mapped port.** dockur prints `visit http://127.0.0.1:8006/ to view the screen` from inside its container, where `8006` IS the listening port. The host maps that to `cfg.pod.vnc_port` (default `8007`, see `core/pod/compose.py`'s `127.0.0.1:{vnc_port}:8006` spec), so the URL streamed to the user's terminal pointed at a port only reachable inside the container. `_drain` in `_wait_ready` now substitutes `127.0.0.1:8006` → `127.0.0.1:{cfg.pod.vnc_port}` per streamed line, using the user's actual configured port (so a custom `vnc_port` in `winpodx.toml` is honored). Reported by @xiyeming. Closes #118.
+- **Packaging workflows tolerate the create-release race.** `debs-publish` and `rhel-publish` both ran an `Ensure release exists` step that did `view || create`. On `v0.4.1` tag push both jobs hit the view-failed branch in parallel and both successfully called `gh release create`; GitHub's release-create POST isn't atomic on tag uniqueness, so two GitHub Releases appeared at the same tag and `release.yml`'s subsequent `softprops/action-gh-release` failed with `tag_name: already_exists`, leaving the release page without sdist/wheel attached. The create call is now idempotent: try create, swallow any `already_exists` error, then verify the release is reachable via `view`. Whichever workflow wins the race creates the release; the loser's create call no-ops; both proceed to upload assets.
+
 ## [0.4.1] - 2026-05-05
 
 The `0.4.x` line's first stable release. `0.4.0rc1` (2026-05-05) was the soak preview; `0.4.1` is the same code path plus the polish that landed during smoke-test triage. Functionally a continuation of `0.4.0`'s stability + UX focus, all of it on the install / migrate path that fresh users actually exercise.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+winpodx (0.4.2) unstable; urgency=medium
+
+  * Patch release. Two small fixes on top of 0.4.1:
+    - wait-ready --logs now rewrites dockur's container-internal VNC URL
+      (http://127.0.0.1:8006/) to the host's actual mapped port so the
+      printed URL matches what the user can open in a browser. Closes #118.
+    - Packaging workflows (debs/rhel) tolerate the create-release race that
+      produced duplicate v0.4.1 release entries on tag push; create is now
+      idempotent.
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Tue, 05 May 2026 12:00:00 +0000
+
 winpodx (0.4.1) unstable; urgency=high
 
   * 0.4.x line's first stable release. Closes the 'agent never installs'

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,14 @@
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-05-05
+
+Patch release. 0.4.1 위에 작은 fix 두 개.
+
+### 수정
+- **`wait-ready --logs` 가 dockur 컨테이너 내부 VNC URL 을 호스트 매핑 포트로 rewrite.** dockur 가 컨테이너 안에서 `visit http://127.0.0.1:8006/` 출력 — 컨테이너 내부에선 8006 이 listen 포트 맞음. 호스트는 그 포트를 `cfg.pod.vnc_port` (기본 `8007`, `core/pod/compose.py` 의 `127.0.0.1:{vnc_port}:8006` 스펙) 로 매핑하므로 사용자 터미널에 스트림된 URL 이 컨테이너 안에서만 reachable 한 포트를 가리키고 있었음. `_wait_ready` 의 `_drain` 이 이제 줄마다 `127.0.0.1:8006` → `127.0.0.1:{cfg.pod.vnc_port}` 치환 — 사용자가 `winpodx.toml` 에 설정한 실제 포트 사용 (커스텀 값도 그대로 반영). @xiyeming 보고. Closes #118.
+- **Packaging 워크플로우가 create-release race 견딤.** `debs-publish` 와 `rhel-publish` 가 `view || create` 패턴으로 release 보장하는데, `v0.4.1` 태그 push 시 두 job 이 동시에 view-failed 분기 → 둘 다 `gh release create` 성공 (GitHub release-create POST 가 tag uniqueness 에 atomic 아님) → 같은 태그에 GitHub Release 두 개 생성 → 후속 `release.yml` 의 `softprops/action-gh-release` 가 `tag_name: already_exists` 로 fail 하면서 sdist/wheel attach 안 됨. create 를 idempotent 로: try create, `already_exists` 에러 swallow, 그 후 view 로 reachable 확인. race 이긴 쪽이 생성, 진 쪽 create 는 no-op, 둘 다 asset upload 진행.
+
 ## [0.4.1] - 2026-05-05
 
 `0.4.x` 라인의 첫 stable 릴리스. `0.4.0rc1` (2026-05-05) 이 soak preview 였고, `0.4.1` 은 동일 코드 경로 + smoke-test triage 중 land 된 polish. 기능적으론 `0.4.0` 의 안정성 + UX 집중의 연장선이며, 모두 fresh 사용자가 거치는 install / migrate 경로에 집중.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.4.1"
+version = "0.4.2"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"

--- a/src/winpodx/__init__.py
+++ b/src/winpodx/__init__.py
@@ -1,3 +1,3 @@
 """winpodx: Windows app integration for Linux desktop."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"


### PR DESCRIPTION
Patch release. Two fixes on top of v0.4.1.

- **wait-ready --logs** rewrites dockur's container-internal VNC URL (`http://127.0.0.1:8006/`) to the host's mapped port (`cfg.pod.vnc_port`, default `8007`, custom values honored) so the URL streamed to the terminal matches what the browser can open. Closes #118.
- **debs-publish + rhel-publish** `Ensure release exists` step is now idempotent (try create → swallow `already_exists` → verify via view). Prevents the duplicate-release race observed on v0.4.1 push.

`591 passed, 1 skipped`, ruff check + format clean.

After merge: tag `v0.4.2` + `REL-v0.4.2` to ship the release.