### PR TITLE
fix(aur): install desktop / icon / config example; anchor sed stamps

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -80,8 +80,12 @@ jobs:
           fi
           echo "sha256: $sha"
 
-          sed -e "s|__PKGVER__|${version}|g" \
-              -e "s|__SHA256__|${sha}|g" \
+          # Anchor on the assignment lines so the template comment at the
+          # top (which mentions __PKGVER__ / __SHA256__ literally) is not
+          # also rewritten — otherwise the published PKGBUILD ships with
+          # the stamped values inlined into the explanatory text.
+          sed -e "s|^pkgver=__PKGVER__$|pkgver=${version}|" \
+              -e "s|^sha256sums=('__SHA256__')$|sha256sums=('${sha}')|" \
               packaging/aur/PKGBUILD > PKGBUILD.rendered
           mv PKGBUILD.rendered packaging/aur/PKGBUILD
           echo "---- rendered PKGBUILD ----"

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -42,4 +42,12 @@ package() {
   cd "$pkgname-$pkgver"
   python -m installer --destdir="$pkgdir" dist/*.whl
   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+  install -Dm644 CHANGELOG.md "$pkgdir/usr/share/doc/$pkgname/CHANGELOG.md"
+  install -Dm644 data/winpodx.desktop \
+    "$pkgdir/usr/share/applications/winpodx.desktop"
+  install -Dm644 data/winpodx-icon.svg \
+    "$pkgdir/usr/share/icons/hicolor/256x256/apps/winpodx.svg"
+  install -Dm644 data/winpodx.toml.example \
+    "$pkgdir/usr/share/winpodx/winpodx.toml.example"
 }


### PR DESCRIPTION
## Summary
- `package()` expanded to install desktop entry, icon, config example, README, and CHANGELOG — bringing the AUR build in line with the `.deb` (`debian/rules`) and `.rpm` layouts. Previously the AUR package only shipped the wheel + LICENSE, so Arch users were missing `/usr/share/applications/winpodx.desktop`, the hicolor icon, and `/usr/share/winpodx/winpodx.toml.example`.
- Anchor the workflow's sed stamps to the assignment lines (`^pkgver=__PKGVER__$`, `^sha256sums=('__SHA256__')$`) instead of unconditional global substitution. Previously the template comment at the top of the PKGBUILD also got rewritten on every publish, so AUR users saw the literal stamped values inside the explanatory comment.

## Test plan
- [x] Locally simulated sed leaves the template comment intact while stamping `pkgver=` and `sha256sums=` correctly.
- [ ] Next `aur-publish.yml -f tag=v0.5.2` run produces a PKGBUILD whose `package()` installs the desktop entry + icon + config example, and whose top-of-file comment still reads `__PKGVER__ / __SHA256__`.
- [ ] `makepkg -si` on an Arch box installs `winpodx.desktop` and the icon visibly.