### PR TITLE
fix(reverse-open): multi-resolution ICOs + full freedesktop mimeapps walk

### DIFF
--- a/src/winpodx/reverse_open/discovery.py
+++ b/src/winpodx/reverse_open/discovery.py
@@ -241,34 +241,71 @@ def _split_mimes(value: str) -> list[str]:
 
 
 def _mimeapps_candidates() -> list[Path]:
-    """Return the per-user ``mimeapps.list`` paths in lookup order.
+    """Return every ``mimeapps.list`` path the freedesktop spec defines.
 
-    Per the freedesktop Associations spec:
+    Walks the full canonical search order so we honour defaults set
+    anywhere a desktop-environment or distro packaging convention puts
+    them — not just the per-user files. For each base directory below,
+    we check the desktop-prefix variant (one per
+    ``XDG_CURRENT_DESKTOP`` colon-component, lowercased) followed by
+    plain ``mimeapps.list``. The base-dir order, from highest to
+    lowest precedence:
 
-      1. ``$XDG_CONFIG_HOME/<desktop>-mimeapps.list`` — desktop-specific
-         override (`KDE-mimeapps.list`, `gnome-mimeapps.list`, …)
-      2. ``$XDG_CONFIG_HOME/mimeapps.list`` — primary user file
-      3. ``$XDG_DATA_HOME/applications/<desktop>-mimeapps.list`` —
-         older location some apps still write
-      4. ``$XDG_DATA_HOME/applications/mimeapps.list`` — legacy
-         fallback
+      1. ``$XDG_CONFIG_HOME``                                 (user)
+      2. Each entry of ``$XDG_CONFIG_DIRS``                   (system config)
+      3. ``$XDG_DATA_HOME/applications``                      (user, legacy)
+      4. Each entry of ``$XDG_DATA_DIRS/applications``        (system data)
 
