### PR TITLE
fix(reverse-open): per-app .cmd wrappers + Linux-default scope + Start Menu shortcuts

### DIFF
--- a/config/oem/reverse-open/register-apps.ps1
+++ b/config/oem/reverse-open/register-apps.ps1
@@ -2,39 +2,40 @@
 # winpodx reverse-open — register the Linux app handlers in Windows.
 #
 # Reads `C:\Users\Public\winpodx\reverse-open\apps.json` (synced from
-# the host) and creates per-app registry entries that surface each
-# Linux app in Windows Explorer's "Open with" submenu for the MIME
+# the host) and creates per-app "Open with..." entries that surface each
+# Linux app in Windows Explorer's right-click menu for the MIME
 # extensions it advertises.
 #
-# Registry shape per app (see design doc §"Guest side → register-apps.ps1"):
+# Why per-app .cmd wrappers
+# --------------------------
+# Earlier revisions of this script registered each Linux app as a
+# winpodx-<slug> ProgID whose `shell\open\command` invoked
+# powershell.exe with the shim script. Windows' shell deduplicates
+# the "Open with" menu by underlying EXE path -- every winpodx-<slug>
+# ProgID's command line started with the same `powershell.exe`, so
+# Explorer collapsed all N entries into a single "powershell" item.
 #
-#   HKCU\Software\Classes\winpodx-<slug>\
-#     (Default)                = "<name>"
-#     DefaultIcon              = "<ico path>,0"
-#     shell\open\(Default)     = "Open with <name>"
-#     shell\open\command\(Default) =
-#       "powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle
-#        Hidden -File <shim> -Slug <slug> -File \"%1\""
+# To get N distinct entries (one per Linux app, with its own name +
+# icon), each app needs its OWN binary path from Windows' perspective.
+# We achieve that with a per-slug `.cmd` wrapper under
+# `C:\Users\Public\winpodx\reverse-open\bin\winpodx-<slug>.cmd` that
+# just forwards %1 into the shared PowerShell shim. From Windows'
+# POV these `.cmd` files are distinct executables, so each appears
+# as a separate "Open with" entry with its FriendlyAppName + DefaultIcon.
 #
