### PR TITLE
chore(funding): add Ko-fi + shields.io badges, dual-platform support

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,9 @@
-# GitHub repo 'Sponsor' button. fairy.hada.io is a Korean tipping
-# platform; it isn't on GitHub's recognized list (github_sponsors,
-# patreon, ko_fi, ...) so we use the `custom:` field, which renders
-# as a generic 'External' link button on the repo page.
+# GitHub repo 'Sponsor' button. Ko-fi is on GitHub's recognized list
+# so it uses the proper `ko_fi:` field (renders with the Ko-fi icon).
+# fairy.hada.io is a Korean tipping platform not on the recognized
+# list, so we add it under `custom:` (renders as a generic external
+# link). When/if GitHub Sponsors gets approved (kernalix7 has to apply
+# at github.com/sponsors), add `github: kernalix7` here too.
+ko_fi: kernalix7
 custom:
   - https://fairy.hada.io/@kernalix7

--- a/README.md
+++ b/README.md
@@ -696,12 +696,14 @@ For security issues, follow the process in [SECURITY.md](SECURITY.md).
 
 ## Support / 후원
 
-If winpodx makes your Linux desktop a little nicer, you can tip the maintainer at
-[fairy.hada.io/@kernalix7](https://fairy.hada.io/@kernalix7).
-Bug reports, PRs, and stars on the repo are equally appreciated and free.
+If winpodx makes your Linux desktop a little nicer:
 
-winpodx 가 도움이 됐다면 [fairy.hada.io/@kernalix7](https://fairy.hada.io/@kernalix7)
-에서 후원할 수 있습니다. 버그 리포트, PR, 별점도 환영합니다.
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-F16061?logo=ko-fi&logoColor=white&style=for-the-badge)](https://ko-fi.com/kernalix7)
+[![Fairy](https://img.shields.io/badge/🧚_Fairy-EE6E73?style=for-the-badge&logoColor=white)](https://fairy.hada.io/@kernalix7)
+
+Ko-fi for international card / PayPal payments; fairy.hada.io 는 국내 결제용.
+Bug reports, PRs, and stars on the repo are equally appreciated and free —
+버그 리포트, PR, 별점도 환영합니다.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,8 @@ winpodx = "winpodx.cli.main:cli"
 Homepage = "https://github.com/kernalix7/winpodx"
 Repository = "https://github.com/kernalix7/winpodx"
 Issues = "https://github.com/kernalix7/winpodx/issues"
-Funding = "https://fairy.hada.io/@kernalix7"
+Funding = "https://ko-fi.com/kernalix7"
+"Funding (KR)" = "https://fairy.hada.io/@kernalix7"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/winpodx"]


### PR DESCRIPTION
Follow-up to #135 — adds Ko-fi as a second tipping platform and upgrades the README Support section from plain text links to shields.io badges.

## Changes

### `.github/FUNDING.yml`
- New `ko_fi: kernalix7` entry (Ko-fi is on GitHub's recognized platform list, so it renders with the official Ko-fi icon in the Sponsor button dropdown)
- fairy.hada.io stays under `custom:` (not on GitHub's recognized list)

### `pyproject.toml` `[project.urls]`
- `Funding` → Ko-fi (canonical slot for PyPI's sidebar, broader international reach)
- `Funding (KR)` → fairy.hada.io for users who prefer Korean payment

### `README.md`
- Support section now uses shields.io badges for both platforms
- Ko-fi: official red-orange Ko-fi badge (`logo=ko-fi`)
- Fairy: custom badge with 🧚 emoji — fairy.hada.io doesn't ship an official creator badge as of 2026-05-07 (verified via direct endpoint probes + their robots.txt + sitemap.xml — no docs/help pages, no /badge endpoint, sitemap only includes user pages and /explore)
- Inline note clarifies international (Ko-fi) vs. Korean (fairy.hada.io) split

## Not in this PR

GitHub Sponsors itself — @kernalix7 still needs to apply at github.com/sponsors, get through KYC + Stripe Connect, and wait for approval (~1-3 weeks). Follow-up will add `github: kernalix7` to FUNDING.yml once that lands.

No code changes. 661 tests pass, ruff check + format clean, pyproject.toml parses.