### PR TITLE
chore(docs): add pyxdg to THIRD_PARTY_LICENSES + Windows EULA note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,13 @@ and registers every installed app with its real icon. No root required
 except for the dependency install step. Works on
 openSUSE, Fedora, Debian/Ubuntu, RHEL-family, and Arch.
 
+> **Windows licensing.** dockur downloads a Windows ISO from Microsoft
+> at first pod boot. Your use of the resulting Windows guest is governed
+> by Microsoft's Software License Terms (the EULA shown on first
+> activation). winpodx does not redistribute Windows; it only orchestrates
+> the install on your machine. Bring your own Windows license key for
+> activation — Home / Pro / Enterprise are all supported by dockur.
+
 By default the installer pins to the **latest published GitHub release**
 (currently `v0.1.9`). Pre-release / development versions stay opt-in.
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -51,6 +51,7 @@ licenses govern.
 | [PySide6](https://pypi.org/project/PySide6/) | LGPL-3.0-or-later (with [Qt for Python FAQ exceptions](https://www.qt.io/qt-for-python)) | `winpodx[gui]` | Dynamic — imported at runtime. Not redistributed by winpodx. |
 | [libvirt-python](https://pypi.org/project/libvirt-python/) | LGPL-2.1-or-later | `winpodx[libvirt]` | Dynamic — imported at runtime. Not redistributed by winpodx. |
 | [docker](https://pypi.org/project/docker/) (docker-py) | Apache-2.0 | `winpodx[docker]` | Dynamic — imported at runtime. |
+| [pyxdg](https://pypi.org/project/pyxdg/) | LGPL-2.0-or-later | (none — soft optional) | Dynamic — try-imported at runtime by `core/reverse_open/mime.py` for the long-tail MIME→extension fallback when a type isn't in the curated 86-entry table. winpodx works without it (fallback simply returns the curated entry only). Not vendored. |
 
 LGPL compliance: winpodx does not statically link, vendor, or redistribute
 PySide6 or libvirt-python binaries. Users install them from PyPI (or their


### PR DESCRIPTION
Two minor doc gaps surfaced during the agent-first install Phase 1 review.

## What's in this PR

- **\`THIRD_PARTY_LICENSES.md\`** — adds pyxdg under "Optional dependencies" (soft optional; LGPL-2.0-or-later; try-imported by \`reverse_open/mime.py\` as the long-tail MIME→extension fallback when a type isn't in the curated 86-entry table). winpodx works without it — fallback simply returns the curated entry only. Not vendored.

- **\`README.md\`** — adds a Windows licensing callout to the Install section. dockur downloads a Windows ISO from Microsoft at first pod boot; the user's use of the resulting Windows guest is governed by Microsoft's EULA. winpodx does not redistribute Windows. The note clarifies the user brings their own Windows license key.

## Not in this PR

- **cairosvg** is planned for reverse-open Phase 2's \`icons.py\` SVG rasterisation but not yet imported anywhere. Will get its own attribution entry when Phase 2 lands.
- **Go (BSD-3)** will be added when the reverse-open Go shim binary lands in Phase 2.

## Test plan

- [x] \`THIRD_PARTY_LICENSES.md\` parses as valid Markdown
- [x] No code touched, no tests affected
- [ ] CI passes

No code changes.