### PR TITLE
feat(arm64): host support for aarch64 Linux (Phase 1+2+3 of #141)

### DIFF
--- a/.github/workflows/check-windows-updates.yml
+++ b/.github/workflows/check-windows-updates.yml
@@ -15,31 +15,47 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check latest dockur Windows image
+      - name: Check latest dockur Windows images
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # x86_64 Windows image (dockur/windows)
           DOCKUR_LATEST=$(gh api repos/dockur/windows/releases/latest --jq '.tag_name' 2>/dev/null || echo "unknown")
           echo "dockur_latest=$DOCKUR_LATEST" >> "$GITHUB_OUTPUT"
 
+          # ARM Windows image (dockur/windows-arm) — pulled in by aarch64
+          # hosts via core/config.py:_default_pod_image. See #141.
+          DOCKUR_ARM_LATEST=$(gh api repos/dockur/windows-arm/releases/latest --jq '.tag_name' 2>/dev/null || echo "unknown")
+          echo "dockur_arm_latest=$DOCKUR_ARM_LATEST" >> "$GITHUB_OUTPUT"
+
           VERSION_FILE="config/oem/VERSIONS.txt"
           DOCKUR_CURRENT=""
+          DOCKUR_ARM_CURRENT=""
           if [ -f "$VERSION_FILE" ]; then
             DOCKUR_CURRENT=$(grep "^dockur=" "$VERSION_FILE" | cut -d= -f2 || echo "")
+            DOCKUR_ARM_CURRENT=$(grep "^dockur-arm=" "$VERSION_FILE" | cut -d= -f2 || echo "")
           fi
 
-          NEEDS_UPDATE=false
+          NEEDS_UPDATE_X86=false
           if [ "$DOCKUR_LATEST" != "$DOCKUR_CURRENT" ] && [ "$DOCKUR_LATEST" != "unknown" ]; then
-            NEEDS_UPDATE=true
+            NEEDS_UPDATE_X86=true
             echo "dockur/windows: ${DOCKUR_CURRENT:-none} -> $DOCKUR_LATEST"
           fi
 
-          echo "needs_update=$NEEDS_UPDATE" >> "$GITHUB_OUTPUT"
-          echo "dockur_current=$DOCKUR_CURRENT" >> "$GITHUB_OUTPUT"
+          NEEDS_UPDATE_ARM=false
+          if [ "$DOCKUR_ARM_LATEST" != "$DOCKUR_ARM_CURRENT" ] && [ "$DOCKUR_ARM_LATEST" != "unknown" ]; then
+            NEEDS_UPDATE_ARM=true
+            echo "dockur/windows-arm: ${DOCKUR_ARM_CURRENT:-none} -> $DOCKUR_ARM_LATEST"
+          fi
 
-      - name: Open tracking issue
-        if: steps.check.outputs.needs_update == 'true'
+          echo "needs_update_x86=$NEEDS_UPDATE_X86" >> "$GITHUB_OUTPUT"
+          echo "needs_update_arm=$NEEDS_UPDATE_ARM" >> "$GITHUB_OUTPUT"
+          echo "dockur_current=$DOCKUR_CURRENT" >> "$GITHUB_OUTPUT"
+          echo "dockur_arm_current=$DOCKUR_ARM_CURRENT" >> "$GITHUB_OUTPUT"
+
+      - name: Open x86_64 tracking issue
+        if: steps.check.outputs.needs_update_x86 == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKUR_LATEST: ${{ steps.check.outputs.dockur_latest }}
@@ -58,15 +74,58 @@ jobs:
           gh issue create \
             --title "$TITLE" \
             --body "$(cat <<EOF
-          ## Windows Build Update
+          ## Windows Build Update (x86_64)
 
           **dockur/windows**: ${DOCKUR_CURRENT:-unknown} → $DOCKUR_LATEST
 
           ### Action items
           1. Update \`config/oem/VERSIONS.txt\` → \`dockur=$DOCKUR_LATEST\`
-          2. Recreate container to pick up the new Windows build
-          3. Check if \`TargetReleaseVersionInfo\` in \`config/oem/install.bat\` needs updating
+          2. Pull the new image and refresh \`DOCKUR_IMAGE_PIN\` in \`src/winpodx/core/config.py\`:
+             \`\`\`
+             podman pull docker.io/dockurr/windows:latest
+             podman image inspect docker.io/dockurr/windows:latest -f '{{json .RepoDigests}}'
+             \`\`\`
+          3. Recreate container to pick up the new Windows build
+          4. Check if \`TargetReleaseVersionInfo\` in \`config/oem/install.bat\` needs updating
 
           Release notes: https://github.com/dockur/windows/releases/tag/$DOCKUR_LATEST
+          EOF
+          )"
+
+      - name: Open aarch64 tracking issue
+        if: steps.check.outputs.needs_update_arm == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKUR_ARM_LATEST: ${{ steps.check.outputs.dockur_arm_latest }}
+          DOCKUR_ARM_CURRENT: ${{ steps.check.outputs.dockur_arm_current }}
+        run: |
+          TITLE="chore: dockur/windows-arm update available ($DOCKUR_ARM_LATEST)"
+
+          EXISTING=$(gh issue list \
+            --search "$TITLE in:title is:open" \
+            --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$EXISTING" ]; then
+            echo "Issue #$EXISTING already tracks this update, skipping"
+            exit 0
+          fi
+
+          gh issue create \
+            --title "$TITLE" \
+            --body "$(cat <<EOF
+          ## Windows Build Update (aarch64)
+
+          **dockur/windows-arm**: ${DOCKUR_ARM_CURRENT:-unknown} → $DOCKUR_ARM_LATEST
+
+          ### Action items
+          1. Update \`config/oem/VERSIONS.txt\` → \`dockur-arm=$DOCKUR_ARM_LATEST\`
+          2. Pull the new image and refresh \`DOCKUR_IMAGE_ARM_PIN\` in \`src/winpodx/core/config.py\`:
+             \`\`\`
+             podman pull docker.io/dockurr/windows-arm:latest
+             podman image inspect docker.io/dockurr/windows-arm:latest -f '{{json .RepoDigests}}'
+             \`\`\`
+          3. Recreate container on an aarch64 host to pick up the new Windows-on-ARM build
+          4. Check if \`TargetReleaseVersionInfo\` in \`config/oem/install.bat\` needs updating
+
+          Release notes: https://github.com/dockur/windows-arm/releases/tag/$DOCKUR_ARM_LATEST
           EOF
           )"

--- a/config/oem/VERSIONS.txt
+++ b/config/oem/VERSIONS.txt
@@ -4,3 +4,4 @@
 #
 # Format: <key>=<version>
 dockur=v5.14
+dockur-arm=v5.14

--- a/install.sh
+++ b/install.sh
@@ -135,6 +135,32 @@ detect_distro() {
 DISTRO=$(detect_distro)
 log "Detected distro: $DISTRO"
 
+# Detect host architecture. winpodx ships two dockur image variants:
+#
+#   x86_64  → dockurr/windows (x86_64 Windows guest, native via KVM)
+#   aarch64 → dockurr/windows-arm (Windows-on-ARM guest, native via KVM)
+#
+# core/config.py:_default_pod_image picks the matching image on a fresh
+# install. install.sh only logs the detected arch here for visibility —
+# the image picker fires inside `winpodx setup` later.
+ARCH="$(uname -m)"
+case "$ARCH" in
+    x86_64|amd64)
+        ARCH_LABEL="x86_64"
+        ;;
+    aarch64|arm64)
+        ARCH_LABEL="aarch64"
+        ;;
+    *)
+        ARCH_LABEL="$ARCH"
+        warn "Untested host architecture: $ARCH"
+        warn "winpodx is packaged for x86_64 and aarch64. The container image"
+        warn "picker will fall through to the x86_64 default; pod start will"
+        warn "likely fail at QEMU. Proceed only if you know what you're doing."
+        ;;
+esac
+log "Detected arch: $ARCH_LABEL"
+
 # Map generic dependency names to distro-specific package names
 pkg_name() {
     local dep="$1"

--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -90,10 +90,22 @@ def _update_image_pin() -> int:
         print(f"`{backend}` not found in PATH.")
         return 2
 
-    print("Pulling docker.io/dockurr/windows:latest...")
+    # Pick the upstream tag matching host architecture. aarch64 hosts
+    # (Raspberry Pi 5, Ampere, Graviton, …) get the Windows-on-ARM
+    # image; everything else gets the x86_64 build. See
+    # ``core/config.py:_default_pod_image`` for the matching rule on
+    # fresh installs.
+    import platform as _platform
+
+    if _platform.machine() == "aarch64":
+        upstream_tag = "docker.io/dockurr/windows-arm:latest"
+    else:
+        upstream_tag = "docker.io/dockurr/windows:latest"
+
+    print(f"Pulling {upstream_tag}...")
     try:
         subprocess.run(
-            [backend, "pull", "docker.io/dockurr/windows:latest"],
+            [backend, "pull", upstream_tag],
             check=True,
         )
     except subprocess.CalledProcessError as e:
@@ -110,7 +122,7 @@ def _update_image_pin() -> int:
                 backend,
                 "image",
                 "inspect",
-                "docker.io/dockurr/windows:latest",
+                upstream_tag,
                 "-f",
                 "{{json .RepoDigests}}",
             ],

--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -8,6 +8,7 @@ section drives the agent-first install flow (see
 
 from __future__ import annotations
 
+import platform
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -44,6 +45,34 @@ DOCKUR_IMAGE_PIN = (
     "docker.io/dockurr/windows@sha256:"
     "20b398ab935465f97ec8ab06489f7a85a5ad58e74e036ce66cc3c9172e7dbea8"
 )
+
+# Pinned dockur/windows-arm image — used as the default ``cfg.pod.image``
+# when the host architecture is aarch64. The image runs Windows 11 ARM
+# inside the container; on ARM64 hosts (e.g. Raspberry Pi 5) KVM
+# accelerates the guest natively. The pinned digest is the multi-arch
+# OCI index, so container runtimes pick the right platform manifest
+# (amd64 or arm64) automatically.
+#
+# As of 2026-05-13:
+DOCKUR_IMAGE_ARM_PIN = (
+    "docker.io/dockurr/windows-arm@sha256:"
+    "9c13f28f484bdf129fb8d951efb3fe3ff0cff20828efa5ed4b62ff1597a62611"
+)
+
+
+def _default_pod_image() -> str:
+    """Pick the dockur image pin matching the host architecture.
+
+    ``platform.machine()`` returns ``aarch64`` on ARM64 Linux hosts
+    (Raspberry Pi 5, Ampere Altra, Graviton, etc.); ``x86_64`` on
+    Intel/AMD. Everything else falls through to the x86_64 pin —
+    winpodx isn't packaged for those platforms but the fall-through
+    means an unexpected arch won't crash config load; it just installs
+    the wrong image and the user gets a clear QEMU error at pod start.
+    """
+    if platform.machine() == "aarch64":
+        return DOCKUR_IMAGE_ARM_PIN
+    return DOCKUR_IMAGE_PIN
 
 
 @dataclass
@@ -91,7 +120,13 @@ class PodConfig:
     # dockur can override to a tag in ``winpodx.toml``; explicit
     # update is via ``winpodx setup --update-image`` (pulls latest +
     # rewrites the pin).
-    image: str = DOCKUR_IMAGE_PIN
+    #
+    # Default is arch-aware (``_default_pod_image``): x86_64 hosts get
+    # ``dockurr/windows`` (x86_64 Windows guest), aarch64 hosts get
+    # ``dockurr/windows-arm`` (Windows-on-ARM guest). The picker only
+    # fires for fresh installs — existing ``winpodx.toml`` files have
+    # an explicit ``image`` line and round-trip unchanged.
+    image: str = field(default_factory=_default_pod_image)
     # Virtual disk size exposed in the compose template (e.g. "64G", "128G").
     disk_size: str = "64G"
     # Maximum concurrent RemoteApp sessions. Writes
@@ -132,7 +167,7 @@ class PodConfig:
             # Fall back silently so a hand-edited config does not brick setup.
             self.container_name = _DEFAULT_CONTAINER_NAME
         if not isinstance(self.image, str) or not self.image.strip():
-            self.image = DOCKUR_IMAGE_PIN
+            self.image = _default_pod_image()
         if not isinstance(self.disk_size, str) or not self.disk_size.strip():
             self.disk_size = "64G"
         # storage_path: keep empty (named-volume mode) or coerce to a

--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import platform
 import secrets
 import shutil
 import string
@@ -52,7 +53,7 @@ name: "winpodx"
       LANGUAGE: "English"
       REGION: "en-001"
       KEYBOARD: "en-US"
-      ARGUMENTS: "-cpu host,arch_capabilities=off"
+      ARGUMENTS: "{qemu_arguments}"
       USER_PORTS: "8765"
     volumes:
       - {storage_mount}
@@ -89,6 +90,22 @@ def _build_compose_template(backend: str) -> str:
         template += _COMPOSE_PODMAN_EXTRAS
     template += _COMPOSE_TEMPLATE_FOOTER
     return template
+
+
+def _qemu_arguments_for_host() -> str:
+    """Return the QEMU ``ARGUMENTS:`` value matching the host architecture.
+
+    On x86_64 we pass ``arch_capabilities=off`` so QEMU doesn't expose
+    Intel-CPU-only capability bits the guest's Windows kernel sometimes
+    trips over. On aarch64 (Raspberry Pi 5, Ampere, Graviton, …) that
+    sub-option doesn't exist — passing it crashes QEMU with
+    ``Property 'host-arm-cpu.arch_capabilities' not found`` (issue
+    #140). On aarch64 we pass only ``-cpu host`` and let QEMU pick the
+    default ARM capability mask.
+    """
+    if platform.machine() == "aarch64":
+        return "-cpu host"
+    return "-cpu host,arch_capabilities=off"
 
 
 def _yaml_escape(val: str) -> str:
@@ -241,6 +258,7 @@ def _build_compose_content(cfg: Config) -> str:
         oem_dir=_find_oem_dir(),
         top_volumes=top_volumes,
         storage_mount=storage_mount,
+        qemu_arguments=_qemu_arguments_for_host(),
     )
 
 

--- a/tests/test_audit5_core.py
+++ b/tests/test_audit5_core.py
@@ -293,20 +293,48 @@ def test_check_freerdp_reports_missing(monkeypatch):
 # M8 / M9
 
 
-def test_pod_config_image_and_disk_size_defaults():
+def test_pod_config_image_and_disk_size_defaults(monkeypatch):
+    """Default image is arch-aware: x86_64 hosts get DOCKUR_IMAGE_PIN."""
+    import winpodx.core.config as _config
     from winpodx.core.config import DOCKUR_IMAGE_PIN
 
+    monkeypatch.setattr(_config.platform, "machine", lambda: "x86_64")
     pod = PodConfig()
     assert pod.image == DOCKUR_IMAGE_PIN
     assert pod.disk_size == "64G"
 
 
-def test_pod_config_image_and_disk_size_fallback_on_empty():
+def test_pod_config_image_defaults_arm_on_aarch64(monkeypatch):
+    """On aarch64 hosts the default image switches to dockur/windows-arm.
+
+    Regression guard for issue #141 Phase 1.
+    """
+    import winpodx.core.config as _config
+    from winpodx.core.config import DOCKUR_IMAGE_ARM_PIN
+
+    monkeypatch.setattr(_config.platform, "machine", lambda: "aarch64")
+    pod = PodConfig()
+    assert pod.image == DOCKUR_IMAGE_ARM_PIN
+
+
+def test_pod_config_image_and_disk_size_fallback_on_empty(monkeypatch):
+    import winpodx.core.config as _config
     from winpodx.core.config import DOCKUR_IMAGE_PIN
 
+    monkeypatch.setattr(_config.platform, "machine", lambda: "x86_64")
     pod = PodConfig(image="", disk_size="   ")
     assert pod.image == DOCKUR_IMAGE_PIN
     assert pod.disk_size == "64G"
+
+
+def test_pod_config_image_fallback_on_empty_arm(monkeypatch):
+    """Empty-string image fallback honours host arch on aarch64 too."""
+    import winpodx.core.config as _config
+    from winpodx.core.config import DOCKUR_IMAGE_ARM_PIN
+
+    monkeypatch.setattr(_config.platform, "machine", lambda: "aarch64")
+    pod = PodConfig(image="", disk_size="   ")
+    assert pod.image == DOCKUR_IMAGE_ARM_PIN
 
 
 def test_pod_config_image_and_disk_size_persist(tmp_path, monkeypatch):

--- a/tests/test_compose_arch.py
+++ b/tests/test_compose_arch.py
@@ -1,0 +1,60 @@
+"""Architecture-aware compose template generation tests.
+
+Issue #141 Phase 2: the QEMU ``ARGUMENTS:`` value must differ between
+x86_64 and aarch64 hosts. On x86_64 we pass
+``-cpu host,arch_capabilities=off``; on aarch64 the ``arch_capabilities``
+sub-option doesn't exist and crashes QEMU at boot (issue #140), so we
+emit only ``-cpu host``.
+"""
+
+from __future__ import annotations
+
+import winpodx.core.config as _config_module
+import winpodx.core.pod.compose as _compose_module
+from winpodx.core.config import Config
+from winpodx.core.pod.compose import _build_compose_content
+
+
+def _cfg() -> Config:
+    cfg = Config()
+    cfg.pod.backend = "podman"
+    cfg.rdp.user = "User"
+    cfg.rdp.password = "TestPassword1!"
+    cfg.rdp.port = 3390
+    cfg.pod.vnc_port = 8007
+    cfg.pod.container_name = "winpodx-windows"
+    return cfg
+
+
+def test_compose_arguments_x86_64(monkeypatch):
+    """x86_64 hosts emit ``-cpu host,arch_capabilities=off``."""
+    monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
+    content = _build_compose_content(_cfg())
+    assert 'ARGUMENTS: "-cpu host,arch_capabilities=off"' in content
+
+
+def test_compose_arguments_aarch64(monkeypatch):
+    """aarch64 hosts emit ``-cpu host`` only (no arch_capabilities).
+
+    Regression guard for issue #140: passing ``arch_capabilities=off`` on
+    aarch64 crashes QEMU with ``Property 'host-arm-cpu.arch_capabilities'
+    not found``.
+    """
+    monkeypatch.setattr(_compose_module.platform, "machine", lambda: "aarch64")
+    monkeypatch.setattr(_config_module.platform, "machine", lambda: "aarch64")
+    content = _build_compose_content(_cfg())
+    assert 'ARGUMENTS: "-cpu host"' in content
+    assert "arch_capabilities" not in content
+
+
+def test_compose_arguments_unknown_arch_falls_through_to_x86(monkeypatch):
+    """Unknown / unexpected machine() value falls through to the x86_64
+    behaviour. This is intentional: an unsupported platform should get the
+    "wrong" arguments and surface a clear QEMU error at pod start rather
+    than silently using a partially-correct ARM config.
+    """
+    monkeypatch.setattr(_compose_module.platform, "machine", lambda: "riscv64")
+    monkeypatch.setattr(_config_module.platform, "machine", lambda: "riscv64")
+    content = _build_compose_content(_cfg())
+    assert 'ARGUMENTS: "-cpu host,arch_capabilities=off"' in content


### PR DESCRIPTION
## Summary

Closes the immediate blocker reported in #140 (Raspberry Pi 5 install failure) and lands Phases 1, 2, 3 of the ARM64 roadmap (#141).

## Changes

- **Phase 1 — arch-aware image selection.** `core/config.py` ships a new `DOCKUR_IMAGE_ARM_PIN` (pinned to the multi-arch OCI index `sha256:9c13f2…` for `dockurr/windows-arm:latest` as of 2026-05-13). `PodConfig.image` default is now `field(default_factory=_default_pod_image)` which returns the ARM pin on `aarch64` hosts and the x86_64 pin otherwise. The empty-string fallback in `PodConfig.__post_init__` also routes through `_default_pod_image()`. `cli/setup_cmd._pull_and_pin_image` pulls the right upstream tag based on `platform.machine()`.
- **Phase 2 — arch-aware compose template.** The QEMU `ARGUMENTS:` value is now a `{qemu_arguments}` placeholder, filled by `_qemu_arguments_for_host()`. x86_64 keeps `-cpu host,arch_capabilities=off`; aarch64 emits only `-cpu host` (the `arch_capabilities` sub-option is x86-only and triggers `Property 'host-arm-cpu.arch_capabilities' not found` on aarch64 — #140's exact symptom).
- **Phase 3 — install.sh arch detection.** Adds `ARCH=$(uname -m)` + normalised `ARCH_LABEL` (`x86_64` / `aarch64`) with a clear log line and a warning for untested architectures.
- **Upstream watcher** (`.github/workflows/check-windows-updates.yml`) gains a second check for `dockur/windows-arm` releases; opens a separate tracking issue with arm-specific action items.
- **VERSIONS.txt** adds `dockur-arm=v5.14` (matches current `dockur/windows-arm` latest tag).
- **Tests**: 5 new — image default arch parametrization + 3 compose `ARGUMENTS` regression tests covering x86_64 / aarch64 / unknown-arch fall-through.

## What this PR does NOT cover

Phases 4–7 of #141 (OEM bundle on arm64 Windows guest, CI build matrix aarch64, packaging arm64, real Pi 5 smoke) — those need actual aarch64 hardware and are tracked separately.

## Test plan

- [x] `pytest tests/` — 1096 passed (+5 new ARM-aware tests), 1 skipped.
- [x] `ruff check src/ tests/` + `ruff format --check` clean.
- [ ] Real-Pi5 smoke (requested from reporter @tslpre in #140; needs aarch64 hardware).
