### PR TITLE
ci: add aarch64 regression-catch job (#141 Phase 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,21 @@ jobs:
       - run: ruff format --check src/ tests/
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        runner: ["ubuntu-latest"]
+        include:
+          # aarch64 regression catch — winpodx ships arch-aware code paths
+          # (image picker in core/config.py, compose ARGUMENTS in
+          # core/pod/compose.py, install.sh arch detection) for ARM64
+          # Linux hosts per #141. The x86_64 matrix covers all 5 Python
+          # versions; we keep aarch64 minimal at the latest Python only
+          # so the regression check is fast + cheap. GitHub Actions
+          # provides free aarch64 runners for public repos since 2024.
+          - python-version: "3.13"
+            runner: "ubuntu-24.04-arm"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

Adds an aarch64 regression-catch job to CI. Follow-up to #176 (ARM64 host support Phase 1+2+3).

Background: `.deb` and `.rpm` packages are already arch-independent (`Architecture: all` / `BuildArch: noarch`), so the existing `winpodx_0.5.0_all_debian13.deb` / `winpodx-0.5.0-43.1.noarch.Fedora_42.rpm` already install cleanly on Pi 5 and other aarch64 Linux hosts. The remaining piece from #141 Phase 5 is CI coverage.

## Change

Single matrix entry added to the `test` job: `python-version: "3.13"` on `ubuntu-24.04-arm`. The five existing x86_64 jobs (Python 3.9–3.13) stay as-is. Total CI footprint goes from 5 → 6 test jobs.

GitHub Actions provides free aarch64 Linux runners for public repos since 2024 (`ubuntu-24.04-arm`).

## Why minimal (one Python version on aarch64, not full matrix)

The arch-aware code paths (`core/config.py` image picker, `core/pod/compose.py` ARGUMENTS, `install.sh` arch detection) are already covered by `platform.machine()` mocking on x86_64 CI. The aarch64 runner is purely a defence-in-depth check for genuine architecture-specific bugs (rare stdlib differences, native-module behaviour, etc.). One Python version at the latest stable is enough to catch those.

## Test plan

- No code changes; pure CI config.
- After merge, the next push to `main` should trigger 6 test jobs (visible in Actions UI).