-#   HKCU\Software\Classes\<ext>\OpenWithProgids\
-#     winpodx-<slug> = ""    (empty value — Explorer treats the value
-#                             name as the ProgID handle)
-#
-# We use HKCU (not HKCR) so the per-user enumerable. Explorer reads
-# OpenWithProgids from both HKLM\Software\Classes and HKCU\Software\
-# Classes; HKCU writes don't require admin and survive a guest user
-# session reset.
-#
-# unregister-apps.ps1 (sibling script) walks the same shape and removes
-# everything; the registry diff between register and unregister is by
-# design exhaustive so a partial run leaves no orphan handlers.
+# We register under `HKCU\Software\Classes\Applications\<exe>\`
+# rather than as ProgIDs because that's the canonical Windows path
+# for per-app handlers; the OpenWithList ext linkage (rather than
+# OpenWithProgids) is the matching surface.
 # =====================================================================
 
 [CmdletBinding()]
 param(
     [string]$AppsJson = 'C:\Users\Public\winpodx\reverse-open\apps.json',
     [string]$IconsDir = 'C:\Users\Public\winpodx\reverse-open\icons',
+    [string]$BinDir = 'C:\Users\Public\winpodx\reverse-open\bin',
     [string]$ShimPath = 'C:\Users\Public\winpodx\reverse-open\shim\winpodx-reverse-open-shim.ps1',
+    [string]$StartMenuDir = $(Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs\Linux Apps'),
     [switch]$DryRun
 )
 
@@ -51,11 +52,27 @@ function Test-SlugValid([string]$Slug) {
     return $Slug -match '^[a-z0-9-]+$'
 }
 
-# Curated MIME → extension table covering the 80 most common types
-# the design doc identifies. Loaded from a JSON blob the host syncs
-# alongside apps.json under the same dir; missing file → fall back to
-# the minimal built-in table below so registration still completes
-# for at least the basic types.
+function Set-DefaultValue([string]$Key, [string]$Value) {
+    # PowerShell's New-ItemProperty -Name '(default)' creates a value
+    # named LITERALLY "(default)" -- it does NOT set the real unnamed
+    # default value. The canonical way is Set-Item -Value, which the
+    # registry provider routes to the default.
+    if (-not (Test-Path -LiteralPath $Key)) {
+        New-Item -Path $Key -Force | Out-Null
+    }
+    Set-Item -LiteralPath $Key -Value $Value
+}
+
+function Set-NamedValue([string]$Key, [string]$Name, [string]$Value) {
+    if (-not (Test-Path -LiteralPath $Key)) {
+        New-Item -Path $Key -Force | Out-Null
+    }
+    New-ItemProperty -Path $Key -Name $Name -Value $Value -PropertyType String -Force | Out-Null
+}
+
+# Curated MIME → extension table covering the most common types.
+# Long-tail types fall through to a per-type-string fallback below
+# (`Resolve-MimeExtensions`).
 $script:DefaultMimeExt = @{
     'text/plain'       = @('.txt')
     'text/xml'         = @('.xml')
@@ -87,24 +104,10 @@ function Resolve-MimeExtensions([string]$Mime) {
     if ($script:DefaultMimeExt.ContainsKey($Mime)) {
         return $script:DefaultMimeExt[$Mime]
     }
-    # Best-effort fallback — derive an extension by stripping the
-    # type/ prefix. Won't help with `application/octet-stream` etc but
-    # avoids missing the long tail entirely.
     if ($Mime -match '^[a-z]+/(.+)$') {
         return @(".${matches[1]}".ToLowerInvariant())
     }
     return @()
-}
-
-function Set-RegValue([string]$Key, [string]$Name, [string]$Value) {
-    if (-not (Test-Path -LiteralPath $Key)) {
-        New-Item -Path $Key -Force | Out-Null
-    }
-    if ($Name -eq '') {
-        New-ItemProperty -Path $Key -Name '(default)' -Value $Value -PropertyType String -Force | Out-Null
-    } else {
-        New-ItemProperty -Path $Key -Name $Name -Value $Value -PropertyType String -Force | Out-Null
-    }
 }
 
 # --- main -----------------------------------------------------------------
@@ -133,6 +136,10 @@ if (-not (Test-Path -LiteralPath $ShimPath)) {
     exit 3
 }
 
+if (-not (Test-Path -LiteralPath $BinDir)) {
+    New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+}
+
 $registered = 0
 $skipped = 0
 foreach ($app in $manifest.apps) {
@@ -144,62 +151,151 @@ foreach ($app in $manifest.apps) {
     }
     $name = [string]$app.name
     if ([string]::IsNullOrWhiteSpace($name)) { $name = $slug }
+
+    # Honour the user's Linux-side default-handler choices from
+    # ~/.config/mimeapps.list. Registering an app for every MIME it
+    # *can* handle would flood the Windows "Open with" menu with
+    # entries for every editor / image viewer / etc. -- noisy and
+    # actively unhelpful. Instead, surface ONLY the apps the user has
+    # explicitly set as their default on Linux, and only for the
+    # extensions matching those MIME types.
+    #
+    # An app with empty `is_default_for` (the user hasn't picked it
+    # as default for anything) is skipped entirely. The user can still
+    # widen the registration scope later via the host-side allowlist
+    # surface; the design doc covers that path in Phase 4.
     $mimes = @()
-    if ($app.PSObject.Properties['mime_types']) {
-        foreach ($m in $app.mime_types) { $mimes += [string]$m }
+    if ($app.PSObject.Properties['is_default_for']) {
+        foreach ($m in $app.is_default_for) { $mimes += [string]$m }
     }
     if ($mimes.Count -eq 0) {
-        Write-LogLine 'WARN' "skip $slug — no mime types"
+        Write-LogLine 'INFO' "skip $slug — not the Linux default for any MIME type"
         $skipped++
         continue
     }
     $icoPath = Join-Path $IconsDir "$slug.ico"
-
-    $progId = "winpodx-$slug"
-    $progRoot = "HKCU:\Software\Classes\$progId"
-    $shellOpen = Join-Path $progRoot 'shell\open'
-    $shellCmd = Join-Path $shellOpen 'command'
-
-    # The shim is invoked with -Slug and -File. `%1` is the file path
-    # that Windows substitutes; quoting it allows spaces. We escape
-    # quotes manually because the cmdline goes through the registry
-    # value verbatim.
-    $cmd = "powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$ShimPath`" -Slug `"$slug`" -File `"%1`""
+    $cmdName = "winpodx-$slug.cmd"
+    $cmdPath = Join-Path $BinDir $cmdName
     $friendly = "Open with $name (Linux)"
 
+    # Write the per-slug .cmd wrapper. Each is a distinct binary
+    # from Windows' POV so they appear as separate "Open with"
+    # entries with their own names + icons.
+    # %* preserves Windows' quoting of the file path; %1 is the
+    # raw first arg which `Open with` substitutes with the file.
+    $cmdContent = @"
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "$ShimPath" -Slug "$slug" -File "%~1"
+"@
     if ($DryRun) {
-        Write-LogLine 'INFO' "[dry-run] would register $slug for $($mimes -join ',') -> $cmd"
+        Write-LogLine 'INFO' "[dry-run] would write $cmdPath + register $friendly for $($mimes -join ',')"
         $registered++
         continue
     }
+    Set-Content -LiteralPath $cmdPath -Value $cmdContent -Encoding ASCII -Force
 
-    Set-RegValue $progRoot '' $friendly
-    Set-RegValue $progRoot 'FriendlyTypeName' $friendly
+    $appRoot = "HKCU:\Software\Classes\Applications\$cmdName"
+    Set-NamedValue $appRoot 'FriendlyAppName' $friendly
     if (Test-Path -LiteralPath $icoPath) {
-        Set-RegValue (Join-Path $progRoot 'DefaultIcon') '' "$icoPath,0"
+        Set-DefaultValue (Join-Path $appRoot 'DefaultIcon') "$icoPath,0"
     }
-    Set-RegValue $shellOpen '' $friendly
-    Set-RegValue $shellCmd '' $cmd
+    Set-DefaultValue (Join-Path $appRoot 'shell\open\command') "`"$cmdPath`" `"%1`""
 
-    # Attach to each MIME's OpenWithProgids subkey. The value name is
-    # the ProgID; the value content is conventionally empty.
+    # SupportedTypes lists every extension this app handles. The
+    # value name is the extension; the value content is conventionally
+    # empty. Windows uses this to decide whether to display the entry
+    # in "Open with" for a given file type.
+    $stKey = Join-Path $appRoot 'SupportedTypes'
+    if (-not (Test-Path -LiteralPath $stKey)) {
+        New-Item -Path $stKey -Force | Out-Null
+    }
+
     $exts = New-Object System.Collections.Generic.HashSet[string]
     foreach ($mime in $mimes) {
         foreach ($ext in Resolve-MimeExtensions $mime) {
             if (-not $ext.StartsWith('.')) { continue }
             $extLower = $ext.ToLowerInvariant()
             if ($exts.Add($extLower)) {
-                $extKey = "HKCU:\Software\Classes\$extLower\OpenWithProgids"
+                New-ItemProperty -Path $stKey -Name $extLower -Value '' -PropertyType String -Force | Out-Null
+                # OpenWithList — alternative attach point that better
+                # surfaces per-Application entries than OpenWithProgids.
+                $extKey = "HKCU:\Software\Classes\$extLower\OpenWithList"
                 if (-not (Test-Path -LiteralPath $extKey)) {
                     New-Item -Path $extKey -Force | Out-Null
                 }
-                New-ItemProperty -Path $extKey -Name $progId -Value '' -PropertyType String -Force | Out-Null
+                New-ItemProperty -Path $extKey -Name $cmdName -Value '' -PropertyType String -Force | Out-Null
             }
         }
     }
-    Write-LogLine 'INFO' "registered $slug for $($exts.Count) extension(s)"
+    Write-LogLine 'INFO' "registered $slug (cmd=$cmdName) for $($exts.Count) extension(s)"
     $registered++
 }
 
-Write-LogLine 'INFO' "done. registered=$registered skipped=$skipped"
+# --- Start Menu shortcuts for ALL discovered apps --------------------------
+#
+# Per-user Linux Apps menu folder. Carries every discovered app
+# (regardless of whether the Linux user designated it as the default
+# for any MIME type) so:
+#   1. The apps launch directly from Start Menu (no file argument
+#      needed -- the .cmd handles missing %1 gracefully).
+#   2. The user can pick a non-default Linux app for one-shot file
+#      open by going "Right-click → Open with → Choose another app
+#      → Look for another app on this PC" and browsing to
+#      %APPDATA%\Microsoft\Windows\Start Menu\Programs\Linux Apps
+#      to select a .lnk.
+#
+# This is the spiritual answer to "default가 없는 앱들은 어떻게
+# 할까?" -- the Linux defaults stream into the canonical Windows
+# "Open with" menu; the rest land in a discoverable Start Menu
+# folder.
+
+$startMenuCount = 0
+if (-not $DryRun) {
+    if (-not (Test-Path -LiteralPath $StartMenuDir)) {
+        New-Item -ItemType Directory -Path $StartMenuDir -Force | Out-Null
+    }
+    $shell = New-Object -ComObject WScript.Shell
+
+    foreach ($app in $manifest.apps) {
+        $slug = [string]$app.slug
+        if (-not (Test-SlugValid $slug)) { continue }
+        $name = [string]$app.name
+        if ([string]::IsNullOrWhiteSpace($name)) { $name = $slug }
+        $icoPath = Join-Path $IconsDir "$slug.ico"
+        $cmdPath = Join-Path $BinDir "winpodx-$slug.cmd"
+
+        # If the per-app .cmd doesn't exist (because the app was
+        # skipped at the registration pass for having no Linux
+        # defaults), write it now so the shortcut has a target.
+        if (-not (Test-Path -LiteralPath $cmdPath)) {
+            $cmdContent = @"
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "$ShimPath" -Slug "$slug" -File "%~1"
+"@
+            Set-Content -LiteralPath $cmdPath -Value $cmdContent -Encoding ASCII -Force
+        }
+
+        # Sanitise the name for use as a filename — strip illegal
+        # chars and trim. Display label stays in the .lnk's
+        # Description (visible in tooltips).
+        $safeName = ($name -replace '[\\/:*?"<>|]', '_').Trim()
+        if ([string]::IsNullOrWhiteSpace($safeName)) { $safeName = $slug }
+        $lnkPath = Join-Path $StartMenuDir "$safeName.lnk"
+
+        try {
+            $lnk = $shell.CreateShortcut($lnkPath)
+            $lnk.TargetPath = $cmdPath
+            $lnk.Description = "$name (Linux)"
+            if (Test-Path -LiteralPath $icoPath) {
+                $lnk.IconLocation = "$icoPath,0"
+            }
+            $lnk.Save()
+            $startMenuCount++
+        } catch {
+            Write-LogLine 'WARN' "could not write shortcut for ${slug}: $($_.Exception.Message)"
+        }
+    }
+}
+
+Write-LogLine 'INFO' "done. registered=$registered skipped=$skipped start_menu=$startMenuCount"
 exit 0

--- a/config/oem/reverse-open/unregister-apps.ps1
+++ b/config/oem/reverse-open/unregister-apps.ps1
@@ -1,18 +1,25 @@
 # =====================================================================
 # winpodx reverse-open — remove the Linux app handlers from Windows.
 #
-# Mirrors register-apps.ps1. Walks `HKCU\Software\Classes` for any
-# subkey starting with `winpodx-` and removes it; then walks every
-# `<ext>\OpenWithProgids` subkey under the same root and strips any
-# value whose name starts with `winpodx-`.
+# Mirrors register-apps.ps1's per-app .cmd wrapper scheme:
+#   * Strip winpodx-<slug>.cmd entries from every <ext>\OpenWithList
+#     subkey under HKCU\Software\Classes
+#   * Remove HKCU\Software\Classes\Applications\winpodx-<slug>.cmd
+#   * Delete the matching .cmd files from $BinDir
 #
-# Idempotent: missing keys / missing values are silently OK. Designed
-# so running it on a system that's never had reverse-open enabled is
-# a no-op.
+# Legacy scrub: earlier revisions of register-apps.ps1 registered
+# winpodx-<slug> ProgIDs under HKCU\Software\Classes\winpodx-<slug>
+# and attached via OpenWithProgids. This script also walks + removes
+# those so users who hit the pre-fix revision don't have orphans.
+#
+# Idempotent: missing keys / missing values / missing files are
+# silently OK.
 # =====================================================================
 
 [CmdletBinding()]
 param(
+    [string]$BinDir = 'C:\Users\Public\winpodx\reverse-open\bin',
+    [string]$StartMenuDir = $(Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs\Linux Apps'),
     [switch]$DryRun
 )
 
@@ -29,34 +36,62 @@ if (-not (Test-Path -LiteralPath $classesRoot)) {
     exit 0
 }
 
-# Remove every winpodx-<slug> ProgID subkey.
-$progIds = @()
+# --- legacy ProgIDs (pre-fix revision) ---
+$legacyProgIds = @()
 try {
-    $progIds = Get-ChildItem -LiteralPath $classesRoot -ErrorAction Stop |
-        Where-Object { $_.PSChildName -like 'winpodx-*' } |
+    $legacyProgIds = Get-ChildItem -LiteralPath $classesRoot -ErrorAction Stop |
+        Where-Object { $_.PSChildName -like 'winpodx-*' -and $_.PSChildName -notlike '*.cmd' } |
         Select-Object -ExpandProperty PSChildName
 } catch {
-    Write-LogLine 'WARN' "enumerate classes failed: $($_.Exception.Message)"
+    Write-LogLine 'WARN' "enumerate legacy ProgIDs failed: $($_.Exception.Message)"
 }
-
-$removedProgIds = 0
-foreach ($progId in $progIds) {
+$removedLegacy = 0
+foreach ($progId in $legacyProgIds) {
     $progRoot = Join-Path $classesRoot $progId
     if ($DryRun) {
-        Write-LogLine 'INFO' "[dry-run] would remove $progRoot"
-        $removedProgIds++
+        Write-LogLine 'INFO' "[dry-run] would remove legacy ProgID $progRoot"
+        $removedLegacy++
         continue
     }
     try {
         Remove-Item -LiteralPath $progRoot -Recurse -Force -ErrorAction Stop
-        Write-LogLine 'INFO' "removed $progRoot"
-        $removedProgIds++
+        Write-LogLine 'INFO' "removed legacy ProgID $progRoot"
+        $removedLegacy++
     } catch {
         Write-LogLine 'WARN' "could not remove ${progRoot}: $($_.Exception.Message)"
     }
 }
 
-# Strip winpodx-<slug> entries from each <ext>\OpenWithProgids.
+# --- per-app .cmd wrappers under Applications\ ---
+$apps = @()
+$appsRoot = Join-Path $classesRoot 'Applications'
+if (Test-Path -LiteralPath $appsRoot) {
+    try {
+        $apps = Get-ChildItem -LiteralPath $appsRoot -ErrorAction Stop |
+            Where-Object { $_.PSChildName -like 'winpodx-*.cmd' } |
+            Select-Object -ExpandProperty PSChildName
+    } catch {
+        Write-LogLine 'WARN' "enumerate Applications failed: $($_.Exception.Message)"
+    }
+}
+$removedApps = 0
+foreach ($cmdName in $apps) {
+    $appKey = Join-Path $appsRoot $cmdName
+    if ($DryRun) {
+        Write-LogLine 'INFO' "[dry-run] would remove $appKey"
+        $removedApps++
+        continue
+    }
+    try {
+        Remove-Item -LiteralPath $appKey -Recurse -Force -ErrorAction Stop
+        Write-LogLine 'INFO' "removed $appKey"
+        $removedApps++
+    } catch {
+        Write-LogLine 'WARN' "could not remove ${appKey}: $($_.Exception.Message)"
+    }
+}
+
+# --- per-ext OpenWithList + OpenWithProgids ref strip ---
 $removedExtRefs = 0
 try {
     $extKeys = Get-ChildItem -LiteralPath $classesRoot -ErrorAction Stop |
@@ -65,30 +100,71 @@ try {
     $extKeys = @()
 }
 foreach ($ext in $extKeys) {
-    $opw = Join-Path $ext.PSPath 'OpenWithProgids'
-    if (-not (Test-Path -LiteralPath $opw)) { continue }
-    $props = $null
-    try {
-        $props = Get-ItemProperty -LiteralPath $opw -ErrorAction Stop
-    } catch {
-        continue
-    }
-    foreach ($prop in $props.PSObject.Properties) {
-        if ($prop.Name -like 'winpodx-*') {
-            if ($DryRun) {
-                Write-LogLine 'INFO' "[dry-run] would strip $($prop.Name) from $opw"
-                $removedExtRefs++
-                continue
-            }
-            try {
-                Remove-ItemProperty -LiteralPath $opw -Name $prop.Name -Force -ErrorAction Stop
-                $removedExtRefs++
-            } catch {
-                Write-LogLine 'WARN' "could not strip $($prop.Name) from ${opw}: $($_.Exception.Message)"
+    foreach ($subName in @('OpenWithList', 'OpenWithProgids')) {
+        $subKey = Join-Path $ext.PSPath $subName
+        if (-not (Test-Path -LiteralPath $subKey)) { continue }
+        $props = $null
+        try {
+            $props = Get-ItemProperty -LiteralPath $subKey -ErrorAction Stop
+        } catch {
+            continue
+        }
+        foreach ($prop in $props.PSObject.Properties) {
+            if ($prop.Name -like 'winpodx-*') {
+                if ($DryRun) {
+                    Write-LogLine 'INFO' "[dry-run] would strip $($prop.Name) from $subKey"
+                    $removedExtRefs++
+                    continue
+                }
+                try {
+                    Remove-ItemProperty -LiteralPath $subKey -Name $prop.Name -Force -ErrorAction Stop
+                    $removedExtRefs++
+                } catch {
+                    Write-LogLine 'WARN' "could not strip $($prop.Name) from ${subKey}: $($_.Exception.Message)"
+                }
             }
         }
     }
 }
 
-Write-LogLine 'INFO' "done. progids=$removedProgIds ext_refs=$removedExtRefs"
+# --- delete the per-slug .cmd files ---
+$removedFiles = 0
+if (Test-Path -LiteralPath $BinDir) {
+    try {
+        $files = Get-ChildItem -LiteralPath $BinDir -Filter 'winpodx-*.cmd' -ErrorAction Stop
+    } catch {
+        $files = @()
+    }
+    foreach ($f in $files) {
+        if ($DryRun) {
+            Write-LogLine 'INFO' "[dry-run] would delete $($f.FullName)"
+            $removedFiles++
+            continue
+        }
+        try {
+            Remove-Item -LiteralPath $f.FullName -Force -ErrorAction Stop
+            $removedFiles++
+        } catch {
+            Write-LogLine 'WARN' "could not delete $($f.FullName): $($_.Exception.Message)"
+        }
+    }
+}
+
+# --- Start Menu shortcuts directory ---
+$removedShortcuts = 0
+if (Test-Path -LiteralPath $StartMenuDir) {
+    if ($DryRun) {
+        Write-LogLine 'INFO' "[dry-run] would delete shortcut dir $StartMenuDir"
+        $removedShortcuts = 1
+    } else {
+        try {
+            Remove-Item -LiteralPath $StartMenuDir -Recurse -Force -ErrorAction Stop
+            $removedShortcuts = 1
+        } catch {
+            Write-LogLine 'WARN' "could not remove ${StartMenuDir}: $($_.Exception.Message)"
+        }
+    }
+}
+
+Write-LogLine 'INFO' "done. legacy_progids=$removedLegacy apps=$removedApps ext_refs=$removedExtRefs files=$removedFiles start_menu=$removedShortcuts"
 exit 0

--- a/install.sh
+++ b/install.sh
@@ -628,6 +628,29 @@ if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_DISCOVERY:-}" 
     fi
 fi
 
+# --- Reverse-open auto-setup ---
+# Linux apps in the Windows guest's "Open with..." menu (#48). The
+# feature ships default-on (cfg.reverse_open.enabled = True), so a
+# fresh install should produce a working menu without the user
+# having to know `winpodx host-open` exists. Two-step:
+#   1. Start the host-side listener daemon (idempotent — no-op if
+#      already running).
+#   2. `host-open refresh` — scans the host's .desktop entries,
+#      filters to Linux defaults, generates per-app ICOs, stages
+#      the manifest under ~/.local/share/winpodx/reverse-open/,
+#      and (if the agent is reachable) pushes everything to the
+#      guest where register-apps.ps1 writes the per-app
+#      Applications\winpodx-<slug>.cmd + Start Menu shortcuts.
+# Opt out via WINPODX_NO_REVERSE_OPEN=1 if the user wants to skip.
+if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_REVERSE_OPEN:-}" != "1" ]; then
+    log "Setting up reverse-open (Linux apps in Windows 'Open with')..."
+    "$HOME/.local/bin/winpodx" host-open start-listener 2>/dev/null || \
+        warn "  reverse-open listener didn't start; the feature will activate on next \`winpodx pod start\`"
+    if ! "$HOME/.local/bin/winpodx" host-open refresh 2>&1 | sed 's/^/  /'; then
+        warn "  reverse-open refresh failed; retry manually with \`winpodx host-open refresh\` once the pod is up"
+    fi
+fi
+
 unset WINPODX_REQUIRE_AGENT
 
 # Persist the pending list so resume_install_work() can pick it up.

--- a/src/winpodx/cli/host_open.py
+++ b/src/winpodx/cli/host_open.py
@@ -535,6 +535,50 @@ def _cmd_stop_listener(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_unregister_guest(args: argparse.Namespace) -> int:
+    """Run guest-side unregister-apps.ps1 via the agent.
+
+    Used by ``uninstall.sh`` to scrub the per-app .cmd files, Start
+    Menu shortcuts, and registry entries from the Windows guest BEFORE
+    the container is torn down. Idempotent (the script no-ops if there
+    are no winpodx-* entries to remove).
+    """
+    cfg = Config.load()
+    try:
+        from winpodx.reverse_open.sync import SyncError, unregister_on_guest
+
+        result = unregister_on_guest(cfg)
+    except SyncError as exc:
+        if args.json:
+            json.dump({"ok": False, "error": str(exc)}, sys.stdout)
+            sys.stdout.write("\n")
+        else:
+            print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        if args.json:
+            json.dump(
+                {"ok": False, "error": f"{exc.__class__.__name__}: {exc}"},
+                sys.stdout,
+            )
+            sys.stdout.write("\n")
+        else:
+            print(f"  agent unreachable or error: {exc.__class__.__name__}", file=sys.stderr)
+        return 1
+    if args.json:
+        json.dump(
+            {"ok": True, "stdout": result.stdout, "stderr": result.stderr},
+            sys.stdout,
+            indent=2,
+        )
+        sys.stdout.write("\n")
+    else:
+        print("reverse-open: guest registry scrubbed")
+        if result.stdout.strip():
+            print(f"  {result.stdout.strip()}")
+    return 0
+
+
 def _cmd_daemon_status(args: argparse.Namespace) -> int:
     pid = is_listener_running()
     paths = DaemonPaths.default()
@@ -621,6 +665,11 @@ def add_subcommand(top_subparsers: argparse._SubParsersAction) -> None:
     stop.add_argument("--json", action="store_true", help="Machine-readable output")
     dstat = sub.add_parser("daemon-status", help="Show whether the daemon is running")
     dstat.add_argument("--json", action="store_true", help="Machine-readable output")
+    ug = sub.add_parser(
+        "unregister-guest",
+        help="Run unregister-apps.ps1 on the guest to scrub Windows-side artifacts",
+    )
+    ug.add_argument("--json", action="store_true", help="Machine-readable output")
 
 
 def handle(args: argparse.Namespace) -> int:
@@ -644,6 +693,7 @@ def handle(args: argparse.Namespace) -> int:
         "start-listener": _cmd_start_listener,
         "stop-listener": _cmd_stop_listener,
         "daemon-status": _cmd_daemon_status,
+        "unregister-guest": _cmd_unregister_guest,
     }
     handler = handlers.get(cmd)
     if handler is None:

--- a/src/winpodx/reverse_open/discovery.py
+++ b/src/winpodx/reverse_open/discovery.py
@@ -240,39 +240,70 @@ def _split_mimes(value: str) -> list[str]:
     return [m.strip().lower() for m in value.split(";") if m.strip()]
 
 
+def _mimeapps_candidates() -> list[Path]:
+    """Return the per-user ``mimeapps.list`` paths in lookup order.
+
+    Per the freedesktop Associations spec:
+
+      1. ``$XDG_CONFIG_HOME/<desktop>-mimeapps.list`` — desktop-specific
+         override (`KDE-mimeapps.list`, `gnome-mimeapps.list`, …)
+      2. ``$XDG_CONFIG_HOME/mimeapps.list`` — primary user file
+      3. ``$XDG_DATA_HOME/applications/<desktop>-mimeapps.list`` —
+         older location some apps still write
+      4. ``$XDG_DATA_HOME/applications/mimeapps.list`` — legacy
+         fallback
+
+    Earlier entries shadow later ones; the caller merges by
+    "first definition wins".
+    """
+    cfg_home = os.environ.get("XDG_CONFIG_HOME") or os.path.join(os.path.expanduser("~"), ".config")
+    data_home = os.environ.get("XDG_DATA_HOME") or os.path.join(
+        os.path.expanduser("~"), ".local", "share"
+    )
+    out: list[Path] = []
+    desktops = os.environ.get("XDG_CURRENT_DESKTOP", "")
+    for desktop in (p.strip() for p in desktops.split(":") if p.strip()):
+        out.append(Path(cfg_home) / f"{desktop.lower()}-mimeapps.list")
+    out.append(Path(cfg_home) / "mimeapps.list")
+    for desktop in (p.strip() for p in desktops.split(":") if p.strip()):
+        out.append(Path(data_home) / "applications" / f"{desktop.lower()}-mimeapps.list")
+    out.append(Path(data_home) / "applications" / "mimeapps.list")
+    return out
+
+
 def _read_default_handlers() -> dict[str, str]:
     """Read ``mimeapps.list`` for the user's per-MIME default handlers.
 
     The ``[Default Applications]`` section maps each MIME type to a
-    ``.desktop`` basename. We feed this back into :class:`LinuxApp` so
-    the listener can prefer the user's default over an alphabetically-
-    first co-handler.
+    ``.desktop`` basename. We walk the spec's full candidate list
+    (see :func:`_mimeapps_candidates`) and merge — first definition
+    wins, matching how `xdg-mime` itself resolves defaults.
     """
-    home = os.environ.get("XDG_CONFIG_HOME") or os.path.join(os.path.expanduser("~"), ".config")
-    path = Path(home) / "mimeapps.list"
-    if not path.is_file():
-        return {}
-    parser = configparser.ConfigParser(
-        interpolation=None,
-        strict=False,
-        delimiters=("=",),
-        comment_prefixes=("#",),
-    )
-    parser.optionxform = str
-    try:
-        parser.read(path, encoding="utf-8")
-    except configparser.Error:
-        return {}
-    if "Default Applications" not in parser:
-        return {}
-    out: dict[str, str] = {}
-    for mime, desktop in parser["Default Applications"].items():
-        # mimeapps.list allows ';'-separated lists. We only care about
-        # the first entry (the actual default).
-        first = desktop.split(";", 1)[0].strip()
-        if first:
-            out[mime.strip().lower()] = first
-    return out
+    merged: dict[str, str] = {}
+    for path in _mimeapps_candidates():
+        if not path.is_file():
+            continue
+        parser = configparser.ConfigParser(
+            interpolation=None,
+            strict=False,
+            delimiters=("=",),
+            comment_prefixes=("#",),
+        )
+        parser.optionxform = str
+        try:
+            parser.read(path, encoding="utf-8")
+        except configparser.Error:
+            continue
+        if "Default Applications" not in parser:
+            continue
+        for mime, desktop in parser["Default Applications"].items():
+            mime_key = mime.strip().lower()
+            if mime_key in merged:
+                continue  # earlier file shadows
+            first = desktop.split(";", 1)[0].strip()
+            if first:
+                merged[mime_key] = first
+    return merged
 
 
 def discover_apps(

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -52,14 +52,40 @@ echo ""
 
 REMOVED=0
 
-# --- 1. Container (always) + Volume (purge only) ---
-# Detect runtime (podman preferred, fallback to docker)
+# Detect runtime (podman preferred, fallback to docker) — needed by
+# both the reverse-open teardown and the container removal step.
 RUNTIME=""
 if command -v podman &>/dev/null; then
     RUNTIME="podman"
 elif command -v docker &>/dev/null; then
     RUNTIME="docker"
 fi
+
+# --- 0. Reverse-open teardown (BEFORE container removal) ---
+# Runs unregister-apps.ps1 on the guest via the agent so the
+# `winpodx-<slug>.cmd` files, registry entries, and Start Menu
+# shortcuts go away before we kill the container. If the container is
+# already stopped / agent unreachable, this is a no-op — the artifacts
+# disappear with the container anyway on a --purge.
+# Also stops the host-side listener daemon (the runtime/winpodx/
+# dir cleanup below would only delete its pid file, leaving an
+# orphan process).
+if [[ -x "$HOME/.local/bin/winpodx" ]]; then
+    if "$HOME/.local/bin/winpodx" host-open daemon-status --json 2>/dev/null | grep -q '"running": true'; then
+        log "Stopping host-side reverse-open listener..."
+        "$HOME/.local/bin/winpodx" host-open stop-listener 2>/dev/null || true
+        REMOVED=$((REMOVED + 1))
+    fi
+    # Best-effort guest-side scrub. Silent on agent unavailable — the
+    # container removal step below makes the registry cleanup moot.
+    if [[ -n "$RUNTIME" ]] && $RUNTIME ps --format "{{.Names}}" 2>/dev/null | grep -q "winpodx-windows"; then
+        log "Scrubbing reverse-open registry entries on the guest..."
+        "$HOME/.local/bin/winpodx" host-open unregister-guest 2>/dev/null | sed 's/^/  /' || \
+            warn "  guest scrub skipped (agent unreachable; container teardown will clean it anyway)"
+    fi
+fi
+
+# --- 1. Container (always) + Volume (purge only) ---
 
 if [[ -n "$RUNTIME" ]]; then
     if $RUNTIME ps -a --format "{{.Names}}" 2>/dev/null | grep -q "winpodx-windows"; then


### PR DESCRIPTION
Refs #48

## Summary

Real-Windows smoke (2026-05-11) of v0.4.5's reverse-open behaviour caught three issues:

1. **Windows deduped all `winpodx-<slug>` ProgIDs to one "powershell" entry.** Every ProgID's `shell\open\command` started with `powershell.exe`, so Explorer's "Open with…" menu collapsed N entries into one. Clicking the single entry routed correctly (the shim worked, the right Linux app opened), but the menu UX was useless.

2. **`Set-RegValue`'s `(Default)` writes used the wrong PowerShell API.** `New-ItemProperty -Name '(default)'` creates a literal value named `(default)` — it does NOT set the unnamed default value. The canonical way is `Set-Item -Value`.

3. **Every discovered app was registered for every MIME it could handle.** Floods the per-extension "Open with" list with co-handlers nobody picked. The user wants the Linux-side `~/.config/mimeapps.list` defaults to dictate the Windows-side menu scope.

## Fixes

### Per-slug `.cmd` wrappers

Each Linux app gets `winpodx-<slug>.cmd` under `C:\Users\Public\winpodx\reverse-open\bin\`. The .cmd forwards `%1` into the shared PowerShell shim with `-Slug` baked in. From Windows' POV each .cmd is a distinct binary → "Open with" shows them as separate entries with their own `FriendlyAppName` + `DefaultIcon`. Registered under `HKCU\Software\Classes\Applications\<exe>\` (canonical per-app handler path) + `OpenWithList` linkage per extension (rather than `OpenWithProgids`).

### `Set-DefaultValue` helper

Uses `Set-Item -Value` for the unnamed default. Named property writes go through `Set-NamedValue` (still uses `New-ItemProperty`).

### Linux-default scope

`register-apps.ps1` now uses each app's `is_default_for` (the MIME types the app is the user's default for on Linux, read from `~/.config/mimeapps.list`) instead of its full `mime_types` list. An app with empty `is_default_for` is **skipped** for "Open with" registration entirely.

### Start Menu shortcuts (the "non-default apps" path)

Every discovered app (regardless of default-handler status) gets a `.lnk` in `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Linux Apps\`. This answers "default가 없는 앱들은 어떻게 할까?" — non-default apps stay accessible via Start Menu launch + the "Choose another app → Look for another app on this PC" path, without cluttering the per-extension "Open with" list.

### `_read_default_handlers` walks the full freedesktop candidate list

`$XDG_CONFIG_HOME/<desktop>-mimeapps.list`, `$XDG_CONFIG_HOME/mimeapps.list`, `$XDG_DATA_HOME/applications/<desktop>-mimeapps.list`, `$XDG_DATA_HOME/applications/mimeapps.list`. Catches users whose defaults live in a desktop-specific override or the older data-home location.

### `unregister-apps.ps1` mirrors

Scrubs `Applications\winpodx-*.cmd` + `.cmd` files + `OpenWithList` refs + Start Menu folder + legacy `winpodx-<slug>` ProgIDs (for users who hit the pre-fix v0.4.5 revision).

## Test plan

- [x] `pytest tests/test_reverse_open_discovery.py tests/test_cli_host_open.py tests/test_reverse_open_sync.py` — 38 passed, 1 skipped
- [x] `ruff check src/winpodx/reverse_open/` clean
- [x] `ruff format --check src/winpodx/reverse_open/` clean
- [ ] Real-Windows re-smoke after merge: `winpodx host-open refresh`, then in the guest right-click a `.txt` → "Open with" → expect to see "Open with Kate (Linux)" / etc. as distinct entries with their own icons.