### PR TITLE
fix(lint): satisfy ruff format on config.py + main_window.py

### DIFF
--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -291,8 +291,7 @@ class PodConfig:
                 setattr(self, field_name, default_val)
             elif any(ch in _DANGEROUS_YAML_CHARS for ch in val):
                 logging.getLogger(__name__).warning(
-                    "%s=%r contains characters reserved by YAML / shell; "
-                    "coercing to default %r",
+                    "%s=%r contains characters reserved by YAML / shell; coercing to default %r",
                     field_name,
                     val,
                     default_val,

--- a/src/winpodx/gui/main_window.py
+++ b/src/winpodx/gui/main_window.py
@@ -134,9 +134,7 @@ class WinpodxWindow(
     def _build_ui(self) -> None:
         central = QWidget()
         central.setObjectName("centralRoot")
-        central.setStyleSheet(
-            f"QWidget#centralRoot {{ background: {C.MANTLE}; }}\n" + GLOBAL_STYLE
-        )
+        central.setStyleSheet(f"QWidget#centralRoot {{ background: {C.MANTLE}; }}\n" + GLOBAL_STYLE)
         self.setCentralWidget(central)
         root = QVBoxLayout(central)
         root.setContentsMargins(0, 0, 0, 0)


### PR DESCRIPTION
## Summary
Re-run `ruff format` on `src/winpodx/core/config.py` and `src/winpodx/gui/main_window.py` — PRs #201 / #203 left format drift behind that's been red-X'ing the `lint` CI job on `main` since 2026-05-17 03:11 UTC, and blocks every subsequent PR (including #206 and #207) from showing green CI.

Cosmetic only — joined short multi-line statements onto single lines under the 100-char limit. No behavior change.

## Test plan
- [x] `ruff format --check src/ tests/` passes locally
- [ ] CI `lint` job goes green on this PR
- [ ] CI `lint` goes green on rebased / re-pushed PRs (#206, #207)