-    Earlier entries shadow later ones; the caller merges by
-    "first definition wins".
+    Defaults follow freedesktop:
+
+      * ``XDG_CONFIG_HOME`` → ``~/.config``
+      * ``XDG_CONFIG_DIRS`` → ``/etc/xdg``
+      * ``XDG_DATA_HOME``  → ``~/.local/share``
+      * ``XDG_DATA_DIRS``  → ``/usr/local/share:/usr/share``
+
+    The caller merges first-definition-wins so user-level always
+    shadows system-level — matching xdg-mime's own resolution. This
+    is how distros that ship a system-wide ``kde-mimeapps.list``
+    (e.g. ``/usr/share/applications/kde-mimeapps.list`` with
+    ``text/plain=org.kde.kate.desktop``) get picked up, and why
+    GNOME-on-Wayland with no user override still resolves to its
+    system-default text editor.
     """
-    cfg_home = os.environ.get("XDG_CONFIG_HOME") or os.path.join(os.path.expanduser("~"), ".config")
-    data_home = os.environ.get("XDG_DATA_HOME") or os.path.join(
-        os.path.expanduser("~"), ".local", "share"
-    )
-    out: list[Path] = []
-    desktops = os.environ.get("XDG_CURRENT_DESKTOP", "")
-    for desktop in (p.strip() for p in desktops.split(":") if p.strip()):
-        out.append(Path(cfg_home) / f"{desktop.lower()}-mimeapps.list")
-    out.append(Path(cfg_home) / "mimeapps.list")
-    for desktop in (p.strip() for p in desktops.split(":") if p.strip()):
-        out.append(Path(data_home) / "applications" / f"{desktop.lower()}-mimeapps.list")
-    out.append(Path(data_home) / "applications" / "mimeapps.list")
-    return out
+    home = os.path.expanduser("~")
+
+    cfg_home = os.environ.get("XDG_CONFIG_HOME") or os.path.join(home, ".config")
+    cfg_dirs_raw = os.environ.get("XDG_CONFIG_DIRS") or "/etc/xdg"
+    cfg_dirs = [d for d in cfg_dirs_raw.split(":") if d]
+
+    data_home = os.environ.get("XDG_DATA_HOME") or os.path.join(home, ".local", "share")
+    data_dirs_raw = os.environ.get("XDG_DATA_DIRS") or "/usr/local/share:/usr/share"
+    data_dirs = [d for d in data_dirs_raw.split(":") if d]
+
+    desktops = [
+        p.strip().lower() for p in os.environ.get("XDG_CURRENT_DESKTOP", "").split(":") if p.strip()
+    ]
+
+    def _expand(base: Path) -> list[Path]:
+        """Desktop-prefix variants (each component of XDG_CURRENT_DESKTOP)
+        followed by the plain mimeapps.list under ``base``."""
+        out: list[Path] = []
+        for d in desktops:
+            out.append(base / f"{d}-mimeapps.list")
+        out.append(base / "mimeapps.list")
+        return out
+
+    paths: list[Path] = []
+    # 1. user config
+    paths.extend(_expand(Path(cfg_home)))
+    # 2. system config (XDG_CONFIG_DIRS)
+    for d in cfg_dirs:
+        paths.extend(_expand(Path(d)))
+    # 3. user data (legacy applications/ location)
+    paths.extend(_expand(Path(data_home) / "applications"))
+    # 4. system data (XDG_DATA_DIRS)
+    for d in data_dirs:
+        paths.extend(_expand(Path(d) / "applications"))
+    return paths
 
 
 def _read_default_handlers() -> dict[str, str]:

--- a/src/winpodx/reverse_open/icons.py
+++ b/src/winpodx/reverse_open/icons.py
@@ -263,27 +263,48 @@ def convert_to_ico(src: Path, dst: Path) -> bool:
                 break
             images.append(Image.open(io.BytesIO(png_bytes)).convert("RGBA"))
     else:
-        # Raster — open once, resize per target size.
+        # Raster — open once, then upscale to the largest target size
+        # before resampling down to every other size. Pillow's ICO
+        # encoder silently SKIPS any requested size larger than the
+        # source (``if size[0] > width: continue`` in IcoImagePlugin),
+        # so a 16×16 source PNG would produce a single-frame 16×16
+        # .ico even though we asked for 7 sizes. Win11's OpenWith
+        # chooser then renders that tiny frame fuzzy or falls back
+        # to the generic .exe icon entirely. Upscaling first guarantees
+        # every requested size lands in the output.
         try:
             base = Image.open(src).convert("RGBA")
         except Exception as exc:
             logger.warning("Pillow cannot open %s: %s", src, exc)
             used_placeholder = True
         else:
+            max_size = max(ICO_SIZES)
+            if base.size != (max_size, max_size):
+                base = base.resize((max_size, max_size), Image.Resampling.LANCZOS)
             for size in ICO_SIZES:
-                images.append(base.resize((size, size), Image.Resampling.LANCZOS))
+                if size == max_size:
+                    images.append(base)
+                else:
+                    images.append(base.resize((size, size), Image.Resampling.LANCZOS))
 
     if used_placeholder or not images:
         images = [_placeholder_image(size) for size in ICO_SIZES]
 
+    # Order frames largest-first. Pillow's ICO encoder uses the BASE
+    # image's dimensions as the cap for which ``sizes=`` entries it
+    # actually writes — anything larger than the base is dropped.
+    # Saving the 256×256 frame as the base guarantees all 7 sizes
+    # land in the output.
+    by_size_desc = sorted(images, key=lambda im: im.size[0], reverse=True)
+
     dst.parent.mkdir(parents=True, exist_ok=True)
     tmp = dst.with_suffix(dst.suffix + ".tmp")
     try:
-        images[0].save(
+        by_size_desc[0].save(
             tmp,
             format="ICO",
             sizes=[(s, s) for s in ICO_SIZES],
-            append_images=images[1:],
+            append_images=by_size_desc[1:],
         )
         os.replace(tmp, dst)
     finally:

--- a/tests/test_reverse_open_discovery.py
+++ b/tests/test_reverse_open_discovery.py
@@ -244,6 +244,42 @@ def test_discover_apps_default_handlers_marked(monkeypatch: pytest.MonkeyPatch) 
     assert apps[0].is_default_for == ["text/plain"]
 
 
+def test_discover_apps_picks_up_system_level_kde_mimeapps_list(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Defaults set in a system-wide ``<desktop>-mimeapps.list``
+    (e.g. ``/usr/share/applications/kde-mimeapps.list``) must be
+    honoured. This is where distro packaging puts per-DE defaults —
+    KDE Plasma installs typically ship a kde-mimeapps.list with
+    ``text/plain=org.kde.kate.desktop`` that the user inherits without
+    any per-user mimeapps.list.
+
+    Regression guard for the v0.4.6 smoke finding where only 6 of 95
+    discovered apps had ``is_default_for`` populated because the
+    candidate walk stopped at $XDG_CONFIG_HOME / $XDG_DATA_HOME.
+    """
+    _write_desktop("org.kde.kate.desktop", _kate_entry())
+
+    # Stand up a fake XDG_DATA_DIRS entry containing a system-wide
+    # kde-mimeapps.list with the default. We DO NOT write any
+    # user-level mimeapps.list — that's the point: the default lives
+    # purely in the system file and discovery must still find it.
+    sys_share = tmp_path / "share"
+    sys_apps = sys_share / "applications"
+    sys_apps.mkdir(parents=True)
+    (sys_apps / "kde-mimeapps.list").write_text(
+        "[Default Applications]\ntext/plain=org.kde.kate.desktop\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("XDG_DATA_DIRS", str(sys_share))
+    monkeypatch.setenv("XDG_CURRENT_DESKTOP", "KDE")
+
+    apps = discover_apps()
+    kate = next((a for a in apps if a.slug == "org-kde-kate"), None)
+    assert kate is not None
+    assert kate.is_default_for == ["text/plain"]
+
+
 def test_discover_apps_extra_dirs_after_xdg() -> None:
     _write_desktop("kate.desktop", _kate_entry())
     extra = Path(os.environ["XDG_DATA_HOME"]).parent / "extra" / "apps"

--- a/tests/test_reverse_open_icons.py
+++ b/tests/test_reverse_open_icons.py
@@ -119,6 +119,35 @@ def test_convert_to_ico_from_png(tmp_path: Path) -> None:
     _assert_ico_valid(dst)
 
 
+def test_convert_to_ico_small_source_upscales_to_full_size_set(tmp_path: Path) -> None:
+    """Source PNGs smaller than the largest target must NOT collapse the
+    output to a single frame.
+
+    Pillow's ICO encoder silently skips any requested size larger than
+    the source (``if size[0] > width: continue``). Without upscaling the
+    base image first, a 16×16 firefox.png would produce a single 16×16
+    frame in the .ico — Win11's OpenWith chooser then falls back to the
+    generic .exe icon. ``convert_to_ico`` must pre-upscale so every
+    requested ICO_SIZES entry lands in the output.
+    """
+    src = tmp_path / "tiny.png"
+    _make_png(src, size=16)  # smaller than max(ICO_SIZES)=256
+    dst = tmp_path / "out.ico"
+    assert convert_to_ico(src, dst) is True
+
+    with Image.open(dst) as img:
+        sizes = getattr(img, "ico", None)
+        if sizes is not None:
+            actual = {(w, h) for (w, h) in sizes.sizes()}
+        else:
+            actual = set(img.info.get("sizes", []))
+        # Every declared ICO size must be present, not just the
+        # source's own 16×16. Win11 chooser typically renders at 32 or
+        # 48 — failing to embed those was the v0.4.5/v0.4.6 smoke bug.
+        for s in ICO_SIZES:
+            assert (s, s) in actual, f"{s}x{s} missing — actual sizes: {actual}"
+
+
 def test_convert_to_ico_creates_parent_directory(tmp_path: Path) -> None:
     src = tmp_path / "in.png"
     _make_png(src)


### PR DESCRIPTION
Refs #48

## Summary

Two smoke findings from PR #166 testing.

### #1 — Icons did not render in Win11's OpenWith chooser
``icons.py`` asked Pillow for sizes 16/24/32/48/64/128/256 but the output was single-frame 16×16 (the case the user saw was firefox.ico at 863 bytes). Pillow's ICO encoder silently skips any requested size larger than the source — for app icons that resolve to a 16×16 source PNG, every other size gets dropped and Win11 falls back to the generic .exe icon.

**Fix**: upscale the base raster to ``max(ICO_SIZES)`` once (LANCZOS), then resample down for each smaller size, and save with the largest frame as the base. All seven sizes now land in every .ico.

### #2 — System-wide ``<desktop>-mimeapps.list`` ignored
A KDE Plasma install ships ``/usr/share/applications/kde-mimeapps.list`` with ``text/plain=org.kde.kate.desktop``. ``discovery.py`` only walked ``\$XDG_CONFIG_HOME`` + ``\$XDG_DATA_HOME/applications`` for the candidate list, so distro-shipped defaults never surfaced. On the user's KDE host only 6 of 95 discovered apps had ``is_default_for`` populated.

**Fix**: walk the full freedesktop candidate set per the Associations spec, in precedence order:

  1. ``\$XDG_CONFIG_HOME``
  2. ``\$XDG_CONFIG_DIRS`` (default ``/etc/xdg``)
  3. ``\$XDG_DATA_HOME/applications``
  4. ``\$XDG_DATA_DIRS/applications`` (default ``/usr/local/share`` + ``/usr/share``)

Each base directory is checked first for every ``\$XDG_CURRENT_DESKTOP``-prefix variant (colon-split, lowercase) then for plain ``mimeapps.list``. First-definition-wins is preserved so user-level still shadows system-level — same as xdg-mime itself.

## Test plan

- [x] ``pytest tests/`` — 1085 passed, 6 skipped.
- [x] ``ruff check`` + ``ruff format --check`` clean.
- [x] New regression tests pin (a) upscaled multi-frame ICO output from a 16×16 source and (b) discovery honouring a system-wide kde-mimeapps.list with no user-level override.
- [ ] Real-Windows smoke against ``main`` curl|bash install:
    - [ ] Right-click .txt / .md / .pdf → short \"Open with\" menu shows the Linux default handler.
    - [ ] Each entry shows the app icon at full resolution, not a generic .exe placeholder.