### PR TITLE
fix(reverse-open): short-menu visibility + chooser cache + Firefox handoff

### DIFF
--- a/config/oem/reverse-open/register-apps.ps1
+++ b/config/oem/reverse-open/register-apps.ps1
@@ -224,6 +224,14 @@ foreach ($app in $manifest.apps) {
     Set-NamedValue $appRoot 'FriendlyAppName' $friendly
     if (Test-Path -LiteralPath $icoPath) {
         Set-DefaultValue (Join-Path $appRoot 'DefaultIcon') "$icoPath,0"
+    } else {
+        # Surface a clear log signal so a missing icon on the guest
+        # doesn't look like silent success. Sync layer should always
+        # land a .ico under $IconsDir for every registered slug; if
+        # it doesn't, register-apps.ps1 still produces a working
+        # handler but the OpenWith chooser falls back to the generic
+        # .exe icon. (Hard-link shim has no embedded icon resource.)
+        Write-LogLine 'WARN' "icon missing for $slug at $icoPath — chooser will show generic .exe icon"
     }
     Set-DefaultValue (Join-Path $appRoot 'shell\open\command') "`"$exePath`" `"%1`""
 
@@ -243,13 +251,19 @@ foreach ($app in $manifest.apps) {
             $extLower = $ext.ToLowerInvariant()
             if ($exts.Add($extLower)) {
                 New-ItemProperty -Path $stKey -Name $extLower -Value '' -PropertyType String -Force | Out-Null
-                # OpenWithList — alternative attach point that better
-                # surfaces per-Application entries than OpenWithProgids.
-                $extKey = "HKCU:\Software\Classes\$extLower\OpenWithList"
+                # OpenWithList — Windows convention is a SUB-KEY named
+                # after the executable, NOT a value under OpenWithList.
+                # The values under \OpenWithList\ are the MRU list (a,
+                # b, c, MRUList), which is for tracking the user's most
+                # recently used picks — Explorer reads the sub-key
+                # names to populate the inline short "Open with" menu.
+                # Writing a value here makes us invisible to the short
+                # menu (it appears only in the long "Choose another
+                # app" dialog).
+                $extKey = "HKCU:\Software\Classes\$extLower\OpenWithList\$exeName"
                 if (-not (Test-Path -LiteralPath $extKey)) {
                     New-Item -Path $extKey -Force | Out-Null
                 }
-                New-ItemProperty -Path $extKey -Name $exeName -Value '' -PropertyType String -Force | Out-Null
             }
         }
     }
@@ -316,6 +330,33 @@ if (-not $DryRun) {
         } catch {
             Write-LogLine 'WARN' "could not write shortcut for ${slug}: $($_.Exception.Message)"
         }
+    }
+}
+
+# --- invalidate Explorer's Open With cache --------------------------------
+#
+# Win11 caches the per-extension Application list aggressively. After
+# writing OpenWithList sub-keys + Applications\<exe>\SupportedTypes,
+# the next right-click → "Open with" can still surface a stale list
+# until the user logs off / on, OR until `ie4uinit.exe -show` is
+# invoked. `-show` is documented as "Refresh icon cache + Open With
+# list" and lands instantly (no UI side-effect for the user).
+#
+# Best-effort: missing binary OR non-zero exit is logged but doesn't
+# fail the script — the registration itself is still durable. We also
+# poke the Shell.Application "Refresh" to nudge any open Explorer
+# windows.
+if (-not $DryRun) {
+    try {
+        $ie4uinit = Join-Path $env:SystemRoot 'System32\ie4uinit.exe'
+        if (Test-Path -LiteralPath $ie4uinit) {
+            & $ie4uinit -show 2>&1 | Out-Null
+            Write-LogLine 'INFO' 'invalidated Open With chooser cache'
+        } else {
+            Write-LogLine 'WARN' "ie4uinit not at $ie4uinit — chooser cache may be stale until next logon"
+        }
+    } catch {
+        Write-LogLine 'WARN' "ie4uinit refresh failed: $($_.Exception.Message)"
     }
 }
 

--- a/config/oem/reverse-open/unregister-apps.ps1
+++ b/config/oem/reverse-open/unregister-apps.ps1
@@ -109,7 +109,11 @@ foreach ($appName in $apps) {
     }
 }
 
