### PR TITLE
fix(pod): broaden UNRESPONSIVE detection + GUI banner

### DIFF
--- a/src/winpodx/core/pod/backend.py
+++ b/src/winpodx/core/pod/backend.py
@@ -28,12 +28,16 @@ class PodState(Enum):
 
 
 # Container must be running this long before an RDP-port miss can be
-# classified as ``UNRESPONSIVE`` rather than ``STARTING``. Default
-# matches the dockur first-boot floor (Sysprep + OEM apply); legitimate
-# late-boot misses on slower hosts may extend past this — in which case
-# the caller's auto-recovery flow is a no-op (the agent isn't up yet
-# either) and the next poll picks up the real RUNNING state.
-_UNRESPONSIVE_UPTIME_FLOOR_SECS = 600
+# classified as ``UNRESPONSIVE`` rather than ``STARTING``. First-boot
+# Sysprep + OEM apply is driven by ``install.sh`` separately
+# (``[1-3/3] Waiting for ...`` checkpoints) so the GUI / tray are
+# expected to be closed during that window. By the time the GUI is
+# usable to the human, the container is past boot — three minutes is
+# plenty of cushion for an in-place ``winpodx pod restart`` to come
+# back without the user briefly seeing UNRESPONSIVE flicker. Lowered
+# from 600 s after the post-#219 smoke showed the tray still stuck on
+# ``starting`` past the 10-minute mark on a known-stalled pod.
+_UNRESPONSIVE_UPTIME_FLOOR_SECS = 180
 
 
 @dataclass
@@ -93,17 +97,35 @@ def pod_status(cfg: Config) -> PodStatus:
 
     # RDP unreachable. Discriminate STARTING (boot in progress, expected
     # to clear) from UNRESPONSIVE (long-running container whose Windows
-    # guest has stalled — pre-#TBD this was misreported as STARTING
+    # guest has stalled — pre-#219 this was misreported as STARTING
     # forever, leaving the GUI / tray frozen on "starting" until the
     # user noticed). Probe the backend's container uptime: under the
-    # floor → STARTING, past it → UNRESPONSIVE. Backends that don't
-    # expose uptime (libvirt, manual) fall back to the legacy STARTING
-    # answer.
+    # floor → STARTING, past it → UNRESPONSIVE.
+    #
+    # Unknown-uptime fallback (post-smoke v0.5.5): treat ``None`` as
+    # UNRESPONSIVE on container backends. The dockur first-boot window
+    # is owned by ``install.sh`` (`[1-3/3]` checkpoints, no GUI / tray
+    # active), so by the time a probe returns ``None`` from the running
+    # GUI, the container has clearly been up — defaulting to STARTING
+    # was the bug we just hit on real-Windows smoke: uptime parse
+    # failure → STARTING → user thinks pod is still booting after
+    # 50 min. Fall back to STARTING only on backends that don't
+    # implement uptime_secs at all (libvirt / manual return None
+    # because they override nothing; container backends return a real
+    # value or None only on probe failure).
     uptime = None
     try:
         uptime = backend.uptime_secs()
     except Exception as e:  # pragma: no cover - defensive
         log.debug("uptime_secs probe failed: %s", e)
     if uptime is not None and uptime >= _UNRESPONSIVE_UPTIME_FLOOR_SECS:
+        return PodStatus(state=PodState.UNRESPONSIVE, ip=cfg.rdp.ip)
+    if uptime is None and cfg.pod.backend in ("podman", "docker"):
+        log.warning(
+            "Container backend %r did not return an uptime; classifying as "
+            "UNRESPONSIVE on the assumption that an RDP miss without uptime "
+            "data is a stalled long-running pod, not a fresh boot.",
+            cfg.pod.backend,
+        )
         return PodStatus(state=PodState.UNRESPONSIVE, ip=cfg.rdp.ip)
     return PodStatus(state=PodState.STARTING, ip=cfg.rdp.ip)

--- a/src/winpodx/gui/_main_window_pod.py
+++ b/src/winpodx/gui/_main_window_pod.py
@@ -272,6 +272,14 @@ class PodStatusMixin:
                 f"background: transparent; color: {C.BLUE}; font-size: 14px;"
             )
             self.banner_text.setText("Pod is starting...")
