### PR TITLE
docs: README overhaul — split into focused docs/ files + v0.5.0 reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,7 @@
 <p>Native Linux windows for every Windows app — real icons, real <code>WM_CLASS</code>,<br>
 pin-to-taskbar. FreeRDP RemoteApp + dockur/windows. Zero config.</p>
 
-<pre><code># Latest stable release (default)
-curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
-
-# Latest main (development)
-curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash -s -- --main</code></pre>
+<pre><code>curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash</code></pre>
 
 <a href="docs/images/demo.png">
   <img src="docs/images/demo.png" alt="winpodx in action — Windows apps as native Linux windows on KDE" width="720">
@@ -24,7 +20,7 @@ curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh |
 
 [![license](https://img.shields.io/github/license/kernalix7/winpodx?style=flat-square&color=blue)](LICENSE)
 [![python](https://img.shields.io/badge/python-3.9%2B-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
-[![tests](https://img.shields.io/badge/tests-411-2EA44F?style=flat-square)](#testing)
+[![tests](https://img.shields.io/badge/tests-1090%2B-2EA44F?style=flat-square)](#testing)
 [![CI](https://img.shields.io/github/actions/workflow/status/kernalix7/winpodx/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/kernalix7/winpodx/actions/workflows/ci.yml)
 [![stars](https://img.shields.io/github/stars/kernalix7/winpodx?style=flat-square&color=FFD93D&logo=github&logoColor=white)](https://github.com/kernalix7/winpodx/stargazers)
 [![downloads](https://img.shields.io/github/downloads/kernalix7/winpodx/total?style=flat-square&color=2EA44F)](https://github.com/kernalix7/winpodx/releases)
@@ -36,365 +32,57 @@ curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh |
 [![Debian](https://img.shields.io/badge/Debian-A81D33?style=flat-square&logo=debian&logoColor=white)](https://www.debian.org/)
 [![Ubuntu](https://img.shields.io/badge/Ubuntu-E95420?style=flat-square&logo=ubuntu&logoColor=white)](https://ubuntu.com/)
 [![RHEL family](https://img.shields.io/badge/RHEL%20%2F%20Alma%20%2F%20Rocky-EE0000?style=flat-square&logo=redhat&logoColor=white)](https://www.redhat.com/)
-[![Arch (AUR pending)](https://img.shields.io/badge/Arch%20(AUR)-pending-lightgrey?style=flat-square&logo=archlinux&logoColor=white)](packaging/aur/README.md)
-[![NixOS](https://img.shields.io/badge/NixOS-5277C3?style=flat-square&logo=nixos&logoColor=white)](#install)
+[![Arch](https://img.shields.io/badge/Arch-1793D1?style=flat-square&logo=archlinux&logoColor=white)](https://archlinux.org/)
+[![NixOS](https://img.shields.io/badge/NixOS-5277C3?style=flat-square&logo=nixos&logoColor=white)](docs/INSTALL.md#nix)
 
-<sub>**English** &nbsp;·&nbsp; [한국어](docs/README.ko.md) &nbsp;·&nbsp; [Quick start](#quick-start) &nbsp;·&nbsp; [Features](#key-features) &nbsp;·&nbsp; [CLI](#cli-reference) &nbsp;·&nbsp; [Multi-session](#multi-session-rdp)</sub>
+<sub>**English** &nbsp;·&nbsp; [한국어](docs/README.ko.md) &nbsp;·&nbsp; [Install](docs/INSTALL.md) &nbsp;·&nbsp; [Usage](docs/USAGE.md) &nbsp;·&nbsp; [Features](docs/FEATURES.md) &nbsp;·&nbsp; [Architecture](docs/ARCHITECTURE.md) &nbsp;·&nbsp; [Comparison](docs/COMPARISON.md)</sub>
 
 </div>
 
 ---
 
 > ### Status: Beta
-> winpodx is in active development (v0.3.0). v0.3.0 ships a redesigned host→guest pipeline — bearer-authed HTTP agent on `127.0.0.1:8765` is now the default command channel, with FreeRDP RemoteApp kept as fallback. App launches no longer flash a PowerShell window. New `winpodx check` CLI + GUI Health card surface live pod / RDP / agent / round-trip / disk state. First install still takes ~5-10 minutes (Windows VM ISO download + Sysprep + OEM apply); `winpodx pod wait-ready --logs` shows live progress. Please file issues at <https://github.com/kernalix7/winpodx/issues> if something breaks.
+> winpodx is in active development (**v0.5.0**). The headline of v0.5.0 is **reverse-open**: Linux apps now appear in the Windows guest's right-click "Open with…" menu by default, with correct per-app icons. Double-click a `.txt` inside the guest, pick Kate from the menu, and it opens in your Linux Kate against the real host file path. The host→guest pipeline (bearer-authed HTTP agent on `127.0.0.1:8765`, FreeRDP RemoteApp fallback) is unchanged from v0.3.x. First install still takes ~5–10 minutes (Windows VM ISO download + Sysprep + OEM apply); `winpodx pod wait-ready --logs` shows live progress. Please file issues at <https://github.com/kernalix7/winpodx/issues> if something breaks.
 
-**No full-screen RDP.** Each Windows app becomes its own Linux window with its real icon — pinnable, alt-tabbable, file-associated. Drop into a full Windows desktop only when you actually want one (`winpodx app run desktop`).
+**No full-screen RDP.** Each Windows app becomes its own Linux window with its real icon — pinnable, alt-tabbable, file-associated, both directions. Drop into a full Windows desktop only when you actually want one (`winpodx app run desktop`).
 
-winpodx runs a Windows container (via [dockur/windows](https://github.com/dockur/windows)) in the background and presents Windows apps as native Linux applications through FreeRDP RemoteApp, while a bearer-authed HTTP agent inside the guest handles the host→guest command channel without flashing a PowerShell window. No manual VM setup, no ISO downloads, no registry editing. **Near-zero external Python dependencies** (stdlib only on Python 3.11+; one pure-Python `tomli` fallback on 3.9/3.10).
+winpodx runs a Windows container (via [dockur/windows](https://github.com/dockur/windows)) in the background and presents Windows apps as native Linux applications through FreeRDP RemoteApp, while a bearer-authed HTTP agent inside the guest handles the host→guest command channel without flashing a PowerShell window. The reverse direction — Linux apps surfaced in the Windows "Open with…" menu — is handled by a host-side listener that consumes JSON requests written by per-slug Rust shims inside the guest. **Near-zero external Python dependencies** (stdlib only on Python 3.11+; one pure-Python `tomli` fallback on 3.9/3.10).
 
-## Why winpodx?
+## Quick install
 
-Existing tools for running Windows apps on Linux all have trade-offs:
-
-| | winapps | LinOffice | winboat | winpodx |
-|---|---|---|---|---|
-| Core tech | Any RDP-capable Windows host (cloud / physical / container) + FreeRDP | dockur + FreeRDP | dockur + FreeRDP | dockur (Podman) + FreeRDP + HTTP guest agent |
-| Setup | Manual (shell + config + RDP testing) | One-liner script | One-click GUI installer | **Zero-config** (auto on first launch) |
-| Interface | CLI only | CLI only | Electron GUI | **Qt6 GUI + CLI + tray** |
-| App scope | Any Windows app | Office only | Any Windows app | Any Windows app |
-| Language | Shell (86%) | Shell + Python | TypeScript / Vue / Go | **Python (100%)** |
-| Runtime deps | curl, dialog, git, netcat | Podman, FreeRDP | Electron, Docker/Podman, FreeRDP | **Python 3.9+, FreeRDP, Podman** |
-| Auto suspend / resume | No | No | Not documented | **Yes (idle timeout)** |
-| Password rotation | No | No | Not documented | **Yes (7-day, atomic)** |
-| HiDPI auto-detect | No | No | Not documented | **GNOME, KDE, Sway, Hyprland, Cinnamon, xrdb** |
-| Sound default | No | No | Yes (FreeRDP) | Yes (FreeRDP) |
-| Printer redirection default | No | No | Not documented | Yes (FreeRDP) |
-| USB drive auto-mapping | No | No | Smartcard passthrough | **Drive subfolders → drive letters via FileSystemWatcher** |
-| Discovery (auto-scan installed apps) | No | No | Yes | **Yes (Registry + Start Menu + UWP + choco/scoop)** |
-| Multi-session RDP | No | No | Not documented | **Yes (bundled rdprrap, up to 10)** |
-| Offline / air-gapped install | No | No | No | **Yes (`--source` + `--image-tar`)** |
-| License | MIT | AGPL-3.0 | MIT | MIT |
-
-> winboat is the closest peer in scope and was an inspiration. We focus on a different mix — stdlib-leaning Python + Qt6 instead of Electron, deeper auto-config (auto suspend, 7-day password rotation, multi-DE HiDPI), and an explicit air-gapped install path. Both projects build on dockur/windows; that ecosystem is bigger than any one app.
-
-## winpodx vs Wine
-
-**winpodx is not a Wine replacement.** Wine translates Windows API calls; winpodx runs the actual Windows OS in a container. The two solve different problems and many users have both installed.
-
-| When you need... | Use |
-|---|---|
-| Older Win32 apps, indie games, lightweight utilities | **Wine / Bottles / Lutris** |
-| GPU-accelerated games / 3D apps (DirectX 9 – 12) | **Wine** — DXVK / VKD3D give near-native frame rates. winpodx has no GPU passthrough by default; QEMU CPU rendering is much slower. (GPU passthrough via VFIO is a manual bring-your-own setup — not yet packaged.) |
-| Microsoft 365 with full Outlook + Teams + OneDrive integration | **winpodx** |
-| Adobe Creative Suite (Photoshop, Illustrator, Premiere, Lightroom) | winpodx — but heavy GPU effects will be CPU-bound (see GPU row above) |
-| Anti-cheat games (Valorant, EAC, BattlEye) | **TBD** — anti-cheats vary by VM-detection policy (Vanguard needs TPM 2.0 + no hypervisor, EAC mostly blocks VMs, VAC is lenient). Test before committing. |
-| DRM-heavy software / hardware dongle apps | **winpodx** |
-| Apps that ship kernel-mode drivers (some VPNs, security suites) | **winpodx** |
-| Banking / tax / government tools with regional certificates | **winpodx** |
-| Visual Studio, WinUI 3 / WinRT, .NET features Wine hasn't caught up to | **winpodx** |
-| IE-only legacy enterprise web apps | **winpodx** |
-| Anything where "mostly works" isn't acceptable | **winpodx** |
-
-Wine wins on speed and on GPU when DXVK/VKD3D translate cleanly. winpodx wins on **100% Windows feature parity** for everything else — every app runs on a real Windows kernel, rendered into your Linux desktop as a native window via FreeRDP RemoteApp.
-
-## Key Features
-
-<table>
-<tr><td width="50%">
-
-**Seamless App Windows**
-- RemoteApp (RAIL) renders each app as a native Linux window (no full desktop)
-- Per-app taskbar icons via `WM_CLASS` matching (`/wm-class:<stem>` + `StartupWMClass`)
-- File associations: double-click `.docx` in your file manager → Word opens
-- Multi-session RDP: bundled rdprrap auto-enables up to 10 independent sessions
-- RAIL prerequisites (`fDisabledAllowList=1` + `fInheritInitialProgram=1` + `MaxInstanceCount=10`) are set automatically during unattended install
-
-</td><td width="50%">
-
-**Zero-Config Launch**
-- First app click auto-provisions everything: config, container, desktop entries
-- **Auto-discovery on first boot** — winpodx scans the running Windows guest and registers every installed app (Registry App Paths, Start Menu, UWP/MSIX, Chocolatey, Scoop) with the real binary's icon
-- Manual rescan any time via `winpodx app refresh` or the GUI Refresh button
-- Interactive setup wizard for advanced configuration
-
-</td></tr>
-<tr><td width="50%">
-
-**Peripherals & Sharing**
-- **Clipboard**: Bidirectional copy-paste (text + images) enabled by default
-- **Sound**: RDP audio streaming (`/sound:sys:alsa`) enabled by default
-- **Printer**: Linux printers shared to Windows via RDP redirection (default)
-- **USB drives**: Linux mount tree shared as `\\tsclient\media`; drives plugged after session start are still accessible as subfolders
-- **USB drive auto-mapping**: Windows-side FileSystemWatcher script auto-maps `\\tsclient\media\<USB>` subfolders to drive letters (E:, F:, ...)
-- **USB device passthrough**: `/usb:auto` is allowlisted but **not enabled by default** — opt in via `extra_flags` if your FreeRDP build ships the urbdrc plugin
-- **Home directory**: Shared as `\\tsclient\home` (default)
-- **Desktop shortcuts**: Windows desktop auto-populated with `\\tsclient\home` ("Home") and `\\tsclient\media` ("USB") shortcuts during first boot
-
-**GPU acceleration:** not yet supported. dockur/windows runs under QEMU/KVM with software graphics — DirectX-heavy games and 3D apps will be CPU-bound. GPU passthrough via VFIO is feasible but not packaged. (See [winpodx vs Wine](#winpodx-vs-wine) — Wine + DXVK is the right tool when you need GPU.)
-
-</td><td width="50%">
-
-**Automation & Security**
-- Auto suspend/resume: container pauses when idle, resumes on next launch
-- Password auto-rotation: 20-char cryptographic password, 7-day cycle with rollback
-- Smart DPI scaling: auto-detects from GNOME, KDE, Sway, Hyprland, Cinnamon, xrdb
-- Qt6 system tray + full Qt6 main window (Apps / Settings / Tools / Terminal pages)
-- Multi-backend: Podman (default), Docker, libvirt/KVM, manual RDP
-- Windows build pinned to 11 25H2 (`TargetReleaseVersionInfo=25H2`, 365-day feature-update defer)
-- Windows debloat: disable telemetry, ads, Cortana, search indexing, services (DiagTrack / dmwappushservice / WSearch / SysMain)
-- High-performance power plan + hibernation off + tzutil UTC + Cloudflare DNS
-- Time sync: force Windows clock resync after host sleep/wake
-- FreeRDP `extra_flags` allowlist (regex-validated) as the user-input safety boundary
-
-</td></tr>
-</table>
-
-## How It Works
-
-```
-                     ┌─────────────────────────────┐
-  Click "Word"       │     Linux Desktop (KDE,     │
-  in app menu  ───>  │     GNOME, Sway, ...)       │
-                     └──────────────┬──────────────┘
-                                    │
-                     ┌──────────────▼──────────────┐
-                     │         winpodx             │
-                     │  ┌─────────────────────┐    │
-                     │  │ auto-provision:     │    │
-                     │  │  config → password  │    │
-                     │  │  → container → RDP  │    │
-                     │  │  → desktop entries  │    │
-                     │  └─────────────────────┘    │
-                     └──────────────┬──────────────┘
-                                    │ FreeRDP RemoteApp
-                     ┌──────────────▼──────────────┐
-                     │   Windows Container (Podman)│
-                     │   ┌──────────────────────┐  │
-                     │   │  Word  Excel  PPT ...│  │
-                     │   │ multi-session/rdprrap│  │
-                     │   └──────────────────────┘  │
-                     │   127.0.0.1:3390 (TLS)      │
-                     └─────────────────────────────┘
-```
-
-## GUI
-
-Launch with `winpodx gui`. The Qt6 main window has four pages:
-
-| Page | What it does |
-|------|--------------|
-| **Apps** | Grid / list view of installed app profiles, search + category filter, per-app launch with 3s cooldown, Add / Edit / Delete app profile dialogs |
-| **Settings** | RDP (user / IP / port / scale / DPI / password rotation) and Container (backend / CPU / RAM / idle timeout) in one screen |
-| **Tools** | Suspend / Resume / Full Desktop buttons, Clean Locks / Sync Time / Debloat, and a one-click Windows Update **enable / disable** toggle |
-| **Terminal** | Embedded shell limited to a command allowlist (`podman`, `docker`, `virsh`, `winpodx`, `xfreerdp`, `systemctl`, `journalctl`, `ss`, `ip`, `ping`, ...) with quick buttons (Status / Logs / Inspect / RDP Test / Clear) |
-| **Info** | Live **Health** card (pod / RDP / agent / OEM / disk / password age / app count) + System / Display / Dependencies / Pod / Config snapshot |
-
-The system tray (`winpodx tray`) is a lighter-weight alternative — pod controls, app launcher submenu (top 20 + Full Desktop), maintenance submenu (Clean Locks / Sync Time / Suspend), and an optional idle-monitor thread.
-
-### Health checks
-
-`winpodx check` runs every probe used by the GUI Health card and prints a one-line verdict for each:
-
-```
-=== winpodx check ===
-
-  [OK  ] pod_running        running (ip=127.0.0.1)  (58ms)
-  [OK  ] rdp_port           127.0.0.1:3390 reachable  (0ms)
-  [OK  ] agent_health       version=0.2.2-rev4  (63ms)
-  [OK  ] oem_version        bundle=12  (3ms)
-  [OK  ] password_age       7d remaining (max_age=7d)  (0ms)
-  [OK  ] apps_discovered    41 app(s) in /home/.../discovered  (3ms)
-  [OK  ] disk_free          401.0/3725 GiB free  (0ms)
-
-Overall: OK
-```
-
-Status legend: `OK` (green) / `WARN` (yellow — informational, exit 0) / `FAIL` (red — exit 1) / `SKIP` (grey — disabled by config). Use `--json` for machine-readable output.
-
-## Tech Stack
-
-| Layer | Technology |
-|-------|------------|
-| Language | Python 3.9+ (stdlib only on 3.11+; `tomli` fallback on 3.9/3.10) |
-| CLI | argparse (stdlib) |
-| GUI (optional) | PySide6 (Qt6) |
-| Config | TOML (stdlib `tomllib` on 3.11+ / `tomli` on 3.9/3.10; built-in writer) |
-| RDP | FreeRDP 3+ (xfreerdp, RemoteApp/RAIL) |
-| Guest agent | PowerShell `HttpListener` on `127.0.0.1:8765` (bearer auth, base64-encoded `/exec` payloads) |
-| Container | Podman / Docker ([dockur/windows](https://github.com/dockur/windows)) |
-| VM | libvirt / KVM |
-| CI | GitHub Actions (lint + test on 3.9-3.13 + pip-audit) |
-
-## Quick Start
-
-### Install
-
-**One-line install** (any supported Linux distro):
+One-liner (any supported Linux distro):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
 ```
 
-Detects your distro, installs missing system dependencies (Podman, FreeRDP,
-KVM, Python 3.9+) with your confirmation, drops winpodx into
-`~/.local/bin/winpodx-app/`. The Windows-app menu populates automatically
-the first time the pod boots — discovery scans your running Windows guest
-and registers every installed app with its real icon. No root required
-except for the dependency install step. Works on
-openSUSE, Fedora, Debian/Ubuntu, RHEL-family, and Arch.
-
-> **Windows licensing.** dockur downloads a Windows ISO from Microsoft
-> at first pod boot. Your use of the resulting Windows guest is governed
-> by Microsoft's Software License Terms (the EULA shown on first
-> activation). winpodx does not redistribute Windows; it only orchestrates
-> the install on your machine. Bring your own Windows license key for
-> activation — Home / Pro / Enterprise are all supported by dockur.
-
-By default the installer pins to the **latest published GitHub release**
-(currently `v0.1.9`). Pre-release / development versions stay opt-in.
-
-**Choose a version** — pass `--main` (or `--ref TAG`) for development
-builds, otherwise stick with the default release:
+Or via a native package manager:
 
 ```bash
-# Install the latest stable release (default)
-curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
-
-# Install the latest main HEAD (development; may be unstable)
-curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash -s -- --main
-
-# Install a specific tag, branch, or commit
-curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash -s -- --ref v0.1.9
-
-# Env-var equivalent (works under curl | bash without -s --)
-WINPODX_REF=main  curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
-WINPODX_REF=v0.1.9 curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
-```
-
-**Offline / air-gapped install** — the installer takes three optional flags
-for machines with no registry / package-repo access:
-
-```bash
-# Copy winpodx from a local clone instead of git clone (also env: WINPODX_SOURCE)
-./install.sh --source /media/usb/winpodx
-
-# Preload the Windows image tar instead of fetching at first boot (env: WINPODX_IMAGE_TAR)
-./install.sh --image-tar /media/usb/windows-image.tar
-
-# Skip distro package install (env: WINPODX_SKIP_DEPS=1) — fails early if deps aren't present
-./install.sh --skip-deps
-
-# Everything at once:
-./install.sh --source /media/usb/winpodx --image-tar /media/usb/windows-image.tar --skip-deps
-```
-
-Env vars are honored even under `curl | bash`, so
-`WINPODX_SKIP_DEPS=1 curl ... | bash` works.
-
-**Nix** — a flake is provided for NixOS / nix-on-any-distro users:
-
-```bash
-# Run directly without installing
-nix run github:kernalix7/winpodx
-
-# Install into your profile
-nix profile install github:kernalix7/winpodx
-
-# As a flake input
-inputs.winpodx.url = "github:kernalix7/winpodx";
-```
-
-The wrapper bundles FreeRDP, podman / podman-compose, iproute2 and
-libnotify, so the default podman backend works out of the box. The
-docker and libvirt backends still require the respective tools to be
-present on the host.
-
-**One-line uninstall** — `--confirm` or `--purge` is required under pipe
-(the interactive prompts can't read from a terminal while bash consumes
-stdin from curl):
-
-```bash
-# Remove winpodx files, keep the Windows container + its data
-curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh | bash -s -- --confirm
-
-# Full wipe: container, volume, config, launcher, everything
-curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh | bash -s -- --purge
-```
-
-Prefer a native package manager? Prebuilt RPM / `.deb` / AUR packages are
-attached to every [GitHub Release](https://github.com/kernalix7/winpodx/releases/latest)
-— openSUSE/Fedora RPMs from the
-[openSUSE Build Service (`home:Kernalix7/winpodx`)](https://build.opensuse.org/package/show/home:Kernalix7/winpodx),
-the rest from GitHub Actions:
-
-**openSUSE Tumbleweed / Leap 15.6 / Leap 16.0 / Slowroll**
-
-```bash
-sudo zypper addrepo \
-  https://download.opensuse.org/repositories/home:/Kernalix7/openSUSE_Tumbleweed/home:Kernalix7.repo
-sudo zypper refresh
+# openSUSE Tumbleweed / Leap / Slowroll
+sudo zypper addrepo https://download.opensuse.org/repositories/home:/Kernalix7/openSUSE_Tumbleweed/home:Kernalix7.repo
 sudo zypper install winpodx
-```
 
-Replace `openSUSE_Tumbleweed` with `openSUSE_Leap_16.0`, `openSUSE_Leap_15.6`,
-or `openSUSE_Slowroll` as needed.
-
-**Fedora 42 / 43**
-
-```bash
-sudo dnf config-manager --add-repo \
-  https://download.opensuse.org/repositories/home:/Kernalix7/Fedora_43/home:Kernalix7.repo
+# Fedora 42 / 43
+sudo dnf config-manager --add-repo https://download.opensuse.org/repositories/home:/Kernalix7/Fedora_43/home:Kernalix7.repo
 sudo dnf install winpodx
+
+# Debian / Ubuntu — grab the matching .deb from the latest release
+sudo apt install ./winpodx_0.5.0_all_debian13.deb
+
+# AlmaLinux / Rocky / RHEL 9 / 10 — grab the matching .rpm
+sudo dnf install ./winpodx-0.5.0-0.noarch.el10.rpm
+
+# Arch
+yay -S winpodx
+
+# Nix
+nix run github:kernalix7/winpodx
 ```
 
-**Debian 12 / 13, Ubuntu 24.04 / 25.04 / 25.10**
+See [docs/INSTALL.md](docs/INSTALL.md) for offline / air-gapped builds, source installs, version pinning, and uninstall.
 
-Download the matching `.deb` from the
-[latest release](https://github.com/Kernalix7/winpodx/releases/latest) and
-install:
-
-```bash
-sudo apt install ./winpodx_<version>_all_debian13.deb   # pick your flavor
-```
-
-**AlmaLinux / Rocky / RHEL 9 & 10**
-
-EPEL is required on el9 for `python3-tomli`. Download the matching `.rpm`
-from the [latest release](https://github.com/Kernalix7/winpodx/releases/latest)
-and install:
-
-```bash
-sudo dnf install epel-release                     # el9 only
-sudo dnf install ./winpodx-<version>-1.noarch.el9.rpm   # or .el10.rpm
-```
-
-**Arch Linux (AUR)**
-
-> Note: AUR publishing is wired up but pending a one-time maintainer setup
-> (see [`packaging/aur/README.md`](packaging/aur/README.md)). Once activated,
-> tag pushes publish automatically.
-
-```bash
-yay -S winpodx        # or:
-paru -S winpodx
-```
-
-**From source (development)**
-
-```bash
-git clone https://github.com/kernalix7/winpodx.git
-cd winpodx
-./install.sh
-```
-
-The source installer automatically:
-1. Detects your distro (openSUSE, Fedora, Ubuntu, Arch, ...)
-2. Installs missing dependencies (Podman, FreeRDP, KVM), asks before installing
-3. Copies winpodx to `~/.local/bin/winpodx-app/`
-4. Creates config and compose.yaml
-5. Auto-discovery (`winpodx app refresh`) fires on first pod boot to populate the menu
-
-### Launch
+## Launch
 
 ```bash
 winpodx app run word              # Launch Word
@@ -402,290 +90,61 @@ winpodx app run word ~/doc.docx   # Open a file
 winpodx app run desktop           # Full Windows desktop
 ```
 
-Or just click an app icon in your menu.
+Or just click an app icon in your application menu. See [docs/USAGE.md](docs/USAGE.md) for the full CLI, the Qt6 GUI, health checks, and configuration.
 
-### Manual Run (no install)
+## Key features
 
-```bash
-git clone https://github.com/kernalix7/winpodx.git
-cd winpodx
-export PYTHONPATH="$PWD/src"
-python3 -m winpodx app run word
-```
+- **Reverse-open (new in v0.5.0).** Linux apps appear in the Windows guest's right-click "Open with…" menu by default, with correct per-app icons. Selecting one round-trips the file open to host `xdg-open`. ([details](docs/FEATURES.md#reverse-open-linux-apps-in-windows-open-with))
+- **Seamless app windows.** FreeRDP RemoteApp renders each Windows app as a native Linux window with its real icon, real `WM_CLASS`, taskbar pinning, and bidirectional file associations.
+- **Zero-config launch.** First app click auto-provisions everything: config, container, desktop entries. Auto-discovery scans the running Windows guest on first boot and registers every installed app (Registry App Paths, Start Menu, UWP/MSIX, Chocolatey, Scoop) with its real icon.
+- **Multi-session RDP.** Bundled [rdprrap](https://github.com/kernalix7/rdprrap) lifts the single-session-per-user cap; each app window runs in its own independent session, up to 10 concurrent.
+- **Auto suspend / resume.** Container pauses when idle, resumes on next launch.
+- **Password auto-rotation.** 20-char cryptographic password on a 7-day cycle with atomic rollback.
+- **Peripherals out of the box.** Clipboard, sound, printer redirection, home directory share, USB drive auto-mapping — all on by default.
+- **Multi-backend.** Podman (default), Docker, libvirt/KVM, manual RDP.
+- **Offline / air-gapped install.** `--source` + `--image-tar` lets you install without network access.
 
----
+See [docs/FEATURES.md](docs/FEATURES.md) for the deep dives.
 
-## CLI Reference
+## Documentation
 
-<details>
-<summary><b>Click to expand full CLI reference</b></summary>
+| Document | What's inside |
+|----------|---------------|
+| [INSTALL.md](docs/INSTALL.md) | Every install path — one-liner, package managers, offline, Nix, source |
+| [USAGE.md](docs/USAGE.md) | CLI reference, Qt6 GUI tour, health checks, configuration file |
+| [FEATURES.md](docs/FEATURES.md) | Reverse-open, multi-session RDP, peripherals, app profiles, auto-discovery |
+| [ARCHITECTURE.md](docs/ARCHITECTURE.md) | How it works (diagram), tech stack, source tree, data flows |
+| [COMPARISON.md](docs/COMPARISON.md) | winpodx vs winapps / LinOffice / winboat, and winpodx vs Wine |
+| [CHANGELOG.md](CHANGELOG.md) | Full version history |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Development setup and workflow |
+| [SECURITY.md](SECURITY.md) | Security disclosure process |
 
-```bash
-# Apps
-winpodx app list                  # List available apps
-winpodx app run word              # Launch Word (auto-provisions on first run)
-winpodx app run word ~/doc.docx   # Open a file in Word
-winpodx app run desktop           # Full Windows desktop session
-winpodx app install-all           # Register all apps in desktop menu
-winpodx app sessions              # Show active sessions
-winpodx app kill word             # Kill an active session
+## Supported distros
 
-# Pod management
-winpodx pod start --wait          # Start and wait for RDP readiness
-winpodx pod stop                  # Stop (warns about active sessions)
-winpodx pod status                # Status with session count
-winpodx pod restart
-winpodx pod apply-fixes           # Re-apply Windows-side runtime fixes (idempotent)
-winpodx pod sync-password         # Recover from password drift (cfg ↔ Windows)
-winpodx pod multi-session on      # Toggle bundled rdprrap multi-session RDP
-winpodx pod multi-session status
-winpodx pod wait-ready --logs     # Wait for Windows first-boot with progress + container logs
+| Distro | Package manager | Status |
+|--------|-----------------|--------|
+| openSUSE Tumbleweed / Leap 15.6 / Leap 16.0 / Slowroll | zypper | Tested |
+| Fedora 42 / 43 | dnf | Tested |
+| Debian 12 / 13, Ubuntu 24.04 / 25.04 / 25.10 | apt | Supported |
+| AlmaLinux / Rocky / RHEL 9 / 10 | dnf | Supported |
+| Arch / Manjaro | pacman / AUR | Supported |
+| NixOS (and Nix on any distro) | nix flake | Supported |
 
-# Power management
-winpodx power --suspend           # Pause container (free CPU, keep memory)
-winpodx power --resume            # Resume paused container
-
-# Security
-winpodx rotate-password           # Rotate Windows RDP password
-
-# Maintenance
-winpodx cleanup                   # Remove Office lock files (~$*.*)
-winpodx timesync                  # Force Windows time synchronization
-winpodx debloat                   # Disable telemetry, ads, bloat
-winpodx uninstall                 # Remove winpodx files (keeps container)
-winpodx uninstall --purge         # Remove everything including config
-
-# System
-winpodx setup                     # Interactive setup wizard
-winpodx info                      # Display, dependencies, config diagnostics
-winpodx check                     # Run all health probes (pod / RDP / agent / disk / …)
-winpodx check --json              # Same probes, machine-readable JSON
-winpodx gui                       # Launch Qt6 main window (Apps / Settings / Tools / Terminal)
-winpodx tray                      # Launch Qt system tray icon
-winpodx config show               # Show current config
-winpodx config set rdp.scale 140  # Change a config value
-winpodx config import             # Import existing winapps.conf
-```
-
-</details>
-
-## Peripherals & Sharing
-
-| Feature | How it works | Default |
-|---------|-------------|---------|
-| **Clipboard** | Bidirectional copy-paste via RDP (`+clipboard`) | Enabled |
-| **Sound** | Audio streaming via ALSA (`/sound:sys:alsa`) | Enabled |
-| **Printer** | Linux printers shared to Windows (`/printer`) | Enabled |
-| **Home directory** | Shared as `\\tsclient\home` (`+home-drive`) | Enabled |
-| **USB drives** | Media folder shared as `\\tsclient\media` (`/drive:media`); USB drives plugged in after session start are accessible as subfolders | Enabled |
-| **USB device passthrough** | Native USB redirection (`/usb:auto`) — requires FreeRDP urbdrc plugin | **Opt-in** (add to `extra_flags`) |
-| **USB drive mapping** | Windows-side script auto-maps USB subfolders to drive letters (E:, F:, ...) via FileSystemWatcher | Enabled |
-
-### USB Drive Flow
-
-```
-Plug in USB on Linux
-    │
-    ▼
-Linux mounts to /run/media/$USER/USBNAME
-    │
-    ▼
-FreeRDP shares as \\tsclient\media\USBNAME
-    │
-    ▼
-media_monitor.ps1 detects → net use E: \\tsclient\media\USBNAME
-    │
-    ▼
-Windows Explorer shows E: drive
-```
-
-## Configuration
-
-Config file: `~/.config/winpodx/winpodx.toml` (auto-created, 0600 permissions)
-
-```toml
-[rdp]
-user = "User"
-password = ""                # Auto-generated random password
-password_updated = ""        # ISO 8601 timestamp
-password_max_age = 7         # Days before auto-rotation (0 = disable)
-ip = "127.0.0.1"
-port = 3390
-scale = 100                  # Auto-detected from your DE
-dpi = 0                      # Windows DPI % (0 = auto)
-extra_flags = ""             # Additional FreeRDP flags (allowlisted)
-
-[pod]
-backend = "podman"
-win_version = "11"                               # 11 | 10 | ltsc10 | tiny11 | tiny10
-cpu_cores = 4
-ram_gb = 4
-vnc_port = 8007
-auto_start = true                                # Start pod automatically when launching an app
-idle_timeout = 0                                 # Seconds before auto-suspend (0 = disabled)
-boot_timeout = 300                               # Seconds to wait for first-boot unattended install
-image = "docker.io/dockurr/windows:latest"          # Container image (override for air-gapped mirror)
-disk_size = "64G"                                # Virtual disk size passed to dockur
-```
-
-## App Profiles
-
-App profiles are **metadata only**: they describe where a Windows app lives so winpodx can launch it through FreeRDP RemoteApp. The actual Windows application must be installed inside the Windows container.
-
-### Auto-discovery (default)
-
-Starting from v0.1.9 winpodx ships **no curated profile list**. The first time the Windows pod boots, the provisioner runs `winpodx app refresh` and that scans the running guest:
-
-- Registry `App Paths` (`HKLM` + `HKCU`)
-- Start Menu `.lnk` recursion (depth-capped)
-- UWP / MSIX packages via `Get-AppxPackage` + `AppxManifest.xml`
-- Chocolatey + Scoop shims
-
-For each result it extracts the icon directly from the binary (or the package's logo asset for UWP) and writes the entry to `~/.local/share/winpodx/discovered/<slug>/`. Re-run any time:
-
-```bash
-winpodx app refresh        # CLI
-# or click "Refresh Apps" on the GUI Apps page
-```
-
-<details>
-<summary><b>Adding a custom app profile manually</b></summary>
-
-User-authored profiles live under `~/.local/share/winpodx/apps/` and override anything discovery finds with the same `name`:
-
-```bash
-mkdir -p ~/.local/share/winpodx/apps/myapp
-cat > ~/.local/share/winpodx/apps/myapp/app.toml << 'EOF'
-name = "myapp"
-full_name = "My Application"
-executable = "C:\\Program Files\\MyApp\\myapp.exe"
-categories = ["Utility"]
-mime_types = []
-EOF
-
-winpodx app install myapp   # Register in desktop menu
-```
-
-</details>
-
-## Multi-Session RDP
-
-Stock Windows Desktop editions limit RDP to one session per user; a second app
-would otherwise reconnect and steal the first session. winpodx bundles
-[rdprrap](https://github.com/kernalix7/rdprrap) — a Rust reimplementation of
-RDPWrap — inside the package itself and installs it automatically during the
-Windows unattended install, so each RemoteApp window gets its own independent
-session.
-
-**RAIL prerequisites.** RemoteApp itself requires three registry settings that
-winpodx applies during unattended setup: `fDisabledAllowList=1` (enables
-RemoteApp publishing), `fInheritInitialProgram=1` (required for
-`/app:program:...` to launch the target executable instead of a shell), and
-`MaxInstanceCount=10` paired with `fSingleSessionPerUser=0` (lifts the
-single-session cap up to 10 concurrent RemoteApp windows). These are set
-regardless of whether rdprrap installs successfully — rdprrap is what makes
-the sessions *independent*, but the registry keys are what make RemoteApp
-work at all. After rdprrap install `TermService` is cycled so the wrapper
-DLL activates without a reboot.
-
-**Authentication channel.** NLA is disabled (`UserAuthentication=0`) so the
-FreeRDP command line can authenticate unattended from under
-`podman unshare --rootless-netns`, but `SecurityLayer=2` keeps the RDP
-channel itself encrypted with TLS (so `/sec:tls /cert:ignore` against
-`127.0.0.1` is the full authenticated + encrypted path — no cleartext on the
-wire even though NLA is off).
-
-**Works fully offline.** The rdprrap zip ships inside winpodx's data directory
-(`config/oem/`) and is staged into `C:\OEM\` during the guest's first boot.
-sha256 is verified against a pin file before extraction. No network access is
-required at install time.
-
-Install is one-shot: the patch is applied during dockur's unattended setup
-phase. If anything in that step fails (hash mismatch, extraction, installer
-error), winpodx logs a warning and the guest stays in single-session mode —
-app launch never blocks on this step. A guest-side management channel
-(enable/disable/status after install) is planned for a later release.
-
-## Install / Uninstall
-
-```bash
-# From a cloned repo:
-./install.sh                # Install (detects distro, installs deps, registers apps)
-./uninstall.sh              # Uninstall (interactive, asks before each step)
-./uninstall.sh --confirm    # Uninstall (auto, keeps config)
-./uninstall.sh --purge      # Uninstall (removes everything including config)
-
-# Or one-liner (no clone needed):
-curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh   | bash
-curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh | bash -s -- --confirm
-curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh | bash -s -- --purge
-```
-
-**Uninstall only removes winpodx files.** It never touches:
-- Your Podman containers/volumes (Windows VM data)
-- System packages (podman, freerdp, python3)
-- Your home directory files
-
-## Project Structure
-
-```
-winpodx/
-├── install.sh             # One-line installer (no pip)
-├── uninstall.sh           # Clean uninstaller
-├── src/winpodx/
-│   ├── cli/               # argparse commands (app, pod, config, setup, ...)
-│   ├── core/              # Config, RDP, pod lifecycle, provisioner, daemon
-│   ├── backend/           # Podman, Docker, libvirt, manual
-│   ├── desktop/           # .desktop entries, icons, MIME, tray, notifications
-│   ├── display/           # X11/Wayland detection, DPI scaling
-│   ├── gui/               # Qt6 main window, app dialog, theme
-│   └── utils/             # XDG paths, deps, TOML writer, winapps compat
-├── data/                  # winpodx GUI desktop entry + icon + config example
-├── config/oem/            # Windows OEM scripts (post-install)
-├── scripts/windows/       # PowerShell scripts (debloat, time sync, USB mapping, app discovery)
-├── .github/workflows/     # CI: lint + test + upstream update checker
-└── tests/                 # pytest test suite (411 tests)
-```
-
-## Supported Distros
-
-| Distro | Package Manager | Status |
-|--------|----------------|--------|
-| openSUSE Tumbleweed/Leap | zypper | Tested |
-| Fedora / RHEL / CentOS | dnf | Supported |
-| Ubuntu / Debian / Mint | apt | Supported |
-| Arch / Manjaro | pacman | Supported |
+Each tag push (`v*.*.*`) publishes to all channels automatically — see [packaging/](packaging/) for maintainer details.
 
 ## Testing
 
 ```bash
 # From repo root (no install needed)
 export PYTHONPATH="$PWD/src"
-python3 -m pytest tests/ -v    # 411 tests
-ruff check src/ tests/         # Lint
+python3 -m pytest tests/    # 1090+ tests
+ruff check src/ tests/      # Lint
+ruff format --check src/ tests/
 ```
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and workflow.
-
-## Releasing & Packaging
-
-Each tag push (`v*.*.*`) publishes to all supported channels automatically:
-
-| Channel | Distros |
-|---------|---------|
-| RPM (openSUSE / Fedora / Slowroll) | Tumbleweed, Leap 15.6, Leap 16.0, Slowroll, Fedora 42/43 |
-| RPM (RHEL-family) | AlmaLinux 9 / 10 (also covers RHEL, Rocky, Oracle Linux 9/10) |
-| `.deb` | Debian 12 / 13, Ubuntu 24.04 / 25.04 / 25.10 |
-| AUR | Arch Linux (once activated — see [`packaging/aur/README.md`](packaging/aur/README.md)) |
-| `sdist` + `wheel` | PyPI-compatible source/binary distributions |
-
-Maintainer setup for each channel lives under [`packaging/`](packaging/):
-
-- [`packaging/obs/README.md`](packaging/obs/README.md) — openSUSE Build Service (RPM family).
-- [`packaging/aur/README.md`](packaging/aur/README.md) — Arch User Repository.
-- Debian/Ubuntu and AlmaLinux builds are self-contained in their respective GitHub Actions workflows and need no external setup.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, branch naming, commit conventions, and CI expectations.
 
 ## Security
 
@@ -714,4 +173,4 @@ Bug reports, PRs, and stars on the repo are equally appreciated and free —
 
 ## License
 
-[MIT](LICENSE) - Kim DaeHyun (kernalix7@kodenet.io)
+[MIT](LICENSE) — Kim DaeHyun (kernalix7@kodenet.io)

--- a/docs/ARCHITECTURE.ko.md
+++ b/docs/ARCHITECTURE.ko.md
@@ -1,0 +1,87 @@
+# 아키텍처
+
+[English](ARCHITECTURE.md) | **한국어**
+
+winpodx 가 어떻게 조립되어 있는지: 앱 실행 시 데이터 흐름, 기술 스택, 소스 트리 레이아웃.
+
+## 동작 방식
+
+```
+                     ┌─────────────────────────────┐
+  앱 메뉴에서         │     Linux Desktop (KDE,     │
+  "Word" 클릭   ───>  │     GNOME, Sway, ...)       │
+                     └──────────────┬──────────────┘
+                                    │
+                     ┌──────────────▼──────────────┐
+                     │         winpodx             │
+                     │  ┌─────────────────────┐    │
+                     │  │ 자동 프로비저닝:    │    │
+                     │  │  config → password  │    │
+                     │  │  → container → RDP  │    │
+                     │  │  → desktop entries  │    │
+                     │  └─────────────────────┘    │
+                     └──────────────┬──────────────┘
+                                    │ FreeRDP RemoteApp
+                     ┌──────────────▼──────────────┐
+                     │   Windows Container (Podman)│
+                     │   ┌──────────────────────┐  │
+                     │   │  Word  Excel  PPT ...│  │
+                     │   │ multi-session/rdprrap│  │
+                     │   └──────────────────────┘  │
+                     │   127.0.0.1:3390 (TLS)      │
+                     └─────────────────────────────┘
+```
+
+Pod 의 명령 채널은 게스트 안에서 `127.0.0.1:8765` 에 listen 하는 bearer-auth HTTP agent (loopback 전용). RDP 자체는 `127.0.0.1:3390` 에서 TLS 암호화로 동작. Reverse-open (Linux 앱이 Windows "Open with..." 메뉴에 노출되는 기능) 은 별도의 호스트 측 listener daemon 이 `\\tsclient\home` 공유를 통해 요청을 받음.
+
+## 기술 스택
+
+| 레이어 | 기술 |
+|-------|------|
+| 언어 | Python 3.9+ (3.11+ 는 stdlib 만; 3.9/3.10 은 `tomli` 폴백) |
+| CLI | argparse (stdlib) |
+| GUI (선택) | PySide6 (Qt6) |
+| 설정 | TOML (3.11+ 는 stdlib `tomllib` / 3.9/3.10 은 `tomli`; 자체 writer) |
+| RDP | FreeRDP 3+ (xfreerdp, RemoteApp/RAIL) |
+| Guest agent | PowerShell `HttpListener` on `127.0.0.1:8765` (bearer auth, base64 인코딩 `/exec` payload) |
+| 컨테이너 | Podman / Docker ([dockur/windows](https://github.com/dockur/windows)) |
+| VM | libvirt / KVM |
+| Reverse-open shim | Rust (`windows_subsystem = "windows"`, vendored rcedit 로 슬러그별 아이콘 embed) |
+| CI | GitHub Actions (lint + test on 3.9-3.13 + pip-audit) |
+
+## 프로젝트 구조
+
+```
+winpodx/
+├── install.sh             # 원라인 인스톨러 (pip 없음)
+├── uninstall.sh           # 깔끔한 언인스톨러
+├── src/winpodx/
+│   ├── cli/               # argparse 명령 (app, pod, config, setup, host-open, ...)
+│   ├── core/              # Config, RDP, pod lifecycle, provisioner, daemon
+│   ├── backend/           # Podman, Docker, libvirt, manual
+│   ├── desktop/           # .desktop 엔트리, 아이콘, MIME, tray, 알림
+│   ├── display/           # X11/Wayland 감지, DPI 스케일링
+│   ├── gui/               # Qt6 메인 윈도, 앱 다이얼로그, 테마, reverse-open Settings 카드
+│   ├── reverse_open/      # Discovery, ICO 변환, listener daemon, sync transport
+│   └── utils/             # XDG 경로, 의존성, TOML writer, winapps 호환
+├── data/                  # winpodx GUI desktop 엔트리 + 아이콘 + 설정 예시
+├── config/oem/
+│   ├── install.bat        # Windows OEM 첫 부팅 오케스트레이션
+│   └── reverse-open/      # register-apps.ps1, unregister-apps.ps1, Rust shim, rcedit
+├── scripts/windows/       # PowerShell 스크립트 (debloat, time sync, USB mapping, 앱 discovery)
+├── packaging/             # OBS / AUR / RHEL spec + 메인테이너 문서
+├── debian/                # Debian 소스 패키지 레이아웃
+├── docs/                  # 사용자 문서 (영어 + 한국어 mirror)
+├── .github/workflows/     # CI: lint + test + publish (OBS / RHEL / deb / AUR)
+└── tests/                 # pytest 테스트 스위트
+```
+
+## 주요 데이터 흐름
+
+- **앱 실행.** CLI → `provisioner.ensure_ready()` (config + 비밀번호 회전 + compose + resume + pod + bundled apps + desktop 엔트리) → FreeRDP 세션 → `.cproc` 추적 + reaper 스레드 + desktop 알림.
+- **앱 설치 (Linux 측).** AppInfo (TOML) → `.desktop` 파일 생성 → 아이콘 설치 → MIME 등록 → 아이콘 캐시 refresh.
+- **파일 열기 (host → guest).** Linux 경로 → UNC 경로 변환 (`\\tsclient\home\...`) → RDP `/app-cmd`.
+- **자동 suspend.** `daemon.run_idle_monitor()` → N 초 동안 세션 없으면 `podman pause` → lock 파일 정리.
+- **자동 resume.** `provisioner` → `daemon.ensure_pod_awake()` → `podman unpause` → RDP 대기.
+- **비밀번호 회전.** `ensure_ready()` → `password_max_age` 확인 → 새 비밀번호 생성 → config + compose 저장 → 컨테이너 재생성 → 실패 시 rollback.
+- **Reverse-open (guest → host).** Windows Explorer "Open with..." → 슬러그별 `winpodx-<slug>.exe` shim → `\\tsclient\home\.local\share\winpodx\reverse-open\incoming\<uuid>.json` 에 atomic JSON 쓰기 → host listener 가 픽업 → `safe_open_unc` TOCTOU-safe 경로 해소 → 호스트에서 `xdg-open` 호출.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,87 @@
+# Architecture
+
+**English** | [한국어](ARCHITECTURE.ko.md)
+
+How winpodx is put together: the data flow on app launch, the technology stack, and the source tree layout.
+
+## How It Works
+
+```
+                     ┌─────────────────────────────┐
+  Click "Word"       │     Linux Desktop (KDE,     │
+  in app menu  ───>  │     GNOME, Sway, ...)       │
+                     └──────────────┬──────────────┘
+                                    │
+                     ┌──────────────▼──────────────┐
+                     │         winpodx             │
+                     │  ┌─────────────────────┐    │
+                     │  │ auto-provision:     │    │
+                     │  │  config → password  │    │
+                     │  │  → container → RDP  │    │
+                     │  │  → desktop entries  │    │
+                     │  └─────────────────────┘    │
+                     └──────────────┬──────────────┘
+                                    │ FreeRDP RemoteApp
+                     ┌──────────────▼──────────────┐
+                     │   Windows Container (Podman)│
+                     │   ┌──────────────────────┐  │
+                     │   │  Word  Excel  PPT ...│  │
+                     │   │ multi-session/rdprrap│  │
+                     │   └──────────────────────┘  │
+                     │   127.0.0.1:3390 (TLS)      │
+                     └─────────────────────────────┘
+```
+
+The pod's command channel is a bearer-authed HTTP agent listening on `127.0.0.1:8765` inside the guest (loopback only). RDP itself runs on `127.0.0.1:3390` with TLS encryption. Reverse-open (Linux apps appearing in the Windows "Open with..." menu) runs through a separate host-side listener daemon that receives requests pushed via the `\\tsclient\home` share.
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|------------|
+| Language | Python 3.9+ (stdlib only on 3.11+; `tomli` fallback on 3.9/3.10) |
+| CLI | argparse (stdlib) |
+| GUI (optional) | PySide6 (Qt6) |
+| Config | TOML (stdlib `tomllib` on 3.11+ / `tomli` on 3.9/3.10; built-in writer) |
+| RDP | FreeRDP 3+ (xfreerdp, RemoteApp/RAIL) |
+| Guest agent | PowerShell `HttpListener` on `127.0.0.1:8765` (bearer auth, base64-encoded `/exec` payloads) |
+| Container | Podman / Docker ([dockur/windows](https://github.com/dockur/windows)) |
+| VM | libvirt / KVM |
+| Reverse-open shim | Rust (`windows_subsystem = "windows"`, embedded per-slug icon via vendored rcedit) |
+| CI | GitHub Actions (lint + test on 3.9-3.13 + pip-audit) |
+
+## Project Structure
+
+```
+winpodx/
+├── install.sh             # One-line installer (no pip)
+├── uninstall.sh           # Clean uninstaller
+├── src/winpodx/
+│   ├── cli/               # argparse commands (app, pod, config, setup, host-open, ...)
+│   ├── core/              # Config, RDP, pod lifecycle, provisioner, daemon
+│   ├── backend/           # Podman, Docker, libvirt, manual
+│   ├── desktop/           # .desktop entries, icons, MIME, tray, notifications
+│   ├── display/           # X11/Wayland detection, DPI scaling
+│   ├── gui/               # Qt6 main window, app dialog, theme, reverse-open Settings card
+│   ├── reverse_open/      # Discovery, ICO conversion, listener daemon, sync transport
+│   └── utils/             # XDG paths, deps, TOML writer, winapps compat
+├── data/                  # winpodx GUI desktop entry + icon + config example
+├── config/oem/
+│   ├── install.bat        # Windows OEM first-boot orchestration
+│   └── reverse-open/      # register-apps.ps1, unregister-apps.ps1, Rust shim, rcedit
+├── scripts/windows/       # PowerShell scripts (debloat, time sync, USB mapping, app discovery)
+├── packaging/             # OBS / AUR / RHEL spec + maintainer docs
+├── debian/                # Debian source package layout
+├── docs/                  # User docs (English + Korean mirrors)
+├── .github/workflows/     # CI: lint + test + publish (OBS / RHEL / deb / AUR)
+└── tests/                 # pytest test suite
+```
+
+## Key Data Flows
+
+- **App launch.** CLI → `provisioner.ensure_ready()` (config + password rotation + compose + resume + pod + bundled apps + desktop entries) → FreeRDP session → `.cproc` tracking + reaper thread + desktop notification.
+- **App install (Linux side).** AppInfo (TOML) → `.desktop` file generation → icon install → MIME registration → icon cache refresh.
+- **File open (host → guest).** Linux path → UNC path conversion (`\\tsclient\home\...`) → RDP `/app-cmd`.
+- **Auto suspend.** `daemon.run_idle_monitor()` → no sessions for N seconds → `podman pause` → lock file cleanup.
+- **Auto resume.** `provisioner` → `daemon.ensure_pod_awake()` → `podman unpause` → wait for RDP.
+- **Password rotation.** `ensure_ready()` → check `password_max_age` → generate new password → save config + compose → recreate container → rollback on failure.
+- **Reverse-open (guest → host).** Windows Explorer "Open with..." → per-slug `winpodx-<slug>.exe` shim → atomic JSON write to `\\tsclient\home\.local\share\winpodx\reverse-open\incoming\<uuid>.json` → host listener picks it up → `safe_open_unc` TOCTOU-safe path resolution → `xdg-open` invocation on the host.

--- a/docs/COMPARISON.ko.md
+++ b/docs/COMPARISON.ko.md
@@ -1,0 +1,51 @@
+# 비교
+
+[English](COMPARISON.md) | **한국어**
+
+Linux 에서 Windows 앱을 실행하기 위한 다른 도구들과 winpodx 의 비교.
+
+## 왜 winpodx인가?
+
+Linux 에서 Windows 앱을 실행하는 기존 도구들은 각각 한계가 있습니다:
+
+| | winapps | LinOffice | winboat | winpodx |
+|---|---|---|---|---|
+| 핵심 기술 | RDP 가능한 Windows 호스트 (클라우드 / 물리 / 컨테이너) + FreeRDP | dockur + FreeRDP | dockur + FreeRDP | dockur (Podman) + FreeRDP + HTTP guest agent |
+| 설정 | 수동 (셸 + 설정 파일 + RDP 테스트) | 원라인 스크립트 | 원클릭 GUI 설치 | **제로 설정** (첫 실행 시 자동) |
+| 인터페이스 | CLI 만 | CLI 만 | Electron GUI | **Qt6 GUI + CLI + 트레이** |
+| 앱 범위 | 모든 Windows 앱 | Office 전용 | 모든 Windows 앱 | 모든 Windows 앱 |
+| 언어 | Shell (86%) | Shell + Python | TypeScript / Vue / Go | **Python (100%)** |
+| 런타임 의존성 | curl, dialog, git, netcat | Podman, FreeRDP | Electron, Docker/Podman, FreeRDP | **Python 3.9+, FreeRDP, Podman** |
+| 자동 suspend / resume | 없음 | 없음 | 문서화 안 됨 | **있음 (idle timeout)** |
+| 비밀번호 회전 | 없음 | 없음 | 문서화 안 됨 | **있음 (7일, atomic)** |
+| HiDPI 자동 감지 | 없음 | 없음 | 문서화 안 됨 | **GNOME, KDE, Sway, Hyprland, Cinnamon, xrdb** |
+| 사운드 기본 | 없음 | 없음 | 있음 (FreeRDP) | 있음 (FreeRDP) |
+| 프린터 리디렉션 기본 | 없음 | 없음 | 문서화 안 됨 | 있음 (FreeRDP) |
+| USB 드라이브 자동 매핑 | 없음 | 없음 | 스마트카드 패스스루 | **드라이브 서브폴더 → 드라이브 레터, FileSystemWatcher** |
+| Discovery (설치된 앱 자동 스캔) | 없음 | 없음 | 있음 | **있음 (Registry + Start Menu + UWP + choco/scoop)** |
+| 멀티세션 RDP | 없음 | 없음 | 문서화 안 됨 | **있음 (bundled rdprrap, 최대 10)** |
+| Reverse 파일 열기 (guest → host xdg-open) | 없음 | 없음 | 없음 | **있음 (Linux 앱이 Windows "Open with…" 메뉴에 노출)** |
+| 오프라인 / 에어갭 설치 | 없음 | 없음 | 없음 | **있음 (`--source` + `--image-tar`)** |
+| 라이선스 | MIT | AGPL-3.0 | MIT | MIT |
+
+> winboat 가 스코프상 가장 가까운 peer 이고 영감을 준 프로젝트. 우리는 다른 조합에 집중 — Electron 대신 stdlib 지향 Python + Qt6, 더 깊은 자동 설정 (auto suspend, 7일 비밀번호 회전, 다중 DE HiDPI), reverse-open (Linux 앱이 Windows "Open with…" 메뉴에 기본 노출되는 유일한 프로젝트), 명시적 에어갭 설치 경로. 두 프로젝트 모두 dockur/windows 위에 빌드 — 그 생태계는 한 앱보다 크다.
+
+## winpodx vs Wine
+
+**winpodx 는 Wine 의 대체재가 아닙니다.** Wine 은 Windows API 호출을 변환; winpodx 는 실제 Windows OS 를 컨테이너에서 실행. 둘은 다른 문제를 해결하고, 많은 사용자가 둘 다 설치합니다.
+
+| 필요한 것... | 사용 |
+|---|---|
+| 구형 Win32 앱, 인디 게임, 가벼운 유틸리티 | **Wine / Bottles / Lutris** |
+| GPU 가속 게임 / 3D 앱 (DirectX 9 – 12) | **Wine** — DXVK / VKD3D 가 거의 네이티브 프레임레이트 제공. winpodx 는 기본적으로 GPU 패스스루 없음; QEMU CPU 렌더링은 훨씬 느림. (VFIO 통한 GPU 패스스루는 수동 BYO 설정 — 패키징 안 됨.) |
+| Microsoft 365 with 완전한 Outlook + Teams + OneDrive 통합 | **winpodx** |
+| Adobe Creative Suite (Photoshop, Illustrator, Premiere, Lightroom) | winpodx — 단 무거운 GPU 이펙트는 CPU 바운드 (위 GPU 행 참조) |
+| 안티치트 게임 (Valorant, EAC, BattlEye) | **TBD** — 안티치트마다 VM 감지 정책 다름 (Vanguard 는 TPM 2.0 + hypervisor 없음 필요, EAC 는 대부분 VM 차단, VAC 는 관대). 시도 전 테스트 필수. |
+| DRM 무거운 소프트웨어 / 하드웨어 동글 앱 | **winpodx** |
+| 커널 모드 드라이버 출시 앱 (일부 VPN, 보안 스위트) | **winpodx** |
+| 지역 인증서 사용 은행 / 세무 / 행정 도구 | **winpodx** |
+| Visual Studio, WinUI 3 / WinRT, Wine 이 따라잡지 못한 .NET 기능 | **winpodx** |
+| IE 전용 레거시 엔터프라이즈 웹 앱 | **winpodx** |
+| "대부분 동작" 이 허용 안 되는 모든 것 | **winpodx** |
+
+Wine 은 속도와 GPU 에서 (DXVK/VKD3D 변환이 깔끔하게 될 때) 이김. winpodx 는 그 외 모든 곳에서 **100% Windows 기능 동등성** 으로 이김 — 모든 앱이 실제 Windows 커널 위에서 실행되고, FreeRDP RemoteApp 통해 Linux 데스크톱에 네이티브 윈도로 렌더링됨.

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -1,0 +1,51 @@
+# Comparison
+
+**English** | [한국어](COMPARISON.ko.md)
+
+How winpodx compares to other tools for running Windows applications on Linux.
+
+## Why winpodx?
+
+Existing tools for running Windows apps on Linux all have trade-offs:
+
+| | winapps | LinOffice | winboat | winpodx |
+|---|---|---|---|---|
+| Core tech | Any RDP-capable Windows host (cloud / physical / container) + FreeRDP | dockur + FreeRDP | dockur + FreeRDP | dockur (Podman) + FreeRDP + HTTP guest agent |
+| Setup | Manual (shell + config + RDP testing) | One-liner script | One-click GUI installer | **Zero-config** (auto on first launch) |
+| Interface | CLI only | CLI only | Electron GUI | **Qt6 GUI + CLI + tray** |
+| App scope | Any Windows app | Office only | Any Windows app | Any Windows app |
+| Language | Shell (86%) | Shell + Python | TypeScript / Vue / Go | **Python (100%)** |
+| Runtime deps | curl, dialog, git, netcat | Podman, FreeRDP | Electron, Docker/Podman, FreeRDP | **Python 3.9+, FreeRDP, Podman** |
+| Auto suspend / resume | No | No | Not documented | **Yes (idle timeout)** |
+| Password rotation | No | No | Not documented | **Yes (7-day, atomic)** |
+| HiDPI auto-detect | No | No | Not documented | **GNOME, KDE, Sway, Hyprland, Cinnamon, xrdb** |
+| Sound default | No | No | Yes (FreeRDP) | Yes (FreeRDP) |
+| Printer redirection default | No | No | Not documented | Yes (FreeRDP) |
+| USB drive auto-mapping | No | No | Smartcard passthrough | **Drive subfolders → drive letters via FileSystemWatcher** |
+| Discovery (auto-scan installed apps) | No | No | Yes | **Yes (Registry + Start Menu + UWP + choco/scoop)** |
+| Multi-session RDP | No | No | Not documented | **Yes (bundled rdprrap, up to 10)** |
+| Reverse file open (guest → host xdg-open) | No | No | No | **Yes (Linux apps in Windows "Open with…" menu)** |
+| Offline / air-gapped install | No | No | No | **Yes (`--source` + `--image-tar`)** |
+| License | MIT | AGPL-3.0 | MIT | MIT |
+
+> winboat is the closest peer in scope and was an inspiration. We focus on a different mix — stdlib-leaning Python + Qt6 instead of Electron, deeper auto-config (auto suspend, 7-day password rotation, multi-DE HiDPI), reverse-open (the only project where Linux apps appear in the Windows "Open with…" menu by default), and an explicit air-gapped install path. Both projects build on dockur/windows; that ecosystem is bigger than any one app.
+
+## winpodx vs Wine
+
+**winpodx is not a Wine replacement.** Wine translates Windows API calls; winpodx runs the actual Windows OS in a container. The two solve different problems and many users have both installed.
+
+| When you need... | Use |
+|---|---|
+| Older Win32 apps, indie games, lightweight utilities | **Wine / Bottles / Lutris** |
+| GPU-accelerated games / 3D apps (DirectX 9 – 12) | **Wine** — DXVK / VKD3D give near-native frame rates. winpodx has no GPU passthrough by default; QEMU CPU rendering is much slower. (GPU passthrough via VFIO is a manual bring-your-own setup — not yet packaged.) |
+| Microsoft 365 with full Outlook + Teams + OneDrive integration | **winpodx** |
+| Adobe Creative Suite (Photoshop, Illustrator, Premiere, Lightroom) | winpodx — but heavy GPU effects will be CPU-bound (see GPU row above) |
+| Anti-cheat games (Valorant, EAC, BattlEye) | **TBD** — anti-cheats vary by VM-detection policy (Vanguard needs TPM 2.0 + no hypervisor, EAC mostly blocks VMs, VAC is lenient). Test before committing. |
+| DRM-heavy software / hardware dongle apps | **winpodx** |
+| Apps that ship kernel-mode drivers (some VPNs, security suites) | **winpodx** |
+| Banking / tax / government tools with regional certificates | **winpodx** |
+| Visual Studio, WinUI 3 / WinRT, .NET features Wine hasn't caught up to | **winpodx** |
+| IE-only legacy enterprise web apps | **winpodx** |
+| Anything where "mostly works" isn't acceptable | **winpodx** |
+
+Wine wins on speed and on GPU when DXVK/VKD3D translate cleanly. winpodx wins on **100% Windows feature parity** for everything else — every app runs on a real Windows kernel, rendered into your Linux desktop as a native window via FreeRDP RemoteApp.

--- a/docs/FEATURES.ko.md
+++ b/docs/FEATURES.ko.md
@@ -1,0 +1,151 @@
+# 기능
+
+[English](FEATURES.md) | **한국어**
+
+전체 기능 셋: 주변기기 & 공유, 멀티세션 RDP, 앱 프로필, reverse-open (Linux 앱이 Windows "Open with…" 메뉴에 등장).
+
+## Reverse-open (Linux 앱이 Windows "Open with…" 에)
+
+**v0.5.0 신규.** Windows 게스트 안에서 아무 파일이나 우클릭하면 Linux 측 핸들러가 "Open with…" 메뉴에 등장 — `.txt` 는 Kate, `.png` 는 gwenview, `.html` 은 Firefox 등. 하나 선택하면 파일 열기가 호스트의 `xdg-open` 으로 round-trip 해서 실제로 Linux 에서 설정한 앱에 도착.
+
+동작 방식:
+
+```
+Windows Explorer 우클릭        ─┐
+                               │  슬러그별 winpodx-<slug>.exe
+                               │  (Rust shim, rcedit 으로 아이콘 embed)
+                               ▼
+   \\tsclient\home\.local\share\winpodx\reverse-open\incoming\<uuid>.json 에 atomic JSON 쓰기
+                               │
+                               ▼
+   host listener daemon 이 픽업, safe_open_unc 가 경로 검증
+                               │
+                               ▼
+   subprocess: <app.exec_argv> 와 실제 호스트 파일 경로
+```
+
+기능은 **기본 활성** (`cfg.reverse_open.enabled = true`). 사용자가 Linux 기본 핸들러로 설정한 각 Linux 앱 — `xdg-mime default` 또는 DE 의 "기본 앱" 설정 통해 — 이 Windows 측에 매칭되는 확장자와 함께 등록. Discovery 가 `$XDG_DATA_HOME/applications` + `$XDG_DATA_DIRS` 와 freedesktop 검색 경로의 모든 `mimeapps.list` 를 walk.
+
+CLI 로 관리:
+
+```bash
+winpodx host-open status        # listener + manifest 상태
+winpodx host-open list          # push 될 앱들
+winpodx host-open refresh       # 재스캔 + 게스트로 push
+winpodx host-open add <slug>    # allowlist
+winpodx host-open remove <slug> # 제거 (또는 --deny)
+winpodx host-open disable       # 기능 전체 끄기
+```
+
+또는 GUI Settings 페이지 → reverse-open 패널 (같은 컨트롤).
+
+슬러그별 아이콘이 짧은 Open With 메뉴 + 긴 "다른 앱 선택" 다이얼로그 양쪽에 렌더링되는 이유: 각 `winpodx-<slug>.exe` 가 Rust shim 의 독립 사본이고 매칭되는 `.ico` 가 PE resource section 에 embed 되어있기 때문 (vendored `rcedit.exe`, electron/rcedit v2.0.0, MIT). Chooser 아이콘 트레이드오프: 슬러그별 `.exe` 사본이 디스크에 ~500 KB × N 앱 차지 (hard-link inode 공유 없음) — Win10/Win11 에서 reliably 동작하는 유일한 chooser 아이콘 경로라서.
+
+## 매끄러운 앱 윈도
+
+- RemoteApp (RAIL) 이 각 앱을 네이티브 Linux 윈도로 렌더링 — 전체 데스크톱 아님
+- `WM_CLASS` 매칭 통한 앱별 taskbar 아이콘 (`/wm-class:<stem>` + `StartupWMClass`)
+- 파일 연결: Linux 파일 관리자에서 `.docx` 더블클릭 → Word 가 열림
+- 멀티세션 RDP: bundled rdprrap 이 최대 10개 독립 세션 자동 활성화
+- RAIL 전제조건 (`fDisabledAllowList=1` + `fInheritInitialProgram=1` + `MaxInstanceCount=10`) 이 unattended 설치 중 자동 설정
+
+## 제로 설정 실행
+
+- 첫 앱 클릭이 모든 것 자동 프로비저닝: config, 컨테이너, desktop 엔트리
+- 첫 부팅 시 자동 discovery 가 실행 중인 Windows 게스트 스캔, 설치된 모든 앱 (Registry App Paths, Start Menu, UWP/MSIX, Chocolatey, Scoop) 을 실제 바이너리 아이콘과 함께 등록
+- `winpodx app refresh` 또는 GUI Refresh 버튼으로 언제든 수동 재스캔
+- 고급 설정용 대화형 setup 마법사
+
+## 주변기기 & 공유
+
+| 기능 | 동작 방식 | 기본값 |
+|---------|-------------|---------|
+| **클립보드** | RDP 통한 양방향 복사-붙여넣기 (`+clipboard`) | 활성 |
+| **사운드** | ALSA 통한 오디오 스트리밍 (`/sound:sys:alsa`) | 활성 |
+| **프린터** | Linux 프린터가 Windows 에 공유 (`/printer`) | 활성 |
+| **홈 디렉토리** | `\\tsclient\home` 으로 공유 (`+home-drive`) | 활성 |
+| **USB 드라이브** | media 폴더가 `\\tsclient\media` 로 공유 (`/drive:media`); 세션 시작 후 꽂은 USB 도 서브폴더로 접근 가능 | 활성 |
+| **USB 디바이스 패스스루** | 네이티브 USB 리디렉션 (`/usb:auto`) — FreeRDP urbdrc 플러그인 필요 | **Opt-in** (`extra_flags` 에 추가) |
+| **USB 드라이브 매핑** | Windows 측 스크립트가 FileSystemWatcher 로 USB 서브폴더를 드라이브 레터 (E:, F:, ...) 로 자동 매핑 | 활성 |
+| **Reverse 파일 열기** | Linux 앱이 Windows 게스트 우클릭 "Open with…" 메뉴에 등장; 선택 시 호스트 `xdg-open` 으로 round-trip | 활성 |
+
+### USB 드라이브 흐름
+
+```
+Linux 에서 USB 꽂음
+    │
+    ▼
+Linux 가 /run/media/$USER/USBNAME 으로 마운트
+    │
+    ▼
+FreeRDP 가 \\tsclient\media\USBNAME 으로 공유
+    │
+    ▼
+media_monitor.ps1 감지 → net use E: \\tsclient\media\USBNAME
+    │
+    ▼
+Windows Explorer 에 E: 드라이브 표시
+```
+
+**GPU 가속:** 아직 미지원. dockur/windows 가 QEMU/KVM 위에서 소프트웨어 그래픽으로 실행 — DirectX 무거운 게임과 3D 앱은 CPU 바운드. VFIO 통한 GPU 패스스루는 가능하지만 패키징 안 됨. ([COMPARISON.md](COMPARISON.ko.md) → winpodx vs Wine 참조 — GPU 필요하면 Wine + DXVK 가 맞는 도구.)
+
+## 자동화 & 보안
+
+- 자동 suspend / resume: idle 시 컨테이너 pause, 다음 실행 시 resume
+- 비밀번호 자동 회전: 20자 암호학적 비밀번호, 7일 주기 + rollback
+- 스마트 DPI 스케일링: GNOME, KDE, Sway, Hyprland, Cinnamon, xrdb 에서 자동 감지
+- 멀티 백엔드: Podman (기본), Docker, libvirt/KVM, manual RDP
+- Windows 빌드를 11 25H2 에 pin (`TargetReleaseVersionInfo=25H2`, 365일 feature-update 지연)
+- Windows debloat: 텔레메트리, 광고, Cortana, 검색 인덱싱, 서비스 (DiagTrack / dmwappushservice / WSearch / SysMain) 비활성화
+- 고성능 전원 플랜 + hibernation off + tzutil UTC + Cloudflare DNS
+- 시간 동기화: 호스트 sleep/wake 후 Windows 시계 강제 resync
+- FreeRDP `extra_flags` allowlist (regex 검증) 가 사용자 input 안전 경계
+
+## 앱 프로필
+
+앱 프로필은 **메타데이터만**: Windows 앱이 어디 있는지를 기술해서 winpodx 가 FreeRDP RemoteApp 통해 실행 가능. 실제 Windows 애플리케이션은 Windows 컨테이너 안에 설치되어 있어야 함.
+
+### 자동 discovery (기본)
+
+v0.1.9 부터 winpodx 는 **큐레이트된 프로필 리스트 없음**. Windows pod 첫 부팅 시 provisioner 가 `winpodx app refresh` 실행, 실행 중인 게스트를 스캔:
+
+- Registry `App Paths` (`HKLM` + `HKCU`)
+- Start Menu `.lnk` 재귀 (depth-cap)
+- UWP / MSIX 패키지 — `Get-AppxPackage` + `AppxManifest.xml`
+- Chocolatey + Scoop shim
+
+각 결과에 대해 바이너리에서 아이콘 직접 추출 (UWP 는 패키지의 logo 자산) 하고 `~/.local/share/winpodx/discovered/<slug>/` 에 엔트리 작성. 언제든 재실행:
+
+```bash
+winpodx app refresh        # CLI
+# 또는 GUI Apps 페이지의 "Refresh Apps" 클릭
+```
+
+### 사용자 정의 앱 프로필 수동 추가
+
+사용자 작성 프로필은 `~/.local/share/winpodx/apps/` 에 위치, 같은 `name` 의 discovery 결과를 override:
+
+```bash
+mkdir -p ~/.local/share/winpodx/apps/myapp
+cat > ~/.local/share/winpodx/apps/myapp/app.toml << 'EOF'
+name = "myapp"
+full_name = "My Application"
+executable = "C:\\Program Files\\MyApp\\myapp.exe"
+categories = ["Utility"]
+mime_types = []
+EOF
+
+winpodx app install myapp   # desktop 메뉴에 등록
+```
+
+## 멀티세션 RDP
+
+기본 Windows Desktop 에디션은 RDP 를 사용자당 1 세션으로 제한 — 두 번째 앱이 재연결하면서 첫 세션을 빼앗아감. winpodx 는 [rdprrap](https://github.com/kernalix7/rdprrap) — RDPWrap 의 Rust 재구현 — 을 패키지 내부에 bundle 하고 Windows unattended 설치 중 자동 설치, 그래서 각 RemoteApp 윈도가 독립 세션을 받음.
+
+**RAIL 전제조건.** RemoteApp 자체가 unattended setup 중 winpodx 가 적용하는 세 개의 레지스트리 설정 필요: `fDisabledAllowList=1` (RemoteApp publishing 활성), `fInheritInitialProgram=1` (`/app:program:...` 가 셸이 아닌 타겟 실행파일을 실행하도록), `MaxInstanceCount=10` + `fSingleSessionPerUser=0` (단일 세션 제한 해제, 최대 10개 동시 RemoteApp 윈도). 이 키들은 rdprrap 설치 성공 여부와 관계없이 설정 — rdprrap 가 세션을 *독립적으로* 만들어주지만, 레지스트리 키들이 RemoteApp 을 일단 동작하게 만드는 것. rdprrap 설치 후 `TermService` 가 cycle 되어 wrapper DLL 이 재부팅 없이 활성화.
+
+**인증 채널.** NLA 비활성 (`UserAuthentication=0`) 으로 FreeRDP 명령줄이 `podman unshare --rootless-netns` 아래에서 unattended 인증 가능, 하지만 `SecurityLayer=2` 가 RDP 채널 자체는 TLS 로 암호화 유지 (그래서 `127.0.0.1` 에 대한 `/sec:tls /cert:ignore` 가 완전 인증 + 암호화 경로 — NLA 가 꺼져있어도 wire 에 평문 없음).
+
+**완전 오프라인 동작.** rdprrap zip 이 winpodx 의 data 디렉토리 (`config/oem/`) 안에 ship 되고 게스트 첫 부팅 중 `C:\OEM\` 에 stage. 추출 전 pin 파일에 대해 sha256 검증. 설치 시점에 네트워크 접근 불필요.
+
+설치는 일회성: dockur 의 unattended setup 단계 중 패치 적용. 그 단계의 무엇이라도 실패하면 (해시 불일치, 추출, installer 에러), winpodx 가 경고 로그 + 게스트는 단일 세션 모드 유지 — 앱 실행이 이 단계에서 막히지 않음. guest 측 management 채널 (설치 후 활성/비활성/상태) 은 차후 릴리스 예정.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,0 +1,151 @@
+# Features
+
+**English** | [한국어](FEATURES.ko.md)
+
+The full feature set: peripherals & sharing, multi-session RDP, app profiles, and reverse-open (Linux apps in the Windows "Open with…" menu).
+
+## Reverse-open (Linux apps in Windows "Open with…")
+
+**New in v0.5.0.** Right-click any file inside the Windows guest and your Linux-side handler appears in the "Open with…" menu — Kate for `.txt`, gwenview for `.png`, Firefox for `.html`, and so on. Picking one round-trips the file open back to the host's `xdg-open` so it lands in the Linux app you actually configured.
+
+How it works:
+
+```
+Windows Explorer right-click  ─┐
+                               │  per-slug winpodx-<slug>.exe
+                               │  (Rust shim, icon embedded via rcedit)
+                               ▼
+   atomic JSON write to \\tsclient\home\.local\share\winpodx\reverse-open\incoming\<uuid>.json
+                               │
+                               ▼
+   host listener daemon picks it up, safe_open_unc validates the path
+                               │
+                               ▼
+   subprocess: <app.exec_argv> with the real host file path
+```
+
+The feature is **on by default** (`cfg.reverse_open.enabled = true`). Each Linux app the user has set as a Linux default handler — via `xdg-mime default` or their DE's "Default Applications" settings — is registered on the Windows side with the matching extensions. Discovery walks `$XDG_DATA_HOME/applications` + `$XDG_DATA_DIRS` plus every `mimeapps.list` in the freedesktop search path.
+
+Manage via the CLI:
+
+```bash
+winpodx host-open status        # listener + manifest state
+winpodx host-open list          # apps that would be pushed
+winpodx host-open refresh       # rescan + push to guest
+winpodx host-open add <slug>    # allowlist
+winpodx host-open remove <slug> # remove (or --deny)
+winpodx host-open disable       # turn the whole feature off
+```
+
+Or via the GUI Settings page → reverse-open panel (same controls).
+
+Per-slug icons render in both the short Open With menu and the long "Choose another app" dialog because each `winpodx-<slug>.exe` is an independent copy of the Rust shim with the matching `.ico` embedded into its PE resource section (via vendored `rcedit.exe`, electron/rcedit v2.0.0, MIT). The chooser icon trade-off: the per-slug `.exe` copies cost ~500 KB × N apps on disk (no hard-link inode sharing) because that's the only chooser-icon path Win10/Win11 reliably honour.
+
+## Seamless app windows
+
+- RemoteApp (RAIL) renders each app as a native Linux window — no full desktop
+- Per-app taskbar icons via `WM_CLASS` matching (`/wm-class:<stem>` + `StartupWMClass`)
+- File associations: double-click `.docx` in your Linux file manager → Word opens
+- Multi-session RDP: bundled rdprrap auto-enables up to 10 independent sessions
+- RAIL prerequisites (`fDisabledAllowList=1` + `fInheritInitialProgram=1` + `MaxInstanceCount=10`) set automatically during unattended install
+
+## Zero-config launch
+
+- First app click auto-provisions everything: config, container, desktop entries
+- Auto-discovery on first boot scans the running Windows guest and registers every installed app (Registry App Paths, Start Menu, UWP/MSIX, Chocolatey, Scoop) with the real binary's icon
+- Manual rescan any time via `winpodx app refresh` or the GUI Refresh button
+- Interactive setup wizard for advanced configuration
+
+## Peripherals & Sharing
+
+| Feature | How it works | Default |
+|---------|-------------|---------|
+| **Clipboard** | Bidirectional copy-paste via RDP (`+clipboard`) | Enabled |
+| **Sound** | Audio streaming via ALSA (`/sound:sys:alsa`) | Enabled |
+| **Printer** | Linux printers shared to Windows (`/printer`) | Enabled |
+| **Home directory** | Shared as `\\tsclient\home` (`+home-drive`) | Enabled |
+| **USB drives** | Media folder shared as `\\tsclient\media` (`/drive:media`); USB drives plugged in after session start are accessible as subfolders | Enabled |
+| **USB device passthrough** | Native USB redirection (`/usb:auto`) — requires FreeRDP urbdrc plugin | **Opt-in** (add to `extra_flags`) |
+| **USB drive mapping** | Windows-side script auto-maps USB subfolders to drive letters (E:, F:, ...) via FileSystemWatcher | Enabled |
+| **Reverse file open** | Linux apps appear in the Windows guest's right-click "Open with…" menu; selecting one round-trips the file open to host `xdg-open` | Enabled |
+
+### USB Drive Flow
+
+```
+Plug in USB on Linux
+    │
+    ▼
+Linux mounts to /run/media/$USER/USBNAME
+    │
+    ▼
+FreeRDP shares as \\tsclient\media\USBNAME
+    │
+    ▼
+media_monitor.ps1 detects → net use E: \\tsclient\media\USBNAME
+    │
+    ▼
+Windows Explorer shows E: drive
+```
+
+**GPU acceleration:** not yet supported. dockur/windows runs under QEMU/KVM with software graphics — DirectX-heavy games and 3D apps will be CPU-bound. GPU passthrough via VFIO is feasible but not packaged. (See [COMPARISON.md](COMPARISON.md) → winpodx vs Wine — Wine + DXVK is the right tool when you need GPU.)
+
+## Automation & Security
+
+- Auto suspend / resume: container pauses when idle, resumes on next launch
+- Password auto-rotation: 20-char cryptographic password, 7-day cycle with rollback
+- Smart DPI scaling: auto-detects from GNOME, KDE, Sway, Hyprland, Cinnamon, xrdb
+- Multi-backend: Podman (default), Docker, libvirt/KVM, manual RDP
+- Windows build pinned to 11 25H2 (`TargetReleaseVersionInfo=25H2`, 365-day feature-update defer)
+- Windows debloat: disable telemetry, ads, Cortana, search indexing, services (DiagTrack / dmwappushservice / WSearch / SysMain)
+- High-performance power plan + hibernation off + tzutil UTC + Cloudflare DNS
+- Time sync: force Windows clock resync after host sleep/wake
+- FreeRDP `extra_flags` allowlist (regex-validated) as the user-input safety boundary
+
+## App Profiles
+
+App profiles are **metadata only**: they describe where a Windows app lives so winpodx can launch it through FreeRDP RemoteApp. The actual Windows application must be installed inside the Windows container.
+
+### Auto-discovery (default)
+
+Starting from v0.1.9 winpodx ships **no curated profile list**. The first time the Windows pod boots, the provisioner runs `winpodx app refresh` and that scans the running guest:
+
+- Registry `App Paths` (`HKLM` + `HKCU`)
+- Start Menu `.lnk` recursion (depth-capped)
+- UWP / MSIX packages via `Get-AppxPackage` + `AppxManifest.xml`
+- Chocolatey + Scoop shims
+
+For each result it extracts the icon directly from the binary (or the package's logo asset for UWP) and writes the entry to `~/.local/share/winpodx/discovered/<slug>/`. Re-run any time:
+
+```bash
+winpodx app refresh        # CLI
+# or click "Refresh Apps" on the GUI Apps page
+```
+
+### Adding a custom app profile manually
+
+User-authored profiles live under `~/.local/share/winpodx/apps/` and override anything discovery finds with the same `name`:
+
+```bash
+mkdir -p ~/.local/share/winpodx/apps/myapp
+cat > ~/.local/share/winpodx/apps/myapp/app.toml << 'EOF'
+name = "myapp"
+full_name = "My Application"
+executable = "C:\\Program Files\\MyApp\\myapp.exe"
+categories = ["Utility"]
+mime_types = []
+EOF
+
+winpodx app install myapp   # Register in desktop menu
+```
+
+## Multi-Session RDP
+
+Stock Windows Desktop editions limit RDP to one session per user; a second app would otherwise reconnect and steal the first session. winpodx bundles [rdprrap](https://github.com/kernalix7/rdprrap) — a Rust reimplementation of RDPWrap — inside the package itself and installs it automatically during the Windows unattended install, so each RemoteApp window gets its own independent session.
+
+**RAIL prerequisites.** RemoteApp itself requires three registry settings that winpodx applies during unattended setup: `fDisabledAllowList=1` (enables RemoteApp publishing), `fInheritInitialProgram=1` (required for `/app:program:...` to launch the target executable instead of a shell), and `MaxInstanceCount=10` paired with `fSingleSessionPerUser=0` (lifts the single-session cap up to 10 concurrent RemoteApp windows). These are set regardless of whether rdprrap installs successfully — rdprrap is what makes the sessions *independent*, but the registry keys are what make RemoteApp work at all. After rdprrap install `TermService` is cycled so the wrapper DLL activates without a reboot.
+
+**Authentication channel.** NLA is disabled (`UserAuthentication=0`) so the FreeRDP command line can authenticate unattended from under `podman unshare --rootless-netns`, but `SecurityLayer=2` keeps the RDP channel itself encrypted with TLS (so `/sec:tls /cert:ignore` against `127.0.0.1` is the full authenticated + encrypted path — no cleartext on the wire even though NLA is off).
+
+**Works fully offline.** The rdprrap zip ships inside winpodx's data directory (`config/oem/`) and is staged into `C:\OEM\` during the guest's first boot. sha256 is verified against a pin file before extraction. No network access is required at install time.
+
+Install is one-shot: the patch is applied during dockur's unattended setup phase. If anything in that step fails (hash mismatch, extraction, installer error), winpodx logs a warning and the guest stays in single-session mode — app launch never blocks on this step. A guest-side management channel (enable/disable/status after install) is planned for a later release.

--- a/docs/INSTALL.ko.md
+++ b/docs/INSTALL.ko.md
@@ -1,0 +1,161 @@
+# 설치
+
+[English](INSTALL.md) | **한국어**
+
+winpodx 설치하는 모든 방법 — 원라인 인스톨러, distro 패키지 매니저, Nix, 소스 빌드, 오프라인 시나리오.
+
+## 원라인 설치
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
+```
+
+distro 를 감지하고, 누락된 시스템 의존성 (Podman, FreeRDP, KVM, Python 3.9+) 을 확인 후 설치, winpodx 를 `~/.local/bin/winpodx-app/` 에 배치. Windows 앱 메뉴는 pod 첫 부팅 시 자동으로 채워짐 — discovery 가 실행 중인 Windows 게스트를 스캔하고 설치된 모든 앱을 실제 아이콘과 함께 등록. 의존성 설치 단계 외에는 root 불필요. openSUSE, Fedora, Debian/Ubuntu, RHEL-family, Arch, NixOS 에서 동작.
+
+> **Windows 라이선스.** dockur 가 pod 첫 부팅 시 Microsoft 에서 Windows ISO 를 다운로드. 결과로 만들어진 Windows 게스트의 사용은 Microsoft 의 Software License Terms (첫 활성화 시 표시되는 EULA) 의 적용을 받음. winpodx 는 Windows 를 재배포하지 않음, 본인 머신에서의 설치를 오케스트레이션할 뿐. 활성화는 본인의 Windows 라이선스 키로 — Home / Pro / Enterprise 모두 dockur 가 지원.
+
+기본적으로 인스톨러는 **가장 최신의 GitHub release** (현재 `v0.5.0`) 에 pin. 프리릴리스 / 개발 버전은 opt-in.
+
+## 버전 선택
+
+`--main` (또는 `--ref TAG`) 로 개발 빌드 사용 가능, 그렇지 않으면 기본 release 사용:
+
+```bash
+# 최신 안정 release 설치 (기본)
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
+
+# 최신 main HEAD 설치 (개발용, 불안정할 수 있음)
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash -s -- --main
+
+# 특정 태그, 브랜치, 커밋 설치
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash -s -- --ref v0.5.0
+
+# 환경변수 등가 (curl | bash 에서 -s -- 없이 동작)
+WINPODX_REF=main   curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
+WINPODX_REF=v0.5.0 curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
+```
+
+## 오프라인 / 에어갭 설치
+
+인스톨러는 registry / 패키지 저장소 접근이 없는 머신을 위한 세 가지 선택 플래그 제공:
+
+```bash
+# git clone 대신 로컬 사본에서 winpodx 복사 (환경변수: WINPODX_SOURCE)
+./install.sh --source /media/usb/winpodx
+
+# 첫 부팅 시 가져오는 대신 Windows 이미지 tar 미리 로드 (환경변수: WINPODX_IMAGE_TAR)
+./install.sh --image-tar /media/usb/windows-image.tar
+
+# distro 패키지 설치 건너뛰기 (환경변수: WINPODX_SKIP_DEPS=1) — 의존성 없으면 일찍 실패
+./install.sh --skip-deps
+
+# 한 번에:
+./install.sh --source /media/usb/winpodx --image-tar /media/usb/windows-image.tar --skip-deps
+```
+
+환경변수는 `curl | bash` 에서도 동작 — `WINPODX_SKIP_DEPS=1 curl ... | bash` 가능.
+
+## 네이티브 패키지 매니저
+
+미리 빌드된 RPM / `.deb` / AUR 패키지가 모든 [GitHub Release](https://github.com/kernalix7/winpodx/releases/latest) 에 첨부됨 — openSUSE/Fedora RPM 은 [openSUSE Build Service (`home:Kernalix7/winpodx`)](https://build.opensuse.org/package/show/home:Kernalix7/winpodx) 에서, 나머지는 GitHub Actions 에서.
+
+### openSUSE Tumbleweed / Leap 15.6 / Leap 16.0 / Slowroll
+
+```bash
+sudo zypper addrepo \
+  https://download.opensuse.org/repositories/home:/Kernalix7/openSUSE_Tumbleweed/home:Kernalix7.repo
+sudo zypper refresh
+sudo zypper install winpodx
+```
+
+필요에 따라 `openSUSE_Tumbleweed` 를 `openSUSE_Leap_16.0`, `openSUSE_Leap_15.6`, `openSUSE_Slowroll` 로 교체.
+
+### Fedora 42 / 43
+
+```bash
+sudo dnf config-manager --add-repo \
+  https://download.opensuse.org/repositories/home:/Kernalix7/Fedora_43/home:Kernalix7.repo
+sudo dnf install winpodx
+```
+
+### Debian 12 / 13, Ubuntu 24.04 / 25.04 / 25.10
+
+[최신 release](https://github.com/kernalix7/winpodx/releases/latest) 에서 맞는 `.deb` 를 다운로드 후 설치:
+
+```bash
+sudo apt install ./winpodx_<version>_all_debian13.deb   # 본인 환경에 맞는 것 선택
+```
+
+### AlmaLinux / Rocky / RHEL 9 & 10
+
+el9 는 `python3-tomli` 위해 EPEL 필요. [최신 release](https://github.com/kernalix7/winpodx/releases/latest) 에서 맞는 `.rpm` 다운로드 후 설치:
+
+```bash
+sudo dnf install epel-release                            # el9 만
+sudo dnf install ./winpodx-<version>-1.noarch.el9.rpm    # 또는 .el10.rpm
+```
+
+### Arch Linux (AUR)
+
+```bash
+yay -S winpodx        # 또는:
+paru -S winpodx
+```
+
+## Nix
+
+NixOS / nix-on-any-distro 사용자를 위한 flake 제공:
+
+```bash
+# 설치 없이 바로 실행
+nix run github:kernalix7/winpodx
+
+# 프로필에 설치
+nix profile install github:kernalix7/winpodx
+
+# flake input 으로
+inputs.winpodx.url = "github:kernalix7/winpodx";
+```
+
+wrapper 가 FreeRDP, podman / podman-compose, iproute2, libnotify 를 bundle 해서 기본 Podman 백엔드는 바로 동작. Docker 와 libvirt 백엔드는 해당 도구가 호스트에 설치되어 있어야 함.
+
+## 소스에서
+
+```bash
+git clone https://github.com/kernalix7/winpodx.git
+cd winpodx
+./install.sh
+```
+
+소스 인스톨러는 자동으로:
+1. distro 감지 (openSUSE, Fedora, Ubuntu, Arch, ...)
+2. 누락된 의존성 (Podman, FreeRDP, KVM) 설치, 설치 전 확인
+3. winpodx 를 `~/.local/bin/winpodx-app/` 로 복사
+4. config 와 `compose.yaml` 생성
+5. pod 첫 부팅 시 자동 discovery (`winpodx app refresh`) fire 해서 메뉴 채우기
+
+### 수동 실행 (설치 없이)
+
+```bash
+git clone https://github.com/kernalix7/winpodx.git
+cd winpodx
+export PYTHONPATH="$PWD/src"
+python3 -m winpodx app run word
+```
+
+## 언인스톨
+
+파이프 환경에서는 `--confirm` 또는 `--purge` 필수 (curl 이 stdin 을 소비하는 동안 대화형 프롬프트가 터미널에서 읽을 수 없음):
+
+```bash
+# winpodx 파일만 제거, Windows 컨테이너 + 데이터 유지
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh | bash -s -- --confirm
+
+# 완전 삭제: 컨테이너, 볼륨, config, 런처, 전부
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh | bash -s -- --purge
+```
+
+**언인스톨은 winpodx 파일만 제거.** 다음은 절대 건드리지 않음:
+- Podman 컨테이너 / 볼륨 (Windows VM 데이터) — `--purge` 없이는 그대로
+- 시스템 패키지 (podman, freerdp, python3)
+- 홈 디렉토리 파일들

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,161 @@
+# Install
+
+**English** | [한국어](INSTALL.ko.md)
+
+Every way to install winpodx — the one-line installer, distro package managers, Nix, source builds, and offline scenarios.
+
+## One-line install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
+```
+
+Detects your distro, installs missing system dependencies (Podman, FreeRDP, KVM, Python 3.9+) with your confirmation, drops winpodx into `~/.local/bin/winpodx-app/`. The Windows-app menu populates automatically the first time the pod boots — discovery scans your running Windows guest and registers every installed app with its real icon. No root required except for the dependency install step. Works on openSUSE, Fedora, Debian/Ubuntu, RHEL-family, Arch, and NixOS.
+
+> **Windows licensing.** dockur downloads a Windows ISO from Microsoft at first pod boot. Your use of the resulting Windows guest is governed by Microsoft's Software License Terms (the EULA shown on first activation). winpodx does not redistribute Windows; it only orchestrates the install on your machine. Bring your own Windows license key for activation — Home / Pro / Enterprise are all supported by dockur.
+
+By default the installer pins to the **latest published GitHub release** (currently `v0.5.0`). Pre-release / development versions stay opt-in.
+
+## Choose a version
+
+Pass `--main` (or `--ref TAG`) for development builds, otherwise stick with the default release:
+
+```bash
+# Install the latest stable release (default)
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
+
+# Install the latest main HEAD (development; may be unstable)
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash -s -- --main
+
+# Install a specific tag, branch, or commit
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash -s -- --ref v0.5.0
+
+# Env-var equivalent (works under curl | bash without -s --)
+WINPODX_REF=main   curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
+WINPODX_REF=v0.5.0 curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
+```
+
+## Offline / air-gapped install
+
+The installer takes three optional flags for machines with no registry / package-repo access:
+
+```bash
+# Copy winpodx from a local clone instead of git clone (also env: WINPODX_SOURCE)
+./install.sh --source /media/usb/winpodx
+
+# Preload the Windows image tar instead of fetching at first boot (env: WINPODX_IMAGE_TAR)
+./install.sh --image-tar /media/usb/windows-image.tar
+
+# Skip distro package install (env: WINPODX_SKIP_DEPS=1) — fails early if deps aren't present
+./install.sh --skip-deps
+
+# Everything at once:
+./install.sh --source /media/usb/winpodx --image-tar /media/usb/windows-image.tar --skip-deps
+```
+
+Env vars are honored even under `curl | bash`, so `WINPODX_SKIP_DEPS=1 curl ... | bash` works.
+
+## Native package managers
+
+Prebuilt RPM / `.deb` / AUR packages are attached to every [GitHub Release](https://github.com/kernalix7/winpodx/releases/latest) — openSUSE/Fedora RPMs come from the [openSUSE Build Service (`home:Kernalix7/winpodx`)](https://build.opensuse.org/package/show/home:Kernalix7/winpodx), the rest from GitHub Actions.
+
+### openSUSE Tumbleweed / Leap 15.6 / Leap 16.0 / Slowroll
+
+```bash
+sudo zypper addrepo \
+  https://download.opensuse.org/repositories/home:/Kernalix7/openSUSE_Tumbleweed/home:Kernalix7.repo
+sudo zypper refresh
+sudo zypper install winpodx
+```
+
+Replace `openSUSE_Tumbleweed` with `openSUSE_Leap_16.0`, `openSUSE_Leap_15.6`, or `openSUSE_Slowroll` as needed.
+
+### Fedora 42 / 43
+
+```bash
+sudo dnf config-manager --add-repo \
+  https://download.opensuse.org/repositories/home:/Kernalix7/Fedora_43/home:Kernalix7.repo
+sudo dnf install winpodx
+```
+
+### Debian 12 / 13, Ubuntu 24.04 / 25.04 / 25.10
+
+Download the matching `.deb` from the [latest release](https://github.com/kernalix7/winpodx/releases/latest) and install:
+
+```bash
+sudo apt install ./winpodx_<version>_all_debian13.deb   # pick your flavor
+```
+
+### AlmaLinux / Rocky / RHEL 9 & 10
+
+EPEL is required on el9 for `python3-tomli`. Download the matching `.rpm` from the [latest release](https://github.com/kernalix7/winpodx/releases/latest) and install:
+
+```bash
+sudo dnf install epel-release                            # el9 only
+sudo dnf install ./winpodx-<version>-1.noarch.el9.rpm    # or .el10.rpm
+```
+
+### Arch Linux (AUR)
+
+```bash
+yay -S winpodx        # or:
+paru -S winpodx
+```
+
+## Nix
+
+A flake is provided for NixOS / nix-on-any-distro users:
+
+```bash
+# Run directly without installing
+nix run github:kernalix7/winpodx
+
+# Install into your profile
+nix profile install github:kernalix7/winpodx
+
+# As a flake input
+inputs.winpodx.url = "github:kernalix7/winpodx";
+```
+
+The wrapper bundles FreeRDP, podman / podman-compose, iproute2 and libnotify, so the default Podman backend works out of the box. The Docker and libvirt backends still require the respective tools to be present on the host.
+
+## From source
+
+```bash
+git clone https://github.com/kernalix7/winpodx.git
+cd winpodx
+./install.sh
+```
+
+The source installer automatically:
+1. Detects your distro (openSUSE, Fedora, Ubuntu, Arch, ...)
+2. Installs missing dependencies (Podman, FreeRDP, KVM), asks before installing
+3. Copies winpodx to `~/.local/bin/winpodx-app/`
+4. Creates config and `compose.yaml`
+5. Auto-discovery (`winpodx app refresh`) fires on first pod boot to populate the menu
+
+### Manual run (no install)
+
+```bash
+git clone https://github.com/kernalix7/winpodx.git
+cd winpodx
+export PYTHONPATH="$PWD/src"
+python3 -m winpodx app run word
+```
+
+## Uninstall
+
+`--confirm` or `--purge` is required under pipe (the interactive prompts can't read from a terminal while bash consumes stdin from curl):
+
+```bash
+# Remove winpodx files, keep the Windows container + its data
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh | bash -s -- --confirm
+
+# Full wipe: container, volume, config, launcher, everything
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh | bash -s -- --purge
+```
+
+**Uninstall only removes winpodx files.** It never touches:
+- Your Podman containers / volumes (Windows VM data) unless `--purge` is passed
+- System packages (podman, freerdp, python3)
+- Your home directory files

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -20,7 +20,7 @@
 
 [![license](https://img.shields.io/github/license/kernalix7/winpodx?style=flat-square&color=blue)](../LICENSE)
 [![python](https://img.shields.io/badge/python-3.9%2B-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
-[![tests](https://img.shields.io/badge/tests-411-2EA44F?style=flat-square)](#테스트)
+[![tests](https://img.shields.io/badge/tests-1090%2B-2EA44F?style=flat-square)](#테스트)
 [![CI](https://img.shields.io/github/actions/workflow/status/kernalix7/winpodx/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/kernalix7/winpodx/actions/workflows/ci.yml)
 [![stars](https://img.shields.io/github/stars/kernalix7/winpodx?style=flat-square&color=FFD93D&logo=github&logoColor=white)](https://github.com/kernalix7/winpodx/stargazers)
 [![downloads](https://img.shields.io/github/downloads/kernalix7/winpodx/total?style=flat-square&color=2EA44F)](https://github.com/kernalix7/winpodx/releases)
@@ -32,600 +32,123 @@
 [![Debian](https://img.shields.io/badge/Debian-A81D33?style=flat-square&logo=debian&logoColor=white)](https://www.debian.org/)
 [![Ubuntu](https://img.shields.io/badge/Ubuntu-E95420?style=flat-square&logo=ubuntu&logoColor=white)](https://ubuntu.com/)
 [![RHEL family](https://img.shields.io/badge/RHEL%20%2F%20Alma%20%2F%20Rocky-EE0000?style=flat-square&logo=redhat&logoColor=white)](https://www.redhat.com/)
-[![Arch (AUR pending)](https://img.shields.io/badge/Arch%20(AUR)-pending-lightgrey?style=flat-square&logo=archlinux&logoColor=white)](../packaging/aur/README.md)
-[![NixOS](https://img.shields.io/badge/NixOS-5277C3?style=flat-square&logo=nixos&logoColor=white)](#install)
+[![Arch](https://img.shields.io/badge/Arch-1793D1?style=flat-square&logo=archlinux&logoColor=white)](https://archlinux.org/)
+[![NixOS](https://img.shields.io/badge/NixOS-5277C3?style=flat-square&logo=nixos&logoColor=white)](INSTALL.ko.md#nix)
 
-<sub>[English](../README.md) &nbsp;·&nbsp; **한국어** &nbsp;·&nbsp; [빠른 시작](#빠른-시작) &nbsp;·&nbsp; [기능](#주요-기능) &nbsp;·&nbsp; [CLI](#cli-레퍼런스) &nbsp;·&nbsp; [멀티세션](#multi-session-rdp)</sub>
+<sub>[English](../README.md) &nbsp;·&nbsp; **한국어** &nbsp;·&nbsp; [설치](INSTALL.ko.md) &nbsp;·&nbsp; [사용법](USAGE.ko.md) &nbsp;·&nbsp; [기능](FEATURES.ko.md) &nbsp;·&nbsp; [아키텍처](ARCHITECTURE.ko.md) &nbsp;·&nbsp; [비교](COMPARISON.ko.md)</sub>
 
 </div>
 
 ---
 
 > ### 상태: 베타
-> winpodx는 활발히 개발 중입니다 (v0.3.0). v0.3.0 은 host→guest 파이프라인을 새로 설계 — bearer-authed HTTP agent (`127.0.0.1:8765`) 가 기본 명령 채널, FreeRDP RemoteApp 은 폴백. 앱 launch 마다 PowerShell 창 깜빡이지 않음. 새 `winpodx check` CLI + GUI Health 카드가 pod / RDP / agent / round-trip / disk 상태 실시간 표시. 첫 설치는 여전히 ~5-10분 소요 (Windows VM ISO 다운로드 + Sysprep + OEM apply); 진행 상황은 `winpodx pod wait-ready --logs` 로 확인. 문제 발생 시 <https://github.com/kernalix7/winpodx/issues> 에 이슈 등록해주세요.
+> winpodx 는 활발히 개발 중입니다 (**v0.5.0**). v0.5.0 의 헤드라인은 **reverse-open**: Linux 앱이 Windows 게스트 우클릭 "Open with…" 메뉴에 기본으로 노출, 앱별 정확한 아이콘과 함께. 게스트 안에서 `.txt` 더블클릭, 메뉴에서 Kate 선택 → 실제 호스트 파일 경로로 Linux Kate 에서 열림. host→guest 파이프라인 (`127.0.0.1:8765` bearer-auth HTTP agent, FreeRDP RemoteApp 폴백) 은 v0.3.x 부터 그대로. 첫 설치는 여전히 ~5–10분 소요 (Windows VM ISO 다운로드 + Sysprep + OEM apply); 진행 상황은 `winpodx pod wait-ready --logs` 로 확인. 문제 발생 시 <https://github.com/kernalix7/winpodx/issues> 에 이슈 등록해주세요.
 
-**Full-screen RDP 아님.** Windows 앱이 각각 네이티브 Linux 윈도 — pin 가능, alt-tab 됨, 파일 연결 동작. 진짜 Windows 데스크톱 필요할 때만 `winpodx app run desktop`.
+**Full-screen RDP 아님.** Windows 앱이 각각 네이티브 Linux 윈도 — 진짜 아이콘, pin 가능, alt-tab, 파일 연결 양방향. 진짜 Windows 데스크톱 필요할 때만 `winpodx app run desktop`.
 
-winpodx는 백그라운드에서 Windows 컨테이너([dockur/windows](https://github.com/dockur/windows))를 실행하고, FreeRDP RemoteApp으로 Windows 앱을 네이티브 Linux 앱처럼 표시합니다. 게스트 안의 bearer-authed HTTP agent 가 host→guest 명령 채널을 처리해서 PowerShell 창이 깜빡이지 않음. VM 수동 설정 불필요, ISO 다운로드 불필요, 레지스트리 편집 불필요. **외부 Python 의존성 거의 없음** (Python 3.11+ 는 표준 라이브러리만; 3.9/3.10 은 순수 파이썬 `tomli` 폴백 1개).
+winpodx 는 백그라운드에서 Windows 컨테이너 ([dockur/windows](https://github.com/dockur/windows)) 를 실행하고, FreeRDP RemoteApp 으로 Windows 앱을 네이티브 Linux 앱처럼 표시합니다. 게스트 안의 bearer-auth HTTP agent 가 host→guest 명령 채널을 처리해서 PowerShell 창이 깜빡이지 않음. 반대 방향 — Linux 앱이 Windows "Open with…" 메뉴에 노출 — 은 호스트 측 listener 가 게스트 내 슬러그별 Rust shim 이 작성한 JSON 요청을 소비하는 식으로 처리. **외부 Python 의존성 거의 없음** (Python 3.11+ 는 표준 라이브러리만; 3.9/3.10 은 순수 파이썬 `tomli` 폴백 1개).
 
-## 왜 winpodx인가?
+## 빠른 설치
 
-Linux에서 Windows 앱을 실행하는 기존 도구들은 각각 한계가 있습니다:
-
-| | winapps | LinOffice | winboat | winpodx |
-|---|---|---|---|---|
-| 핵심 기술 | RDP 가능한 Windows 호스트 (클라우드 / 물리 / 컨테이너) + FreeRDP | dockur + FreeRDP | dockur + FreeRDP | dockur (Podman) + FreeRDP + HTTP guest agent |
-| 설정 | 수동 (셸 + 설정 파일 + RDP 테스트) | 원라인 스크립트 | 원클릭 GUI 설치 | **제로 설정** (첫 실행 시 자동) |
-| 인터페이스 | CLI 만 | CLI 만 | Electron GUI | **Qt6 GUI + CLI + 트레이** |
-| 앱 범위 | 모든 Windows 앱 | Office 전용 | 모든 Windows 앱 | 모든 Windows 앱 |
-| 언어 | Shell (86%) | Shell + Python | TypeScript / Vue / Go | **Python (100%)** |
-| 런타임 의존성 | curl, dialog, git, netcat | Podman, FreeRDP | Electron, Docker/Podman, FreeRDP | **Python 3.9+, FreeRDP, Podman** |
-| 자동 일시정지 / 재개 | 없음 | 없음 | 명시 안됨 | **있음 (idle timeout)** |
-| 비밀번호 회전 | 없음 | 없음 | 명시 안됨 | **있음 (7일, 원자적)** |
-| HiDPI 자동 감지 | 없음 | 없음 | 명시 안됨 | **GNOME, KDE, Sway, Hyprland, Cinnamon, xrdb** |
-| 사운드 기본 | 없음 | 없음 | 있음 (FreeRDP) | 있음 (FreeRDP) |
-| 프린터 리다이렉션 기본 | 없음 | 없음 | 명시 안됨 | 있음 (FreeRDP) |
-| USB 드라이브 자동 매핑 | 없음 | 없음 | 스마트카드 패스스루 | **드라이브 서브폴더 → 드라이브 문자 (FileSystemWatcher)** |
-| 디스커버리 (설치된 앱 자동 스캔) | 없음 | 없음 | 있음 | **있음 (Registry + Start Menu + UWP + choco/scoop)** |
-| 멀티 세션 RDP | 없음 | 없음 | 명시 안됨 | **있음 (번들 rdprrap, 최대 10)** |
-| 오프라인 / 에어갭 설치 | 없음 | 없음 | 없음 | **있음 (`--source` + `--image-tar`)** |
-| 라이선스 | MIT | AGPL-3.0 | MIT | MIT |
-
-> winboat 가 가장 가까운 동급 프로젝트이고 영감 중 하나입니다. winpodx 는 다른 조합을 추구합니다 — Electron 대신 stdlib 중심 Python + Qt6, 더 깊은 자동 설정 (auto suspend, 7일 비밀번호 회전, 다중 DE HiDPI), 명시적 에어갭 설치 경로. 두 프로젝트 모두 dockur/windows 위에 빌드되어 있고, 그 생태계는 어떤 한 앱보다도 큽니다.
-
-## winpodx vs Wine
-
-**winpodx 는 Wine 대체재가 아닙니다.** Wine 은 Windows API 호출을 Linux 로 번역하고, winpodx 는 실제 Windows OS 를 컨테이너에서 돌립니다. 두 도구는 다른 문제를 풉니다 — 많은 사용자가 둘 다 설치합니다.
-
-| 필요한 게... | 사용 |
-|---|---|
-| 오래된 Win32 앱, 인디 게임, 가벼운 유틸 | **Wine / Bottles / Lutris** |
-| GPU 가속 게임 / 3D 앱 (DirectX 9 ~ 12) | **Wine** — DXVK / VKD3D 가 거의 네이티브 프레임 레이트. winpodx 는 GPU 패스스루 기본 미지원, QEMU CPU 렌더링은 훨씬 느림. (VFIO 기반 GPU 패스스루는 가능하지만 별도 수동 설정 필요, 패키징 안 됨.) |
-| Outlook + Teams + OneDrive 풀 통합된 Microsoft 365 | **winpodx** |
-| Adobe Creative Suite (Photoshop, Illustrator, Premiere, Lightroom) | winpodx — 단 무거운 GPU 효과는 CPU bound (위 GPU 행 참조) |
-| 안티치트 게임 (Valorant, EAC, BattlEye 계열) | **TBD** — 안티치트마다 VM 감지 정책 다름 (Vanguard 는 TPM 2.0 + 하이퍼바이저 없음 요구, EAC 는 대부분 VM 차단, VAC 는 관대). 본격 사용 전 테스트 필요. |
-| DRM 무거운 소프트웨어 / 하드웨어 동글 앱 | **winpodx** |
-| 커널 모드 드라이버 동반 앱 (일부 VPN, 보안 소프트웨어) | **winpodx** |
-| 지역 인증서 필요한 은행 / 세무 / 공공기관 도구 | **winpodx** |
-| Visual Studio, WinUI 3 / WinRT, Wine 이 못 따라가는 .NET 기능 | **winpodx** |
-| IE 전용 레거시 사내 웹앱 | **winpodx** |
-| "대충 됨" 이 허용 안 되는 모든 경우 | **winpodx** |
-
-Wine 은 속도와 GPU (DXVK/VKD3D 가 깔끔히 번역해줄 때) 에서 이깁니다. winpodx 는 **그 외 모든 경우에서 100% Windows 기능 호환성** 으로 이깁니다 — 진짜 Windows 커널 위에서 앱이 돌고, FreeRDP RemoteApp 으로 Linux 데스크톱에 네이티브 윈도로 렌더링될 뿐입니다.
-
-## 주요 기능
-
-<table>
-<tr><td width="50%">
-
-**심리스 앱 창**
-- RemoteApp (RAIL)으로 각 앱을 네이티브 Linux 창으로 렌더링 (전체 데스크톱 없음)
-- 앱별 독립 작업 표시줄 아이콘 (`/wm-class:<stem>` + `StartupWMClass` 매칭)
-- 파일 연결: 파일 관리자에서 `.docx` 더블클릭 → Word 실행
-- 멀티세션 RDP: 번들된 rdprrap 가 최대 10개 독립 세션을 자동 활성화
-- RAIL 전제 레지스트리 (`fDisabledAllowList=1` + `fInheritInitialProgram=1` + `MaxInstanceCount=10`) 를 무인 설치 중 자동 설정
-
-</td><td width="50%">
-
-**제로 설정 실행**
-- 첫 앱 클릭 시 모든 것을 자동 프로비저닝: 설정, 컨테이너, 데스크톱 엔트리
-- **첫 부팅 시 자동 발견** — winpodx 가 실행 중인 Windows 게스트를 스캔해 설치된 모든 앱 (Registry App Paths, Start Menu, UWP/MSIX, Chocolatey, Scoop) 을 등록하고 실제 바이너리에서 추출한 아이콘을 사용
-- `winpodx app refresh` 또는 GUI Refresh 버튼으로 언제든 재스캔 가능
-- 고급 설정을 위한 대화형 설정 위자드
-
-</td></tr>
-<tr><td width="50%">
-
-**주변기기 및 공유**
-- **클립보드**: 양방향 복사-붙여넣기 (텍스트 + 이미지) 기본 활성화
-- **사운드**: RDP 오디오 스트리밍 (`/sound:sys:alsa`) 기본 활성화
-- **프린터**: Linux 프린터를 Windows 로 RDP 리다이렉션 (기본)
-- **USB 드라이브**: Linux 마운트 트리가 `\\tsclient\media` 로 공유; 세션 시작 후 꽂힌 드라이브도 서브폴더로 접근 가능
-- **USB 드라이브 자동 매핑**: Windows 측 FileSystemWatcher 스크립트가 `\\tsclient\media\<USB>` 서브폴더를 드라이브 문자 (E:, F:, ...) 로 자동 매핑
-- **USB 장치 패스스루**: `/usb:auto` 가 allowlist 에 있지만 **기본 비활성화** — FreeRDP 빌드에 urbdrc 플러그인 있으면 `extra_flags` 로 opt-in
-- **홈 디렉토리**: `\\tsclient\home` 으로 공유 (기본)
-- **데스크탑 바로가기**: 첫 부팅 시 Windows 바탕화면에 `\\tsclient\home` ("Home"), `\\tsclient\media` ("USB") 바로가기 자동 생성
-
-**GPU 가속:** 아직 미지원. dockur/windows 가 QEMU/KVM + 소프트웨어 그래픽으로 동작 — DirectX 무거운 게임 / 3D 앱은 CPU bound. VFIO 기반 GPU 패스스루는 가능하지만 패키징 안 됨. (GPU 필요한 경우 [winpodx vs Wine](#winpodx-vs-wine) 참조 — Wine + DXVK 가 정답.)
-
-</td><td width="50%">
-
-**자동화 및 보안**
-- 자동 일시정지/재개: 유휴 시 컨테이너 일시정지, 다음 실행 시 자동 재개
-- 비밀번호 자동 로테이션: 20자 암호학적 비밀번호, 7일 주기, 롤백 지원
-- 스마트 DPI 스케일링: GNOME, KDE, Sway, Hyprland, Cinnamon, xrdb 자동 감지
-- Qt6 시스템 트레이 + 전체 Qt6 메인 윈도우 (Apps / Settings / Tools / Terminal)
-- 멀티 백엔드: Podman (기본), Docker, libvirt/KVM, 수동 RDP
-- Windows 빌드 고정: 11 25H2 (`TargetReleaseVersionInfo=25H2`, 365일 기능 업데이트 연기)
-- Windows 디블로트: 텔레메트리, 광고, Cortana, 검색 인덱싱 및 서비스 (DiagTrack / dmwappushservice / WSearch / SysMain) 비활성화
-- 고성능 전원 관리 + 최대 절전 해제 + tzutil UTC + Cloudflare DNS 기본값
-- 시간 동기화: 호스트 sleep/wake 후 Windows 시계 강제 재동기화
-- FreeRDP `extra_flags` 허용 목록 (정규식 검증) — 사용자 입력 안전 경계
-
-</td></tr>
-</table>
-
-## 동작 방식
-
-```
-                     ┌─────────────────────────────┐
-  앱 메뉴에서          │     Linux 데스크톱 (KDE,      │
-  "Word" 클릭  ───>   │     GNOME, Sway, ...)       │
-                     └──────────────┬──────────────┘
-                                    │
-                     ┌──────────────▼──────────────┐
-                     │         winpodx             │
-                     │  ┌─────────────────────┐    │
-                     │  │ 자동 프로비저닝:       │    │
-                     │  │  설정 → 비밀번호       │    │
-                     │  │  → 컨테이너 → RDP     │    │
-                     │  │  → 데스크톱 엔트리     │    │
-                     │  └─────────────────────┘    │
-                     └──────────────┬──────────────┘
-                                    │ FreeRDP RemoteApp
-                     ┌──────────────▼──────────────┐
-                     │   Windows 컨테이너 (Podman)   │
-                     │   ┌──────────────────────┐  │
-                     │   │  Word  Excel  PPT ...│  │
-                     │   │ rdprrap 멀티세션       │  │
-                     │   └──────────────────────┘  │
-                     │   127.0.0.1:3390 (TLS)      │
-                     └─────────────────────────────┘
-```
-
-## GUI
-
-`winpodx gui` 명령으로 실행. Qt6 메인 윈도우는 4개 페이지로 구성되어 있습니다:
-
-| 페이지 | 내용 |
-|--------|------|
-| **Apps** | 설치된 앱 프로필 그리드 / 리스트 뷰, 검색 + 카테고리 필터, 앱별 3초 쿨다운 런치, 앱 프로필 Add / Edit / Delete 다이얼로그 |
-| **Settings** | RDP (사용자 / IP / 포트 / 스케일 / DPI / 비밀번호 로테이션) + Container (백엔드 / CPU / RAM / 유휴 타임아웃) 를 한 화면에 |
-| **Tools** | Suspend / Resume / Full Desktop 버튼, Clean Locks / Sync Time / Debloat, 그리고 Windows Update **enable / disable** 원클릭 토글 |
-| **Terminal** | 명령 허용 목록 (`podman`, `docker`, `virsh`, `winpodx`, `xfreerdp`, `systemctl`, `journalctl`, `ss`, `ip`, `ping`, ...) 으로 제한된 임베디드 셸. 빠른 버튼 제공 (Status / Logs / Inspect / RDP Test / Clear) |
-
-시스템 트레이 (`winpodx tray`) 는 경량 대안입니다 — 팟 제어, 앱 런처 서브메뉴 (상위 20개 + Full Desktop), 유지보수 서브메뉴 (Clean Locks / Sync Time / Suspend), 선택적 유휴 모니터 스레드.
-
-## 기술 스택
-
-| 레이어 | 기술 |
-|--------|------|
-| 언어 | Python 3.9+ (3.11+ 는 표준 라이브러리만; 3.9/3.10 은 `tomli` 폴백) |
-| CLI | argparse (표준 라이브러리) |
-| GUI (선택) | PySide6 (Qt6) |
-| 설정 | TOML (3.11+ 는 표준 라이브러리 `tomllib` / 3.9/3.10 은 `tomli`; 내장 writer) |
-| RDP | FreeRDP 3+ (xfreerdp, RemoteApp/RAIL) |
-| Guest agent | PowerShell `HttpListener` on `127.0.0.1:8765` (bearer auth, base64-encoded `/exec` payloads) |
-| 컨테이너 | Podman / Docker ([dockur/windows](https://github.com/dockur/windows)) |
-| VM | libvirt / KVM |
-| CI | GitHub Actions (lint + test on 3.9-3.13 + pip-audit) |
-
-## 빠른 시작
-
-### 설치
-
-**원 라인 설치** (지원하는 모든 Linux 배포판):
+원라인 (지원되는 모든 Linux distro):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
 ```
 
-배포판 자동 감지 → 누락된 시스템 의존성 (Podman, FreeRDP, KVM, Python 3.9+) 을
-사용자 확인 후 설치 → winpodx 를 `~/.local/bin/winpodx-app/` 에 배치 → 14개
-Windows 앱을 데스크탑 메뉴에 등록. 의존성 설치 단계 외에는 root 권한 불필요.
-openSUSE, Fedora, Debian/Ubuntu, RHEL 계열, Arch 지원.
-
-**오프라인 / 에어갭 설치** — 레지스트리 / 패키지 레포 접근이 없는 환경을 위해
-3개 플래그 제공:
+또는 네이티브 패키지 매니저:
 
 ```bash
-# git clone 대신 로컬 클론 경로 사용 (환경변수: WINPODX_SOURCE)
-./install.sh --source /media/usb/winpodx
-
-# 첫 부팅 시 registry pull 없이 Windows 이미지 tar 미리 로드 (환경변수: WINPODX_IMAGE_TAR)
-./install.sh --image-tar /media/usb/windows-image.tar
-
-# 배포판 의존성 설치 단계 스킵 (환경변수: WINPODX_SKIP_DEPS=1) — 필수 도구 부재 시 즉시 실패
-./install.sh --skip-deps
-
-# 셋 다 조합:
-./install.sh --source /media/usb/winpodx --image-tar /media/usb/windows-image.tar --skip-deps
-```
-
-환경변수는 `curl | bash` 에서도 동작하므로
-`WINPODX_SKIP_DEPS=1 curl ... | bash` 형태 사용 가능.
-
-**Nix** — NixOS / nix 사용자를 위한 flake 제공:
-
-```bash
-# 설치 없이 바로 실행
-nix run github:kernalix7/winpodx
-
-# 프로필에 설치
-nix profile install github:kernalix7/winpodx
-
-# flake input 으로 사용
-inputs.winpodx.url = "github:kernalix7/winpodx";
-```
-
-래퍼가 FreeRDP, podman / podman-compose, iproute2, libnotify 를 번들로
-포함하므로 기본 podman 백엔드는 추가 설정 없이 동작합니다. docker 및
-libvirt 백엔드는 해당 도구가 호스트에 별도 설치되어 있어야 합니다.
-
-**원 라인 삭제** — 파이프 실행에서는 `--confirm` 또는 `--purge` 플래그가 필수입니다
-(bash 가 curl 의 stdin 을 소비 중이라 대화형 프롬프트가 터미널을 읽을 수 없음):
-
-```bash
-# winpodx 파일만 삭제, Windows 컨테이너/데이터는 보존
-curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh | bash -s -- --confirm
-
-# 완전 제거: 컨테이너, 볼륨, 설정, 런처까지 전부
-curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh | bash -s -- --purge
-```
-
-배포판 패키지 매니저로 설치하려면? 모든
-[GitHub Release](https://github.com/kernalix7/winpodx/releases/latest)
-에 RPM / `.deb` / AUR 패키지가 자동 첨부됩니다. openSUSE/Fedora RPM 은
-[openSUSE Build Service (`home:Kernalix7/winpodx`)](https://build.opensuse.org/package/show/home:Kernalix7/winpodx)
-에서, 나머지는 GitHub Actions 에서 빌드/발행:
-
-**openSUSE Tumbleweed / Leap 15.6 / Leap 16.0 / Slowroll**
-
-```bash
-sudo zypper addrepo \
-  https://download.opensuse.org/repositories/home:/Kernalix7/openSUSE_Tumbleweed/home:Kernalix7.repo
-sudo zypper refresh
+# openSUSE Tumbleweed / Leap / Slowroll
+sudo zypper addrepo https://download.opensuse.org/repositories/home:/Kernalix7/openSUSE_Tumbleweed/home:Kernalix7.repo
 sudo zypper install winpodx
-```
 
-`openSUSE_Tumbleweed` 부분은 `openSUSE_Leap_16.0`, `openSUSE_Leap_15.6`,
-`openSUSE_Slowroll` 등으로 교체 가능.
-
-**Fedora 42 / 43**
-
-```bash
-sudo dnf config-manager --add-repo \
-  https://download.opensuse.org/repositories/home:/Kernalix7/Fedora_43/home:Kernalix7.repo
+# Fedora 42 / 43
+sudo dnf config-manager --add-repo https://download.opensuse.org/repositories/home:/Kernalix7/Fedora_43/home:Kernalix7.repo
 sudo dnf install winpodx
+
+# Debian / Ubuntu — 최신 release 에서 맞는 .deb 다운로드 후
+sudo apt install ./winpodx_0.5.0_all_debian13.deb
+
+# AlmaLinux / Rocky / RHEL 9 / 10 — 최신 release 에서 맞는 .rpm
+sudo dnf install ./winpodx-0.5.0-0.noarch.el10.rpm
+
+# Arch
+yay -S winpodx
+
+# Nix
+nix run github:kernalix7/winpodx
 ```
 
-**Debian 12 / 13, Ubuntu 24.04 / 25.04 / 25.10**
+오프라인 / 에어갭 빌드, 소스 설치, 버전 pin, 언인스톨은 [docs/INSTALL.ko.md](INSTALL.ko.md) 참조.
 
-[최신 Release](https://github.com/Kernalix7/winpodx/releases/latest) 에서
-본인 배포판에 맞는 `.deb` 를 다운받아 설치:
-
-```bash
-sudo apt install ./winpodx_<version>_all_debian13.deb   # 배포판에 맞게 선택
-```
-
-**AlmaLinux / Rocky / RHEL 9 & 10**
-
-el9 에서는 `python3-tomli` 때문에 EPEL 이 필요합니다.
-[최신 Release](https://github.com/Kernalix7/winpodx/releases/latest) 에서
-`.rpm` 을 받아 설치:
-
-```bash
-sudo dnf install epel-release                     # el9 만 필요
-sudo dnf install ./winpodx-<version>-1.noarch.el9.rpm   # 또는 .el10.rpm
-```
-
-**Arch Linux (AUR)**
-
-> 참고: AUR 자동 발행은 인프라만 준비되어 있고 메인테이너 1회 세팅이 완료되기
-> 전까지는 비활성 상태입니다 (자세한 절차는
-> [`packaging/aur/README.md`](../packaging/aur/README.md)). 활성화 이후에는
-> 태그 푸시마다 자동 발행됩니다.
-
-```bash
-yay -S winpodx        # 또는:
-paru -S winpodx
-```
-
-**소스에서 (개발용)**
-
-```bash
-git clone https://github.com/kernalix7/winpodx.git
-cd winpodx
-./install.sh
-```
-
-소스 설치 스크립트가 자동으로:
-1. 배포판 감지 (openSUSE, Fedora, Ubuntu, Arch, ...)
-2. 없는 의존성 설치 (Podman, FreeRDP, KVM), 설치 전 확인
-3. winpodx를 `~/.local/bin/winpodx-app/`에 복사
-4. 설정 및 compose.yaml 생성
-5. 첫 포드 부팅 시 자동 발견 (`winpodx app refresh`) 이 메뉴를 채움
-
-### 실행
+## 실행
 
 ```bash
 winpodx app run word              # Word 실행
-winpodx app run word ~/문서.docx   # 파일과 함께 실행
+winpodx app run word ~/doc.docx   # 파일 열기
 winpodx app run desktop           # 전체 Windows 데스크톱
 ```
 
-또는 앱 메뉴에서 아이콘을 클릭하세요.
+또는 그냥 애플리케이션 메뉴에서 앱 아이콘 클릭. 전체 CLI, Qt6 GUI, 헬스 체크, 설정은 [docs/USAGE.ko.md](USAGE.ko.md) 참조.
 
-### 직접 실행 (설치 없이)
+## 주요 기능
 
-```bash
-git clone https://github.com/kernalix7/winpodx.git
-cd winpodx
-export PYTHONPATH="$PWD/src"
-python3 -m winpodx app run word
-```
+- **Reverse-open (v0.5.0 신규).** Linux 앱이 Windows 게스트 우클릭 "Open with…" 메뉴에 기본으로 노출, 앱별 정확한 아이콘과 함께. 선택 시 호스트 `xdg-open` 으로 파일 열기 round-trip. ([상세](FEATURES.ko.md#reverse-open-linux-앱이-windows-open-with-에))
+- **매끄러운 앱 윈도.** FreeRDP RemoteApp 이 각 Windows 앱을 진짜 아이콘, 진짜 `WM_CLASS`, taskbar pin, 양방향 파일 연결과 함께 네이티브 Linux 윈도로 렌더링.
+- **제로 설정 실행.** 첫 앱 클릭이 모든 것 자동 프로비저닝: config, 컨테이너, desktop 엔트리. 첫 부팅 시 자동 discovery 가 실행 중인 Windows 게스트 스캔, 설치된 모든 앱 (Registry App Paths, Start Menu, UWP/MSIX, Chocolatey, Scoop) 을 실제 아이콘과 함께 등록.
+- **멀티세션 RDP.** bundled [rdprrap](https://github.com/kernalix7/rdprrap) 가 사용자당 단일 세션 제한 해제; 각 앱 윈도가 독립 세션, 최대 10 동시.
+- **자동 suspend / resume.** idle 시 컨테이너 pause, 다음 실행 시 resume.
+- **비밀번호 자동 회전.** 20자 암호학적 비밀번호, 7일 주기, atomic rollback.
+- **주변기기 즉시 동작.** 클립보드, 사운드, 프린터 리디렉션, 홈 디렉토리 공유, USB 드라이브 자동 매핑 — 모두 기본 활성.
+- **멀티 백엔드.** Podman (기본), Docker, libvirt/KVM, manual RDP.
+- **오프라인 / 에어갭 설치.** `--source` + `--image-tar` 로 네트워크 없이 설치 가능.
 
----
+자세한 deep dive 는 [docs/FEATURES.ko.md](FEATURES.ko.md) 에.
 
-## CLI 참조
+## 문서
 
-<details>
-<summary><b>전체 CLI 참조 펼치기</b></summary>
+| 문서 | 내용 |
+|----------|---------------|
+| [INSTALL.ko.md](INSTALL.ko.md) | 모든 설치 경로 — 원라인, 패키지 매니저, 오프라인, Nix, 소스 |
+| [USAGE.ko.md](USAGE.ko.md) | CLI 레퍼런스, Qt6 GUI 투어, 헬스 체크, 설정 파일 |
+| [FEATURES.ko.md](FEATURES.ko.md) | Reverse-open, 멀티세션 RDP, 주변기기, 앱 프로필, 자동 discovery |
+| [ARCHITECTURE.ko.md](ARCHITECTURE.ko.md) | 동작 방식 (다이어그램), 기술 스택, 소스 트리, 데이터 흐름 |
+| [COMPARISON.ko.md](COMPARISON.ko.md) | winpodx vs winapps / LinOffice / winboat, 그리고 winpodx vs Wine |
+| [CHANGELOG.ko.md](CHANGELOG.ko.md) | 전체 버전 이력 |
+| [CONTRIBUTING.ko.md](CONTRIBUTING.ko.md) | 개발 셋업 + 워크플로우 |
+| [SECURITY.ko.md](SECURITY.ko.md) | 보안 공개 프로세스 |
 
-```bash
-# 앱
-winpodx app list                  # 사용 가능한 앱 목록
-winpodx app run word              # Word 실행 (첫 실행 시 자동 프로비저닝)
-winpodx app run word ~/doc.docx   # 파일과 함께 실행
-winpodx app run desktop           # 전체 Windows 데스크톱 세션
-winpodx app install-all           # 전체 앱 데스크톱 메뉴 등록
-winpodx app sessions              # 활성 세션 확인
-winpodx app kill word             # 세션 종료
+## 지원 distro
 
-# 팟 관리
-winpodx pod start --wait          # 시작 + RDP 준비 대기
-winpodx pod stop                  # 정지 (활성 세션 경고)
-winpodx pod status                # 세션 수 포함 상태
-winpodx pod restart
-winpodx pod apply-fixes           # Windows 런타임 수정 재적용 (멱등)
-winpodx pod sync-password         # 비밀번호 drift 복구 (cfg ↔ Windows)
-winpodx pod multi-session on      # 번들 rdprrap 다중 세션 RDP 토글
-winpodx pod multi-session status
-winpodx pod wait-ready --logs     # Windows 첫 부팅 대기 (진행 + 컨테이너 로그)
+| Distro | 패키지 매니저 | 상태 |
+|--------|-----------------|--------|
+| openSUSE Tumbleweed / Leap 15.6 / Leap 16.0 / Slowroll | zypper | Tested |
+| Fedora 42 / 43 | dnf | Tested |
+| Debian 12 / 13, Ubuntu 24.04 / 25.04 / 25.10 | apt | Supported |
+| AlmaLinux / Rocky / RHEL 9 / 10 | dnf | Supported |
+| Arch / Manjaro | pacman / AUR | Supported |
+| NixOS (와 모든 distro 위의 Nix) | nix flake | Supported |
 
-# 전원 관리
-winpodx power --suspend           # 일시정지 (CPU 해제, 메모리 유지)
-winpodx power --resume            # 재개
-
-# 보안
-winpodx rotate-password           # Windows RDP 비밀번호 수동 변경
-
-# 유지보수
-winpodx cleanup                   # Office 잠금 파일 제거 (~$*.*)
-winpodx timesync                  # Windows 시간 강제 동기화
-winpodx debloat                   # 텔레메트리, 광고, 블로트 비활성화
-winpodx uninstall                 # winpodx 파일 제거 (컨테이너 유지)
-winpodx uninstall --purge         # 설정 포함 전체 제거
-
-# 시스템
-winpodx setup                     # 대화형 설정 위자드
-winpodx info                      # 디스플레이, 의존성, 설정 진단
-winpodx gui                       # Qt6 메인 윈도우 실행 (Apps / Settings / Tools / Terminal)
-winpodx tray                      # Qt 시스템 트레이 아이콘
-winpodx config show               # 현재 설정 확인
-winpodx config set rdp.scale 140  # 설정 값 변경
-winpodx config import             # 기존 winapps.conf 가져오기
-```
-
-</details>
-
-## 주변기기 및 공유
-
-| 기능 | 동작 방식 | 기본값 |
-|------|----------|--------|
-| **클립보드** | RDP를 통한 양방향 복사-붙여넣기 (`+clipboard`) | 활성화 |
-| **사운드** | ALSA를 통한 오디오 스트리밍 (`/sound:sys:alsa`) | 활성화 |
-| **프린터** | Linux 프린터를 Windows에 공유 (`/printer`) | 활성화 |
-| **홈 디렉토리** | `\\tsclient\home`으로 공유 (`+home-drive`) | 활성화 |
-| **USB 드라이브** | 미디어 폴더를 `\\tsclient\media`로 공유 (`/drive:media`); 세션 시작 후 꽂은 USB도 하위 폴더로 접근 가능 | 활성화 |
-| **USB 장치 패스스루** | 네이티브 USB 리다이렉션 (`/usb:auto`) — FreeRDP urbdrc 플러그인 필요 | **opt-in** (`extra_flags` 로 활성화) |
-| **USB 드라이브 매핑** | Windows 측 스크립트가 USB 하위 폴더를 드라이브 문자(E:, F:, ...)로 자동 매핑 (FileSystemWatcher) | 활성화 |
-
-### USB 드라이브 흐름
-
-```
-Linux에서 USB 꽂기
-    │
-    ▼
-Linux가 /run/media/$USER/USBNAME에 마운트
-    │
-    ▼
-FreeRDP가 \\tsclient\media\USBNAME으로 공유
-    │
-    ▼
-media_monitor.ps1이 감지 → net use E: \\tsclient\media\USBNAME
-    │
-    ▼
-Windows 탐색기에 E: 드라이브 표시
-```
-
-## 설정
-
-설정 파일: `~/.config/winpodx/winpodx.toml` (자동 생성, 0600 권한)
-
-```toml
-[rdp]
-user = "User"
-password = ""                # 자동 생성 랜덤 비밀번호
-password_updated = ""        # ISO 8601 타임스탬프
-password_max_age = 7         # 자동 변경 주기 (일, 0 = 비활성화)
-ip = "127.0.0.1"
-port = 3390
-scale = 100                  # DE에서 자동 감지
-dpi = 0                      # Windows DPI % (0 = 자동)
-extra_flags = ""             # 추가 FreeRDP 플래그 (허용 목록)
-
-[pod]
-backend = "podman"
-win_version = "11"                               # 11 | 10 | ltsc10 | tiny11 | tiny10
-cpu_cores = 4
-ram_gb = 4
-vnc_port = 8007
-auto_start = true                                # 앱 실행 시 자동 팟 시작
-idle_timeout = 0                                 # 자동 일시정지 (초, 0 = 비활성화)
-boot_timeout = 300                               # 최초 부팅 무인 설치 대기 시간 (초)
-image = "docker.io/dockurr/windows:latest"          # 컨테이너 이미지 (에어갭 미러 지정 가능)
-disk_size = "64G"                                # dockur 에 전달되는 가상 디스크 크기
-```
-
-## 앱 프로필
-
-앱 프로필은 **메타데이터 전용**입니다. winpodx 가 FreeRDP RemoteApp 으로 실행할 수 있도록 Windows 앱의 위치를 알려줄 뿐, 앱 자체가 아닙니다. 실제 Windows 앱은 Windows 컨테이너 안에 설치해야 합니다.
-
-### 자동 발견 (기본)
-
-v0.1.9 부터 winpodx 는 **번들 프로필을 더 이상 제공하지 않습니다**. Windows 포드 첫 부팅 직후 provisioner 가 `winpodx app refresh` 를 자동 실행하면 게스트를 스캔합니다:
-
-- Registry `App Paths` (`HKLM` + `HKCU`)
-- Start Menu `.lnk` 재귀 (depth 캡)
-- UWP / MSIX (`Get-AppxPackage` + `AppxManifest.xml`)
-- Chocolatey + Scoop shim
-
-각 결과에서 바이너리 (또는 UWP 패키지의 로고 자산) 직접 아이콘을 추출해 `~/.local/share/winpodx/discovered/<slug>/` 에 기록합니다. 언제든 재실행:
-
-```bash
-winpodx app refresh        # CLI
-# 또는 GUI Apps 페이지의 "Refresh Apps" 버튼 클릭
-```
-
-<details>
-<summary><b>커스텀 앱 프로필 수동 추가</b></summary>
-
-사용자 작성 프로필은 `~/.local/share/winpodx/apps/` 에 두면 같은 `name` 의 발견 결과를 덮어씁니다:
-
-```bash
-mkdir -p ~/.local/share/winpodx/apps/myapp
-cat > ~/.local/share/winpodx/apps/myapp/app.toml << 'EOF'
-name = "myapp"
-full_name = "My Application"
-executable = "C:\\Program Files\\MyApp\\myapp.exe"
-categories = ["Utility"]
-mime_types = []
-EOF
-
-winpodx app install myapp   # 데스크톱 메뉴에 등록
-```
-
-</details>
-
-## 멀티세션 RDP
-
-기본 Windows Desktop 에디션은 사용자당 RDP 세션 1개로 제한되며, 두 번째 앱을
-열면 기존 세션을 빼앗아 재연결됩니다. winpodx 는
-[rdprrap](https://github.com/kernalix7/rdprrap) — RDPWrap 의 Rust 재구현 —
-을 패키지 자체에 번들로 포함하며, Windows 무인 설치 단계에서 자동 적용해 각
-RemoteApp 창이 독립된 세션을 갖도록 만듭니다.
-
-**RAIL 전제 조건.** RemoteApp 자체가 동작하려면 3개의 레지스트리 값이
-필요하며, winpodx 는 무인 설치 중 이를 자동 적용합니다:
-`fDisabledAllowList=1` (RemoteApp 게시 활성화), `fInheritInitialProgram=1`
-(`/app:program:...` 가 셸 대신 지정한 실행 파일을 실행하도록),
-`MaxInstanceCount=10` + `fSingleSessionPerUser=0` (단일 세션 제한 해제,
-최대 10개 동시 RemoteApp 창). 이 키들은 rdprrap 설치 성공 여부와 무관하게
-적용됩니다 — rdprrap 은 세션을 *독립적*으로 만들어 주는 것이고, 레지스트리
-키는 RemoteApp 자체가 켜지게 만드는 부분입니다. rdprrap 설치 후 wrapper DLL
-활성화를 위해 `TermService` 를 재기동합니다 (재부팅 불필요).
-
-**인증 채널.** `podman unshare --rootless-netns` 내부에서 FreeRDP 가 무인
-인증을 수행할 수 있도록 NLA 를 비활성화 (`UserAuthentication=0`) 하지만,
-`SecurityLayer=2` 로 RDP 채널 자체는 TLS 로 암호화됩니다. 즉
-`127.0.0.1` 상대로 `/sec:tls /cert:ignore` 를 쓰는 구성이 "인증 + 암호화"
-완전 경로이며, NLA 가 꺼져 있더라도 평문이 와이어에 노출되지 않습니다.
-
-**완전 오프라인 동작.** rdprrap zip 은 winpodx 데이터 디렉토리
-(`config/oem/`) 안에 함께 배포되며, 게스트 최초 부팅 시 `C:\OEM\` 로
-스테이징됩니다. 핀 파일과 sha256 이 일치하는지 확인한 뒤에만 압축을 풉니다.
-설치 시점에 네트워크 접근은 필요하지 않습니다.
-
-설치는 1회성입니다. dockur 의 무인 설치 단계에서 패치가 적용되며, 그 단계에서
-문제가 생기더라도(해시 불일치, 압축 해제 실패, 설치기 오류) winpodx 는 경고만
-남기고 단일 세션 상태를 유지합니다. 앱 실행은 이 단계에서 블록되지 않습니다.
-게스트 측 관리 채널(설치 후 enable/disable/status)은 향후 릴리즈로 예정되어
-있습니다.
-
-## 설치 / 삭제
-
-```bash
-# 클론한 repo 에서:
-./install.sh                # 설치 (배포판 감지, 의존성 설치, 앱 등록)
-./uninstall.sh              # 삭제 (대화형, 단계별 확인)
-./uninstall.sh --confirm    # 삭제 (자동, 설정 보존)
-./uninstall.sh --purge      # 삭제 (설정 포함 전체 제거)
-
-# 또는 원 라인 (클론 불필요):
-curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh   | bash
-curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh | bash -s -- --confirm
-curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh | bash -s -- --purge
-```
-
-**삭제 시 winpodx 파일만 제거합니다.** 절대 건드리지 않는 것:
-- Podman 컨테이너/볼륨 (Windows VM 데이터)
-- 시스템 패키지 (podman, freerdp, python3)
-- 홈 디렉토리 파일
-
-## 프로젝트 구조
-
-```
-winpodx/
-├── install.sh             # 원라인 설치 (pip 불필요)
-├── uninstall.sh           # 깔끔한 삭제
-├── src/winpodx/
-│   ├── cli/               # argparse 명령 (app, pod, config, setup, ...)
-│   ├── core/              # 설정, RDP, 팟 생명주기, 프로비저너, 데몬
-│   ├── backend/           # Podman, Docker, libvirt, 수동
-│   ├── desktop/           # .desktop 엔트리, 아이콘, MIME, 트레이, 알림
-│   ├── display/           # X11/Wayland 감지, DPI 스케일링
-│   ├── gui/               # Qt6 메인 윈도우, 앱 다이얼로그, 테마
-│   └── utils/             # XDG 경로, 의존성, TOML writer, winapps 호환
-├── data/                  # winpodx GUI 데스크톱 엔트리 + 아이콘 + 설정 예시
-├── config/oem/            # Windows OEM 스크립트 (포스트인스톨)
-├── scripts/windows/       # PowerShell 스크립트 (디블로트, 시간 동기화, USB 매핑, 앱 발견)
-├── .github/workflows/     # CI: lint + test on 3.9-3.13 + pip-audit
-└── tests/                 # pytest 테스트 스위트 (411개 테스트)
-```
-
-## 지원 배포판
-
-| 배포판 | 패키지 매니저 | 상태 |
-|--------|-------------|------|
-| openSUSE Tumbleweed/Leap | zypper | 테스트됨 |
-| Fedora / RHEL / CentOS | dnf | 지원 |
-| Ubuntu / Debian / Mint | apt | 지원 |
-| Arch / Manjaro | pacman | 지원 |
+각 태그 푸시 (`v*.*.*`) 마다 모든 채널에 자동 publish — 메인테이너 상세는 [packaging/](../packaging/) 참조.
 
 ## 테스트
 
 ```bash
-# 저장소 루트에서 (설치 불필요)
+# 리포 루트에서 (설치 불필요)
 export PYTHONPATH="$PWD/src"
-python3 -m pytest tests/ -v    # 411개 테스트
-ruff check src/ tests/         # 린트
+python3 -m pytest tests/    # 1090+ 테스트
+ruff check src/ tests/      # 린트
+ruff format --check src/ tests/
 ```
 
 ## 기여
 
-개발 설정 및 워크플로우는 [CONTRIBUTING.ko.md](CONTRIBUTING.ko.md)를 참조하세요.
-
-## 릴리즈 및 패키징
-
-태그 (`v*.*.*`) 푸시 시 모든 지원 채널로 자동 배포됩니다:
-
-| 채널 | 배포판 |
-|------|--------|
-| RPM (openSUSE / Fedora / Slowroll) | Tumbleweed, Leap 15.6, Leap 16.0, Slowroll, Fedora 42/43 |
-| RPM (RHEL 계열) | AlmaLinux 9 / 10 (RHEL, Rocky, Oracle Linux 9/10 에도 설치 가능) |
-| `.deb` | Debian 12 / 13, Ubuntu 24.04 / 25.04 / 25.10 |
-| AUR | Arch Linux (활성화 이후 — [`packaging/aur/README.md`](../packaging/aur/README.md) 참조) |
-| `sdist` + `wheel` | PyPI 호환 소스/바이너리 배포판 |
-
-각 채널별 메인테이너 설정은 [`packaging/`](../packaging/) 아래에 있습니다:
-- [`packaging/obs/README.md`](../packaging/obs/README.md) — openSUSE Build Service (RPM 계열).
-- [`packaging/aur/README.md`](../packaging/aur/README.md) — Arch User Repository.
-- Debian/Ubuntu 및 AlmaLinux 빌드는 각자의 GitHub Actions 워크플로우에서 자체 완결되어 별도 설정 불필요.
+개발 셋업, 브랜치 명명, 커밋 컨벤션, CI 기대치는 [CONTRIBUTING.ko.md](CONTRIBUTING.ko.md) 참조.
 
 ## 보안
 
-보안 이슈는 [SECURITY.ko.md](SECURITY.ko.md)의 절차를 따라 주세요.
+보안 이슈는 [SECURITY.ko.md](SECURITY.ko.md) 의 프로세스 따르기.
 
 ## Star History
 
@@ -637,6 +160,17 @@ ruff check src/ tests/         # 린트
   </picture>
 </a>
 
+## 후원 / Support
+
+winpodx 가 Linux 데스크톱을 조금이라도 더 좋게 만들었다면:
+
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-F16061?logo=ko-fi&logoColor=white&style=for-the-badge)](https://ko-fi.com/kernalix7)
+[![Fairy](https://img.shields.io/badge/🧚_Fairy-EE6E73?style=for-the-badge&logoColor=white)](https://fairy.hada.io/@kernalix7)
+
+Ko-fi 는 해외 카드 / PayPal 결제; fairy.hada.io 는 국내 결제용.
+버그 리포트, PR, 별점도 환영합니다 —
+Bug reports, PRs, and stars on the repo are equally appreciated and free.
+
 ## 라이선스
 
-[MIT](LICENSE) - Kim DaeHyun (kernalix7@kodenet.io)
+[MIT](../LICENSE) — Kim DaeHyun (kernalix7@kodenet.io)

--- a/docs/USAGE.ko.md
+++ b/docs/USAGE.ko.md
@@ -1,0 +1,148 @@
+# 사용법
+
+[English](USAGE.md) | **한국어**
+
+CLI, GUI, 설정, 헬스 체크. 설치 후 필요한 모든 것.
+
+## 앱 실행
+
+```bash
+winpodx app run word              # Word 실행
+winpodx app run word ~/doc.docx   # 파일 열기
+winpodx app run desktop           # 전체 Windows 데스크톱
+```
+
+또는 그냥 애플리케이션 메뉴에서 앱 아이콘 클릭 — winpodx 가 pod 첫 부팅 시 발견된 모든 Windows 앱을 `.desktop` 엔트리로 등록함.
+
+## CLI 레퍼런스
+
+```bash
+# 앱
+winpodx app list                  # 사용 가능한 앱 목록
+winpodx app run word              # Word 실행 (첫 실행 시 자동 프로비저닝)
+winpodx app run word ~/doc.docx   # Word 에서 파일 열기
+winpodx app run desktop           # 전체 Windows 데스크톱 세션
+winpodx app install-all           # 모든 앱을 desktop 메뉴에 등록
+winpodx app sessions              # 활성 세션 표시
+winpodx app kill word             # 활성 세션 종료
+winpodx app refresh               # 게스트 재스캔 후 앱 목록 재구성
+
+# Pod 관리
+winpodx pod start --wait          # 시작 후 RDP 준비 대기
+winpodx pod stop                  # 중지 (활성 세션 있으면 경고)
+winpodx pod status                # 상태 + 세션 수
+winpodx pod restart
+winpodx pod apply-fixes           # Windows 측 런타임 fix 재적용 (idempotent)
+winpodx pod sync-password         # 비밀번호 drift 복구 (cfg ↔ Windows)
+winpodx pod multi-session on      # bundled rdprrap 멀티세션 RDP 토글
+winpodx pod multi-session status
+winpodx pod wait-ready --logs     # Windows 첫 부팅 대기 + 진행 + 컨테이너 로그
+
+# 전원 관리
+winpodx power --suspend           # 컨테이너 pause (CPU 해제, 메모리 유지)
+winpodx power --resume            # pause 된 컨테이너 resume
+
+# 보안
+winpodx rotate-password           # Windows RDP 비밀번호 회전
+
+# Reverse-open (host listener / guest sync)
+winpodx host-open status          # listener daemon + manifest 상태
+winpodx host-open list            # 발견된 호스트 앱 목록 (live 또는 --cached)
+winpodx host-open refresh         # 호스트 재스캔 + 게스트로 manifest push
+winpodx host-open enable          # reverse-open 켜기
+winpodx host-open disable         # reverse-open 끄기
+winpodx host-open add <slug>      # allowlist 에 앱 추가
+winpodx host-open remove <slug>   # allowlist 에서 제거 (또는 --deny)
+winpodx host-open start-listener
+winpodx host-open stop-listener
+winpodx host-open daemon-status
+
+# 유지보수
+winpodx cleanup                   # Office lock 파일 제거 (~$*.*)
+winpodx timesync                  # Windows 시간 강제 동기화
+winpodx debloat                   # 텔레메트리, 광고, bloat 비활성화
+winpodx uninstall                 # winpodx 파일 제거 (컨테이너 유지)
+winpodx uninstall --purge         # config 포함 전부 제거
+
+# 시스템
+winpodx setup                     # 대화형 설정 마법사
+winpodx info                      # 디스플레이, 의존성, config 진단
+winpodx check                     # 모든 헬스 프로브 실행 (pod / RDP / agent / disk / …)
+winpodx check --json              # 같은 프로브, machine-readable JSON
+winpodx gui                       # Qt6 메인 윈도 실행 (Apps / Settings / Tools / Terminal)
+winpodx tray                      # Qt 시스템 트레이 아이콘 실행
+winpodx config show               # 현재 config 표시
+winpodx config set rdp.scale 140  # config 값 변경
+winpodx config import             # 기존 winapps.conf import
+```
+
+## GUI
+
+`winpodx gui` 로 실행. Qt6 메인 윈도는 5개 페이지:
+
+| 페이지 | 동작 |
+|------|------|
+| **Apps** | 설치된 앱 프로필의 grid / list view, 검색 + 카테고리 필터, 앱별 실행 (3초 cooldown), Add / Edit / Delete 앱 프로필 다이얼로그 |
+| **Settings** | RDP (user / IP / port / scale / DPI / 비밀번호 회전), Container (backend / CPU / RAM / idle timeout), 그리고 reverse-open 패널 (enable 토글, allowlist + denylist, 라이브 daemon 상태, refresh / start / stop 버튼) 한 화면에 |
+| **Tools** | Suspend / Resume / Full Desktop 버튼, Clean Locks / Sync Time / Debloat, 그리고 원클릭 Windows Update **활성/비활성** 토글 |
+| **Terminal** | 명령 allowlist 제한된 embedded 셸 (`podman`, `docker`, `virsh`, `winpodx`, `xfreerdp`, `systemctl`, `journalctl`, `ss`, `ip`, `ping`, ...) + 퀵 버튼 (Status / Logs / Inspect / RDP Test / Clear) |
+| **Info** | 라이브 **Health** 카드 (pod / RDP / agent / OEM / disk / 비밀번호 age / 앱 수) + System / Display / Dependencies / Pod / Config 스냅샷 |
+
+시스템 트레이 (`winpodx tray`) 는 가벼운 대안 — pod 컨트롤, 앱 런처 서브메뉴 (상위 20 + Full Desktop), 유지보수 서브메뉴 (Clean Locks / Sync Time / Suspend), 선택적 idle-monitor 스레드.
+
+## 헬스 체크
+
+`winpodx check` 가 GUI Health 카드가 쓰는 모든 프로브를 실행하고 각각 한 줄 결과 출력:
+
+```
+=== winpodx check ===
+
+  [OK  ] pod_running        running (ip=127.0.0.1)  (58ms)
+  [OK  ] rdp_port           127.0.0.1:3390 reachable  (0ms)
+  [OK  ] agent_health       version=0.2.2-rev4  (63ms)
+  [OK  ] agent_auth_ready   bearer token available  (1ms)
+  [OK  ] oem_version        bundle=24  (3ms)
+  [OK  ] password_age       7d remaining (max_age=7d)  (0ms)
+  [OK  ] apps_discovered    41 app(s) in /home/.../discovered  (3ms)
+  [OK  ] disk_free          401.0/3725 GiB free  (0ms)
+
+Overall: OK
+```
+
+상태 범례: `OK` (녹색) / `WARN` (노랑 — 정보성, exit 0) / `FAIL` (빨강 — exit 1) / `SKIP` (회색 — config 로 비활성). machine-readable output 은 `--json`.
+
+## 설정
+
+설정 파일: `~/.config/winpodx/winpodx.toml` (자동 생성, `0600` 권한)
+
+```toml
+[rdp]
+user = "User"
+password = ""                # 자동 생성 랜덤 비밀번호
+password_updated = ""        # ISO 8601 timestamp
+password_max_age = 7         # 자동 회전까지 일수 (0 = 비활성)
+ip = "127.0.0.1"
+port = 3390
+scale = 100                  # DE 에서 자동 감지
+dpi = 0                      # Windows DPI % (0 = 자동)
+extra_flags = ""             # 추가 FreeRDP 플래그 (allowlist)
+
+[pod]
+backend = "podman"
+win_version = "11"                               # 11 | 10 | ltsc10 | tiny11 | tiny10
+cpu_cores = 4
+ram_gb = 4
+vnc_port = 8007
+auto_start = true                                # 앱 실행 시 pod 자동 시작
+idle_timeout = 0                                 # 자동 suspend 까지 초 (0 = 비활성)
+boot_timeout = 300                               # 첫 부팅 unattended 설치 대기 초
+image = "docker.io/dockurr/windows:latest"       # 컨테이너 이미지 (에어갭 미러용 override)
+disk_size = "64G"                                # dockur 에 전달하는 가상 디스크 크기
+
+[reverse_open]
+enabled = true                                   # v0.5.0 부터 기본 활성
+allow = []                                       # 비어있으면 발견된 모든 앱
+deny = []                                        # manifest 에서 제외할 앱
+```
+
+`winpodx config set <key> <value>` 또는 에디터로 직접 수정 — TOML 은 3.11+ 에서 stdlib (`tomli` on 3.9/3.10) 로 파싱.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,148 @@
+# Usage
+
+**English** | [한국어](USAGE.ko.md)
+
+CLI, GUI, configuration, and health checks. Everything you need after install.
+
+## Launch an app
+
+```bash
+winpodx app run word              # Launch Word
+winpodx app run word ~/doc.docx   # Open a file
+winpodx app run desktop           # Full Windows desktop
+```
+
+Or just click an app icon in your application menu — winpodx registers every discovered Windows app as a `.desktop` entry the first time the pod boots.
+
+## CLI reference
+
+```bash
+# Apps
+winpodx app list                  # List available apps
+winpodx app run word              # Launch Word (auto-provisions on first run)
+winpodx app run word ~/doc.docx   # Open a file in Word
+winpodx app run desktop           # Full Windows desktop session
+winpodx app install-all           # Register all apps in desktop menu
+winpodx app sessions              # Show active sessions
+winpodx app kill word             # Kill an active session
+winpodx app refresh               # Re-scan the guest and rebuild the app list
+
+# Pod management
+winpodx pod start --wait          # Start and wait for RDP readiness
+winpodx pod stop                  # Stop (warns about active sessions)
+winpodx pod status                # Status with session count
+winpodx pod restart
+winpodx pod apply-fixes           # Re-apply Windows-side runtime fixes (idempotent)
+winpodx pod sync-password         # Recover from password drift (cfg ↔ Windows)
+winpodx pod multi-session on      # Toggle bundled rdprrap multi-session RDP
+winpodx pod multi-session status
+winpodx pod wait-ready --logs     # Wait for Windows first-boot with progress + container logs
+
+# Power management
+winpodx power --suspend           # Pause container (free CPU, keep memory)
+winpodx power --resume            # Resume paused container
+
+# Security
+winpodx rotate-password           # Rotate Windows RDP password
+
+# Reverse-open (host listener / guest sync)
+winpodx host-open status          # Show listener daemon + manifest state
+winpodx host-open list            # List discovered host apps (live or --cached)
+winpodx host-open refresh         # Rescan host + push manifest to guest
+winpodx host-open enable          # Turn reverse-open on
+winpodx host-open disable         # Turn reverse-open off
+winpodx host-open add <slug>      # Add app to allowlist
+winpodx host-open remove <slug>   # Remove from allowlist (or --deny)
+winpodx host-open start-listener
+winpodx host-open stop-listener
+winpodx host-open daemon-status
+
+# Maintenance
+winpodx cleanup                   # Remove Office lock files (~$*.*)
+winpodx timesync                  # Force Windows time synchronization
+winpodx debloat                   # Disable telemetry, ads, bloat
+winpodx uninstall                 # Remove winpodx files (keeps container)
+winpodx uninstall --purge         # Remove everything including config
+
+# System
+winpodx setup                     # Interactive setup wizard
+winpodx info                      # Display, dependencies, config diagnostics
+winpodx check                     # Run all health probes (pod / RDP / agent / disk / …)
+winpodx check --json              # Same probes, machine-readable JSON
+winpodx gui                       # Launch Qt6 main window (Apps / Settings / Tools / Terminal)
+winpodx tray                      # Launch Qt system tray icon
+winpodx config show               # Show current config
+winpodx config set rdp.scale 140  # Change a config value
+winpodx config import             # Import existing winapps.conf
+```
+
+## GUI
+
+Launch with `winpodx gui`. The Qt6 main window has five pages:
+
+| Page | What it does |
+|------|--------------|
+| **Apps** | Grid / list view of installed app profiles, search + category filter, per-app launch with 3 s cooldown, Add / Edit / Delete app profile dialogs |
+| **Settings** | RDP (user / IP / port / scale / DPI / password rotation), Container (backend / CPU / RAM / idle timeout), and the reverse-open panel (enable toggle, allowlist + denylist, live daemon status, refresh / start / stop buttons) all in one screen |
+| **Tools** | Suspend / Resume / Full Desktop buttons, Clean Locks / Sync Time / Debloat, and a one-click Windows Update **enable / disable** toggle |
+| **Terminal** | Embedded shell limited to a command allowlist (`podman`, `docker`, `virsh`, `winpodx`, `xfreerdp`, `systemctl`, `journalctl`, `ss`, `ip`, `ping`, ...) with quick buttons (Status / Logs / Inspect / RDP Test / Clear) |
+| **Info** | Live **Health** card (pod / RDP / agent / OEM / disk / password age / app count) + System / Display / Dependencies / Pod / Config snapshot |
+
+The system tray (`winpodx tray`) is a lighter-weight alternative — pod controls, app launcher submenu (top 20 + Full Desktop), maintenance submenu (Clean Locks / Sync Time / Suspend), and an optional idle-monitor thread.
+
+## Health checks
+
+`winpodx check` runs every probe used by the GUI Health card and prints a one-line verdict for each:
+
+```
+=== winpodx check ===
+
+  [OK  ] pod_running        running (ip=127.0.0.1)  (58ms)
+  [OK  ] rdp_port           127.0.0.1:3390 reachable  (0ms)
+  [OK  ] agent_health       version=0.2.2-rev4  (63ms)
+  [OK  ] agent_auth_ready   bearer token available  (1ms)
+  [OK  ] oem_version        bundle=24  (3ms)
+  [OK  ] password_age       7d remaining (max_age=7d)  (0ms)
+  [OK  ] apps_discovered    41 app(s) in /home/.../discovered  (3ms)
+  [OK  ] disk_free          401.0/3725 GiB free  (0ms)
+
+Overall: OK
+```
+
+Status legend: `OK` (green) / `WARN` (yellow — informational, exit 0) / `FAIL` (red — exit 1) / `SKIP` (grey — disabled by config). Use `--json` for machine-readable output.
+
+## Configuration
+
+Config file: `~/.config/winpodx/winpodx.toml` (auto-created, `0600` permissions)
+
+```toml
+[rdp]
+user = "User"
+password = ""                # Auto-generated random password
+password_updated = ""        # ISO 8601 timestamp
+password_max_age = 7         # Days before auto-rotation (0 = disable)
+ip = "127.0.0.1"
+port = 3390
+scale = 100                  # Auto-detected from your DE
+dpi = 0                      # Windows DPI % (0 = auto)
+extra_flags = ""             # Additional FreeRDP flags (allowlisted)
+
+[pod]
+backend = "podman"
+win_version = "11"                               # 11 | 10 | ltsc10 | tiny11 | tiny10
+cpu_cores = 4
+ram_gb = 4
+vnc_port = 8007
+auto_start = true                                # Start pod automatically when launching an app
+idle_timeout = 0                                 # Seconds before auto-suspend (0 = disabled)
+boot_timeout = 300                               # Seconds to wait for first-boot unattended install
+image = "docker.io/dockurr/windows:latest"       # Container image (override for air-gapped mirror)
+disk_size = "64G"                                # Virtual disk size passed to dockur
+
+[reverse_open]
+enabled = true                                   # Default since v0.5.0
+allow = []                                       # Empty = all discovered apps
+deny = []                                        # Apps to exclude from the manifest
+```
+
+Edit via `winpodx config set <key> <value>` or directly with your editor — TOML is parsed via the stdlib on Python 3.11+ (`tomli` on 3.9/3.10).


### PR DESCRIPTION
## Summary

README is heavily restructured. The old 717-line "marketing brochure" is replaced with a 176-line entry point that links out to five focused documents under `docs/`. Stale facts from the v0.3.x era are updated to v0.5.0 reality. Reverse-open (the headline of v0.5.0) is given a proper section.

## Changes

- **README.md / docs/README.ko.md**: trimmed from 717 / 642 lines to 176 each. New structure: hero → status → quick install → launch → 9 key features → documentation index → supported distros → testing / contributing / security / star history / support / license.
- **New `docs/INSTALL.md` + `.ko.md`** (161 lines each) — all install paths (one-liner, package managers, offline, Nix, source, uninstall). Version refs updated `v0.1.9` → `v0.5.0`.
- **New `docs/USAGE.md` + `.ko.md`** (148 lines each) — CLI reference (now including `winpodx host-open` subcommands), Qt6 GUI tour, health checks, configuration with new `[reverse_open]` section.
- **New `docs/FEATURES.md` + `.ko.md`** (151 lines each) — opens with the reverse-open feature, then seamless app windows, zero-config launch, peripherals (now lists reverse-open as a peripheral row), automation & security, app profiles, multi-session RDP.
- **New `docs/ARCHITECTURE.md` + `.ko.md`** (87 lines each) — how it works diagram, tech stack (rcedit added), source tree (`reverse_open/` module + `config/oem/reverse-open/` added), key data flows (reverse-open flow added).
- **New `docs/COMPARISON.md` + `.ko.md`** (51 lines each) — winpodx vs winapps / LinOffice / winboat (with reverse-open row added — only winpodx has it), winpodx vs Wine.

## Test plan

- Internal link check passes — every `docs/*.md` link from README and README.ko resolves to an existing file.
- No code changes; pure docs.
