### PR TITLE
chore(ci): bump actions/checkout to v5 (Node.js 24 runtime)

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -17,7 +17,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Secret-gated so tag pushes made before AUR_SSH_PRIVATE_KEY is set up
       # (see packaging/aur/README.md for the one-time onboarding flow) do not

--- a/.github/workflows/check-windows-updates.yml
+++ b/.github/workflows/check-windows-updates.yml
@@ -13,7 +13,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check latest dockur Windows images
         id: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
@@ -42,7 +42,7 @@ jobs:
           - python-version: "3.13"
             runner: "ubuntu-24.04-arm"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -56,7 +56,7 @@ jobs:
     # PowerShell syntax regressions before they hit the Windows guest.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Defense in depth: the DryRun path is read-only, but we still
           # do not want the job's GITHUB_TOKEN left persisted in
@@ -86,7 +86,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"

--- a/.github/workflows/debs-publish.yml
+++ b/.github/workflows/debs-publish.yml
@@ -41,7 +41,7 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends ca-certificates git
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Enable backports if needed
         if: matrix.backports

--- a/.github/workflows/obs-publish.yml
+++ b/.github/workflows/obs-publish.yml
@@ -26,7 +26,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve tag
         id: tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
@@ -63,7 +63,7 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
@@ -81,7 +81,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v4
         with:
           name: dist

--- a/.github/workflows/rhel-publish.yml
+++ b/.github/workflows/rhel-publish.yml
@@ -52,7 +52,7 @@ jobs:
           dnf config-manager --set-enabled crb || \
             dnf config-manager --set-enabled powertools || true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve tag
         id: tag


### PR DESCRIPTION
## Summary
GitHub deprecated Node.js 20 in actions on 2025-09-19; the forced switch to Node.js 24 lands 2026-06-02. `actions/checkout@v5` (released 2025-11-17) runs on Node.js 24. Bump all 12 usages across `ci.yml`, `release.yml`, `obs-publish.yml`, `debs-publish.yml`, `rhel-publish.yml`, `aur-publish.yml`, and `check-windows-updates.yml`.

Inputs and behavior are unchanged between v4 and v5.

## Test plan
- [ ] CI passes on this PR (every workflow that runs on PR will exercise v5)
- [ ] Future tag pushes still produce the same release artifacts