### PR TITLE
docs(aur): mark AUR package as live + gitignore housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,17 @@ htmlcov/
 *.p12
 id_rsa*
 id_ed25519*
+
+# Editor / assistant scratch & backup paths
+CLAUDE.md.bak
+AGENTS.md.bak
+.cursorrules.bak
+WORK_STATUS.md.bak
+.gitignore.bak
+.codex/
+.aider*
+.continue/
+.cline/
+.roo/
+uninstall-backup-*/
+.priv-storage/.allow-setup-reread

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ See [docs/FEATURES.md](docs/FEATURES.md) for deep dives, including multi-session
 | Fedora Silverblue / Kinoite / Sericea / Bluefin / Bazzite (42 / 43 / 44) | rpm-ostree (OBS, `--apply-live`) | Supported |
 | Debian 12 / 13, Ubuntu 24.04 / 25.04 / 25.10 | apt | Supported |
 | AlmaLinux / Rocky / RHEL 9 / 10 | dnf | Supported |
-| Arch / Manjaro | pacman + `install.sh` | Source install supported · AUR package pending maintainer onboarding |
+| Arch / Manjaro | pacman + `yay -S winpodx` | Supported |
 | NixOS (and Nix on any distro) | nix flake | Supported |
 
 Each tag push (`v*.*.*`) publishes to all channels automatically — see [packaging/](packaging/) for maintainer details.

--- a/docs/INSTALL.ko.md
+++ b/docs/INSTALL.ko.md
@@ -115,7 +115,7 @@ keyboard = "ko-KR"
 
 ## 네이티브 패키지 매니저
 
