### PR TITLE
feat(setup): --win-version flag for CLI + install.sh (#178 follow-up)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,11 @@ WINPODX_SKIP_DEPS="${WINPODX_SKIP_DEPS:-}"
 # v0.2.2.2: explicit ref selection. Empty -> auto-detect latest release tag
 # at install time. Set to "main" via --main flag for development builds.
 WINPODX_REF="${WINPODX_REF:-}"
+# v0.5.x: --win-version flag picks the dockur Windows edition for fresh
+# installs (e.g. ltsc10, iot11, tiny11). Empty -> dockur default "11".
+# Ignored when an existing winpodx.toml is present (setup skips
+# re-configuration for upgrade flows). See #178.
+WINPODX_WIN_VERSION="${WINPODX_WIN_VERSION:-}"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
 log()  { echo -e "${GREEN}[winpodx]${NC} $*"; }
@@ -57,6 +62,10 @@ Flags:
   --source PATH       Copy from local repo instead of git clone
   --image-tar PATH    Load container image from local tar
   --skip-deps         Skip distro dependency install
+  --win-version VER   Windows edition for fresh installs
+                      (11 | 10 | ltsc11 | ltsc10 | iot11 | tiny11 |
+                       tiny10 | 2025 | 2022 | 2019 | 2016 — see
+                       docs/ARCHITECTURE.md for custom ISOs)
   -h, --help          Print this help and exit
 USAGE_EOF
 }
@@ -83,6 +92,14 @@ while [ $# -gt 0 ]; do
         --skip-deps)
             WINPODX_SKIP_DEPS=1
             shift
+            ;;
+        --win-version)
+            WINPODX_WIN_VERSION="${2:-}"
+            if [ -z "$WINPODX_WIN_VERSION" ]; then
+                err "--win-version requires a value (e.g. ltsc10, iot11, tiny11)"
+                exit 1
+            fi
+            shift 2
             ;;
         -h|--help)
             usage
@@ -461,7 +478,12 @@ fi
 # --- Run setup ---
 log "Running winpodx setup..."
 export PYTHONPATH="$INSTALL_DIR/src${PYTHONPATH:+:$PYTHONPATH}"
-python3 -m winpodx setup --non-interactive 2>/dev/null || true
+SETUP_ARGS=(--non-interactive)
+if [ -n "$WINPODX_WIN_VERSION" ]; then
+    SETUP_ARGS+=(--win-version "$WINPODX_WIN_VERSION")
+    log "Installing Windows edition: $WINPODX_WIN_VERSION"
+fi
+python3 -m winpodx setup "${SETUP_ARGS[@]}" 2>/dev/null || true
 
 # --- Install winpodx GUI desktop entry & icon ---
 DESKTOP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"

--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -174,6 +174,19 @@ def cli(argv: list[str] | None = None) -> None:
     # --- setup ---
     setup_p = sub.add_parser("setup", help="Run setup wizard")
     setup_p.add_argument("--backend", choices=["podman", "docker", "libvirt", "manual"])
