### PR TITLE
docs: CHANGELOG Highlights format + release notes guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,39 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+<!--
+Template for each new version section — copy this stanza when cutting a release.
+Keep `### Highlights` at the very top: it is the first thing users see on the
+GitHub release page because `release.yml`'s awk extract takes the whole section
+verbatim.
+
+### Highlights
+
+**One-sentence headline.** Optional 1-2 sentence elaboration if needed.
+
+- Most important user-visible change (one line, scannable)
+- Second most important change
+- (3-6 bullets max, no prose blocks)
+
+### Added
+### Changed
+### Fixed
+-->
+
 ## [0.5.0] - 2026-05-13
 
 Reverse-open (#48) ships end-to-end and is the headline feature of this release. Linux apps now appear in the Windows guest's right-click "Open with…" menu by default — no opt-in flag, no Settings toggle required — with correct per-app icons in both the short menu and the long "Choose another app" dialog. Phase 2 series complete (a / b / c / d), plus the full fix-forward stack: per-app `.cmd` wrappers, Rust `.exe` shim, short-menu visibility, Firefox handoff, uninstall `--purge` scope, multi-resolution ICOs, Desktop folder shortcut + Quick Access pin, and the embedded-EXE-icon chooser fix.
 
 The chooser icon problem deserves a callout: Win10/Win11 Explorer reads chooser entry icons from the .exe's embedded PE resource, not from `Applications\<exe>\DefaultIcon` nor from a per-slug ProgID's `\DefaultIcon`. PR #171 ships the only path that actually works — embed the per-slug `.ico` directly into each per-slug `.exe` via vendored rcedit (electron/rcedit v2.0.0, MIT). PR #165's hard-link inode-sharing optimisation is intentionally dropped (~500 KB × N apps on disk) since there is no chooser-icon path that also preserves shared inodes on stock Windows.
+
+### Highlights
+
+**Reverse-open ships end-to-end (#48).** Linux apps now appear in the Windows guest's right-click "Open with…" menu by default, with correct per-app icons in both chooser surfaces. Selecting one round-trips the file open back to the host's `xdg-open`.
+
+- Reverse-open Phase 2 series complete (#157, #159, #160, #161, #162) — host-side discovery, listener daemon, Qt Settings card, guest handlers + sync transport, default-on.
+- Reverse-open fix-forward stack (#164–#171) from real-Windows smoke — culminating in #171's embedded EXE icons via vendored rcedit (the working chooser-icon fix).
+- PR #165's hard-link inode-sharing is intentionally dropped (~500 KB × N apps on disk); no chooser-icon path also preserves shared inodes on Win10/Win11.
+- `cfg.reverse_open.enabled` defaults to `True`; turn off with `winpodx host-open disable` or the GUI Settings panel.
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,43 @@ You wrote the patch — the human author of record is you. AI tooling doesn't ge
 
 Human co-authors (e.g., a colleague who pair-programmed with you on the change) are fine and welcome — those should use real human identities + emails.
 
+## Writing release notes
+
+Each version section in `CHANGELOG.md` (and `docs/CHANGELOG.ko.md`) starts with `### Highlights` — a one-sentence headline followed by 3–6 scannable bullets. This is what users see at the top of the GitHub release page: `release.yml` extracts the version's section verbatim, so the first thing in the section is the first thing in the release body.
+
+The detailed `### Added` / `### Changed` / `### Fixed` bullets follow underneath. They're for archeology and exhaustive tracking, not first-read.
+
+Skeleton:
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Highlights
+
+**One-sentence headline.** Optional 1-2 sentence elaboration if needed.
+
+- Most important user-visible change (one line, scannable)
+- Second most important change
+- (3-6 bullets max; no prose blocks)
+
+### Added
+- (detailed bullets)
+
+### Changed
+- (detailed bullets)
+
+### Fixed
+- (detailed bullets)
+```
+
+When cutting a release, also push the `REL-vX.Y.Z` marker tag — this is what fires `release.yml` (which builds the `wheel` + `sdist`, extracts the CHANGELOG section, and updates the GitHub release body). Without the REL- marker, the version tag (`vX.Y.Z`) triggers only the four packaging workflows (`obs-publish.yml`, `rhel-publish.yml`, `debs-publish.yml`, `aur-publish.yml`) but no `wheel` / `sdist` and no auto-extracted release body.
+
+```bash
+git tag vX.Y.Z <commit>
+git tag REL-vX.Y.Z vX.Y.Z^{}    # dereference to commit to avoid a nested-tag warning
+git push origin vX.Y.Z REL-vX.Y.Z
+```
+
 ## Security
 
 If you discover a security vulnerability, please follow the process described in [SECURITY.md](SECURITY.md). **Do NOT open a public issue.**

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,11 +9,38 @@
 
 ## [Unreleased]
 
+<!--
+새 버전 섹션 템플릿 — 릴리스 컷할 때 이 형식을 복사하세요.
+`### Highlights` 는 반드시 맨 위 — `release.yml` 의 awk 추출이 섹션 전체를
+verbatim 으로 가져오기 때문에 GitHub 릴리스 페이지에서 사용자가 가장 먼저 보는 곳.
+
+### Highlights
+
+**한 줄 헤드라인.** 필요시 1-2 문장 추가 컨텍스트.
+
+- 가장 중요한 사용자 가시적 변경 (한 줄, 스캔 가능)
+- 두 번째 중요한 변경
+- (최대 3-6 bullets, prose 블록 금지)
+
+### Added
+### Changed
+### Fixed
+-->
+
 ## [0.5.0] - 2026-05-13
 
 Reverse-open (#48) 이 end-to-end 출시 — 이 릴리스의 headline 기능. Linux 앱이 Windows guest 우클릭 "Open with…" 메뉴에 기본으로 노출되고, **짧은 메뉴 + 긴 "다른 앱 선택" 다이얼로그 양쪽에 앱별 아이콘이 정상 표시**됨. Phase 2 시리즈 완료 (a / b / c / d) + 전체 fix-forward 스택: per-app `.cmd` wrapper, Rust `.exe` shim, 짧은 메뉴 가시성, Firefox handoff, uninstall `--purge` scope, multi-resolution ICO, Desktop 폴더 단축키 + Quick Access 핀, 그리고 embedded-EXE-icon chooser 수정.
 
 Chooser 아이콘 문제에 대한 부연: Win10/Win11 Explorer 는 chooser entry 아이콘을 EXE 의 embedded PE resource 에서만 읽고, `Applications\<exe>\DefaultIcon` 도 per-slug ProgID 의 `\DefaultIcon` 도 무시함. PR #171 이 유일하게 동작하는 경로 — per-slug `.ico` 를 per-slug `.exe` 의 PE resource 에 직접 embed (vendored rcedit, electron/rcedit v2.0.0, MIT). PR #165 의 hard-link inode 공유 최적화는 의도적으로 폐기 (~500 KB × N 앱 디스크) — Win10/Win11 에서 chooser 아이콘과 inode 공유를 동시에 유지하는 경로는 없음.
+
+### Highlights
+
+**Reverse-open 이 end-to-end 출시 (#48).** Linux 앱이 Windows 게스트 우클릭 "Open with…" 메뉴에 기본으로 노출, 양쪽 chooser surface 에서 앱별 정확한 아이콘. 선택 시 호스트 `xdg-open` 으로 파일 열기 round-trip.
+
+- Reverse-open Phase 2 시리즈 완료 (#157, #159, #160, #161, #162) — host 측 discovery, listener daemon, Qt Settings 카드, guest handler + sync transport, default-on.
+- Reverse-open fix-forward 스택 (#164–#171) 이 real-Windows smoke 거치고 — 최종 #171 의 vendored rcedit 통한 EXE embed 아이콘 (동작하는 chooser-icon fix) 으로 마무리.
+- PR #165 의 hard-link inode 공유는 의도적으로 폐기 (~500 KB × N 앱 디스크); Win10/Win11 에서 chooser 아이콘과 공유 inode 를 동시 유지하는 경로 없음.
+- `cfg.reverse_open.enabled` 기본값 `True`; 끄려면 `winpodx host-open disable` 또는 GUI Settings 패널.
 
 ### 추가
 

--- a/docs/CONTRIBUTING.ko.md
+++ b/docs/CONTRIBUTING.ko.md
@@ -86,6 +86,43 @@ chore: update ruff to 0.8.x
 
 사람 co-author (예: 변경 사항을 함께 페어 프로그래밍한 동료) 는 환영 — 실제 사람 정체성 + 이메일 사용.
 
+## 릴리스 노트 작성
+
+`CHANGELOG.md` (그리고 `docs/CHANGELOG.ko.md`) 의 각 버전 섹션은 `### Highlights` 로 시작합니다 — 한 줄 헤드라인 + 3–6 개 스캔 가능한 bullet. 이것이 GitHub 릴리스 페이지 맨 위에 보이는 내용입니다. `release.yml` 이 해당 버전 섹션을 verbatim 으로 추출해서 릴리스 body 에 넣기 때문에, 섹션 맨 앞에 있는 게 릴리스 본문 맨 앞에 옴.
+
+자세한 `### Added` / `### Changed` / `### Fixed` bullet 은 그 아래에. archeology 와 exhaustive tracking 용이지 first-read 용이 아님.
+
+스켈레톤:
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Highlights
+
+**한 줄 헤드라인.** 필요시 1-2 문장 추가 컨텍스트.
+
+- 가장 중요한 사용자 가시적 변경 (한 줄, 스캔 가능)
+- 두 번째 중요한 변경
+- (최대 3-6 bullets; prose 블록 금지)
+
+### Added
+- (자세한 bullet)
+
+### Changed
+- (자세한 bullet)
+
+### Fixed
+- (자세한 bullet)
+```
+
+릴리스 컷할 때 `REL-vX.Y.Z` marker tag 도 같이 푸시 — 이것이 `release.yml` 을 fire 시킴 (`wheel` + `sdist` 빌드, CHANGELOG 섹션 추출, GitHub 릴리스 body 갱신). REL- marker 없으면 버전 태그 (`vX.Y.Z`) 가 4개 패키징 워크플로우 (`obs-publish.yml`, `rhel-publish.yml`, `debs-publish.yml`, `aur-publish.yml`) 만 trigger 하고 `wheel` / `sdist` 없음 + 자동 추출 릴리스 body 없음.
+
+```bash
+git tag vX.Y.Z <commit>
+git tag REL-vX.Y.Z vX.Y.Z^{}    # nested-tag 경고 피하려고 commit 으로 dereference
+git push origin vX.Y.Z REL-vX.Y.Z
+```
+
 ## 보안
 
 보안 취약점을 발견한 경우, [SECURITY.ko.md](SECURITY.ko.md)에 설명된 절차를 따라 주세요. **공개 이슈를 열지 마세요.**


### PR DESCRIPTION
## Summary

Establishes a scannable release-notes format. The v0.5.0 release notes were a wall of text because `release.yml` extracts the CHANGELOG version section verbatim, and that section had only dense `### Added` bullets. This adds a `### Highlights` subsection at the top of each version section that release.yml naturally surfaces first.

## Changes

- **`CHANGELOG.md` / `docs/CHANGELOG.ko.md`**: `[Unreleased]` template now shows the new shape (Highlights → Added → Changed → Fixed). `[0.5.0]` gains a Highlights subsection (one-line headline + 4 scannable bullets) sitting between the prose intro and the existing `### Added` detail bullets.
- **`CONTRIBUTING.md` / `docs/CONTRIBUTING.ko.md`**: new "Writing release notes" section documents the format + the `REL-vX.Y.Z` marker tag step (push both `vX.Y.Z` and `REL-vX.Y.Z`; skipping REL- means no `wheel` + `sdist` and no auto release body — discovered on v0.5.0).

## Test plan

- No code changes; pure docs.
- Future releases following the template will produce scannable GitHub release bodies automatically (release.yml's awk extract unchanged).
