### PR TITLE
fix(reverse-open): per-slug ProgID for chooser icons + SHChangeNotify + spawn argv logging

### DIFF
--- a/config/oem/reverse-open/register-apps.ps1
+++ b/config/oem/reverse-open/register-apps.ps1
@@ -28,10 +28,29 @@
 #    300 KB × 95 = 28 MB. The shim reads its own filename at runtime
 #    (`std::env::current_exe`) to figure out which slug it represents.
 #
-# We register under `HKCU\Software\Classes\Applications\<exe>\`
-# rather than as ProgIDs because that's the canonical Windows path
-# for per-app handlers; the OpenWithList ext linkage (rather than
-# OpenWithProgids) is the matching surface.
+# We register under THREE surfaces, because Windows' "Open with…"
+# chooser is a minefield and no single one is sufficient on its own:
+#
+#   a. `HKCU\Software\Classes\Applications\<exe>\` — FriendlyAppName +
+#      SupportedTypes + shell\open\command. Required for the entry to
+#      appear in the "Open with → Choose another app" long dialog at
+#      all.
+#
+#   b. `HKCU\Software\Classes\<ext>\OpenWithList\<exe>` — SUB-KEY (NOT
+#      a value). Drives the inline short "Open with" menu visibility
+#      (Win10 + Win11). #166's fix.
+#
+#   c. `HKCU\Software\Classes\winpodx-<slug>` — per-slug **ProgID**
+#      with `DefaultIcon` + `shell\open\command`, linked to each
+#      extension via `<ext>\OpenWithProgids\winpodx-<slug>` value.
+#      This is the **canonical surface for the chooser's per-entry
+#      ICON**: `Applications\<exe>\DefaultIcon` is widely ignored by
+#      Explorer's chooser, and the hard-linked shim has no embedded
+#      icon resource, so without the ProgID surface every entry
+#      falls back to the generic .exe glyph. Same hard-linked .exe
+#      per slug — the EXE-dedup concern in the header above applies
+#      to `OpenWithList` (where Windows collapses by EXE path), NOT
+#      to `OpenWithProgids` (where the ProgID name is the dedup key).
 # =====================================================================
 
 [CmdletBinding()]
@@ -223,17 +242,30 @@ foreach ($app in $manifest.apps) {
     $appRoot = "HKCU:\Software\Classes\Applications\$exeName"
     Set-NamedValue $appRoot 'FriendlyAppName' $friendly
     if (Test-Path -LiteralPath $icoPath) {
+        # Kept for upgrade/back-compat — older revisions read it. The
+        # canonical icon surface for the chooser is the per-slug
+        # ProgID's DefaultIcon below; this Applications-key value is
+        # belt-and-suspenders and harmless.
         Set-DefaultValue (Join-Path $appRoot 'DefaultIcon') "$icoPath,0"
     } else {
-        # Surface a clear log signal so a missing icon on the guest
-        # doesn't look like silent success. Sync layer should always
-        # land a .ico under $IconsDir for every registered slug; if
-        # it doesn't, register-apps.ps1 still produces a working
-        # handler but the OpenWith chooser falls back to the generic
-        # .exe icon. (Hard-link shim has no embedded icon resource.)
         Write-LogLine 'WARN' "icon missing for $slug at $icoPath — chooser will show generic .exe icon"
     }
     Set-DefaultValue (Join-Path $appRoot 'shell\open\command') "`"$exePath`" `"%1`""
+
+    # --- per-slug ProgID (canonical icon surface) ------------------------
+    # Without this, Explorer's chooser uses the .exe's embedded icon
+    # resource — which our hard-linked Rust shim doesn't have — and
+    # falls back to the generic .exe glyph. The ProgID's DefaultIcon
+    # is the surface Explorer reliably honours when an entry is
+    # surfaced via `<ext>\OpenWithProgids\winpodx-<slug>` (written in
+    # the per-extension loop below).
+    $progIdRoot = "HKCU:\Software\Classes\winpodx-$slug"
+    Set-DefaultValue $progIdRoot $friendly
+    Set-NamedValue $progIdRoot 'FriendlyTypeName' $friendly
+    if (Test-Path -LiteralPath $icoPath) {
+        Set-DefaultValue (Join-Path $progIdRoot 'DefaultIcon') "$icoPath,0"
+    }
+    Set-DefaultValue (Join-Path $progIdRoot 'shell\open\command') "`"$exePath`" `"%1`""
 
     # SupportedTypes lists every extension this app handles. The
     # value name is the extension; the value content is conventionally
@@ -264,6 +296,16 @@ foreach ($app in $manifest.apps) {
                 if (-not (Test-Path -LiteralPath $extKey)) {
                     New-Item -Path $extKey -Force | Out-Null
                 }
+                # OpenWithProgids — VALUE (not sub-key). Names the
+                # per-slug ProgID we registered above so Explorer
+                # resolves the entry's icon from the ProgID's
+                # DefaultIcon. Empty REG_NONE value is the documented
+                # convention.
+                $owpKey = "HKCU:\Software\Classes\$extLower\OpenWithProgids"
+                if (-not (Test-Path -LiteralPath $owpKey)) {
+                    New-Item -Path $owpKey -Force | Out-Null
+                }
+                New-ItemProperty -Path $owpKey -Name "winpodx-$slug" -Value ([byte[]]@()) -PropertyType None -Force | Out-Null
             }
         }
     }
