### PR TITLE
feat(setup): auto-disable btrfs Copy-on-Write on container storage root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added
+- **Auto-disable btrfs Copy-on-Write on the container backend's storage root.** dockur warns about btrfs in its container output for a real reason: btrfs' default CoW combined with the access pattern of a Windows VM raw disk image (every pagefile / swap / boot write forks a new extent) causes the disk image to fragment aggressively. Pod recreates that should take ~30 s on ext4 take many minutes (or time out at the 300 s budget — kernalix7's reporters on cachyos hit this in #121, #122). `winpodx setup` now detects the filesystem under `podman info --format '{{.Store.GraphRoot}}'` (or the docker equivalent) via `findmnt` and, if it's btrfs, runs `chattr +C` on the directory. `chattr +C` on a directory affects only NEW files created inside, so existing podman volumes keep their CoW flags untouched and the new winpodx-data volume materialised by the next `podman-compose up` inherits NoCoW. Idempotent — re-running setup short-circuits via `lsattr` if the flag is already on. Status reasons (`disabled` / `already_off` / `not_btrfs` / `unknown` / `failed`) surface as friendly setup output; failures don't abort the install.
+
 ## [0.4.2] - 2026-05-05
 
 Patch release. Two small fixes on top of 0.4.1.

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,9 @@
 
 ## [Unreleased]
 
+### 추가
+- **컨테이너 백엔드 storage root 가 btrfs 면 Copy-on-Write 자동 비활성화.** dockur 가 btrfs 경고 출력하는 진짜 이유 — btrfs 의 기본 CoW 가 Windows VM raw disk image 의 access pattern (pagefile / swap / 부팅 시 매 쓰기마다 새 extent fork) 과 안 어울려서 디스크 이미지가 심하게 fragment. ext4 에선 ~30초 걸릴 pod 재생성이 btrfs 에선 수 분 (또는 300s timeout — kernalix7 의 cachyos 리포터들이 #121, #122 에서 hit). `winpodx setup` 이 이제 `podman info --format '{{.Store.GraphRoot}}'` (docker 등가물) 로 백엔드 storage root 의 파일시스템을 `findmnt` 로 감지, btrfs 면 디렉터리에 `chattr +C` 적용. 디렉터리 `chattr +C` 는 그 안에 **새로 생성될** 파일에만 영향이라 기존 podman 볼륨은 그대로, 다음 `podman-compose up` 에서 lazily 생성될 winpodx-data 볼륨이 NoCoW 로 상속. Idempotent — `lsattr` 로 이미 +C 면 short-circuit. 상태 코드 (`disabled` / `already_off` / `not_btrfs` / `unknown` / `failed`) 가 setup 출력에 노출되고 실패해도 install 진행.
+
 ## [0.4.2] - 2026-05-05
 
 Patch release. 0.4.1 위에 작은 fix 두 개.

--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -352,12 +352,51 @@ def handle_setup(args: argparse.Namespace) -> None:
     print("Just click any app. winpodx handles the rest automatically.")
 
 
+def _maybe_disable_btrfs_cow(cfg: Config) -> None:
+    """v0.4.x: detect btrfs on the container backend's storage root and run
+    ``chattr +C`` so Windows VM raw disk images (which dockur creates inside
+    the named volume) bypass btrfs Copy-on-Write.
+
+    Background: kernalix7's reporters on cachyos (#121, #122) hit pod
+    recreate timeouts that traced back to btrfs CoW thrashing on the
+    Windows raw disk. The chattr on the directory affects only NEW files,
+    so existing podman volumes keep their CoW behaviour and we don't risk
+    breaking other workloads sharing the graph root. Idempotent — running
+    on an already-NoCoW root short-circuits via ``is_cow_disabled``.
+
+    Best-effort: every failure path logs a friendly note and returns;
+    install proceeds. The user can still run ``chattr +C`` manually if
+    they care.
+    """
+    from winpodx.utils.btrfs import disable_cow_if_btrfs
+
+    status, detail = disable_cow_if_btrfs(cfg.pod.backend)
+    if status == "disabled":
+        print(f"  Disabled btrfs CoW on container storage ({detail}).")
+        print("    New files inside the storage root inherit NoCoW —")
+        print("    Windows VM disk image will avoid CoW fragmentation.")
+    elif status == "already_off":
+        # silent — common case on second-run setup, no need to surface
+        pass
+    elif status == "failed":
+        print(f"  Note: btrfs CoW disable skipped ({detail}).")
+        print("    Pod recreate may be slow on this filesystem; if you")
+        print("    notice that, run `chattr +C` on the storage root")
+        print("    manually while it's empty.")
+    # status == "not_btrfs" or "unknown" — say nothing
+
+
 def _recreate_container(cfg: Config) -> None:
     """Stop existing container and start fresh with new compose config."""
     import subprocess as sp
 
     compose_path = config_dir() / "compose.yaml"
     backend = cfg.pod.backend
+
+    # Pre-flight btrfs CoW handling. Done BEFORE the compose-up so the
+    # winpodx-data volume that podman lazily materialises during `up`
+    # inherits the +C flag from its parent.
+    _maybe_disable_btrfs_cow(cfg)
 
     compose_cmd: list[str] | None = None
     if backend == "podman":

--- a/src/winpodx/utils/btrfs.py
+++ b/src/winpodx/utils/btrfs.py
@@ -1,0 +1,145 @@
+"""btrfs Copy-on-Write detection and one-shot disable helper.
+
+dockur prints `Warning: you are using the BTRFS filesystem for /storage,
+this might introduce issues with Windows Setup!` for a real reason: btrfs
+defaults to Copy-on-Write on every block of every file, and a Windows VM
+raw disk image has the worst possible access pattern for that — every
+pagefile / swap / boot write forks a new extent. The disk image fragments
+aggressively and grows past its declared size; pod recreates that should
+take ~30 s on ext4 take many minutes (and often time out on the 300 s
+budget). kernalix7 hit this on cachyos (#121, #122).
+
+This module exposes two operations:
+
+- :func:`detect_storage_fs` — asks the container backend (podman /
+  docker) for its graph root and returns ``(fs_type, path)``. Tolerates
+  missing tools / unparseable output by returning ``("unknown", path)``.
+- :func:`disable_cow_if_btrfs` — when the storage root is btrfs and
+  CoW isn't already off, runs ``chattr +C <path>``. ``chattr +C`` on a
+  directory only affects NEW files created inside (existing files are
+  silently untouched), so this is safe to run on a populated graph
+  root. The flag is inherited by new subdirectories — when winpodx's
+  named volume is later materialised by ``podman-compose up``, the
+  Windows raw disk image lands as NoCoW.
+
+Both helpers are best-effort: every external command is wrapped in
+``try/except``, every failure surfaces as a string detail to the
+caller (typically winpodx setup) which logs and proceeds. We never
+abort the install on a btrfs detection failure.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+__all__ = [
+    "detect_storage_fs",
+    "disable_cow_if_btrfs",
+    "is_cow_disabled",
+]
+
+
+def _run(cmd: list[str], timeout: float = 5.0) -> tuple[int, str, str]:
+    """Run a subprocess and return (rc, stdout, stderr). Returns (-1, '', err) on missing binary."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return result.returncode, result.stdout, result.stderr
+    except FileNotFoundError as e:
+        return -1, "", str(e)
+    except (subprocess.SubprocessError, OSError) as e:
+        return -1, "", str(e)
+
+
+def detect_storage_fs(backend: str) -> tuple[str, Path | None]:
+    """Return ``(fs_type, storage_root_path)`` for the container backend.
+
+    fs_type is the lowercase string from ``findmnt`` (``btrfs``, ``ext4``,
+    ``xfs``, ...) or ``"unknown"`` when the backend isn't reachable, the
+    binaries aren't installed, or output can't be parsed.
+    """
+    if backend == "podman":
+        cmd = ["podman", "info", "--format", "{{.Store.GraphRoot}}"]
+    elif backend == "docker":
+        cmd = ["docker", "info", "--format", "{{.DockerRootDir}}"]
+    else:
+        return "unknown", None
+
+    rc, stdout, _ = _run(cmd, timeout=10.0)
+    if rc != 0:
+        return "unknown", None
+    raw = stdout.strip()
+    if not raw:
+        return "unknown", None
+    path = Path(raw)
+    if not path.exists():
+        return "unknown", path
+
+    if shutil.which("findmnt") is None:
+        return "unknown", path
+
+    rc, stdout, _ = _run(["findmnt", "-no", "FSTYPE", "--target", str(path)])
+    if rc != 0:
+        return "unknown", path
+    fs = stdout.strip().lower()
+    return fs or "unknown", path
+
+
+def is_cow_disabled(path: Path) -> bool | None:
+    """Return ``True`` if ``+C`` is set on ``path``, ``False`` if not, ``None`` if unknown.
+
+    Uses ``lsattr -d`` (lists the directory's own attributes, not its
+    children). The 'C' flag in the leading attribute string means CoW
+    is disabled for new files created inside.
+    """
+    if shutil.which("lsattr") is None:
+        return None
+    rc, stdout, _ = _run(["lsattr", "-d", str(path)])
+    if rc != 0:
+        return None
+    parts = stdout.split()
+    if not parts:
+        return None
+    attrs = parts[0]
+    return "C" in attrs
+
+
+def disable_cow_if_btrfs(backend: str) -> tuple[str, str]:
+    """Run ``chattr +C`` on the container backend's graph root if it's btrfs.
+
+    Returns ``(status, detail)``:
+
+    - ``"disabled"`` — applied chattr +C successfully (or it was already on).
+    - ``"already_off"`` — graph root already has +C; no-op.
+    - ``"not_btrfs"`` — graph root is some other filesystem; nothing to do.
+    - ``"unknown"`` — couldn't determine fs type or graph root.
+    - ``"failed"`` — fs is btrfs but chattr couldn't apply (permission /
+      kernel reject / etc.); detail carries the reason.
+
+    Idempotent: running this on an already-NoCoW graph root short-circuits
+    via ``is_cow_disabled``. Safe to call from every ``winpodx setup`` run.
+    """
+    fs, path = detect_storage_fs(backend)
+    if fs != "btrfs":
+        return ("not_btrfs" if fs != "unknown" else "unknown"), f"fs={fs} path={path}"
+
+    assert path is not None  # detect_storage_fs returns Path with btrfs
+
+    state = is_cow_disabled(path)
+    if state is True:
+        return "already_off", f"path={path}"
+
+    if shutil.which("chattr") is None:
+        return "failed", "chattr binary not on PATH (install e2fsprogs)"
+
+    rc, _stdout, stderr = _run(["chattr", "+C", str(path)])
+    if rc != 0:
+        return "failed", f"chattr +C {path} failed: {stderr.strip() or f'rc={rc}'}"
+
+    return "disabled", f"path={path}"

--- a/tests/test_btrfs.py
+++ b/tests/test_btrfs.py
@@ -1,0 +1,173 @@
+"""Tests for winpodx.utils.btrfs — Copy-on-Write detection + disable helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from winpodx.utils import btrfs
+
+
+def _run_factory(scripted):
+    """Build a fake _run that pops scripted (rc, stdout, stderr) tuples in order."""
+
+    calls = []
+
+    def fake(cmd, timeout=5.0):
+        calls.append(cmd)
+        if not scripted:
+            return -1, "", "no more scripted responses"
+        return scripted.pop(0)
+
+    return fake, calls
+
+
+class TestDetectStorageFs:
+    def test_returns_unknown_for_unsupported_backend(self):
+        fs, path = btrfs.detect_storage_fs("libvirt")
+        assert fs == "unknown"
+        assert path is None
+
+    def test_returns_unknown_when_podman_info_fails(self):
+        scripted = [(1, "", "podman not installed")]
+        fake, _ = _run_factory(scripted)
+        with patch.object(btrfs, "_run", fake):
+            fs, path = btrfs.detect_storage_fs("podman")
+        assert fs == "unknown"
+        assert path is None
+
+    def test_returns_btrfs_when_findmnt_says_btrfs(self, tmp_path):
+        # Pretend the graph root exists by pointing at tmp_path.
+        scripted = [
+            (0, str(tmp_path) + "\n", ""),  # podman info
+            (0, "btrfs\n", ""),  # findmnt
+        ]
+        fake, calls = _run_factory(scripted)
+        with (
+            patch.object(btrfs, "_run", fake),
+            patch.object(btrfs.shutil, "which", return_value="/usr/bin/findmnt"),
+        ):
+            fs, path = btrfs.detect_storage_fs("podman")
+        assert fs == "btrfs"
+        assert path == tmp_path
+        # Sanity: first call was podman info, second was findmnt.
+        assert calls[0][:2] == ["podman", "info"]
+        assert calls[1][:2] == ["findmnt", "-no"]
+
+    def test_returns_ext4_for_non_btrfs(self, tmp_path):
+        scripted = [
+            (0, str(tmp_path) + "\n", ""),
+            (0, "ext4\n", ""),
+        ]
+        fake, _ = _run_factory(scripted)
+        with (
+            patch.object(btrfs, "_run", fake),
+            patch.object(btrfs.shutil, "which", return_value="/usr/bin/findmnt"),
+        ):
+            fs, path = btrfs.detect_storage_fs("podman")
+        assert fs == "ext4"
+        assert path == tmp_path
+
+    def test_findmnt_missing_returns_unknown(self, tmp_path):
+        scripted = [(0, str(tmp_path) + "\n", "")]
+        fake, _ = _run_factory(scripted)
+        with (
+            patch.object(btrfs, "_run", fake),
+            patch.object(btrfs.shutil, "which", return_value=None),
+        ):
+            fs, path = btrfs.detect_storage_fs("podman")
+        assert fs == "unknown"
+        assert path == tmp_path  # we still report the path even if fs unknown
+
+
+class TestIsCowDisabled:
+    def test_returns_true_when_C_flag_present(self, tmp_path):
+        scripted = [(0, "----C-------------- " + str(tmp_path) + "\n", "")]
+        fake, _ = _run_factory(scripted)
+        with (
+            patch.object(btrfs, "_run", fake),
+            patch.object(btrfs.shutil, "which", return_value="/usr/bin/lsattr"),
+        ):
+            assert btrfs.is_cow_disabled(tmp_path) is True
+
+    def test_returns_false_when_C_flag_absent(self, tmp_path):
+        scripted = [(0, "------------------- " + str(tmp_path) + "\n", "")]
+        fake, _ = _run_factory(scripted)
+        with (
+            patch.object(btrfs, "_run", fake),
+            patch.object(btrfs.shutil, "which", return_value="/usr/bin/lsattr"),
+        ):
+            assert btrfs.is_cow_disabled(tmp_path) is False
+
+    def test_returns_none_when_lsattr_missing(self, tmp_path):
+        with patch.object(btrfs.shutil, "which", return_value=None):
+            assert btrfs.is_cow_disabled(tmp_path) is None
+
+    def test_returns_none_on_lsattr_error(self, tmp_path):
+        scripted = [(1, "", "lsattr: Operation not supported")]
+        fake, _ = _run_factory(scripted)
+        with (
+            patch.object(btrfs, "_run", fake),
+            patch.object(btrfs.shutil, "which", return_value="/usr/bin/lsattr"),
+        ):
+            assert btrfs.is_cow_disabled(tmp_path) is None
+
+
+class TestDisableCowIfBtrfs:
+    def test_skips_when_not_btrfs(self):
+        with patch.object(
+            btrfs, "detect_storage_fs", return_value=("ext4", Path("/var/lib/containers"))
+        ):
+            status, _ = btrfs.disable_cow_if_btrfs("podman")
+        assert status == "not_btrfs"
+
+    def test_unknown_when_detect_returns_unknown(self):
+        with patch.object(btrfs, "detect_storage_fs", return_value=("unknown", None)):
+            status, _ = btrfs.disable_cow_if_btrfs("podman")
+        assert status == "unknown"
+
+    def test_already_off_when_cow_already_disabled(self, tmp_path):
+        with (
+            patch.object(btrfs, "detect_storage_fs", return_value=("btrfs", tmp_path)),
+            patch.object(btrfs, "is_cow_disabled", return_value=True),
+        ):
+            status, detail = btrfs.disable_cow_if_btrfs("podman")
+        assert status == "already_off"
+        assert str(tmp_path) in detail
+
+    def test_failed_when_chattr_missing(self, tmp_path):
+        with (
+            patch.object(btrfs, "detect_storage_fs", return_value=("btrfs", tmp_path)),
+            patch.object(btrfs, "is_cow_disabled", return_value=False),
+            patch.object(btrfs.shutil, "which", return_value=None),
+        ):
+            status, detail = btrfs.disable_cow_if_btrfs("podman")
+        assert status == "failed"
+        assert "chattr" in detail
+
+    def test_disabled_on_successful_chattr(self, tmp_path):
+        scripted = [(0, "", "")]
+        fake, calls = _run_factory(scripted)
+        with (
+            patch.object(btrfs, "detect_storage_fs", return_value=("btrfs", tmp_path)),
+            patch.object(btrfs, "is_cow_disabled", return_value=False),
+            patch.object(btrfs.shutil, "which", return_value="/usr/bin/chattr"),
+            patch.object(btrfs, "_run", fake),
+        ):
+            status, detail = btrfs.disable_cow_if_btrfs("podman")
+        assert status == "disabled"
+        assert str(tmp_path) in detail
+        assert calls[0] == ["chattr", "+C", str(tmp_path)]
+
+    def test_failed_when_chattr_returns_nonzero(self, tmp_path):
+        scripted = [(1, "", "Operation not permitted\n")]
+        fake, _ = _run_factory(scripted)
+        with (
+            patch.object(btrfs, "detect_storage_fs", return_value=("btrfs", tmp_path)),
+            patch.object(btrfs, "is_cow_disabled", return_value=False),
+            patch.object(btrfs.shutil, "which", return_value="/usr/bin/chattr"),
+            patch.object(btrfs, "_run", fake),
+        ):
+            status, detail = btrfs.disable_cow_if_btrfs("podman")
+        assert status == "failed"
+        assert "Operation not permitted" in detail


### PR DESCRIPTION
Closes #122. Likely improves #121 (root cause overlaps).

## Summary

dockur warns about btrfs in its container output for a real reason: btrfs' default CoW combined with the access pattern of a Windows VM raw disk image (every pagefile / swap / boot write forks a new extent) causes the disk image to fragment aggressively. Pod recreates that should take ~30 s on ext4 take many minutes (or time out at the 300 s budget — kernalix7's reporters on cachyos hit this in #121, #122).

`winpodx setup` now detects the filesystem under `podman info --format '{{.Store.GraphRoot}}'` (or the docker equivalent) via `findmnt` and, if it's btrfs, runs `chattr +C` on the directory.

## Why this is safe

- `chattr +C` on a directory affects only **NEW files** created inside. Existing podman volumes keep their CoW flags untouched.
- The new `winpodx-data` volume is materialised lazily by the next `podman-compose up` inside the graph root, so it inherits NoCoW from the parent.
- Idempotent: `lsattr -d` short-circuits when `+C` is already set.

## Status reasons

| Status | Detail |
|---|---|
| `disabled` | Applied `chattr +C` successfully |
| `already_off` | Already NoCoW; no-op |
| `not_btrfs` | Other filesystem; nothing to do |
| `unknown` | Couldn't determine fs type or graph root |
| `failed` | btrfs but `chattr` couldn't apply (permission / kernel reject / etc.) |

Failures don't abort the install — the user can still run `chattr +C` manually if they want.

## Tests

15 new in `tests/test_btrfs.py` covering `detect_storage_fs`, `is_cow_disabled`, and `disable_cow_if_btrfs` across all status reasons.

`606 passed, 1 skipped`, ruff check + format clean.

## Test plan

- [x] Local test suite (subprocess mocked).
- [ ] Smoke test on a btrfs host (cachyos): `winpodx setup` should print `Disabled btrfs CoW on container storage (path=...).` and `lsattr -d` on the path should show `C` flag set.
- [ ] Smoke test on ext4 host: setup prints nothing about btrfs, `lsattr` either shows no flag (skipped) or `not_btrfs` status (silent).