### PR TITLE
fix(oem): token_staged silently failed when icacls grant didn't take effect

### DIFF
--- a/config/oem/install-step-functions.ps1
+++ b/config/oem/install-step-functions.ps1
@@ -350,15 +350,44 @@ function Invoke-Step-token_staged {
             # readable to BUILTIN\Users for the ~60-90s window between
             # Phase 0 (Defender exclusion) and this step. Tightening the
             # source first ensures no other user (or background process)
-            # can read the token while we're staging it. Grant the
-            # auto-logon user (R,W) -- NOT bare R -- because Phase 3
-            # later zeroes this same file via [IO.File]::WriteAllBytes
-            # before deletion. Read-only would make the zero-write throw
-            # UnauthorizedAccessException, the post-condition would fail,
-            # and every install would end in install_failure.json.
-            # (security review #12 / re-review #18)
-            & icacls.exe $script:WpxAgentTokenSrc /inheritance:r 2>&1 | Out-Null
-            & icacls.exe $script:WpxAgentTokenSrc /grant:r ("${user}:(R,W)") 2>&1 | Out-Null
+            # can read the token while we're staging it. Grant SYSTEM,
+            # Administrators, and the current user (R,W) -- NOT bare R --
+            # because Phase 3 later zeroes this same file via
+            # [IO.File]::WriteAllBytes before deletion. Read-only would
+            # make the zero-write throw UnauthorizedAccessException, the
+            # post-condition would fail, and every install would end in
+            # install_failure.json. (security review #12 / re-review #18)
+            #
+            # SYSTEM (S-1-5-18) and BUILTIN\Administrators (S-1-5-32-544)
+            # are pinned by SID rather than name to survive locale
+            # differences (Korean / Japanese / German Windows translates
+            # the canonical names). Including SYSTEM is required because
+            # /inheritance:r removes the inherited SYSTEM ACE, and
+            # install.bat may run under a service principal that needs
+            # SYSTEM-equivalent access. Including Administrators keeps
+            # the file recoverable for support / debugging.
+            #
+            # icacls failures must NOT be silently swallowed: if the
+            # /inheritance:r succeeds but /grant fails, the file becomes
+            # unreadable to everyone (the actual production failure mode
+            # from the first agent-first install attempt). Both calls
+            # check $LASTEXITCODE and abort the step with a logged error.
+            $icaclsArgs = @(
+                $script:WpxAgentTokenSrc, '/inheritance:r',
+                '/grant:r', '*S-1-5-18:(R,W)',
+                '/grant:r', '*S-1-5-32-544:(R,W)',
+                '/grant:r', "${user}:(R,W)"
+            )
+            $icaclsOut = & icacls.exe @icaclsArgs 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                Write-WinpodxLog -Level 'ERROR' -Step 'token_staged' `
+                    -Event 'icacls_src_failed' -Extra @{
+                        rc = $LASTEXITCODE
+                        output = ("$icaclsOut" | Out-String).Trim()
+                        principal = $user
+                    }
+                return 1
+            }
 
             $dstDir = Split-Path -Parent $script:WpxAgentTokenDst
             if (-not (Test-Path -LiteralPath $dstDir)) {
@@ -367,12 +396,26 @@ function Invoke-Step-token_staged {
             Copy-Item -LiteralPath $script:WpxAgentTokenSrc `
                 -Destination $script:WpxAgentTokenDst -Force
 
-            # User-only ACL on the dst: remove inherited, grant current
-            # user R+W, deny everyone else implicitly. icacls is more
-            # reliable than PS Acl APIs against Windows's odd default
-            # DACLs on copies.
-            & icacls.exe $script:WpxAgentTokenDst /inheritance:r 2>&1 | Out-Null
-            & icacls.exe $script:WpxAgentTokenDst /grant:r ("${user}:(R,W)") 2>&1 | Out-Null
+            # Same hardened ACL on the dst: SYSTEM + Administrators +
+            # current user, no inheritance. icacls is more reliable
+            # than PS Acl APIs against Windows's odd default DACLs on
+            # copies.
+            $icaclsDstArgs = @(
+                $script:WpxAgentTokenDst, '/inheritance:r',
+                '/grant:r', '*S-1-5-18:(R,W)',
+                '/grant:r', '*S-1-5-32-544:(R,W)',
+                '/grant:r', "${user}:(R,W)"
+            )
+            $icaclsDstOut = & icacls.exe @icaclsDstArgs 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                Write-WinpodxLog -Level 'ERROR' -Step 'token_staged' `
+                    -Event 'icacls_dst_failed' -Extra @{
+                        rc = $LASTEXITCODE
+                        output = ("$icaclsDstOut" | Out-String).Trim()
+                        principal = $user
+                    }
+                return 1
+            }
             return 0
         }
 }
@@ -849,12 +892,29 @@ function Invoke-Step-install_complete {
             $newToken = [Convert]::ToBase64String($bytes)
             $rng.Dispose()
 
-            # Write new token to staged location with User-only ACL.
+            # Write new token to staged location with hardened ACL
+            # (SYSTEM + Administrators + current user). See Phase 0.6
+            # for the SID/locale rationale and the silent-failure bug
+            # this guards against.
             Set-Content -LiteralPath $script:WpxAgentTokenDst -Value $newToken -Encoding ASCII -NoNewline
             $user = "$env:USERDOMAIN\$env:USERNAME"
             if (-not $env:USERDOMAIN) { $user = $env:USERNAME }
-            & icacls.exe $script:WpxAgentTokenDst /inheritance:r 2>&1 | Out-Null
-            & icacls.exe $script:WpxAgentTokenDst /grant:r ("${user}:(R,W)") 2>&1 | Out-Null
+            $icaclsRotateArgs = @(
+                $script:WpxAgentTokenDst, '/inheritance:r',
+                '/grant:r', '*S-1-5-18:(R,W)',
+                '/grant:r', '*S-1-5-32-544:(R,W)',
+                '/grant:r', "${user}:(R,W)"
+            )
+            $icaclsRotateOut = & icacls.exe @icaclsRotateArgs 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                Write-WinpodxLog -Level 'ERROR' -Step 'install_complete' `
+                    -Event 'icacls_dst_failed' -Extra @{
+                        rc = $LASTEXITCODE
+                        output = ("$icaclsRotateOut" | Out-String).Trim()
+                        principal = $user
+                    }
+                return 1
+            }
 
             # Zero + delete the OEM-source token. Failure here is
             # propagated up -- the post-condition will catch it, the