-미리 빌드된 RPM 과 `.deb` 패키지가 모든 [GitHub Release](https://github.com/kernalix7/winpodx/releases/latest) 에 첨부됨 — openSUSE/Fedora RPM 은 [openSUSE Build Service (`home:Kernalix7/winpodx`)](https://build.opensuse.org/package/show/home:Kernalix7/winpodx) 에서, 나머지는 GitHub Actions 에서. AUR publishing 은 워크플로우는 준비되어 있지만 현재는 비활성 (메인테이너 SSH 키 온보딩 대기 중) — Arch 사용자는 당분간 `install.sh` 사용 권장.
+미리 빌드된 RPM 과 `.deb` 패키지가 모든 [GitHub Release](https://github.com/kernalix7/winpodx/releases/latest) 에 첨부됨 — openSUSE/Fedora RPM 은 [openSUSE Build Service (`home:Kernalix7/winpodx`)](https://build.opensuse.org/package/show/home:Kernalix7/winpodx) 에서, 나머지는 GitHub Actions 에서. [`winpodx` AUR 패키지](https://aur.archlinux.org/packages/winpodx) 는 v0.5.2 부터 라이브 — Arch 사용자는 `yay -S winpodx` 또는 `paru -S winpodx` 로 설치.
 
 ### openSUSE Tumbleweed / Leap 15.6 / Leap 16.0 / Slowroll
 
@@ -172,13 +172,15 @@ sudo dnf install ./winpodx-<version>-1.noarch.el9.rpm    # 또는 .el10.rpm
 
 ### Arch Linux / Manjaro
 
-AUR publish 워크플로우는 존재하지만 메인테이너 SSH 키가 프로비저닝되기 전까지 휴면 상태 — 아직 `winpodx` AUR 패키지 없음. 당분간 위의 universal installer 사용; `pacman` 감지하고 모든 의존성 자동 설치:
+선호하는 AUR helper 로 설치:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
+yay -S winpodx
+# 또는
+paru -S winpodx
 ```
 
-AUR 패키지가 활성화되면 이 섹션이 `yay -S winpodx` / `paru -S winpodx` 안내로 업데이트됨.
+PKGBUILD 는 [`packaging/aur/PKGBUILD`](../packaging/aur/PKGBUILD) 에 있고, 태그 푸시 (`v*.*.*`) 마다 버전 + tarball sha256 자동 stamp 후 `aur.archlinux.org/winpodx.git` 로 푸시.
 
 ## Nix
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -114,7 +114,7 @@ For the complete list of supported languages and region codes, see the [dockur/w
 
 ## Native package managers
 
-Prebuilt RPM and `.deb` packages are attached to every [GitHub Release](https://github.com/kernalix7/winpodx/releases/latest) — openSUSE/Fedora RPMs come from the [openSUSE Build Service (`home:Kernalix7/winpodx`)](https://build.opensuse.org/package/show/home:Kernalix7/winpodx), the rest from GitHub Actions. AUR publishing is wired but currently inactive (maintainer SSH key onboarding pending) — Arch users should use `install.sh` for now.
+Prebuilt RPM and `.deb` packages are attached to every [GitHub Release](https://github.com/kernalix7/winpodx/releases/latest) — openSUSE/Fedora RPMs come from the [openSUSE Build Service (`home:Kernalix7/winpodx`)](https://build.opensuse.org/package/show/home:Kernalix7/winpodx), the rest from GitHub Actions. The [`winpodx` AUR package](https://aur.archlinux.org/packages/winpodx) is live as of v0.5.2 — Arch users can install via `yay -S winpodx` or `paru -S winpodx`.
 
 ### openSUSE Tumbleweed / Leap 15.6 / Leap 16.0 / Slowroll
 
@@ -171,13 +171,15 @@ sudo dnf install ./winpodx-<version>-1.noarch.el9.rpm    # or .el10.rpm
 
 ### Arch Linux / Manjaro
 
-The AUR publish workflow exists but is dormant until the maintainer's SSH key is provisioned — there is no `winpodx` AUR package yet. In the meantime, use the universal installer above; it detects `pacman` and installs all dependencies cleanly:
+Install from the AUR using your preferred helper:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash
+yay -S winpodx
+# or
+paru -S winpodx
 ```
 
-Once the AUR package goes live, this section will be updated with `yay -S winpodx` / `paru -S winpodx`.
+The PKGBUILD lives at [`packaging/aur/PKGBUILD`](../packaging/aur/PKGBUILD); each tag push (`v*.*.*`) auto-stamps the version + tarball sha256 and pushes to `aur.archlinux.org/winpodx.git`.
 
 ## Nix
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -188,7 +188,7 @@ winpodx app run desktop           # 전체 Windows 데스크톱
 | Fedora Silverblue / Kinoite / Sericea / Bluefin / Bazzite (42 / 43 / 44) | rpm-ostree (OBS, `--apply-live`) | Supported |
 | Debian 12 / 13, Ubuntu 24.04 / 25.04 / 25.10 | apt | Supported |
 | AlmaLinux / Rocky / RHEL 9 / 10 | dnf | Supported |
-| Arch / Manjaro | pacman + `install.sh` | 소스 설치 지원 · AUR 패키지는 메인테이너 온보딩 대기 |
+| Arch / Manjaro | pacman + `yay -S winpodx` | Supported |
 | NixOS (와 모든 distro 위의 Nix) | nix flake | Supported |
 
 각 태그 푸시 (`v*.*.*`) 마다 모든 채널에 자동 publish — 메인테이너 상세는 [packaging/](../packaging/) 참조.


### PR DESCRIPTION
**Depends on #207 merging + `aur-publish.yml -f tag=v0.5.2` rerun succeeding.** Hold as draft until `aur.archlinux.org/packages/winpodx` reflects v0.5.2.

## Summary
- Once the AUR publish workflow runs successfully (PR #207 + `AUR_SSH_PRIVATE_KEY`), the package will be live. Drop "dormant / pending maintainer onboarding" wording in `README` + `INSTALL` (en + ko), point Arch users to `yay -S winpodx` / `paru -S winpodx`. Status column in `README` / `README.ko` changes from caveat → `Supported`.
- Add editor / assistant scratch + backup paths to `.gitignore` (`CLAUDE.md.bak`, `.codex/`, `.aider*`, `.continue/`, `.cline/`, `.roo/`, `uninstall-backup-*/`, `.priv-storage/.allow-setup-reread`) so they can't slip into future commits.

## Test plan
- [ ] `aur.archlinux.org/packages/winpodx` shows v0.5.2
- [ ] `yay -S winpodx` on an Arch test box pulls & builds (smoke)
- [ ] README quick-start `yay -S winpodx` line still resolves