### PR TITLE
feat(config): Win10+ edition allowlist + GUI picker (closes part of #178)

### DIFF
--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -8,6 +8,7 @@ section drives the agent-first install flow (see
 
 from __future__ import annotations
 
+import logging
 import platform
 import re
 from dataclasses import dataclass, field
@@ -24,6 +25,39 @@ from winpodx.utils.paths import config_dir
 from winpodx.utils.toml_writer import dumps as toml_dumps
 
 _VALID_BACKENDS = frozenset({"podman", "docker", "libvirt", "manual"})
+
+# Windows edition strings winpodx ships explicit support for. Mirrors
+# dockur/windows' own VERSION allowlist (see #178). Unknown values are
+# allowed at the config layer with a warning — bleeding-edge dockur
+# releases may add editions winpodx hasn't documented yet, and we
+# shouldn't block users from opting in. Validation is strictness=warn,
+# not strictness=reject.
+_KNOWN_WIN_VERSIONS = frozenset(
+    {
+        # Desktop editions
+        "11",
+        "10",
+        "8",
+        "7",
+        "vista",
+        "xp",
+        # LTSC / IoT (long-term servicing — #178 ask)
+        "ltsc11",
+        "ltsc10",
+        "iot11",
+        # Debloated community builds
+        "tiny11",
+        "tiny10",
+        # Server editions
+        "2025",
+        "2022",
+        "2019",
+        "2016",
+        "2012",
+        "2008",
+        "2003",
+    }
+)
 
 # Podman/Docker container name rules: alnum/_/-/., must start with alnum.
 _CONTAINER_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
@@ -101,7 +135,14 @@ class PodConfig:
     backend: str = "podman"  # podman | docker | libvirt | manual
     vm_name: str = "RDPWindows"
     container_name: str = "winpodx-windows"
-    win_version: str = "11"  # 11 | 10 | ltsc10 | tiny11 | tiny10
+    # Windows edition picker — passed through to dockur/windows via the
+    # ``VERSION`` env var (see ``compose.py``). Supported values mirror
+    # dockur's own allowlist; see #178 for the rationale (LTSC IoT and
+    # Win10 LTSC are common asks). Unknown values fall back to "11"
+    # with a warning in ``__post_init__`` so a typo doesn't brick the
+    # install — bleeding-edge dockur versions are still settable, just
+    # log a one-line "value not on the winpodx-known list" notice.
+    win_version: str = "11"
     cpu_cores: int = 4
     # v0.2.1: default bumped 4 -> 6 GB so the new 25-session default
     # doesn't trip the session-budget warning (2.0 base + 25 × 0.1 ≈
@@ -168,6 +209,19 @@ class PodConfig:
             self.container_name = _DEFAULT_CONTAINER_NAME
         if not isinstance(self.image, str) or not self.image.strip():
             self.image = _default_pod_image()
+        # win_version: keep a string; coerce empty to default; warn (don't
+        # reject) on unknown values so future dockur additions still work.
+        if not isinstance(self.win_version, str) or not self.win_version.strip():
+            self.win_version = "11"
+        else:
+            self.win_version = self.win_version.strip().lower()
+            if self.win_version not in _KNOWN_WIN_VERSIONS:
+                logging.getLogger(__name__).warning(
+                    "win_version=%r not in winpodx's known list (%s); "
+                    "passing through to dockur as-is",
+                    self.win_version,
+                    ", ".join(sorted(_KNOWN_WIN_VERSIONS)),
+                )
         if not isinstance(self.disk_size, str) or not self.disk_size.strip():
             self.disk_size = "64G"
         # storage_path: keep empty (named-volume mode) or coerce to a

--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -26,36 +26,33 @@ from winpodx.utils.toml_writer import dumps as toml_dumps
 
 _VALID_BACKENDS = frozenset({"podman", "docker", "libvirt", "manual"})
 
-# Windows edition strings winpodx ships explicit support for. Mirrors
-# dockur/windows' own VERSION allowlist (see #178). Unknown values are
-# allowed at the config layer with a warning — bleeding-edge dockur
-# releases may add editions winpodx hasn't documented yet, and we
-# shouldn't block users from opting in. Validation is strictness=warn,
-# not strictness=reject.
+# Windows edition strings winpodx ships explicit support for. Subset
+# of dockur/windows' full VERSION set, restricted to Windows 10-era
+# kernels and newer (see #178). Pre-Win10 editions (XP / Vista / 7 /
+# 8 / Server 2003-2012) are intentionally excluded — they're out of
+# Microsoft security support, and winpodx's stack (rdprrap multi-
+# session, agent.ps1 modern PowerShell APIs, dockur's RDP shim)
+# targets the Win10+ family. Unknown values are still permitted at
+# the config layer with a warning so bleeding-edge dockur additions
+# winpodx hasn't documented yet still work — validation is
+# strictness=warn, not strictness=reject.
 _KNOWN_WIN_VERSIONS = frozenset(
     {
-        # Desktop editions
+        # Mainstream desktop
         "11",
         "10",
-        "8",
-        "7",
-        "vista",
-        "xp",
-        # LTSC / IoT (long-term servicing — #178 ask)
+        # LTSC / IoT (long-term servicing — #178 core ask)
         "ltsc11",
         "ltsc10",
         "iot11",
         # Debloated community builds
         "tiny11",
         "tiny10",
-        # Server editions
+        # Server editions (Win10+ kernel only)
         "2025",
         "2022",
         "2019",
         "2016",
-        "2012",
-        "2008",
-        "2003",
     }
 )
 
@@ -136,12 +133,13 @@ class PodConfig:
     vm_name: str = "RDPWindows"
     container_name: str = "winpodx-windows"
     # Windows edition picker — passed through to dockur/windows via the
-    # ``VERSION`` env var (see ``compose.py``). Supported values mirror
-    # dockur's own allowlist; see #178 for the rationale (LTSC IoT and
-    # Win10 LTSC are common asks). Unknown values fall back to "11"
-    # with a warning in ``__post_init__`` so a typo doesn't brick the
-    # install — bleeding-edge dockur versions are still settable, just
-    # log a one-line "value not on the winpodx-known list" notice.
+    # ``VERSION`` env var (see ``compose.py``). Restricted to the
+    # Win10+ kernel family (see ``_KNOWN_WIN_VERSIONS``) — older
+    # editions are out of Microsoft security support and don't match
+    # winpodx's stack assumptions (rdprrap multi-session, agent.ps1
+    # modern APIs). Unknown values pass through with a one-line
+    # WARNING log in ``__post_init__`` so newer dockur releases that
+    # add editions winpodx hasn't documented yet still work.
     win_version: str = "11"
     cpu_cores: int = 4
     # v0.2.1: default bumped 4 -> 6 GB so the new 25-session default

--- a/src/winpodx/gui/_main_window_settings.py
+++ b/src/winpodx/gui/_main_window_settings.py
@@ -175,11 +175,57 @@ class SettingsPageMixin:
         self.input_idle = QLineEdit(str(self.cfg.pod.idle_timeout))
         self.input_max_sessions = QLineEdit(str(self.cfg.pod.max_sessions))
 
+        # Windows edition picker (#178). Editable so a power user can
+        # type a value dockur added after winpodx was released — config
+        # validation will accept it with a warning rather than reject.
+        # Labels mirror dockur/windows' README ordering so users
+        # cross-referencing the upstream docs see the same names.
+        self.input_win_version = QComboBox()
+        self.input_win_version.setEditable(True)
+        win_version_options = [
+            ("Windows 11", "11"),
+            ("Windows 11 LTSC", "ltsc11"),
+            ("Windows 11 IoT Enterprise LTSC", "iot11"),
+            ("Windows 11 (Tiny11, debloated)", "tiny11"),
+            ("Windows 10", "10"),
+            ("Windows 10 LTSC", "ltsc10"),
+            ("Windows 10 (Tiny10, debloated)", "tiny10"),
+            ("Windows 8.1", "8"),
+            ("Windows 7", "7"),
+            ("Windows Vista", "vista"),
+            ("Windows XP", "xp"),
+            ("Windows Server 2025", "2025"),
+            ("Windows Server 2022", "2022"),
+            ("Windows Server 2019", "2019"),
+            ("Windows Server 2016", "2016"),
+            ("Windows Server 2012", "2012"),
+            ("Windows Server 2008", "2008"),
+            ("Windows Server 2003", "2003"),
+        ]
+        for label, value in win_version_options:
+            self.input_win_version.addItem(label, value)
+        # Map current cfg value back onto the dropdown. If unknown
+        # (custom dockur edition), insert it verbatim so the editable
+        # combo still shows what's in winpodx.toml.
+        current_wv = self.cfg.pod.win_version
+        idx = self.input_win_version.findData(current_wv)
+        if idx >= 0:
+            self.input_win_version.setCurrentIndex(idx)
+        else:
+            self.input_win_version.addItem(current_wv, current_wv)
+            self.input_win_version.setCurrentIndex(self.input_win_version.count() - 1)
+        self.input_win_version.setToolTip(
+            "Windows edition passed to dockur via VERSION env var.\n"
+            "Pick from the list or type any value dockur supports.\n"
+            "Changing this requires recreating the container."
+        )
+
         pod_card = self._settings_card(
             "▨  Container / VM",
             "Backend and resource allocation",
             [
                 ("Backend", self.input_backend),
+                ("Windows Edition", self.input_win_version),
                 ("CPU Cores", self.input_cpu),
                 ("RAM (GB)", self.input_ram),
                 ("Idle Timeout", self.input_idle),
@@ -325,12 +371,20 @@ class SettingsPageMixin:
             )
             return
 
+        # Pull Windows edition: prefer the combo's data role (canonical
+        # dockur tag) over its display text. If the user typed a custom
+        # value, currentData() is None — fall back to the edit-line text.
+        new_win_version = self.input_win_version.currentData()
+        if not new_win_version:
+            new_win_version = self.input_win_version.currentText().strip()
+
         old_cfg = Config.load()
         needs_container = (
             cpu != old_cfg.pod.cpu_cores
             or ram != old_cfg.pod.ram_gb
             or port != old_cfg.rdp.port
             or self.input_user.text() != old_cfg.rdp.user
+            or new_win_version != old_cfg.pod.win_version
         )
 
         self.cfg.rdp.user = self.input_user.text()
@@ -341,6 +395,7 @@ class SettingsPageMixin:
         self.cfg.rdp.password_max_age = self.input_pw_max_age.currentData()
         self.cfg.rdp.extra_flags = self.input_extra_flags.text().strip()
         self.cfg.pod.backend = self.input_backend.currentText()
+        self.cfg.pod.win_version = new_win_version
         self.cfg.pod.cpu_cores = cpu
         self.cfg.pod.ram_gb = ram
         self.cfg.pod.idle_timeout = idle
@@ -353,7 +408,8 @@ class SettingsPageMixin:
             reply = QMessageBox.question(
                 self,
                 "Restart Container",
-                "CPU, RAM, or port changed.\nContainer must be recreated to apply.\n\nRestart now?",
+                "CPU, RAM, port, user, or Windows edition changed.\n"
+                "Container must be recreated to apply.\n\nRestart now?",
             )
             if reply == QMessageBox.StandardButton.Yes:
                 self.info_label.setText("Recreating container...")

--- a/src/winpodx/gui/_main_window_settings.py
+++ b/src/winpodx/gui/_main_window_settings.py
@@ -182,6 +182,12 @@ class SettingsPageMixin:
         # cross-referencing the upstream docs see the same names.
         self.input_win_version = QComboBox()
         self.input_win_version.setEditable(True)
+        # Win10+ kernel family only — see ``_KNOWN_WIN_VERSIONS`` in
+        # ``core/config.py`` for the policy rationale. Pre-Win10
+        # editions are intentionally not offered; if a user really
+        # needs one, they can type the dockur tag into the editable
+        # combo and config validation will pass it through with a
+        # warning.
         win_version_options = [
             ("Windows 11", "11"),
             ("Windows 11 LTSC", "ltsc11"),
@@ -190,17 +196,10 @@ class SettingsPageMixin:
             ("Windows 10", "10"),
             ("Windows 10 LTSC", "ltsc10"),
             ("Windows 10 (Tiny10, debloated)", "tiny10"),
-            ("Windows 8.1", "8"),
-            ("Windows 7", "7"),
-            ("Windows Vista", "vista"),
-            ("Windows XP", "xp"),
             ("Windows Server 2025", "2025"),
             ("Windows Server 2022", "2022"),
             ("Windows Server 2019", "2019"),
             ("Windows Server 2016", "2016"),
-            ("Windows Server 2012", "2012"),
-            ("Windows Server 2008", "2008"),
-            ("Windows Server 2003", "2003"),
         ]
         for label, value in win_version_options:
             self.input_win_version.addItem(label, value)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,9 +49,20 @@ def test_pod_config_idle_timeout_clamping():
 
 
 def test_pod_config_win_version_known_values():
-    # All shipped values mirror dockur/windows' VERSION set; round-trip untouched.
-    for v in ("11", "10", "ltsc11", "ltsc10", "iot11", "tiny11", "2022", "xp"):
+    # Win10+ family — round-trip untouched without triggering the warning.
+    for v in ("11", "10", "ltsc11", "ltsc10", "iot11", "tiny11", "tiny10", "2022", "2016"):
         assert PodConfig(win_version=v).win_version == v
+
+
+def test_pod_config_win_version_pre_win10_warns_but_passes_through(caplog):
+    # Pre-Win10 editions are off the known list but still accepted with a
+    # warning so users on bleeding-edge dockur builds aren't blocked.
+    import logging as _logging
+
+    with caplog.at_level(_logging.WARNING, logger="winpodx.core.config"):
+        pod = PodConfig(win_version="xp")
+    assert pod.win_version == "xp"
+    assert any("not in winpodx's known list" in r.message for r in caplog.records)
 
 
 def test_pod_config_win_version_normalises_case_and_whitespace():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,6 +48,31 @@ def test_pod_config_idle_timeout_clamping():
     assert pod.idle_timeout == 0
 
 
+def test_pod_config_win_version_known_values():
+    # All shipped values mirror dockur/windows' VERSION set; round-trip untouched.
+    for v in ("11", "10", "ltsc11", "ltsc10", "iot11", "tiny11", "2022", "xp"):
+        assert PodConfig(win_version=v).win_version == v
+
+
+def test_pod_config_win_version_normalises_case_and_whitespace():
+    assert PodConfig(win_version="  LTSC11  ").win_version == "ltsc11"
+
+
+def test_pod_config_win_version_empty_falls_back_to_default():
+    assert PodConfig(win_version="").win_version == "11"
+    assert PodConfig(win_version="   ").win_version == "11"
+
+
+def test_pod_config_win_version_unknown_passes_through_with_warning(caplog):
+    # Bleeding-edge dockur values aren't blocked — just warned.
+    import logging as _logging
+
+    with caplog.at_level(_logging.WARNING, logger="winpodx.core.config"):
+        pod = PodConfig(win_version="future-edition")
+    assert pod.win_version == "future-edition"
+    assert any("not in winpodx's known list" in r.message for r in caplog.records)
+
+
 def test_config_save_load(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 


### PR DESCRIPTION
## Summary

Adds first-class support for the Win10+ Windows editions dockur/windows
boots. Closes the LTSC IoT / Win10 LTSC / Tiny / Server asks in #178
without exposing pre-Win10 editions that winpodx's stack isn't tested
against.

## Why limit to Win10+ kernels

| Concern | Pre-Win10 (XP / Vista / 7 / 8 / 2003-2012) |
|---|---|
| Microsoft security support | Out of support — no patches |
| rdprrap (multi-session) | Targets Win10+ RDP stack; older editions either won't take the hook or lose parallel sessions |
| agent.ps1 modern PowerShell APIs | `Get-AppxPackage`, `Get-NetAdapter`, etc. don't exist or differ pre-Win10 |

Users who really need a pre-Win10 edition can still type the dockur
tag into the editable combo — `core.config` accepts unknown values
with a one-line `WARNING` log and passes them through to dockur
as-is.

## Curated set (12 editions)

```
11, 10                          desktop
ltsc11, ltsc10, iot11           long-term-service + IoT (#178 core ask)
tiny11, tiny10                  debloated community builds
2025, 2022, 2019, 2016          servers (Win10+ kernel only)
```

## Changes

- **config.py** — `_KNOWN_WIN_VERSIONS` constant + `PodConfig.__post_init__` normalises whitespace/case, falls empty back to `"11"`, and emits a one-line WARNING for unknown values (no rejection).
- **gui/_main_window_settings.py** — new "Windows Edition" combo on the Container/VM card. Editable so power users can type custom dockur tags; current `cfg.pod.win_version` is preserved across reloads even if it isn't a shipped option. Container-recreate prompt updated to mention the new field.
- **tests/test_config.py** — 5 new tests: known-values round-trip, case/whitespace normalisation, empty fallback, unknown-value pass-through with warning, and pre-Win10 warning behaviour.

## Out of scope (follow-up #178 PR 2)

Custom ISO mount support (user-provided `.iso` for editions dockur
doesn't ship presets for) lands in a separate PR — it needs a host
filesystem bind mount, path validation, and security review.

## Test plan

- [x] `pytest tests/test_config.py -q` — 37 passed (5 new).
- [x] `pytest tests/ -q` — 1100 passed, 1 skipped.
- [x] `ruff check + format --check` — clean.
- [ ] Manual smoke after merge: launch GUI, open Settings, verify the
      Windows Edition combo shows the 12 options + your current value;
      change to LTSC10, save, accept container recreate prompt.
