### PR TITLE
fix(ci): pin AUR publish action to v4.1.3

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -93,7 +93,7 @@ jobs:
       # Pinned to v2 (floating on minor) per standard third-party action use.
       - name: Publish to AUR
         if: steps.check.outputs.skip == 'false'
-        uses: KSXGitHub/github-actions-deploy-aur@v2
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: winpodx
           pkgbuild: packaging/aur/PKGBUILD

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -90,7 +90,10 @@ jobs:
       # KSXGitHub/github-actions-deploy-aur handles: makepkg-style SRCINFO
       # regeneration, SSH key material setup, ssh-keyscan of aur.archlinux.org,
       # and the git clone/commit/push to ssh://aur@aur.archlinux.org/<pkg>.git.
-      # Pinned to v2 (floating on minor) per standard third-party action use.
+      # Pinned to v4.1.3 (specific patch) — v2 floating tag has an upstream
+      # regression that fails with `bash: --command: invalid option`
+      # (upstream issue #50, fixed 2026-04-18). v3+ uses the same input
+      # shape, so the pin is safe.
       - name: Publish to AUR
         if: steps.check.outputs.skip == 'false'
         uses: KSXGitHub/github-actions-deploy-aur@v4.1.3


### PR DESCRIPTION
## Summary
- `KSXGitHub/github-actions-deploy-aur@v2` floating tag now fails with `bash: --command: invalid option` (upstream issue [#50](https://github.com/KSXGitHub/github-actions-deploy-aur/issues/50), fixed in v4.1.3 on 2026-04-18). The regression wasn't visible until `AUR_SSH_PRIVATE_KEY` was provisioned because the secret-gate short-circuited before reaching the action.
- Pin to v4.1.3. Inputs are unchanged (`pkgname`, `pkgbuild`, `commit_username`, `commit_email`, `ssh_private_key`, `commit_message`, `ssh_keyscan_types`).

## Test plan
- [ ] After merge: `gh workflow run aur-publish.yml -f tag=v0.5.2` succeeds
- [ ] `aur.archlinux.org/packages/winpodx` updates to 0.5.2 with correct sha256