### PR TITLE
fix(pod): suppress dockur's cosmetic btrfs warning in wait-ready --logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Changed
+- **Suppress dockur's cosmetic "you are using the BTRFS filesystem for /storage" warning in `winpodx pod wait-ready --logs`.** dockur's `proc.sh` fires this warning unconditionally on every btrfs host based purely on `df --output=fstype`, without checking whether NoCoW (`chattr +C`) has been applied. v0.4.3 ships per-user bind-mount + auto chattr +C migration, so on a post-migration host the warning is a false positive — the actual fragmentation signal (`COW (copy on write) is not disabled for disk image file ...`) is gone. The streamed log line is now rewritten to `(btrfs warning suppressed: NoCoW bind mount in use)` when `cfg.pod.storage_path` is set, so install.sh output stops looking alarming. Legacy users still on the named volume (`storage_path = ""`) keep seeing the original warning so they're prompted to run `winpodx setup --migrate-storage`.
+
 ## [0.4.3] - 2026-05-06
 
 The btrfs Copy-on-Write fragmentation fix. The `0.4.x` line's headline storage rework: a per-user bind mount with automatic NoCoW so Windows VM disk image writes (every pagefile / boot / swap byte) stop forking new btrfs extents on every overwrite. On btrfs hosts that means pod recreates that previously took many minutes — and frequently timed out on the 300 s budget — finish in 30 s like they always did on ext4. Reported by @xiyeming in #121, #122 (and indirectly the actual-failure cause behind #126's "Unable to open apps and desktop" cascade on cachyos).

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,9 @@
 
 ## [Unreleased]
 
+### 변경
+- **`winpodx pod wait-ready --logs` 출력에서 dockur 의 cosmetic "you are using the BTRFS filesystem for /storage" 경고 suppress.** dockur 의 `proc.sh` 가 이 경고를 `df --output=fstype` 만 보고 모든 btrfs 호스트에 무조건 출력 — NoCoW (`chattr +C`) 적용 여부는 확인 안 함. v0.4.3 가 사용자별 bind-mount + 자동 chattr +C 마이그레이션 제공하므로, post-migration 호스트에서 이 경고는 false positive — 실제 fragmentation 신호 (`COW (copy on write) is not disabled for disk image file ...`) 는 이미 사라짐. 스트리밍 되는 로그 라인이 `cfg.pod.storage_path` 가 set 일 때 `(btrfs warning suppressed: NoCoW bind mount in use)` 로 재작성됨 — install.sh 출력이 더 이상 경고처럼 보이지 않음. 아직 named volume 쓰는 legacy 사용자 (`storage_path = ""`) 는 원본 경고 그대로 보여서 `winpodx setup --migrate-storage` 안내가 유지됨.
+
 ## [0.4.3] - 2026-05-06
 
 btrfs Copy-on-Write fragmentation 을 정조준한 패치 릴리즈. `0.4.x` 라인의 핵심 storage rework: 사용자별 bind mount + 자동 NoCoW 로 Windows VM 디스크 이미지의 매 write (pagefile / boot / swap 바이트 모두) 가 btrfs extent 를 새로 fork 하던 걸 차단. btrfs 호스트에서 이전엔 수분~수십분 걸려 300초 예산을 자주 timeout 시키던 pod recreate 가 ext4 처럼 30초에 끝남. @xiyeming 의 #121, #122 보고 (cachyos 환경의 #126 "Unable to open apps and desktop" 도 actual root cause 이 동일 — install.bat 가 btrfs CoW 로 인한 file ops 정체로 mid-stage 에서 죽고, agent 가 안 올라오니 host 의 모든 FreeRDP fallback 이 multi-session 으로 reset).

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -554,6 +554,16 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
                     return line
                 return line.replace("127.0.0.1:8006", f"127.0.0.1:{vnc_port}")
 
+            # dockur's `Warning: you are using the BTRFS filesystem for
+            # /storage` fires on every btrfs host regardless of whether
+            # we've applied chattr +C — it just reads df. With
+            # storage_path set, NoCoW is in effect so the warning is
+            # cosmetic; rewrite it to a one-liner so install.sh output
+            # doesn't look alarming. Without storage_path (legacy named
+            # volume), keep the warning visible so the user knows to
+            # migrate.
+            suppress_btrfs_warning = bool(cfg.pod.storage_path)
+
             def _drain(stream) -> None:  # type: ignore[no-untyped-def]
                 if stream is None:
                     return
@@ -561,8 +571,14 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
                     if log_stop.is_set():
                         break
                     line = line.rstrip()
-                    if line:
-                        print(f"       [container] {_rewrite_vnc_url(line)}")
+                    if not line:
+                        continue
+                    if (
+                        suppress_btrfs_warning
+                        and "you are using the BTRFS filesystem for /storage" in line
+                    ):
+                        line = "(btrfs warning suppressed: NoCoW bind mount in use)"
+                    print(f"       [container] {_rewrite_vnc_url(line)}")
 
             threading.Thread(target=_drain, args=(log_proc.stdout,), daemon=True).start()
             threading.Thread(target=_drain, args=(log_proc.stderr,), daemon=True).start()


### PR DESCRIPTION
Follow-up after v0.4.3 — kernalix7 noticed `Warning: you are using the BTRFS filesystem for /storage` still appears in `podman logs winpodx-windows` after a post-migration v0.4.3 install, even though chattr +C is correctly applied and the actual fragmentation warning (`COW (copy on write) is not disabled ...`) is gone.

## Why

dockur's `proc.sh` fires this generic warning on every btrfs host based purely on `df --output=fstype`. It doesn't check whether NoCoW has been applied. So on a post-migration host the warning is a cosmetic false positive — alarming-looking red text in install.sh output for a problem we've already solved.

## Fix

`_wait_ready --logs` rewrites the line to `(btrfs warning suppressed: NoCoW bind mount in use)` when `cfg.pod.storage_path` is set. Legacy users still on the named volume (`storage_path = ""`) keep seeing the original warning so they're prompted to migrate.

Same code path as the existing VNC URL rewrite (PR #119) — single substring check inside `_drain`'s line loop.

## Test plan

- [ ] kernalix7 re-runs `winpodx pod wait-ready --logs` (or fresh install.sh) — output line `[container] Warning: you are using the BTRFS filesystem for /storage ...` is replaced with `[container] (btrfs warning suppressed: NoCoW bind mount in use)`.
- [ ] User on legacy named volume (`storage_path = ""`) still sees the original warning so the migration prompt remains visible.

`657 passed, 1 skipped`, ruff check + format clean.