### PR TITLE
fix(install.sh): restore real-time wait-ready --logs output (PR #143 regression)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -511,7 +511,13 @@ if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_WAIT:-}" != "1
     # abort install.sh — `|| true` keeps us going so we can inspect
     # the captured output.
     WAIT_READY_OUT="$(mktemp)"
-    "$HOME/.local/bin/winpodx" pod wait-ready --timeout 3600 --logs 2>&1 \
+    # PYTHONUNBUFFERED=1 forces Python's stdout to line-buffered even
+    # when piped (otherwise the pipe to `tee` flips Python from
+    # line-buffered to 4KB-block-buffered, batching minutes of progress
+    # into a single flush at the end). Without this, `[1/3] container
+    # ...`, the [container] log tail, and `OK ...` lines all arrive at
+    # once when the step completes — see Task #45 / PR #143 regression.
+    PYTHONUNBUFFERED=1 "$HOME/.local/bin/winpodx" pod wait-ready --timeout 3600 --logs 2>&1 \
         | tee "$WAIT_READY_OUT" || true
     WAIT_READY_RC="${PIPESTATUS[0]}"
     if [ "$WAIT_READY_RC" -ne 0 ]; then


### PR DESCRIPTION
## Summary

User reported that `winpodx pod wait-ready --logs` output (the
`[1/3] container running`, `[container] ...` log tail, `[2/3] RDP
port`, `[3/3] activation`) used to flow in real time during install
but now appears all at once at the end.

Bisected to PR #143 (`1575af6`, half-uninstalled-state fix), which
added:

```bash
"$HOME/.local/bin/winpodx" pod wait-ready --timeout 3600 --logs 2>&1 \
    | tee "$WAIT_READY_OUT" || true
```

The `| tee` was added to capture wait-ready output for the
"no such container" discrimination, but it has an unrelated side
effect: with a pipe between Python and the terminal, Python's stdout
auto-switches from line-buffered (terminal) to 4KB-block-buffered
(pipe). Minutes of output get batched into one flush at process exit.

## Fix

Prepend `PYTHONUNBUFFERED=1` to the wait-ready invocation. One line.

This forces Python's stdout to line-buffered regardless of whether
it's a pipe or a tty. The `tee`-captured file contents are unchanged
(`grep -q "no such container" "$WAIT_READY_OUT"` still works the same
way). No behavior change for non-interactive / CI runs.

## Test plan

- [x] `bash -n install.sh` (syntax check)
- [ ] Real-Windows re-run: `winpodx pod purge` + curl-install from
      main + observe `[1/3]`, `[container] ...`, `[2/3]`, `[3/3]`
      lines stream live as install progresses (not all at once)