+        elif state == "unresponsive":
+            self.banner_icon.setText("⚠")
+            self.banner_icon.setStyleSheet(
+                f"background: transparent; color: {C.PEACH}; font-size: 14px;"
+            )
+            self.banner_text.setText(
+                "Pod is alive but RDP is unresponsive — auto-recovering, or click Restart Pod"
+            )
         elif state == "error":
             self.banner_icon.setText("✗")
             self.banner_icon.setStyleSheet(

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -122,11 +122,12 @@ def test_docker_backend_is_running_uses_configured_container_name():
 # control the RDP probe, and verify each of the five states resolves.
 
 
-def _patched_pod_status(*, running, paused, rdp_ok, uptime):
+def _patched_pod_status(*, running, paused, rdp_ok, uptime, backend_name="podman"):
     """Helper — run pod_status with the four input switches mocked."""
     from winpodx.core.pod import pod_status
 
     cfg = Config()
+    cfg.pod.backend = backend_name
     fake_backend = MagicMock()
     fake_backend.is_running.return_value = running
     fake_backend.is_paused.return_value = paused
@@ -145,23 +146,47 @@ def test_pod_status_running_when_container_up_and_rdp_reachable():
 
 
 def test_pod_status_starting_when_container_recent_and_rdp_down():
-    """Container up < 600s + RDP miss = still booting, do not yet
+    """Container up < 180s + RDP miss = still booting, do not yet
     classify as UNRESPONSIVE."""
     status = _patched_pod_status(running=True, paused=False, rdp_ok=False, uptime=60)
     assert status.state == PodState.STARTING
 
 
 def test_pod_status_unresponsive_when_container_old_and_rdp_down():
-    """Container up past the 600s floor + RDP miss = guest stalled."""
+    """Container up past the 180s floor + RDP miss = guest stalled."""
     status = _patched_pod_status(running=True, paused=False, rdp_ok=False, uptime=900)
     assert status.state == PodState.UNRESPONSIVE
 
 
-def test_pod_status_starting_when_uptime_unknown_legacy_fallback():
-    """libvirt + manual backends return None from uptime_secs() — must
-    fall back to the legacy STARTING answer instead of UNRESPONSIVE."""
-    status = _patched_pod_status(running=True, paused=False, rdp_ok=False, uptime=None)
+def test_pod_status_starting_when_uptime_unknown_on_non_container_backend():
+    """libvirt + manual backends return None from uptime_secs() — they
+    must fall back to STARTING (no auto-recovery for non-container)."""
+    status = _patched_pod_status(
+        running=True,
+        paused=False,
+        rdp_ok=False,
+        uptime=None,
+        backend_name="libvirt",
+    )
     assert status.state == PodState.STARTING
+
+
+def test_pod_status_unresponsive_when_uptime_unknown_on_container_backend():
+    """Container backend (podman / docker) returning None from
+    ``uptime_secs`` means the probe parse failed on a known-running
+    container — by the time the GUI / tray polls, first-boot Sysprep
+    has already finished (install.sh owns that window). Treating
+    parse failure as "still STARTING after 50 min" was the bug in the
+    pre-fix smoke run (#219 follow-up), so an unknown uptime on a
+    container backend now resolves to UNRESPONSIVE."""
+    status = _patched_pod_status(
+        running=True,
+        paused=False,
+        rdp_ok=False,
+        uptime=None,
+        backend_name="podman",
+    )
+    assert status.state == PodState.UNRESPONSIVE
 
 
 def test_pod_status_paused_short_circuits_before_rdp_probe():


### PR DESCRIPTION
## Summary

Follow-up to #219 after the v0.5.5 real-Windows smoke. The post-#219 classifier still resolved to `STARTING` on a 50-minute-old pod with dead RDP + agent \`Connection reset by peer\`. Two gaps closed:

- **600 s uptime floor → 180 s.** First-boot Sysprep + OEM apply is owned by `install.sh`'s `[1-3/3]` checkpoints, so by the time the GUI / tray polls for the human user the container is past boot. Three minutes is plenty of cushion for an in-place `winpodx pod restart` to land without UNRESPONSIVE flicker.
- **`uptime_secs() → None` on a container backend now resolves to UNRESPONSIVE instead of STARTING.** Parse failure on a known-running podman / docker container means we don't know exactly *how long* it's been up but we do know it's been up — that's the UNRESPONSIVE shape. libvirt / manual backends (which don't override `uptime_secs`) still get STARTING.
- **New GUI banner.** Added a peach `⚠` `_main_window_pod` banner for the `"unresponsive"` state that points the user at Restart Pod (auto-recovery runs in the tray independently).

## Test plan

- [x] `pytest tests/ -q` — 1171 passed, 1 skipped (split previous `uptime=None → STARTING` test into the libvirt fallback case + a podman case that now expects UNRESPONSIVE).
- [x] `ruff check src/ tests/` clean
- [x] `ruff format --check src/ tests/` clean
- [ ] Manual on a real pod: idle past 3 min with RDP dead → confirm GUI banner shows the peach "alive but RDP unresponsive" message, tray fires `notify_pod_unresponsive`, and the recovery worker either restores RDP or fires `notify_pod_needs_manual_restart`.

Bundled in v0.5.5.