### PR TITLE
feat(reverse-open): Desktop folder shortcut + Quick Access pin

### DIFF
--- a/config/oem/reverse-open/register-apps.ps1
+++ b/config/oem/reverse-open/register-apps.ps1
@@ -333,6 +333,74 @@ if (-not $DryRun) {
     }
 }
 
+# --- Desktop folder shortcut + Quick Access pin ----------------------------
+#
+# Win11's "Open with → Choose another app → Look for another app on
+# this PC" surface is a regular file-browse dialog. Without a hint, the
+# user has to navigate to %APPDATA%\Microsoft\Windows\Start Menu\
+# Programs\Linux Apps\ — long path, not obvious. We drop two
+# discoverability aids that point at the existing $StartMenuDir:
+#
+#   1. Desktop\Linux Apps.lnk — folder shortcut on the desktop. The
+#      dialog's left sidebar always has Desktop; one click + one
+#      double-click gets the user to the .lnk list.
+#   2. Quick Access pin — adds the folder to File Explorer's left
+#      sidebar (and every Common Item Dialog inherits that sidebar).
+#      Implemented via the documented "pintohome" shell verb.
+#
+# Both are best-effort: failure logs a WARN but doesn't fail the
+# script, since the per-extension Open With registration above is
+# what actually delivers the feature.
+$folderShortcuts = 0
+if (-not $DryRun -and (Test-Path -LiteralPath $StartMenuDir)) {
+    # Desktop folder shortcut.
+    try {
+        $desktopDir = [Environment]::GetFolderPath('Desktop')
+        if ($desktopDir -and (Test-Path -LiteralPath $desktopDir)) {
+            $desktopLnk = Join-Path $desktopDir 'Linux Apps.lnk'
+            $lnk = $shell.CreateShortcut($desktopLnk)
+            $lnk.TargetPath = $StartMenuDir
+            $lnk.Description = 'Linux apps available via winpodx'
+            # Use the generic shell32 folder icon (index 4) so the
+            # shortcut renders as a normal folder. Trying to embed our
+            # own .ico here would require shipping a winpodx-folder.ico;
+            # the generic folder glyph is sufficient and unsurprising.
+            $lnk.IconLocation = 'shell32.dll,4'
+            $lnk.Save()
+            $folderShortcuts++
+            Write-LogLine 'INFO' "wrote Desktop folder shortcut: $desktopLnk"
+        }
+    } catch {
+        Write-LogLine 'WARN' "could not write Desktop folder shortcut: $($_.Exception.Message)"
+    }
+
+    # Quick Access pin via Shell.Application's "pintohome" verb.
+    # This is the documented mechanism for File Explorer's "Pin to
+    # Quick access" right-click action.
+    try {
+        $shellApp = New-Object -ComObject Shell.Application
+        $folder = $shellApp.Namespace($StartMenuDir)
+        if ($folder) {
+            $item = $folder.Self
+            # Look for the localised verb; fall back to the canonical
+            # English name. Localised systems (e.g. ko-KR
+            # "즐겨찾기에 고정") still respond to "pintohome" when
+            # invoked programmatically.
+            $verb = $item.Verbs() | Where-Object { $_.Name -replace '&', '' -match '(pintohome|Pin to Quick access|즐겨찾기에 고정)' } | Select-Object -First 1
+            if ($null -eq $verb) {
+                # Direct invoke by canonical name — works on all locales.
+                $item.InvokeVerb('pintohome')
+            } else {
+                $verb.DoIt()
+            }
+            $folderShortcuts++
+            Write-LogLine 'INFO' "pinned Linux Apps to Quick Access"
+        }
+    } catch {
+        Write-LogLine 'WARN' "could not pin to Quick Access: $($_.Exception.Message)"
+    }
+}
+
 # --- invalidate Explorer's Open With cache --------------------------------
 #
 # Win11 caches the per-extension Application list aggressively. After
@@ -360,5 +428,5 @@ if (-not $DryRun) {
     }
 }
 
-Write-LogLine 'INFO' "done. registered=$registered skipped=$skipped start_menu=$startMenuCount"
+Write-LogLine 'INFO' "done. registered=$registered skipped=$skipped start_menu=$startMenuCount folder_shortcuts=$folderShortcuts"
 exit 0

--- a/config/oem/reverse-open/unregister-apps.ps1
+++ b/config/oem/reverse-open/unregister-apps.ps1
@@ -236,6 +236,48 @@ if (Test-Path -LiteralPath $StartMenuDir) {
     }
 }
 
