### PR TITLE
docs(contributing): codify contributor attribution in Highlights

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,36 @@ git tag REL-vX.Y.Z vX.Y.Z^{}    # dereference to commit to avoid a nested-tag wa
 git push origin vX.Y.Z REL-vX.Y.Z
 ```
 
+### Crediting contributors in Highlights
+
+When a Highlights bullet covers work that came from outside the
+maintainer (external PR or external bug report / feature request),
+credit the contributor inline. The convention:
+
+| Source | Suffix |
+|---|---|
+| External PR (someone else's commits) | `(by @username, #PR)` |
+| External issue / feature request (maintainer wrote the code) | `(reported by @username, #issue)` |
+| Both — external report **and** external PR by the same person | `(by @username, #PR / #issue)` |
+
+GitHub auto-renders both forms as the user's avatar + handle on the
+release page, so the recognition surfaces without extra work.
+
+Example:
+
+```markdown
+### Highlights
+
+- Atomic Fedora flavours (Silverblue / Kinoite / Bazzite) now ship via the
+  OBS repo with `rpm-ostree install --apply-live`. (by @Zeik0s, #163)
+- LTSC IoT and Win10 LTSC pickable from Settings or `--win-version`.
+  (reported by @gabe39, #178)
+```
+
+The "no AI tool co-author trailers" rule above is unrelated: it bans
+machine-generated attribution. Human contributors are credited
+liberally and explicitly.
+
 ## Security
 
 If you discover a security vulnerability, please follow the process described in [SECURITY.md](SECURITY.md). **Do NOT open a public issue.**

--- a/docs/CONTRIBUTING.ko.md
+++ b/docs/CONTRIBUTING.ko.md
@@ -123,6 +123,36 @@ git tag REL-vX.Y.Z vX.Y.Z^{}    # nested-tag 경고 피하려고 commit 으로 d
 git push origin vX.Y.Z REL-vX.Y.Z
 ```
 
+### Highlights 에서 기여자 표기
+
+Highlights bullet 이 메인테이너 외부에서 온 작업 (외부 PR / 외부 버그
+리포트 / feature request) 을 다룰 때, 인라인으로 기여자 크레딧을 표기.
+컨벤션:
+
+| 출처 | 접미사 |
+|---|---|
+| 외부 PR (다른 사람의 커밋) | `(by @username, #PR)` |
+| 외부 이슈 / feature request (코드는 메인테이너 작성) | `(reported by @username, #issue)` |
+| 둘 다 — 같은 사람의 외부 리포트 **+** 외부 PR | `(by @username, #PR / #issue)` |
+
+GitHub 가 두 형식 모두 릴리스 페이지에 user 아바타 + 핸들로 자동
+렌더링 — 추가 작업 없이 크레딧이 노출됨.
+
+예시:
+
+```markdown
+### Highlights
+
+- Atomic Fedora flavours (Silverblue / Kinoite / Bazzite) now ship via the
+  OBS repo with `rpm-ostree install --apply-live`. (by @Zeik0s, #163)
+- LTSC IoT and Win10 LTSC pickable from Settings or `--win-version`.
+  (reported by @gabe39, #178)
+```
+
+위의 "AI tool co-author trailers 금지" 룰과는 무관: 그것은
+기계 생성 attribution 금지. 사람 기여자는 자유롭고 명시적으로
+크레딧.
+
 ## 보안
 
 보안 취약점을 발견한 경우, [SECURITY.ko.md](SECURITY.ko.md)에 설명된 절차를 따라 주세요. **공개 이슈를 열지 마세요.**


### PR DESCRIPTION
## Summary

Adds a "Crediting contributors in Highlights" subsection to
`CONTRIBUTING.md` (and Korean mirror) under the existing "Writing
release notes" section. Documents the three inline-credit forms
the maintainer has been using ad-hoc:

| Source | Suffix |
|---|---|
| External PR (someone else's commits) | `(by @user, #PR)` |
| External issue / feature request (maintainer wrote the code) | `(reported by @user, #issue)` |
| Both — same person reported and PR'd | `(by @user, #PR / #issue)` |

Why now: PR #163 (@Zeik0s, atomic Fedora) and issue #178 (@gabe39,
LTSC IoT) are both heading for the next release; the convention
should be written down before the next CHANGELOG Highlights bullet
is drafted so the credit form is settled rather than improvised.

Also clarifies that this is unrelated to the "no AI tool co-author
trailers" rule a few sections above. That rule bans machine-
generated attribution; human contributors are credited liberally
and explicitly.

## Test plan

- [x] Doc-only PR; no code touched.
- [x] Renders cleanly on GitHub markdown preview.
- [ ] First release after merge: verify the convention is followed
      in the actual CHANGELOG Highlights bullets.
