### PR TITLE
test(conftest): isolate XDG_STATE_HOME alongside the other XDG dirs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,12 +16,14 @@ def _isolate_xdg_and_home(
     config = root / "xdg_config"
     data = root / "xdg_data"
     cache = root / "xdg_cache"
+    state = root / "xdg_state"
     runtime = root / "xdg_runtime"
-    for directory in (home, config, data, cache, runtime):
+    for directory in (home, config, data, cache, state, runtime):
         directory.mkdir(parents=True, exist_ok=True)
 
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(config))
     monkeypatch.setenv("XDG_DATA_HOME", str(data))
     monkeypatch.setenv("XDG_CACHE_HOME", str(cache))
+    monkeypatch.setenv("XDG_STATE_HOME", str(state))
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime))

--- a/tests/test_install_state.py
+++ b/tests/test_install_state.py
@@ -28,16 +28,6 @@ from winpodx.core.install_state import (
 )
 
 
-@pytest.fixture(autouse=True)
-def _isolate_xdg_state_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """The shared conftest only redirects HOME/XDG_CONFIG/XDG_DATA. The
-    install state cache lives under ``$XDG_STATE_HOME``, which the user's
-    real environment commonly has set — without overriding it the cache
-    path leaks into the developer's home dir between test runs.
-    """
-    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
-
-
 @pytest.fixture
 def cfg() -> Config:
     return Config()


### PR DESCRIPTION
Tiny follow-up to PR #145. `tests/conftest.py`'s `_isolate_xdg_and_home` autouse fixture redirects $HOME and four XDG dirs (config / data / cache / runtime) but not XDG_STATE_HOME. install-state-engineer flagged this in their Phase 1 work because `core/install_state.py`'s cache lives under `$XDG_STATE_HOME/winpodx/last_install_state.json` — without overriding it, the cache path leaks into the developer's real home dir between test runs.

They worked around it with a per-suite autouse fixture in `tests/test_install_state.py`; folding the redirect into the shared conftest is the cleaner fix and avoids future suites needing the same workaround.

Drops the per-suite fixture (now redundant). All 22 install-state tests still pass; full suite unchanged.

## Test plan

- [x] `pytest tests/test_install_state.py -q` → 22 passed
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI green