### PR TITLE
feat(install): flip agent_first default to True (Phase 4)

### DIFF
--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -156,11 +156,11 @@ class PodConfig:
 class InstallConfig:
     """Agent-first install flow tuning (see AGENT_FIRST_INSTALL_DESIGN.md)."""
 
-    # Phase 1-3 ships with this False (legacy install path is the
-    # default); Phase 4 flips the default to True. Persisted absence in
-    # an existing TOML reads as False, so the rollout is opt-in until
-    # the default flips.
-    agent_first: bool = False
+    # Phase 4 flip: agent-first install path is now the default.
+    # Existing TOML files without an [install] section automatically
+    # opt in. Set explicitly to false to fall back to the legacy
+    # OEM install path.
+    agent_first: bool = True
     # Stage 2 of host-side wait-ready: agent /health 200 OK.
     # Default 15min covers the slowest healthy case (HDD ext4, Pi 5
     # aarch64) per the design doc's hardware matrix.

--- a/tests/test_install_config.py
+++ b/tests/test_install_config.py
@@ -11,7 +11,7 @@ from winpodx.core.config import Config, InstallConfig
 
 def test_install_config_defaults():
     cfg = InstallConfig()
-    assert cfg.agent_first is False
+    assert cfg.agent_first is True
     assert cfg.wait_ready_stage2_secs == 900
     assert cfg.wait_ready_stage3_secs == 1800
     assert cfg.auto_resume is True
@@ -23,7 +23,7 @@ def test_install_config_defaults():
 def test_config_includes_install_section():
     cfg = Config()
     assert isinstance(cfg.install, InstallConfig)
-    assert cfg.install.agent_first is False
+    assert cfg.install.agent_first is True
 
 
 # --- bool coercion ------------------------------------------------------------
@@ -115,7 +115,7 @@ def test_config_load_with_no_install_section_uses_defaults(tmp_path, monkeypatch
 
     loaded = Config.load()
     assert loaded.rdp.user == "alice"
-    assert loaded.install.agent_first is False
+    assert loaded.install.agent_first is True
     assert loaded.install.wait_ready_stage2_secs == 900
     assert loaded.install.watchdog_probe_debounce_secs == [2, 5]
 


### PR DESCRIPTION
## Summary

Flips `cfg.install.agent_first` default from `False` to `True`.

Phase 2 (#148) landed the guest-side state machine, watchdog, and
resume script with security-review APPROVE. Phase 3 host-side
wait-ready / GUI work is still pending, but the guest-side flow is
feature-complete and the flag flip is itself a revertable one-line
change.

- Existing TOML files without an `[install]` section now opt in
  automatically.
- Existing users who explicitly set `agent_first = false` keep the
  legacy install path.

## Test plan

- [x] `pytest tests/test_install_config.py` — 17/17 passed (defaults
      assertion updated, round-trip test still passes)
- [ ] Real Windows guest smoke with the new default (this PR is the
      gate for that test — merging triggers it)