+    setup_p.add_argument(
+        "--win-version",
+        metavar="EDITION",
+        help=(
+            "Windows edition to install (passed to dockur via VERSION env "
+            "var). Curated set: 11 | 10 | ltsc11 | ltsc10 | iot11 | tiny11 "
+            "| tiny10 | 2025 | 2022 | 2019 | 2016. Other values pass "
+            "through to dockur with a warning — see ARCHITECTURE.md for "
+            "the custom-ISO workaround. Only takes effect on fresh installs "
+            "(no existing winpodx.toml); for existing installs use the GUI "
+            "Settings → Windows Edition picker or edit winpodx.toml."
+        ),
+    )
     setup_p.add_argument("--non-interactive", action="store_true")
     setup_p.add_argument(
         "--update-image",

--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -447,6 +447,13 @@ def handle_setup(args: argparse.Namespace) -> None:
             print(f"Invalid choice: {choice}")
             raise SystemExit(1)
 
+    # Apply --win-version before the cfg is saved. PodConfig.__post_init__
+    # normalises whitespace/case and warns when the value is off the
+    # curated allowlist (it still passes through to dockur — see #178).
+    win_version_arg = getattr(args, "win_version", None)
+    if win_version_arg:
+        cfg.pod.win_version = win_version_arg
+
     from datetime import datetime, timezone
 
     if non_interactive:

--- a/tests/test_cli_issues.py
+++ b/tests/test_cli_issues.py
@@ -182,6 +182,43 @@ class TestAskHelper:
 
         assert marker.read_text(encoding="utf-8").strip() == "0.1.8"
 
+    def test_setup_applies_win_version_arg_on_fresh_install(self, tmp_path, monkeypatch):
+        """`--win-version ltsc11` must land in cfg.pod.win_version when no
+        existing winpodx.toml is present. #178 follow-up."""
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr("sys.stdin", MagicMock(isatty=lambda: False))
+
+        args = argparse.Namespace(
+            backend="manual",
+            non_interactive=True,
+            win_version="ltsc11",
+        )
+
+        freerdp_dep = MagicMock()
+        freerdp_dep.found = True
+        freerdp_dep.note = ""
+
+        with (
+            patch(
+                "winpodx.cli.setup_cmd.check_all",
+                return_value={"freerdp": freerdp_dep},
+            ),
+            patch("winpodx.cli.setup_cmd.import_winapps_config", return_value=None),
+            patch("winpodx.cli.setup_cmd._generate_compose"),
+            patch("winpodx.cli.setup_cmd._recreate_container"),
+            patch("winpodx.cli.setup_cmd._register_all_desktop_entries"),
+            patch("winpodx.display.scaling.detect_scale_factor", return_value=100),
+            patch("winpodx.display.scaling.detect_raw_scale", return_value=1.0),
+        ):
+            from winpodx.cli.setup_cmd import handle_setup
+
+            handle_setup(args)
+
+        from winpodx.core.config import Config
+
+        loaded = Config.load()
+        assert loaded.pod.win_version == "ltsc11"
+
 
 # Issue 8: password rotation split-brain
 


### PR DESCRIPTION
## Summary

#183 added the GUI Settings → Windows Edition picker for the curated
Win10+ allowlist. This PR wires the same choice through the headless
install path — `winpodx setup --win-version` and `install.sh
--win-version` — so a user can pick LTSC10 / IoT11 / Tiny11 / etc.
from the command line without opening the GUI after install.

## Changes

### `src/winpodx/cli/main.py`

New `--win-version EDITION` argument on the `setup` subparser. Help
text mirrors the curated set and points readers at ARCHITECTURE.md
for the custom-ISO workaround.

### `src/winpodx/cli/setup_cmd.py`

`handle_setup()` reads `args.win_version` defensively via `getattr`
(so existing callers that build their own `argparse.Namespace`
without the field — there's one such call site in install.sh
test scaffolding — still work). When the flag is present, the value
lands on `cfg.pod.win_version` before save; `PodConfig.__post_init__`
does the normalisation + unknown-value warning that #183 introduced.

Placement: after the backend selection block, before the cfg write.
Only applies to fresh installs — the existing-config branch returns
early at line 421, which matches the help text "Only takes effect on
fresh installs."

### `install.sh`

- New `--win-version VER` flag and matching `WINPODX_WIN_VERSION`
  env var. The flag validates non-empty value (errors with usage if
  `--win-version` is the last arg with no value).
- When set, the install runs:

  ```
  winpodx setup --non-interactive --win-version "$WINPODX_WIN_VERSION"
  ```

- The usage block lists the curated set inline so
  `install.sh --help` shows the same hint the CLI does.

### Tests

New `test_setup_applies_win_version_arg_on_fresh_install` in
`tests/test_cli_issues.py` — spawns `handle_setup` with
`--win-version=ltsc11`, mocks the dependency surface, asserts
`cfg.pod.win_version == "ltsc11"` after save. Reuses the same
mock pattern as the existing install-marker tests.

## Usage examples

```bash
# Fresh install with Win10 LTSC (use the standard install.sh invocation
# from the README, plus --win-version ltsc10)
install.sh ... --win-version ltsc10

# CLI-only (assumes winpodx is already installed and no winpodx.toml exists)
winpodx setup --non-interactive --win-version iot11

# Custom dockur edition the curated list doesn't cover — passes
# through with a WARNING; see docs/ARCHITECTURE.md
winpodx setup --non-interactive --win-version custom
```

## Test plan

- [x] `pytest tests/test_cli_issues.py tests/test_config.py tests/test_discovery -q` — 168 passed.
- [x] Full `pytest tests/` — passes (run via background watcher).
- [x] `ruff check + format --check src/ tests/` — clean.
- [ ] Manual smoke after merge: fresh install with `--win-version
      ltsc10`, verify `cfg.pod.win_version == "ltsc10"` in the
      generated winpodx.toml.
