### PR TITLE
docs: README densify — 3-stanza install, key features quadrant, Fedora correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,14 @@
 <p>Native Linux windows for every Windows app — real icons, real <code>WM_CLASS</code>,<br>
 pin-to-taskbar. FreeRDP RemoteApp + dockur/windows. Zero config.</p>
 
-<pre><code>curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash</code></pre>
+<pre><code># Latest stable release (default)
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
+
+# Latest main HEAD (development; may be unstable)
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash -s -- --main
+
+# Uninstall (keeps Windows VM data; pass --purge to wipe everything)
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh | bash -s -- --confirm</code></pre>
 
 <a href="docs/images/demo.png">
   <img src="docs/images/demo.png" alt="winpodx in action — Windows apps as native Linux windows on KDE" width="720">
@@ -94,17 +101,69 @@ Or just click an app icon in your application menu. See [docs/USAGE.md](docs/USA
 
 ## Key features
 
-- **Reverse-open (new in v0.5.0).** Linux apps appear in the Windows guest's right-click "Open with…" menu by default, with correct per-app icons. Selecting one round-trips the file open to host `xdg-open`. ([details](docs/FEATURES.md#reverse-open-linux-apps-in-windows-open-with))
-- **Seamless app windows.** FreeRDP RemoteApp renders each Windows app as a native Linux window with its real icon, real `WM_CLASS`, taskbar pinning, and bidirectional file associations.
-- **Zero-config launch.** First app click auto-provisions everything: config, container, desktop entries. Auto-discovery scans the running Windows guest on first boot and registers every installed app (Registry App Paths, Start Menu, UWP/MSIX, Chocolatey, Scoop) with its real icon.
-- **Multi-session RDP.** Bundled [rdprrap](https://github.com/kernalix7/rdprrap) lifts the single-session-per-user cap; each app window runs in its own independent session, up to 10 concurrent.
-- **Auto suspend / resume.** Container pauses when idle, resumes on next launch.
-- **Password auto-rotation.** 20-char cryptographic password on a 7-day cycle with atomic rollback.
-- **Peripherals out of the box.** Clipboard, sound, printer redirection, home directory share, USB drive auto-mapping — all on by default.
-- **Multi-backend.** Podman (default), Docker, libvirt/KVM, manual RDP.
-- **Offline / air-gapped install.** `--source` + `--image-tar` lets you install without network access.
+<table>
+<tr><td width="50%">
 
-See [docs/FEATURES.md](docs/FEATURES.md) for the deep dives.
+**Reverse-open (new in v0.5.0)**
+- Linux apps appear in the Windows guest's right-click "Open with…" menu by default
+- Correct per-app icons in both the short menu and the long "Choose another app" dialog
+- Selecting one round-trips the file open to host `xdg-open`
+- Auto-discovers host-side Linux apps + their MIME associations from freedesktop standards
+- Manage via `winpodx host-open` CLI or the GUI Settings panel
+- [Details →](docs/FEATURES.md#reverse-open-linux-apps-in-windows-open-with)
+
+</td><td width="50%">
+
+**Seamless app windows**
+- RemoteApp (RAIL) renders each Windows app as a native Linux window — no full desktop
+- Per-app taskbar icons via `WM_CLASS` matching (`/wm-class:<stem>` + `StartupWMClass`)
+- Bidirectional file associations: double-click `.docx` in your file manager → Word opens
+- Multi-session RDP: bundled [rdprrap](https://github.com/kernalix7/rdprrap) auto-enables up to 10 independent sessions
+- RAIL prerequisites set automatically during unattended install
+
+</td></tr>
+<tr><td width="50%">
+
+**Zero-config launch**
+- First app click auto-provisions everything: config, container, desktop entries
+- Auto-discovery on first boot scans the running Windows guest and registers every installed app with its real icon (Registry App Paths, Start Menu, UWP/MSIX, Chocolatey, Scoop)
+- Manual rescan any time via `winpodx app refresh` or the GUI Refresh button
+- Multi-backend: Podman (default), Docker, libvirt/KVM, manual RDP
+
+</td><td width="50%">
+
+**Peripherals & sharing**
+- **Clipboard**: bidirectional copy-paste (text + images) — on by default
+- **Sound**: RDP audio streaming (`/sound:sys:alsa`) — on by default
+- **Printer**: Linux printers shared to Windows — on by default
+- **Home directory**: shared as `\\tsclient\home`
+- **USB drives**: auto-mapped to drive letters (E:, F:, …) via FileSystemWatcher; subfolders work for drives plugged in after session start
+- **USB device passthrough**: opt-in via `extra_flags` (`/usb:auto`)
+
+</td></tr>
+<tr><td width="50%">
+
+**Automation & security**
+- Auto suspend / resume: container pauses when idle, resumes on next launch
+- Password auto-rotation: 20-char cryptographic password, 7-day cycle with atomic rollback
+- Smart DPI scaling: auto-detects from GNOME, KDE, Sway, Hyprland, Cinnamon, xrdb
+- Windows debloat: telemetry, ads, Cortana, search indexing disabled by default
+- FreeRDP `extra_flags` allowlist (regex-validated) as the user-input safety boundary
+- Time sync: force Windows clock resync after host sleep/wake
+
+</td><td width="50%">
+
+**Operations & resilience**
+- Offline / air-gapped install (`--source` + `--image-tar`)
+- One-line uninstall (keeps Windows VM data unless `--purge`)
+- Health checks via `winpodx check` (pod / RDP / agent / disk / round-trip / password age)
+- Qt6 GUI: Apps / Settings / Tools / Terminal / Info pages — plus a lighter system tray
+- Stdlib-leaning Python (no pip-deps on 3.11+; one `tomli` fallback on 3.9 / 3.10)
+
+</td></tr>
+</table>
+
+See [docs/FEATURES.md](docs/FEATURES.md) for deep dives, including multi-session RDP internals, app profile schema, and the reverse-open architecture.
 
 ## Documentation
 
@@ -124,7 +183,7 @@ See [docs/FEATURES.md](docs/FEATURES.md) for the deep dives.
 | Distro | Package manager | Status |
 |--------|-----------------|--------|
 | openSUSE Tumbleweed / Leap 15.6 / Leap 16.0 / Slowroll | zypper | Tested |
-| Fedora 42 / 43 | dnf | Tested |
+| Fedora 42 / 43 | dnf | Supported |
 | Debian 12 / 13, Ubuntu 24.04 / 25.04 / 25.10 | apt | Supported |
 | AlmaLinux / Rocky / RHEL 9 / 10 | dnf | Supported |
 | Arch / Manjaro | pacman / AUR | Supported |
@@ -160,16 +219,14 @@ For security issues, follow the process in [SECURITY.md](SECURITY.md).
   </picture>
 </a>
 
-## Support / 후원
+## Support
 
 If winpodx makes your Linux desktop a little nicer:
 
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-F16061?logo=ko-fi&logoColor=white&style=for-the-badge)](https://ko-fi.com/kernalix7)
 [![Fairy](https://img.shields.io/badge/🧚_Fairy-EE6E73?style=for-the-badge&logoColor=white)](https://fairy.hada.io/@kernalix7)
 
-Ko-fi for international card / PayPal payments; fairy.hada.io 는 국내 결제용.
-Bug reports, PRs, and stars on the repo are equally appreciated and free —
-버그 리포트, PR, 별점도 환영합니다.
+Ko-fi handles international cards and PayPal; fairy.hada.io is a Korean tipping platform. Bug reports, PRs, and stars on the repo are equally appreciated and free.
 
 ## License
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -7,7 +7,14 @@
 <p>Windows 앱마다 네이티브 Linux 윈도 — 진짜 아이콘, 진짜 <code>WM_CLASS</code>,<br>
 태스크바 핀 가능. FreeRDP RemoteApp + dockur/windows. Zero config.</p>
 
-<pre><code>curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash</code></pre>
+<pre><code># 최신 안정 release (기본)
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
+
+# 최신 main HEAD (개발용, 불안정할 수 있음)
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash -s -- --main
+
+# 언인스톨 (Windows VM 데이터 유지; 전부 삭제는 --purge)
+curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh | bash -s -- --confirm</code></pre>
 
 <a href="images/demo.png">
   <img src="images/demo.png" alt="winpodx 실행 모습 — KDE 데스크톱 위에서 Windows 앱이 각각 네이티브 Linux 창으로" width="720">
@@ -94,17 +101,69 @@ winpodx app run desktop           # 전체 Windows 데스크톱
 
 ## 주요 기능
 
-- **Reverse-open (v0.5.0 신규).** Linux 앱이 Windows 게스트 우클릭 "Open with…" 메뉴에 기본으로 노출, 앱별 정확한 아이콘과 함께. 선택 시 호스트 `xdg-open` 으로 파일 열기 round-trip. ([상세](FEATURES.ko.md#reverse-open-linux-앱이-windows-open-with-에))
-- **매끄러운 앱 윈도.** FreeRDP RemoteApp 이 각 Windows 앱을 진짜 아이콘, 진짜 `WM_CLASS`, taskbar pin, 양방향 파일 연결과 함께 네이티브 Linux 윈도로 렌더링.
-- **제로 설정 실행.** 첫 앱 클릭이 모든 것 자동 프로비저닝: config, 컨테이너, desktop 엔트리. 첫 부팅 시 자동 discovery 가 실행 중인 Windows 게스트 스캔, 설치된 모든 앱 (Registry App Paths, Start Menu, UWP/MSIX, Chocolatey, Scoop) 을 실제 아이콘과 함께 등록.
-- **멀티세션 RDP.** bundled [rdprrap](https://github.com/kernalix7/rdprrap) 가 사용자당 단일 세션 제한 해제; 각 앱 윈도가 독립 세션, 최대 10 동시.
-- **자동 suspend / resume.** idle 시 컨테이너 pause, 다음 실행 시 resume.
-- **비밀번호 자동 회전.** 20자 암호학적 비밀번호, 7일 주기, atomic rollback.
-- **주변기기 즉시 동작.** 클립보드, 사운드, 프린터 리디렉션, 홈 디렉토리 공유, USB 드라이브 자동 매핑 — 모두 기본 활성.
-- **멀티 백엔드.** Podman (기본), Docker, libvirt/KVM, manual RDP.
-- **오프라인 / 에어갭 설치.** `--source` + `--image-tar` 로 네트워크 없이 설치 가능.
+<table>
+<tr><td width="50%">
 
-자세한 deep dive 는 [docs/FEATURES.ko.md](FEATURES.ko.md) 에.
+**Reverse-open (v0.5.0 신규)**
+- Linux 앱이 Windows 게스트 우클릭 "Open with…" 메뉴에 기본 노출
+- 짧은 메뉴 + 긴 "다른 앱 선택" 다이얼로그 양쪽에 앱별 정확한 아이콘
+- 선택 시 호스트 `xdg-open` 으로 파일 열기 round-trip
+- 호스트 측 Linux 앱 + MIME 연결을 freedesktop 표준에서 자동 발견
+- `winpodx host-open` CLI 또는 GUI Settings 패널로 관리
+- [상세 →](FEATURES.ko.md#reverse-open-linux-앱이-windows-open-with-에)
+
+</td><td width="50%">
+
+**매끄러운 앱 윈도**
+- RemoteApp (RAIL) 이 각 Windows 앱을 네이티브 Linux 윈도로 렌더링 — 전체 데스크톱 아님
+- `WM_CLASS` 매칭 통한 앱별 taskbar 아이콘 (`/wm-class:<stem>` + `StartupWMClass`)
+- 양방향 파일 연결: Linux 파일 관리자에서 `.docx` 더블클릭 → Word 가 열림
+- 멀티세션 RDP: bundled [rdprrap](https://github.com/kernalix7/rdprrap) 이 최대 10개 독립 세션 자동 활성화
+- RAIL 전제조건이 unattended 설치 중 자동 설정
+
+</td></tr>
+<tr><td width="50%">
+
+**제로 설정 실행**
+- 첫 앱 클릭이 모든 것 자동 프로비저닝: config, 컨테이너, desktop 엔트리
+- 첫 부팅 시 자동 discovery 가 실행 중인 Windows 게스트 스캔, 설치된 모든 앱 (Registry App Paths, Start Menu, UWP/MSIX, Chocolatey, Scoop) 을 실제 아이콘과 함께 등록
+- `winpodx app refresh` 또는 GUI Refresh 버튼으로 언제든 수동 재스캔
+- 멀티 백엔드: Podman (기본), Docker, libvirt/KVM, manual RDP
+
+</td><td width="50%">
+
+**주변기기 & 공유**
+- **클립보드**: 양방향 복사-붙여넣기 (텍스트 + 이미지) — 기본 활성
+- **사운드**: RDP 오디오 스트리밍 (`/sound:sys:alsa`) — 기본 활성
+- **프린터**: Linux 프린터가 Windows 에 공유 — 기본 활성
+- **홈 디렉토리**: `\\tsclient\home` 으로 공유
+- **USB 드라이브**: FileSystemWatcher 통한 드라이브 레터 (E:, F:, …) 자동 매핑; 세션 시작 후 꽂은 USB 도 서브폴더로 접근 가능
+- **USB 디바이스 패스스루**: `extra_flags` 에 `/usb:auto` 추가하면 opt-in
+
+</td></tr>
+<tr><td width="50%">
+
+**자동화 & 보안**
+- 자동 suspend / resume: idle 시 컨테이너 pause, 다음 실행 시 resume
+- 비밀번호 자동 회전: 20자 암호학적 비밀번호, 7일 주기, atomic rollback
+- 스마트 DPI 스케일링: GNOME, KDE, Sway, Hyprland, Cinnamon, xrdb 자동 감지
+- Windows debloat: 텔레메트리, 광고, Cortana, 검색 인덱싱 기본 비활성
+- FreeRDP `extra_flags` allowlist (regex 검증) 가 사용자 input 안전 경계
+- 시간 동기화: 호스트 sleep/wake 후 Windows 시계 강제 resync
+
+</td><td width="50%">
+
+**운영 & 회복력**
+- 오프라인 / 에어갭 설치 (`--source` + `--image-tar`)
+- 원라인 언인스톨 (Windows VM 데이터 유지; `--purge` 로 전부 삭제)
+- `winpodx check` 통한 헬스 체크 (pod / RDP / agent / disk / round-trip / 비밀번호 age)
+- Qt6 GUI: Apps / Settings / Tools / Terminal / Info 페이지 — 가벼운 시스템 트레이도 별도
+- stdlib 지향 Python (3.11+ 는 pip-deps 없음; 3.9 / 3.10 은 `tomli` 폴백 1개)
+
+</td></tr>
+</table>
+
+[docs/FEATURES.ko.md](FEATURES.ko.md) 에서 멀티세션 RDP 내부, 앱 프로필 스키마, reverse-open 아키텍처 등 자세한 deep dive 확인.
 
 ## 문서
 
@@ -124,7 +183,7 @@ winpodx app run desktop           # 전체 Windows 데스크톱
 | Distro | 패키지 매니저 | 상태 |
 |--------|-----------------|--------|
 | openSUSE Tumbleweed / Leap 15.6 / Leap 16.0 / Slowroll | zypper | Tested |
-| Fedora 42 / 43 | dnf | Tested |
+| Fedora 42 / 43 | dnf | Supported |
 | Debian 12 / 13, Ubuntu 24.04 / 25.04 / 25.10 | apt | Supported |
 | AlmaLinux / Rocky / RHEL 9 / 10 | dnf | Supported |
 | Arch / Manjaro | pacman / AUR | Supported |


### PR DESCRIPTION
## Summary

Follow-up to #173 (README overhaul). Two themes:

1. **Densify** — restores meat that was over-trimmed during the split.
2. **Correction** — fixes an unfounded "Tested" claim on Fedora.

## Changes

| Area | Before | After |
|---|---|---|
| Hero install block | One-liner `curl ... install.sh \| bash` | 3-stanza: stable / main / uninstall |
| Key Features section | 9 flat bullets | 2×3 quadrant table — Reverse-open, Seamless app windows, Zero-config launch, Peripherals & sharing, Automation & security, Operations & resilience |
| Supported distros (Fedora row) | "Tested" (unfounded) | "Supported" — only openSUSE has actually been smoke-tested |
| English README Support section | Mixed Korean / English captions | English-only; Korean prose stays in `docs/README.ko.md` |

## Why the Fedora correction matters

The "Tested" claim conflated "OBS publishes for Fedora_42 / Fedora_43" (which is just a build success) with "the maintainer has actually run winpodx on Fedora end-to-end" (which has not happened). Only openSUSE Tumbleweed has had real smoke testing from the maintainer.

## Test plan

- No code changes; pure docs.
- Internal links unchanged; previous link-check still applies.