@@ -425,6 +467,25 @@ if (-not $DryRun) {
         }
     } catch {
         Write-LogLine 'WARN' "ie4uinit refresh failed: $($_.Exception.Message)"
+    }
+
+    # SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, 0, 0) — the
+    # canonical "file associations changed, refresh per-entry icons"
+    # signal. `ie4uinit -show` covers the OpenWith MRU list but does
+    # NOT invalidate the shell icon cache; without this P/Invoke,
+    # per-slug ProgID DefaultIcons land in the registry but Explorer
+    # keeps painting the previous (often generic) icon until next
+    # logon. Shell32 export, present on every supported Windows.
+    try {
+        Add-Type -Namespace WinPodx -Name Shell32Ext -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("shell32.dll")]
+public static extern void SHChangeNotify(int wEventId, uint uFlags, System.IntPtr dwItem1, System.IntPtr dwItem2);
+'@ -ErrorAction Stop
+        # SHCNE_ASSOCCHANGED = 0x08000000; SHCNF_IDLIST = 0x0000
+        [WinPodx.Shell32Ext]::SHChangeNotify(0x08000000, 0x0000, [System.IntPtr]::Zero, [System.IntPtr]::Zero)
+        Write-LogLine 'INFO' 'SHChangeNotify(SHCNE_ASSOCCHANGED) — icon cache invalidated'
+    } catch {
+        Write-LogLine 'WARN' "SHChangeNotify failed (icons may need re-logon to refresh): $($_.Exception.Message)"
     }
 }
 

--- a/config/oem/reverse-open/unregister-apps.ps1
+++ b/config/oem/reverse-open/unregister-apps.ps1
@@ -1,18 +1,18 @@
 # =====================================================================
 # winpodx reverse-open — remove the Linux app handlers from Windows.
 #
-# Mirrors register-apps.ps1's per-app .exe hard-link scheme:
-#   * Strip winpodx-<slug>.exe entries from every <ext>\OpenWithList
-#     subkey under HKCU\Software\Classes
-#   * Remove HKCU\Software\Classes\Applications\winpodx-<slug>.exe
-#   * Delete the matching .exe hard links from $BinDir (and the
-#     source shim binary)
+# Mirrors register-apps.ps1's three registration surfaces:
+#   * Per-slug ProgID at HKCU\Software\Classes\winpodx-<slug>
+#     (canonical icon source — current scheme)
+#   * Applications\winpodx-<slug>.exe key (FriendlyAppName + command)
+#   * Per-extension OpenWithList\winpodx-<slug>.exe sub-keys AND
+#     OpenWithProgids\winpodx-<slug> value entries
+#   * Per-slug .exe hard links under $BinDir + the source shim binary
 #
-# Legacy scrub: earlier revisions of register-apps.ps1 used .cmd or
-# .vbs wrappers, or registered winpodx-<slug> ProgIDs under
-# HKCU\Software\Classes\winpodx-<slug> with OpenWithProgids
-# attachments. This script also walks + removes those so users who
-# hit any prior revision don't end up with orphans.
+# Legacy scrub: earlier revisions used .cmd / .vbs wrappers under
+# Applications\, and an earlier ProgID iteration with the same name —
+# walked + removed by the same patterns so re-installing over any
+# prior layout leaves no orphans.
 #
 # Idempotent: missing keys / missing values / missing files are
 # silently OK.
@@ -38,11 +38,13 @@ if (-not (Test-Path -LiteralPath $classesRoot)) {
     exit 0
 }
 