--- a/tests/test_oem_install_bat.py
+++ b/tests/test_oem_install_bat.py
@@ -90,31 +90,74 @@ def test_step_functions_phase3_hardens_oem_token_cleanup() -> None:
 
 def test_step_functions_phase06_tightens_oem_source_acl() -> None:
     """Security review #12: Phase 0.6 must tighten the ACL on the
-    OEM-source token BEFORE reading. Look for an icacls call on
-    WpxAgentTokenSrc inside the token_staged body."""
+    OEM-source token BEFORE reading. Look for /inheritance:r on
+    WpxAgentTokenSrc inside the token_staged body's icacls splat."""
     text = STEP_FUNCTIONS.read_text(encoding="utf-8")
-    assert "icacls.exe $script:WpxAgentTokenSrc /inheritance:r" in text
+    # Locate the token_staged body and require the splat to reference both
+    # WpxAgentTokenSrc and /inheritance:r (multi-line splat form).
+    body_start = text.index("function Invoke-Step-token_staged")
+    body_end = text.index("# --- Phase 1: agent_ready", body_start)
+    body = text[body_start:body_end]
+    assert "$script:WpxAgentTokenSrc" in body
+    assert "/inheritance:r" in body
 
 
 def test_step_functions_phase06_grants_rw_not_bare_r_on_oem_source() -> None:
     """Security review #18 (re-review BLOCKER): the OEM-source ACL grant
     must be (R,W), not bare R. Phase 3 install_complete zeroes this same
     file via [IO.File]::WriteAllBytes before deletion; a read-only ACL
-    here would throw UnauthorizedAccessException at zero-write time,
-    fail the hard post-condition, and force every install into
-    install_failure.json with error_class=install_complete_failed.
-
-    Pin the (R,W) form on the WpxAgentTokenSrc grant line so the next
-    refactor can't accidentally drop the W."""
+    here would throw UnauthorizedAccessException at zero-write time."""
     text = STEP_FUNCTIONS.read_text(encoding="utf-8")
-    src_grant_line = next(
-        ln for ln in text.splitlines()
-        if "icacls.exe $script:WpxAgentTokenSrc /grant:r" in ln
-    )
-    assert "(R,W)" in src_grant_line, (
+    body_start = text.index("function Invoke-Step-token_staged")
+    body_end = text.index("# --- Phase 1: agent_ready", body_start)
+    body = text[body_start:body_end]
+    # Splat form: a /grant:r line followed by ${user}:(R,W) on the next line.
+    assert '${user}:(R,W)' in body, (
         "Phase 0.6 OEM-source grant lost W permission -- Phase 3 zero-write "
         "will throw UnauthorizedAccessException. See security review #18."
     )
+
+
+def test_step_functions_phase06_grants_system_and_admins_by_sid() -> None:
+    """Production smoke test (2026-05-10): /inheritance:r removes
+    inherited ACEs for SYSTEM and Administrators too. If the /grant
+    only targets the auto-logon user and that grant fails (icacls error
+    swallowed by 2>&1 | Out-Null), the file becomes unreadable to
+    everyone -- the actual failure mode observed on the first
+    agent-first install.
+
+    Pin the SYSTEM SID and Administrators SID in the grant chain so a
+    refactor can't drop them. Use SIDs (not names) to survive locale
+    differences (Korean / Japanese / German Windows translates the
+    canonical names)."""
+    text = STEP_FUNCTIONS.read_text(encoding="utf-8")
+    body_start = text.index("function Invoke-Step-token_staged")
+    body_end = text.index("# --- Phase 1: agent_ready", body_start)
+    body = text[body_start:body_end]
+    assert "*S-1-5-18:(R,W)" in body, "SYSTEM SID grant missing in token_staged"
+    assert "*S-1-5-32-544:(R,W)" in body, (
+        "Administrators SID grant missing in token_staged"
+    )
+
+
+def test_step_functions_phase06_checks_lastexitcode_on_icacls() -> None:
+    """Production smoke test (2026-05-10): the original code piped icacls
+    stderr into Out-Null and never checked $LASTEXITCODE. When the grant
+    silently failed, the script proceeded with a now-unreadable file and
+    Copy-Item threw "Access is denied" downstream, with no diagnostic
+    trail. Pin the LASTEXITCODE check so any refactor that drops it
+    fails this test."""
+    text = STEP_FUNCTIONS.read_text(encoding="utf-8")
+    body_start = text.index("function Invoke-Step-token_staged")
+    body_end = text.index("# --- Phase 1: agent_ready", body_start)
+    body = text[body_start:body_end]
+    assert "$LASTEXITCODE -ne 0" in body, (
+        "token_staged must check $LASTEXITCODE on icacls -- silent failure "
+        "regression from 2026-05-10 first-install attempt."
+    )
+    # And the failure path must log + return 1, not warn-and-continue.
+    assert "icacls_src_failed" in body
+    assert "icacls_dst_failed" in body
 
 
 def test_watchdog_branches_on_install_complete_marker() -> None:


### PR DESCRIPTION
## Summary

Real-Windows reproduction (2026-05-10) of agent-first install Phase 0.6
hang. Found one fix-as-shipped bug + one diagnosability bug.

`install.log` from the failing guest:

```
{"step":"token_staged","event":"body_threw","detail":"C:\\OEM\\agent_token.txt: Access is denied."}
{"step":"token_staged","event":"postcondition_failed","body_rc":1,"attempt":1}
{"step":"_orchestrator","event":"step_failed","rc":1}
```

`whoami` in the autologon session: `win-a980orihiut\user`.

`icacls C:\OEM\agent_token.txt` from that same user: also `Access is denied`.

So the file became unreadable to everyone after Phase 0.6's
`/inheritance:r` + `/grant:r` pair, and the `2>&1 | Out-Null` swallowed
the icacls return code so we never knew which call failed.

### Two fixes

1. `/inheritance:r` removes inherited ACEs for **SYSTEM and
   Administrators** too -- not just BUILTIN\Users. The previous grant
   only targeted the auto-logon user. If that grant silently failed,
   the file became unreadable to every principal, including the
   service context running install.bat. Now grants SYSTEM
   (`*S-1-5-18`) and Administrators (`*S-1-5-32-544`) by SID alongside
   the auto-logon user, so neither is lost.

   SIDs (not names) survive locale differences -- Korean / Japanese /
   German Windows translates the canonical names, and the current code
   would silently fail-by-name on those locales.

2. `icacls` failures are no longer swallowed. Both source and
   destination ACL calls now check `$LASTEXITCODE` and on non-zero
   write an ERROR-level log entry with the rc, captured stderr, and
   the principal we tried to grant, then return 1 (handing off to the
   retry / install-resume loop instead of proceeding with a broken
   ACL).

Same hardening applied to Phase 3 `install_complete`'s icacls on
`WpxAgentTokenDst`, which had the same swallow-and-pray pattern.

### Why security review missed it

Initial review (#12) and re-review (#18) both reasoned about R-vs-RW
on the auto-logon user, but neither pinned SYSTEM / Administrators or
required `$LASTEXITCODE` checking. The pwsh-on-Linux Pester suite
short-circuits when `icacls` is missing, so the silent-failure mode
was real-Windows-only.

### Why this didn't show up as `install_failure.json`

`Invoke-WinpodxStep` writes `install_failure.json` only after retry
count >= MaxRetries (3). First-attempt failure returns 1 to the
orchestrator, which exits and waits for `install-resume.ps1` to be
fired by the logon Scheduled Task on next reboot. The user never
rebooted, so attempts 2 and 3 never happened.

That's intended retry semantics, but it's a UX gap -- a deterministic
first-attempt failure (e.g. broken ACL) should surface diagnostics
sooner. Tracked separately; not in scope for this fix.

## Test plan

- [x] `pytest tests/test_oem_install_bat.py` -- 13/13 passed (4 new
      regression guards: SYSTEM SID present, Admins SID present,
      `$LASTEXITCODE -ne 0` check present, failure events
      `icacls_src_failed` / `icacls_dst_failed` emitted)
- [ ] Real-Windows re-run after merge -- `winpodx pod purge` +
      curl-install from main + `winpodx pod install`. Expected:
      Phase 0.6 token_staged passes, Phase 1 agent_ready brings
      `:8765` /health up, full state machine runs to
      `install_complete.done`.