+# --- Desktop folder shortcut + Quick Access pin ---------------------------
+# Mirror cleanup for the discoverability aids register-apps.ps1 lands
+# alongside the per-slug registrations.
+$removedFolderShortcuts = 0
+if (-not $DryRun) {
+    # Desktop\Linux Apps.lnk
+    try {
+        $desktopDir = [Environment]::GetFolderPath('Desktop')
+        if ($desktopDir) {
+            $desktopLnk = Join-Path $desktopDir 'Linux Apps.lnk'
+            if (Test-Path -LiteralPath $desktopLnk) {
+                Remove-Item -LiteralPath $desktopLnk -Force -ErrorAction Stop
+                $removedFolderShortcuts++
+            }
+        }
+    } catch {
+        Write-LogLine 'WARN' "could not remove Desktop folder shortcut: $($_.Exception.Message)"
+    }
+
+    # Quick Access unpin. The Shell.Application "unpinfromhome" verb
+    # only works if the pinned item still exists on disk, so we run
+    # this BEFORE the Start Menu folder deletion above would have
+    # taken effect — except that section already ran. Fall back to
+    # walking the AutomaticDestinations file the pin lives in.
+    try {
+        $shellApp = New-Object -ComObject Shell.Application
+        # The Quick Access folder is exposed as "shell:::{679f85cb-0220-4080-b29b-5540cc05aab6}"
+        $qa = $shellApp.Namespace('shell:::{679f85cb-0220-4080-b29b-5540cc05aab6}')
+        if ($qa) {
+            foreach ($it in $qa.Items()) {
+                if ($it.Name -eq 'Linux Apps' -or $it.Path -eq $StartMenuDir) {
+                    $it.InvokeVerb('unpinfromhome')
+                    $removedFolderShortcuts++
+                    break
+                }
+            }
+        }
+    } catch {
+        Write-LogLine 'WARN' "could not unpin from Quick Access: $($_.Exception.Message)"
+    }
+}
+
 # Invalidate Open With chooser cache so the removed handlers stop
 # appearing immediately. See register-apps.ps1 for rationale.
 if (-not $DryRun) {
@@ -249,5 +291,5 @@ if (-not $DryRun) {
     }
 }
 
-Write-LogLine 'INFO' "done. legacy_progids=$removedLegacy apps=$removedApps ext_refs=$removedExtRefs files=$removedFiles start_menu=$removedShortcuts"
+Write-LogLine 'INFO' "done. legacy_progids=$removedLegacy apps=$removedApps ext_refs=$removedExtRefs files=$removedFiles start_menu=$removedShortcuts folder_shortcuts=$removedFolderShortcuts"
 exit 0


### PR DESCRIPTION
Refs #48

## Summary

Win11's *Open with → Choose another app → Look for another app on this PC* surface opens a file-browse dialog. The Start Menu ``Linux Apps`` folder is reachable but the path is buried under ``%APPDATA%\Microsoft\Windows\Start Menu\Programs\`` — the user has to manually type or click through six levels to find it.

Add two discoverability aids alongside the existing Start Menu folder:

- **Desktop\\Linux Apps.lnk** — folder shortcut on the desktop. Browse dialogs always show Desktop in the left sidebar; one click + one double-click gets the user to the .lnk list. Generic ``shell32.dll,4`` folder icon.
- **Quick Access pin** — pinned to File Explorer's left sidebar via the documented ``pintohome`` shell verb. Every Common Item Dialog inherits the same sidebar, so the pin shows up in the *Choose another app* chooser too.

Both are best-effort: WARN log on failure, the registry registration itself continues. ``unregister-apps.ps1`` mirrors the cleanup — removes the Desktop ``.lnk`` and walks the Quick Access namespace to unpin ``Linux Apps`` via ``unpinfromhome``.

## Test plan

- [x] Python-side tests + ruff clean (no behaviour change there).
- [ ] Real-Windows smoke against ``main`` curl|bash install:
    - [ ] Desktop shows a ``Linux Apps`` folder shortcut.
    - [ ] File Explorer left sidebar Quick Access shows ``Linux Apps``.
    - [ ] *Open with → Choose another app → Look for another app on this PC* dialog: clicking Desktop reaches the apps in 2 clicks; Quick Access reaches them in 1.
    - [ ] ``./uninstall.sh --confirm`` removes both surfaces.