### PR TITLE
docs(changelog): pin Contributors line to 0.4.1 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ The `0.4.x` line's first stable release. `0.4.0rc1` (2026-05-05) was the soak pr
 ### Added
 - **Star History chart in README** (light/dark variants via `<picture>`). Click goes to the interactive chart on star-history.com.
 
+### Contributors
+Thanks to @Mic92 (Nix flake packaging, default-image switch, FreeRDP argv[0] match, Wayland XWayland gate — PRs #62-#65) and @pgarciaq (SELinux OEM bind mount fix — PR #95).
+
 ## [0.4.0] - 2026-05-03
 
 A significant stability + UX release focused on the install / migrate paths. Container recreates are no longer triggered by dockur's `:latest` push cadence (image is SHA-pinned), every PowerShell console flash on app launch and agent autostart has been eliminated, fresh installs honestly wait for Windows to be ready, and multi-session activation is now hands-free via `apply-fixes` / `migrate`. SELinux-enforcing systems (Fedora) work out of the box. RTM-suffixed pods (`0.3.0-RTM1`) migrate cleanly. The `winpodx app refresh` discovery race is closed in three layers. Contributing policy + lifecycle docs added.

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -44,6 +44,9 @@ Patch release. 0.4.1 위에 작은 fix 두 개.
 ### 추가
 - **README 에 Star History chart** (light/dark `<picture>`). 클릭하면 star-history.com 인터랙티브 차트.
 
+### Contributors
+Thanks to @Mic92 (Nix flake packaging, default-image switch, FreeRDP argv[0] match, Wayland XWayland gate — PRs #62-#65) and @pgarciaq (SELinux OEM bind mount fix — PR #95).
+
 ## [0.4.0] - 2026-05-03
 
 설치 / 마이그레이션 경로의 안정성 + UX 에 집중한 주요 릴리스. dockur 의 `:latest` push cadence 가 더 이상 컨테이너 재생성을 트리거하지 않음 (이미지 SHA pinned). 앱 launch 와 agent autostart 에서 PowerShell 콘솔 깜빡임이 모두 제거됨. fresh install 이 Windows 준비될 때까지 정직하게 대기. multi-session 활성화가 `apply-fixes` / `migrate` 로 hands-free. SELinux-enforcing 시스템 (Fedora) 가 out of the box 동작. RTM-suffix pod (`0.3.0-RTM1`) 정상 마이그레이션. `winpodx app refresh` discovery race 가 3계층으로 차단. Contributing 정책 + 라이프사이클 문서 추가.


### PR DESCRIPTION
Restores the v0.4.1 contributor credits that were lost when a workflow_dispatch re-extracted the release body from CHANGELOG. Pinning the names into a dedicated 'Contributors' subsection in CHANGELOG.md (en + ko) so future re-extractions preserve the credit. Release page already restored manually via `gh release edit`.