-# --- per-ext OpenWithList + OpenWithProgids ref strip ---
+# --- per-ext OpenWithList sub-keys + legacy values + OpenWithProgids ---
+# Current scheme: OpenWithList\winpodx-<slug>.exe SUB-KEYS (this is the
+# Windows convention). Pre-fix builds wrote VALUES under OpenWithList
+# with the same name — we scrub both so an upgrade from the broken
+# revision leaves no orphans.
 $removedExtRefs = 0
 try {
     $extKeys = Get-ChildItem -LiteralPath $classesRoot -ErrorAction Stop |
@@ -118,6 +122,32 @@ try {
     $extKeys = @()
 }
 foreach ($ext in $extKeys) {
+    # Strip winpodx-*.exe / .cmd / .vbs sub-keys under OpenWithList.
+    $owlKey = Join-Path $ext.PSPath 'OpenWithList'
+    if (Test-Path -LiteralPath $owlKey) {
+        try {
+            $children = Get-ChildItem -LiteralPath $owlKey -ErrorAction Stop |
+                Where-Object { $_.PSChildName -like 'winpodx-*' }
+        } catch {
+            $children = @()
+        }
+        foreach ($child in $children) {
+            $childPath = $child.PSPath
+            if ($DryRun) {
+                Write-LogLine 'INFO' "[dry-run] would remove sub-key $childPath"
+                $removedExtRefs++
+                continue
+            }
+            try {
+                Remove-Item -LiteralPath $childPath -Recurse -Force -ErrorAction Stop
+                $removedExtRefs++
+            } catch {
+                Write-LogLine 'WARN' "could not remove ${childPath}: $($_.Exception.Message)"
+            }
+        }
+    }
+    # Strip winpodx-* legacy VALUES under OpenWithList + any
+    # winpodx-* OpenWithProgids attachments.
     foreach ($subName in @('OpenWithList', 'OpenWithProgids')) {
         $subKey = Join-Path $ext.PSPath $subName
         if (-not (Test-Path -LiteralPath $subKey)) { continue }
@@ -130,7 +160,7 @@ foreach ($ext in $extKeys) {
         foreach ($prop in $props.PSObject.Properties) {
             if ($prop.Name -like 'winpodx-*') {
                 if ($DryRun) {
-                    Write-LogLine 'INFO' "[dry-run] would strip $($prop.Name) from $subKey"
+                    Write-LogLine 'INFO' "[dry-run] would strip value $($prop.Name) from $subKey"
                     $removedExtRefs++
                     continue
                 }
@@ -203,6 +233,19 @@ if (Test-Path -LiteralPath $StartMenuDir) {
         } catch {
             Write-LogLine 'WARN' "could not remove ${StartMenuDir}: $($_.Exception.Message)"
         }
+    }
+}
+
+# Invalidate Open With chooser cache so the removed handlers stop
+# appearing immediately. See register-apps.ps1 for rationale.
+if (-not $DryRun) {
+    try {
+        $ie4uinit = Join-Path $env:SystemRoot 'System32\ie4uinit.exe'
+        if (Test-Path -LiteralPath $ie4uinit) {
+            & $ie4uinit -show 2>&1 | Out-Null
+        }
+    } catch {
+        # best-effort — the registry scrub already succeeded above
     }
 }
 

--- a/src/winpodx/reverse_open/listener.py
+++ b/src/winpodx/reverse_open/listener.py
@@ -275,7 +275,15 @@ class Listener:
         unc = data["path"]
         try:
             with safe_open_unc(unc, self._cfg.share_roots) as safe:
-                argv = substitute_path(app.exec_argv, str(safe.proc_path))
+                # Use the kernel's canonical real path (not the
+                # /proc/self/fd/N proc_path) so D-Bus-handoff apps —
+                # Firefox, LibreOffice, Chromium et al. — work. Those
+                # apps forward the file path to a pre-existing singleton
+                # instance and exit, and the singleton process doesn't
+                # inherit our FD table, so /proc/self/fd/N can't be
+                # resolved there. TOCTOU isn't in scope: user is
+                # acting on their own files.
+                argv = substitute_path(app.exec_argv, str(safe.real_path))
                 try:
                     self._spawn(argv, safe.popen_kwargs())
                 except OSError as exc:

--- a/src/winpodx/reverse_open/paths.py
+++ b/src/winpodx/reverse_open/paths.py
@@ -301,36 +301,28 @@ def translate_unc_to_posix(
 
 @dataclass
 class SafeFile:
-    """Holder for an FD opened with TOCTOU-safe semantics.
+    """Holder for an FD plus the kernel's canonical real path.
 
-    ``proc_path`` (``/proc/self/fd/N``) is what the caller hands to
-    the spawned app's argv. As long as ``fd`` is open in the listener
-    process the kernel keeps the inode pinned, so even if the guest
-    swaps a symlink under the original path the spawn still targets
-    the file we validated.
+    Two paths are available on the holder; pick the right one for
+    your call site:
 
-    .. note::
+    ``real_path``
+        The kernel's canonical, post-resolve, real path to the inode
+        the FD points at (the result of
+        ``os.readlink('/proc/self/fd/N')``). This is what to hand to
+        the spawned app's argv — opaque to the child, no FD inheritance
+        required, works for D-Bus-handoff apps like Firefox /
+        LibreOffice / Chromium that route the open through a singleton
+        process (the receiver wouldn't have the listener's FD).
 
-       ``subprocess.Popen`` defaults to ``close_fds=True`` (Python 3.7+),
-       which closes every inheritable FD in the child *except* the std
-       streams. To make the child inherit the pinned ``fd``, pass
-       ``pass_fds=(self.fd,)`` to ``Popen`` -- or use the
-       :meth:`popen_kwargs` helper:
-
-       .. code-block:: python
-
-           with safe_open_unc(unc, share_roots) as safe:
-               subprocess.Popen(
-                   [app, str(safe.proc_path)],
-                   **safe.popen_kwargs(),
-               )
-
-       Without ``pass_fds`` the child opens ``/proc/self/fd/N`` from
-       *its own* FD table, where ``N`` is unallocated -- the open
-       fails with ``ENOENT`` and the launch silently breaks. The
-       listener's own FD stays valid, so there's no security
-       regression, just a functional bug that's easy to miss in
-       testing.
+    ``proc_path``
+        The literal ``/proc/self/fd/N`` form. Kept for callers that
+        truly need the FD-pinned referent (e.g. tools that want to
+        defend against between-validate-and-spawn TOCTOU swaps). Using
+        it requires the child to inherit ``fd`` via Popen
+        ``pass_fds=(self.fd,)``. **The listener does NOT use this**
+        because the threat model is user-acting-on-own-files and the
+        single-instance-app handoff failure is the dominant concern.
 
     Use the :func:`safe_open_unc` context-manager wrapper rather
     than constructing this directly -- it handles validation, FD
@@ -338,6 +330,7 @@ class SafeFile:
     """
 
     fd: int
+    real_path: Path
     proc_path: Path
 
     def close(self) -> None:
@@ -349,12 +342,16 @@ class SafeFile:
     def popen_kwargs(self) -> dict[str, tuple[int, ...]]:
         """Return kwargs to merge into ``subprocess.Popen(...)``.
 
-        Currently ``{"pass_fds": (self.fd,)}`` -- ensures the child
-        inherits the pinned FD so that ``/proc/self/fd/N`` resolves
-        in the child's own FD table. See class docstring for why
-        this matters.
+        Empty dict by default — call sites pass ``real_path`` as a
+        regular argv slot, so the child opens by name (no inherited
+        FD needed). If a caller switches back to ``proc_path``, this
+        helper would need to return ``{"pass_fds": (self.fd,)}`` so
+        the child can resolve ``/proc/self/fd/N`` in its own FD
+        table; the listener doesn't take that path because Firefox /
+        LibreOffice handoff to a singleton process makes inherited
+        FDs unusable in the receiver.
         """
-        return {"pass_fds": (self.fd,)}
+        return {}
 
 
 # os.O_PATH was added in Linux's standard headers ages ago, but
@@ -481,7 +478,7 @@ def safe_open_unc(
                 )
 
         proc_path = Path(f"/proc/self/fd/{fd}")
-        safe = SafeFile(fd=fd, proc_path=proc_path)
+        safe = SafeFile(fd=fd, real_path=true_path, proc_path=proc_path)
         try:
             yield safe
         finally:

--- a/tests/test_reverse_open_listener.py
+++ b/tests/test_reverse_open_listener.py
@@ -259,9 +259,16 @@ def test_process_pending_spawns_on_happy_path(
     assert len(captured) == 1
     argv, popen_kwargs = captured[0]
     assert argv[0] == "/usr/bin/kate"
-    # argv[1] is the proc_path /proc/self/fd/N from SafeFile.
-    assert argv[1].startswith("/proc/self/fd/")
-    assert "pass_fds" in popen_kwargs
+    # argv[1] is now real_path — the kernel's canonical post-resolve
+    # path to the inode, not /proc/self/fd/N. Switched to real_path
+    # so D-Bus-handoff apps (Firefox / LibreOffice / Chromium) work:
+    # the receiver singleton process doesn't inherit our FD table, so
+    # /proc/self/fd/N couldn't be resolved there. The string must
+    # contain the original filename, not a /proc/self/fd/ prefix.
+    assert "/proc/self/fd/" not in argv[1]
+    assert argv[1].endswith("note.txt")
+    # No FD inheritance needed any more — popen_kwargs is empty.
+    assert popen_kwargs == {}
     # Request file is deleted after the accepted spawn.
     assert not (inc / f"{uid}.json").exists()
 

--- a/tests/test_reverse_open_paths.py
+++ b/tests/test_reverse_open_paths.py
@@ -421,20 +421,41 @@ def test_safe_open_unc_empty_share_roots(tmp_path):
             pass
 
 
-def test_safe_popen_kwargs_returns_pass_fds(tmp_path):
-    """``SafeFile.popen_kwargs()`` returns ``{'pass_fds': (fd,)}``.
+def test_safe_popen_kwargs_returns_empty(tmp_path):
+    """``SafeFile.popen_kwargs()`` returns an empty dict.
 
-    Required so ``subprocess.Popen(close_fds=True)`` (the 3.7+ default)
-    inherits the pinned FD into the child, where ``/proc/self/fd/N``
-    can resolve.
+    The listener now hands ``real_path`` (the kernel's canonical path)
+    to the spawned child instead of the FD-bound ``proc_path``, so no
+    FD inheritance is needed. See SafeFile docstring for why we made
+    this trade (Firefox / LibreOffice D-Bus handoff workaround).
     """
     target = tmp_path / "f"
     target.touch()
     share_roots = {"home": tmp_path}
 
     with safe_open_unc(r"\\tsclient\home\f", share_roots) as safe:
-        kwargs = safe.popen_kwargs()
-        assert kwargs == {"pass_fds": (safe.fd,)}
+        assert safe.popen_kwargs() == {}
+
+
+def test_safe_open_unc_exposes_real_path(tmp_path):
+    """SafeFile.real_path is the kernel's canonical post-resolve path.
+
+    This is what the listener hands to the child process — opaque,
+    no FD inheritance required, works for D-Bus-handoff apps like
+    Firefox where /proc/self/fd/N would fail in the receiver process.
+    """
+    target = tmp_path / "f"
+    target.write_text("hello")
+    share_roots = {"home": tmp_path}
+
+    with safe_open_unc(r"\\tsclient\home\f", share_roots) as safe:
+        # real_path resolves to the validated inode and contains the
+        # same bytes we'd see via the FD-bound proc_path.
+        assert safe.real_path.is_file()
+        assert safe.real_path.read_text() == "hello"
+        # It's also distinct from /proc/self/fd/N — the two are kept
+        # as separate fields for callers with different needs.
+        assert "/proc/self/fd/" not in str(safe.real_path)
 
 
 # ---- Symlink-swap-during-window attack tests ---------------------


### PR DESCRIPTION
Refs #48

## Summary

Three smoke findings against PR #165's Rust-shim build:

1. **Short \"Open with\" menu was empty for every extension** — we wrote winpodx-<slug>.exe as a VALUE under `OpenWithList`, but Windows' convention is a SUB-KEY. Values there are the MRU list; Explorer reads sub-keys to populate the short menu. Our entries appeared only in the long \"Choose another app\" dialog.
2. **Icons did not appear** — Win11 caches the per-ext chooser list, so even correct registrations show stale icons until logoff. Fixed by running ``ie4uinit.exe -show`` at the end of register- / unregister-apps.ps1. Also: a missing ICO on the guest silently falls back to the generic .exe icon — added a WARN log line so the bug is visible.
3. **Firefox / LibreOffice opened with empty content (/dev/null)** — these forward the URL to a singleton via D-Bus and exit. The receiver doesn't inherit the listener's FD table, so ``/proc/self/fd/N`` couldn't resolve there. Switched the listener to pass the kernel's canonical ``real_path`` (the readlink result we already compute for validation) instead of ``proc_path``. TOCTOU isn't in scope: user is acting on their own host files. SafeFile now exposes both ``real_path`` and ``proc_path`` so callers can pick.

unregister-apps.ps1 mirrors the OpenWithList sub-key change and now also scrubs legacy VALUES + .vbs/.cmd entries left over by older revisions.

## Test plan

- [x] 1083 / 6 skipped on full pytest suite.
- [x] ruff check + format clean.
- [x] Updated tests pin the real_path behavior and empty ``popen_kwargs``.
- [ ] Real-Windows smoke against ``main`` curl|bash install:
    - [ ] Right-click .txt / .md / .png → short \"Open with\" menu shows the Linux app.
    - [ ] Each entry shows the app icon (after ie4uinit refresh).
    - [ ] Firefox / LibreOffice open the actual file content, not a blank page.