### PR TITLE
chore: add fairy.hada.io funding link to repo, PyPI, and README

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,6 @@
+# GitHub repo 'Sponsor' button. fairy.hada.io is a Korean tipping
+# platform; it isn't on GitHub's recognized list (github_sponsors,
+# patreon, ko_fi, ...) so we use the `custom:` field, which renders
+# as a generic 'External' link button on the repo page.
+custom:
+  - https://fairy.hada.io/@kernalix7

--- a/README.md
+++ b/README.md
@@ -694,6 +694,15 @@ For security issues, follow the process in [SECURITY.md](SECURITY.md).
   </picture>
 </a>
 
+## Support / 후원
+
+If winpodx makes your Linux desktop a little nicer, you can tip the maintainer at
+[fairy.hada.io/@kernalix7](https://fairy.hada.io/@kernalix7).
+Bug reports, PRs, and stars on the repo are equally appreciated and free.
+
+winpodx 가 도움이 됐다면 [fairy.hada.io/@kernalix7](https://fairy.hada.io/@kernalix7)
+에서 후원할 수 있습니다. 버그 리포트, PR, 별점도 환영합니다.
+
 ## License
 
 [MIT](LICENSE) - Kim DaeHyun (kernalix7@kodenet.io)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ winpodx = "winpodx.cli.main:cli"
 Homepage = "https://github.com/kernalix7/winpodx"
 Repository = "https://github.com/kernalix7/winpodx"
 Issues = "https://github.com/kernalix7/winpodx/issues"
+Funding = "https://fairy.hada.io/@kernalix7"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/winpodx"]


### PR DESCRIPTION
Add @kernalix7's tipping link in three places at once so it surfaces wherever someone might land:

- **`.github/FUNDING.yml`** — GitHub repo page gets a Sponsor button (uses `custom:` since fairy.hada.io isn't on GitHub's recognized platform list).
- **`pyproject.toml` `[project.urls]`** — PyPI sidebar gets a 'Funding' link under Project URLs.
- **`README.md`** — short bilingual Support / 후원 section right above License. Bug reports / PRs / stars are highlighted as equally-appreciated free alternatives so the section doesn't read as ask-only.

No code changes. 661 tests pass, ruff check + format clean, pyproject.toml parses.

## Test plan

- [ ] Merge → check that the GitHub repo page now shows a 'Sponsor' button at the top
- [ ] Next PyPI release will pick up the Funding URL automatically; the existing v0.4.3 page won't backfill (PyPI snapshots metadata at upload)