### PR TITLE
fix(oem): rdprrap_installed pin regex + stdout-blind step logging

### DIFF
--- a/config/oem/install-step-functions.ps1
+++ b/config/oem/install-step-functions.ps1
@@ -580,13 +580,25 @@ function Invoke-WinpodxAgentStep {
         -Body {
             $r = Invoke-WinpodxAgentExec -Script $BodyScript -TimeoutSec $TimeoutSec
             if (-not $r.ok) {
+                # Capture both streams. Phase 2 step bodies use
+                # Write-Output (stdout) for diagnostic messages; logging
+                # only stderr was a black hole (see smoke test
+                # 2026-05-10: rdprrap_installed surfaced 'pin_incomplete'
+                # via stdout but install.log showed empty stderr only).
                 Write-WinpodxLog -Level 'ERROR' -Step $Name -Event 'agent_exec_failed' `
-                    -Extra @{ stderr = $r.stderr }
+                    -Extra @{
+                        stdout = ("$($r.stdout)" | Out-String).Trim()
+                        stderr = ("$($r.stderr)" | Out-String).Trim()
+                    }
                 return 1
             }
             if ($r.rc -ne 0) {
                 Write-WinpodxLog -Level 'ERROR' -Step $Name -Event 'agent_exec_nonzero' `
-                    -Extra @{ rc = $r.rc; stderr = $r.stderr }
+                    -Extra @{
+                        rc = $r.rc
+                        stdout = ("$($r.stdout)" | Out-String).Trim()
+                        stderr = ("$($r.stderr)" | Out-String).Trim()
+                    }
                 return $r.rc
             }
             return 0
@@ -607,10 +619,23 @@ $pin = 'C:\OEM\rdprrap_version.txt'
 if (-not (Test-Path -LiteralPath $pin)) { Write-Output 'pin_missing'; exit 1 }
 $cfg = @{}
 foreach ($line in Get-Content -LiteralPath $pin) {
-    if ($line -match '^(?<k>[a-zA-Z_]+)=(?<v>.+)$') { $cfg[$matches.k] = $matches.v.Trim() }
+    # Key pattern is [\w]+ (letters/digits/underscore) -- not just
+    # letters. The earlier [a-zA-Z_]+ pattern silently dropped the
+    # `sha256=` line because `256` isn't in the letter-only group, so
+    # $cfg.sha256 stayed null and the script bailed with 'pin_incomplete'
+    # on every install. Smoke test 2026-05-10 caught this on first
+    # real-Windows attempt with agent-first.
+    if ($line -match '^(?<k>\w+)=(?<v>.+)$') { $cfg[$matches.k] = $matches.v.Trim() }
 }
 $ver = $cfg.version; $name = $cfg.filename; $sha = $cfg.sha256
-if (-not $ver -or -not $name -or -not $sha) { Write-Output 'pin_incomplete'; exit 1 }
+if (-not $ver -or -not $name -or -not $sha) {
+    $missing = @()
+    if (-not $ver)  { $missing += 'version' }
+    if (-not $name) { $missing += 'filename' }
+    if (-not $sha)  { $missing += 'sha256' }
+    Write-Output ("pin_incomplete:missing=" + ($missing -join ','))
+    exit 1
+}
 $src = "C:\OEM\$name"
 if (-not (Test-Path -LiteralPath $src)) { Write-Output 'bundle_missing'; exit 1 }
 $got = (Get-FileHash -LiteralPath $src -Algorithm SHA256).Hash

--- a/tests/test_oem_install_bat.py
+++ b/tests/test_oem_install_bat.py
@@ -118,6 +118,51 @@ def test_step_functions_phase06_grants_rw_not_bare_r_on_oem_source() -> None:
     )
 
 
+def test_step_functions_rdprrap_pin_regex_accepts_digits() -> None:
+    """Smoke test 2026-05-10: the pin-file parser used `[a-zA-Z_]+` for
+    key names, which silently dropped the `sha256=` line (`256` is not
+    in the letter-only group). $cfg.sha256 stayed null, the body wrote
+    'pin_incomplete' to stdout (not stderr), and the orchestrator-side
+    log only captured stderr -- so the diagnostic was invisible.
+
+    Pin the digit-tolerant pattern (`\\w+` or `[a-zA-Z0-9_]+`) so this
+    can't regress."""
+    text = STEP_FUNCTIONS.read_text(encoding="utf-8")
+    rdprrap_start = text.index("# --- Phase 2: rdprrap_installed")
+    rdprrap_end = text.index("# --- Phase 2: vbs_launchers", rdprrap_start)
+    body = text[rdprrap_start:rdprrap_end]
+    # Either \w+ or [a-zA-Z0-9_]+ is acceptable; bare [a-zA-Z_]+ is not.
+    assert "[a-zA-Z_]+)=" not in body, (
+        "rdprrap pin regex regressed to letter-only key pattern -- sha256= "
+        "line will silently drop, breaking every install with "
+        "'pin_incomplete'."
+    )
+
+
+def test_step_functions_agent_exec_logs_stdout_on_failure() -> None:
+    """Smoke test 2026-05-10: Invoke-WinpodxAgentStep originally logged
+    only stderr on failure paths, but Phase 2 step bodies use
+    Write-Output (stdout) for their diagnostic messages. The
+    rdprrap_installed regression surfaced 'pin_incomplete:...' via
+    stdout but install.log showed empty stderr only -- root cause took
+    a manual VNC repro to find.
+
+    Pin both stdout and stderr in the agent_exec_failed and
+    agent_exec_nonzero log paths so a refactor can't drop either."""
+    text = STEP_FUNCTIONS.read_text(encoding="utf-8")
+    factory_start = text.index("function Invoke-WinpodxAgentStep")
+    factory_end = text.index("# --- Phase 2: rdprrap_installed", factory_start)
+    factory = text[factory_start:factory_end]
+    # Both event names must capture both streams.
+    for event in ("agent_exec_failed", "agent_exec_nonzero"):
+        chunk_start = factory.index(f"'{event}'")
+        # Take a 400-char window after the event name to span the -Extra
+        # hashtable.
+        window = factory[chunk_start:chunk_start + 400]
+        assert "stdout" in window, f"{event} log missing stdout capture"
+        assert "stderr" in window, f"{event} log missing stderr capture"
+
+
 def test_step_functions_phase06_grants_system_and_admins_by_sid() -> None:
     """Production smoke test (2026-05-10): /inheritance:r removes
     inherited ACEs for SYSTEM and Administrators too. If the /grant


### PR DESCRIPTION
## Summary

Real-Windows smoke test 2026-05-10 (post PR #150 token_staged fix)
hung at Phase 2 `rdprrap_installed` with `rc=1`, `stderr=""`, and no
hint why. Manual VNC repro pinpointed two bugs that compounded.

### Bug 1 — pin-file regex was letter-only

`config/oem/install-step-functions.ps1` Phase 2 body parsed the
rdprrap version pin file with:

```powershell
if ($line -match '^(?<k>[a-zA-Z_]+)=(?<v>.+)$') { ... }
```

The pin file has three required keys: `version=`, `filename=`,
`sha256=`. Only the first two have purely-letter names, so the
`sha256=` line silently failed to match. `$cfg.sha256` stayed null,
and the body bailed:

```powershell
if (-not $ver -or -not $name -or -not $sha) { Write-Output 'pin_incomplete'; exit 1 }
```

Result: rdprrap never installed → no multi-session → the user's
`winpodx app run desktop` kicked install.bat's autologon RDP session
under Windows's single-session-per-user enforcement → agent died.

Fix: switch the key pattern to `\w+` (letters / digits / underscore).
On miss, log which key(s) are absent (`missing=sha256` etc.) instead
of just `pin_incomplete`.

### Bug 2 — step failures captured stderr but ignored stdout

`Invoke-WinpodxAgentStep`'s failure paths only logged
`stderr = $r.stderr`. Every Phase 2 body uses `Write-Output` (stdout)
for diagnostic messages -- `pin_missing`, `bundle_missing`,
`sha_mismatch`, `installer_missing`, `installer_rc=N`,
`pin_incomplete:missing=sha256`, etc. None of those surfaced in
`install.log`; we just saw an empty stderr and had to repro the body
manually in VNC.

Fix: log both streams in both failure log events (`agent_exec_failed`
and `agent_exec_nonzero`). Same shape of silent-failure bug as PR
#150's swallowed icacls errors -- third instance of this anti-pattern
on this branch, hence regression guards.

## Test plan

- [x] `pytest tests/test_oem_install_bat.py` -- 15/15 passed
      (2 new regression guards: pin regex digit-tolerant; both
      agent_exec_failed and agent_exec_nonzero log stdout AND stderr)
- [ ] Real-Windows re-run after merge: `winpodx pod purge` +
      curl-install from main + `winpodx pod install`. Expected:
      Phase 2 rdprrap_installed completes, vbs_launchers /
      oem_runtime_fixes / max_sessions / multi_session_active /
      install_complete all land their markers,
      `winpodx app run desktop` no longer kicks the autologon session.