-# --- legacy ProgIDs (pre-fix revision) ---
-# Pre-PR-#164 builds registered winpodx-<slug> as a bare ProgID directly
-# under HKCU\Software\Classes. We exclude any winpodx-*.exe / .cmd /
-# .vbs children here because those belong to the Applications\
-# scrubber (or to the legacy wrapper file scrub below).
+# --- per-slug ProgIDs (current scheme + legacy) ---
+# Current scheme registers winpodx-<slug> as a bare ProgID directly
+# under HKCU\Software\Classes (canonical icon surface). An earlier
+# iteration also used the same shape, so this scrub covers both. We
+# exclude any winpodx-*.exe / .cmd / .vbs children here because those
+# belong to the Applications\ scrubber (or to the legacy wrapper file
+# scrub below).
 $legacyProgIds = @()
 try {
     $legacyProgIds = Get-ChildItem -LiteralPath $classesRoot -ErrorAction Stop |
@@ -288,6 +290,20 @@ if (-not $DryRun) {
         }
     } catch {
         # best-effort — the registry scrub already succeeded above
+    }
+
+    # SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, 0, 0) — mirrors
+    # the same call from register-apps.ps1. Required to flush the shell
+    # icon cache; without it Explorer can keep painting the removed
+    # ProgID icons until next logon.
+    try {
+        Add-Type -Namespace WinPodx -Name Shell32Ext -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("shell32.dll")]
+public static extern void SHChangeNotify(int wEventId, uint uFlags, System.IntPtr dwItem1, System.IntPtr dwItem2);
+'@ -ErrorAction Stop
+        [WinPodx.Shell32Ext]::SHChangeNotify(0x08000000, 0x0000, [System.IntPtr]::Zero, [System.IntPtr]::Zero)
+    } catch {
+        # best-effort — registry/file cleanup already succeeded above
     }
 }
 

--- a/src/winpodx/reverse_open/listener.py
+++ b/src/winpodx/reverse_open/listener.py
@@ -284,6 +284,11 @@ class Listener:
                 # resolved there. TOCTOU isn't in scope: user is
                 # acting on their own files.
                 argv = substitute_path(app.exec_argv, str(safe.real_path))
+                # Log the exact argv so a misbehaving spawn (e.g. wrong
+                # file path, dropped placeholder, mistargeted Firefox)
+                # is recoverable from the daemon log instead of needing
+                # a re-instrumentation cycle on the user's machine.
+                logger.info("listener: spawning slug=%s argv=%r", slug, argv)
                 try:
                     self._spawn(argv, safe.popen_kwargs())
                 except OSError as exc:


### PR DESCRIPTION
Part of #48.

## Summary

- **Bug fix — Open With chooser icons.** Register a per-slug ProgID at `HKCU\Software\Classes\winpodx-<slug>` with `DefaultIcon` + `shell\open\command`, and link each handled extension via `OpenWithProgids\winpodx-<slug>`. `Applications\<exe>\DefaultIcon` (the previous surface) is widely ignored by Explorer's chooser, and the hard-linked Rust shim has no embedded icon resource, so every entry was rendering with the generic .exe glyph.
- **Cache invalidation.** Call `SHChangeNotify(SHCNE_ASSOCCHANGED)` via `shell32` P/Invoke after the registry writes. `ie4uinit.exe -show` (already present) refreshes the OpenWith MRU but not the shell icon cache, so previously-registered slugs kept their stale icons until logoff.
- **Diagnostic — spawn argv logging.** Successful spawns in the host listener previously produced zero log entries; only failure paths logged. Add a single INFO line at the spawn site with `slug` + the fully-substituted argv so misbehaving spawns (wrong path, dropped placeholder, mistargeted handoff) are recoverable from the daemon log without re-instrumentation.
- Mirrors the new ProgID + SHChangeNotify cleanup in `unregister-apps.ps1`; updates the header comment so the legacy-scrub block is correctly named (the ProgID shape is now current scheme, not legacy).

Design notes:
- PR #165's hard-link shim design is unchanged — same EXE, same inode-sharing. `OpenWithProgids` dedupes on the ProgID name, not the EXE path, so the EXE-dedup concern from #165 does not apply here.
- PR #166's short-menu visibility fix is preserved — the per-extension `OpenWithList\<exeName>` sub-key stays in place alongside the new ProgID link.

## Test plan

- [x] `pytest tests/test_reverse_open_*.py` — 282 passed locally.
- [ ] Real-Windows smoke on a fresh guest:
  - [ ] App icons appear in both the short Open With menu and the long "Choose another app" dialog (Win10 + Win11).
  - [ ] `winpodx host-open refresh` reports `pushed N app(s) + M icon(s) → registered`.
  - [ ] After right-clicking and picking a Linux app, `~/.config/winpodx/winpodx.log` shows `listener: spawning slug=<slug> argv=[...]` with the expected file path.
  - [ ] Uninstall scrubs the new ProgID and OpenWithProgids entries cleanly (`unregister-apps.ps1`).
