### PR TITLE
fix(discovery): skip reverse-open shims when scanning Windows apps

### DIFF
--- a/scripts/windows/discover_apps.ps1
+++ b/scripts/windows/discover_apps.ps1
@@ -242,8 +242,16 @@ function Add-Result {
     if (-not $name -or -not $path) { return }
     if ($name.Length -gt $MAX_NAME_LEN) { return }
     if ($path.Length -gt $MAX_PATH_LEN) { return }
+    # Reverse-open shims (#48 / v0.5.0) live under
+    # C:\Users\Public\winpodx\reverse-open\bin\. They are Windows .exe
+    # entries created by winpodx itself to surface Linux host apps in
+    # the Windows "Open with..." menu and must not be returned as
+    # Windows apps. Match the directory fragment rather than the full
+    # path so a future layout change still catches the entries.
+    $pathLower = $path.ToLower()
+    if ($pathLower -like '*\winpodx\reverse-open\bin\*') { return }
     $key = if ($Entry.launch_uri) { ([string]$Entry.launch_uri).ToLower() }
-           else { $path.ToLower() }
+           else { $pathLower }
     if ($seen.ContainsKey($key)) { return }
     $seen[$key] = $true
     $results.Add([ordered]@{

--- a/src/winpodx/core/discovery/__init__.py
+++ b/src/winpodx/core/discovery/__init__.py
@@ -134,13 +134,29 @@ def _is_junk_entry(name: str, executable: str, source: str) -> bool:
     """Return True when a discovered entry should be hidden as junk.
 
     Filters by display-name patterns (uninstall / setup / redist / …),
-    by executable basename (vcredist, crashpad_handler, …), and — for
-    UWP — by detection of unresolved PackageFamilyName fallbacks where
+    by executable basename (vcredist, crashpad_handler, …), by
+    reverse-open shim path (winpodx's own Linux-app-into-Windows
+    bridge — must not be re-imported as Windows apps), and — for UWP
+    — by detection of unresolved PackageFamilyName fallbacks where
     the display name still looks like a dotted identifier
     (``Microsoft.AAD.BrokerPlugin``) rather than a real human label.
     """
     name_stripped = name.strip()
     if not name_stripped:
+        return True
+
+    # Reverse-open shims (#48 / v0.5.0) are Windows .exe entries
+    # created by winpodx itself to surface Linux host apps in the
+    # Windows "Open with…" menu — they are not Windows apps and must
+    # not be re-imported as such. The check runs before the name /
+    # basename filters so older guest-side scripts that didn't filter
+    # them out still get caught here. The directory comes from
+    # ``reverse_open.sync._GUEST_BIN_DIR`` (single source of truth)
+    # via ``is_guest_shim_path`` — locally-imported to avoid a hot
+    # module-level cycle.
+    from winpodx.reverse_open.sync import is_guest_shim_path
+
+    if is_guest_shim_path(executable):
         return True
 
     for pattern in _JUNK_NAME_PATTERNS:
@@ -1026,6 +1042,12 @@ def persist_discovered(
     root = target_dir if target_dir is not None else discovered_apps_dir()
     root.mkdir(parents=True, exist_ok=True)
 
+    # Self-heal: earlier winpodx builds (before this fix) could re-import
+    # reverse-open shims as Windows apps on discovery, leaving polluted
+    # entries under discovered/. Sweep them now so this run cleans up
+    # after the bug — users don't need a manual `rm -rf` step.
+    _purge_reverse_open_entries(root)
+
     # Hybrid filter step — guarantee essentials are present (synthesizing
     # stubs when the scan missed them) before we touch disk. Tests can
     # opt out via ``add_essentials=False`` to keep their fixtures
@@ -1254,6 +1276,37 @@ def _validate_png_stdlib(data: bytes) -> bool:
         return saw_ihdr and saw_iend
     except (struct.error, ValueError, IndexError):
         return False
+
+
+def _purge_reverse_open_entries(root: Path) -> None:
+    """Remove any existing per-app subdir whose app.toml points at a reverse-open shim.
+
+    Heals the pre-fix state where the discovery scan returned the
+    winpodx-installed reverse-open .exe shims as Windows apps. The
+    canonical shim directory is owned by ``reverse_open.sync`` and
+    queried via ``is_guest_shim_path`` so this sweep stays in sync
+    with the install layout if it ever moves.
+
+    Failure is non-fatal: a broken TOML or unreadable file is skipped,
+    and the next discovery refresh retries.
+    """
+    from winpodx.reverse_open.sync import is_guest_shim_path
+
+    if not root.exists():
+        return
+    for child in root.iterdir():
+        if not child.is_dir():
+            continue
+        toml_path = child / "app.toml"
+        if not toml_path.is_file():
+            continue
+        try:
+            data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError):
+            continue
+        if is_guest_shim_path(str(data.get("executable", ""))):
+            log.info("Purging stale reverse-open entry from discovered/: %s", child.name)
+            _safe_rmtree(child, root)
 
 
 def _safe_rmtree(path: Path, root: Path) -> None:

--- a/src/winpodx/reverse_open/sync.py
+++ b/src/winpodx/reverse_open/sync.py
@@ -65,6 +65,27 @@ _GUEST_RCEDIT_EXE = _GUEST_BIN_DIR + r"\rcedit.exe"
 _GUEST_REGISTER_PS1 = _GUEST_BASE + r"\register-apps.ps1"
 _GUEST_UNREGISTER_PS1 = _GUEST_BASE + r"\unregister-apps.ps1"
 
+
+def is_guest_shim_path(executable: str) -> bool:
+    """Return True if ``executable`` points inside the guest reverse-open bin dir.
+
+    Single source of truth for the question "is this Windows .exe one of
+    our reverse-open shims, or a real Windows app?". Used by the discovery
+    junk-filter (``core.discovery._is_junk_entry``) and the discovery
+    self-heal sweep (``core.discovery._purge_reverse_open_entries``) so
+    those callers don't hardcode the directory layout — they import this
+    function instead, and any future relocation of ``_GUEST_BIN_DIR``
+    propagates without code churn.
+
+    The match is case-insensitive and accepts forward-slash variants so
+    a guest scanner that emitted POSIX-style paths is still caught.
+    """
+    if not executable:
+        return False
+    needle = (_GUEST_BIN_DIR + "\\").replace("/", "\\").lower()
+    return needle in executable.replace("/", "\\").lower()
+
+
 # Host-bundle layout for the assets we push to the guest. The two
 # PowerShell scripts are text; the shim is a Rust-built Windows .exe
 # shipped pre-compiled in the source tree (the build matrix produces

--- a/tests/test_discovery/test_discovery.py
+++ b/tests/test_discovery/test_discovery.py
@@ -30,7 +30,9 @@ from winpodx.core.discovery import (
     DiscoveredApp,
     DiscoveryError,
     _entry_to_discovered,
+    _is_junk_entry,
     _parse_discovery_output,
+    _purge_reverse_open_entries,
     _safe_rmtree,
     _slugify_name,
     _sniff_icon_ext,
@@ -538,6 +540,98 @@ def test_persist_rejects_unsafe_slug(tmp_path):
     written = persist_discovered([bad], target_dir=tmp_path, add_essentials=False)
     assert written == []
     assert not (tmp_path / "has space").exists()
+
+
+# --- reverse-open shim filter ---------------------------------------------
+
+
+def test_is_junk_entry_rejects_reverse_open_shim():
+    # Reverse-open shims live at C:\Users\Public\winpodx\reverse-open\bin\
+    # and must never be re-imported as Windows apps.
+    assert _is_junk_entry(
+        "Firefox",
+        "C:\\Users\\Public\\winpodx\\reverse-open\\bin\\winpodx-firefox.exe",
+        "win32",
+    )
+    # Case-insensitive: a guest scanner that lowercased or uppercased the path
+    # must still be filtered.
+    assert _is_junk_entry(
+        "Firefox",
+        "c:\\users\\public\\WinPodX\\Reverse-Open\\bin\\winpodx-firefox.exe",
+        "win32",
+    )
+    # Forward-slash variant (just in case a guest scanner emits POSIX paths).
+    assert _is_junk_entry(
+        "Firefox",
+        "C:/Users/Public/winpodx/reverse-open/bin/winpodx-firefox.exe",
+        "win32",
+    )
+
+
+def test_is_junk_entry_accepts_real_windows_app():
+    assert not _is_junk_entry("Notepad", "C:\\Windows\\System32\\notepad.exe", "win32")
+    assert not _is_junk_entry("Firefox", "C:\\Program Files\\Mozilla Firefox\\firefox.exe", "win32")
+
+
+def test_purge_reverse_open_entries_removes_polluted(tmp_path):
+    polluted = tmp_path / "firefox"
+    polluted.mkdir()
+    shim = "C:\\\\Users\\\\Public\\\\winpodx\\\\reverse-open\\\\bin\\\\winpodx-firefox.exe"
+    (polluted / "app.toml").write_text(
+        f'name = "firefox"\nfull_name = "Firefox"\nexecutable = "{shim}"\nsource = "win32"\n',
+        encoding="utf-8",
+    )
+    # And a real Windows app entry that should survive.
+    real = tmp_path / "notepad"
+    real.mkdir()
+    (real / "app.toml").write_text(
+        'name = "notepad"\nfull_name = "Notepad"\nexecutable = "C:\\\\Windows\\\\notepad.exe"\n',
+        encoding="utf-8",
+    )
+
+    _purge_reverse_open_entries(tmp_path)
+    assert not polluted.exists()
+    assert real.exists()
+
+
+def test_purge_reverse_open_entries_skips_when_root_missing(tmp_path):
+    # No-op on missing root; must not raise.
+    _purge_reverse_open_entries(tmp_path / "does-not-exist")
+
+
+def test_purge_reverse_open_entries_tolerates_broken_toml(tmp_path):
+    broken = tmp_path / "broken"
+    broken.mkdir()
+    (broken / "app.toml").write_text("garbage = [unterminated", encoding="utf-8")
+    polluted = tmp_path / "polluted"
+    polluted.mkdir()
+    (polluted / "app.toml").write_text(
+        'executable = "C:\\\\Users\\\\Public\\\\winpodx\\\\reverse-open\\\\bin\\\\winpodx-x.exe"\n',
+        encoding="utf-8",
+    )
+
+    _purge_reverse_open_entries(tmp_path)
+    # Broken stays (we cannot prove it is reverse-open).
+    assert broken.exists()
+    # Polluted is gone.
+    assert not polluted.exists()
+
+
+def test_persist_discovered_self_heals_reverse_open(tmp_path):
+    # Simulate prior pollution: discovered/ contains a stale reverse-open entry.
+    stale = tmp_path / "firefox"
+    stale.mkdir()
+    shim = "C:\\\\Users\\\\Public\\\\winpodx\\\\reverse-open\\\\bin\\\\winpodx-firefox.exe"
+    (stale / "app.toml").write_text(
+        f'name = "firefox"\nexecutable = "{shim}"\n',
+        encoding="utf-8",
+    )
+
+    # A new discovery run with a real Windows app — purge runs first, then write.
+    real = DiscoveredApp(name="notepad", full_name="Notepad", executable="C:\\Windows\\notepad.exe")
+    persist_discovered([real], target_dir=tmp_path, add_essentials=False)
+    assert not stale.exists()  # purged
+    assert (tmp_path / "notepad" / "app.toml").exists()
 
 
 # --- _safe_rmtree ----------------------------------------------------------


### PR DESCRIPTION
## Summary

Reverse-open (#48 / v0.5.0) registers Linux host apps as Windows `.exe`
shims under `C:\Users\Public\winpodx\reverse-open\bin\winpodx-<slug>.exe`
so they surface in the guest's "Open with..." menu. `discover_apps.ps1`
was treating those shims as real Windows apps and re-importing them on
`winpodx app refresh`, polluting the host menu with entries like
firefox, kate, dolphin, blender, etc. — Linux apps appearing as
"Windows" apps in the winpodx GUI.

## Fix (two layers + self-heal)

| Layer | File | What |
|---|---|---|
| Guest | `scripts/windows/discover_apps.ps1` | `Add-Result` drops paths whose lowercased form contains `\winpodx\reverse-open\bin\` |
| Host | `src/winpodx/core/discovery/__init__.py` `_is_junk_entry` | Defensive filter for older guest scripts. Delegates to `reverse_open.sync.is_guest_shim_path` (new public helper) so the canonical bin-dir path lives in exactly one place. |
| Self-heal | `src/winpodx/core/discovery/__init__.py` `_purge_reverse_open_entries` | Runs at the start of `persist_discovered()` and removes any existing `discovered/<slug>/` directory whose `app.toml.executable` points at a reverse-open shim. |

The self-heal step cleans up users who were already polluted by the
prior bug — on their next `winpodx app refresh` the stale Linux-app
entries are removed automatically. No manual `rm -rf` step required.

## Single source of truth

`reverse_open.sync.is_guest_shim_path` is the new gate. The
`_GUEST_BIN_DIR` constant in that module owns the canonical path; if
the reverse-open install layout ever moves (e.g. from `C:\Users\Public\`
to `C:\ProgramData\`), discovery picks up the change automatically
because both `_is_junk_entry` and `_purge_reverse_open_entries`
delegate to that single helper.

## Test plan

- [x] 4 new tests in `tests/test_discovery/test_discovery.py` cover
      `_is_junk_entry` positive + negative paths and
      `_purge_reverse_open_entries` direct + via `persist_discovered`.
- [x] `pytest tests/test_discovery/ tests/test_reverse_open_discovery.py -q` — 121 passed.
- [x] `ruff check + format --check` — clean.
- [ ] Manual smoke after merge: existing user with polluted
      `~/.local/share/winpodx/discovered/` runs `winpodx app refresh`,
      list now shows only Windows apps.
