### PR TITLE
fix(backend): parse Go time.Time.String() format from container inspect

### DIFF
--- a/src/winpodx/backend/base.py
+++ b/src/winpodx/backend/base.py
@@ -2,9 +2,135 @@
 
 from __future__ import annotations
 
+import datetime
+import json
+import logging
+import re
+import subprocess
 from abc import ABC, abstractmethod
 
 from winpodx.core.config import Config
+
+log = logging.getLogger(__name__)
+
+
+# Go's `time.Time.String()` format that podman / docker emit when you
+# format a timestamp via ``-f '{{.State.StartedAt}}'`` --
+# ``2026-05-21 07:55:40.190529036 +0900 KST`` -- isn't ISO 8601 and
+# Python's ``datetime.fromisoformat`` rejects it across the entire 3.9
+# -> 3.13 range. ``--format '{{json ...}}'`` instead marshals via Go's
+# json package which always emits RFC3339Nano (``"2026-05-21T07:55:40.
+# 190529036+09:00"``) -- portable and stable across all podman / docker
+# releases on every distro. The helpers below build the right command
+# and parse the result, with one regex fallback for any case where the
+# user's CLI version still emits the Go default shape.
+
+_GO_TIME_RE = re.compile(
+    r"^(?P<date>\d{4}-\d{2}-\d{2})[T ](?P<time>\d{2}:\d{2}:\d{2})"
+    r"(?P<frac>\.\d+)?"
+    r"\s*(?:Z|(?P<sign>[+-])(?P<hh>\d{2}):?(?P<mm>\d{2}))?"
+)
+
+
+def _parse_inspect_timestamp(raw: str) -> datetime.datetime | None:
+    """Parse podman / docker ``StartedAt`` into an aware datetime.
+
+    Handles three on-the-wire shapes we've seen in the wild:
+      * ``"2026-05-21T07:55:40.190529036+09:00"`` (RFC3339Nano, quoted
+        by ``{{json ...}}``)
+      * ``2026-05-21T07:55:40.190529036Z`` (RFC3339Nano, bare)
+      * ``2026-05-21 07:55:40.190529036 +0900 KST`` (Go's
+        ``time.Time.String()`` default -- emitted by older / non-JSON
+        formatted ``-f '{{.State.StartedAt}}'``)
+
+    Returns None on any unparseable / zero-time / pre-2000 input so the
+    caller treats it as "uptime unknown" rather than acting on garbage.
+    """
+    raw = (raw or "").strip().strip('"')
+    if not raw:
+        return None
+    m = _GO_TIME_RE.match(raw)
+    if not m:
+        log.debug("inspect timestamp %r did not match parser regex", raw)
+        return None
+    date = m.group("date")
+    time_ = m.group("time")
+    frac = (m.group("frac") or "")[:7]  # microseconds-precision max
+    sign = m.group("sign")
+    if sign:
+        hh, mm = m.group("hh"), m.group("mm")
+        offset = f"{sign}{hh}:{mm}"
+    else:
+        offset = "+00:00"
+    iso = f"{date}T{time_}{frac}{offset}"
+    try:
+        parsed = datetime.datetime.fromisoformat(iso)
+    except ValueError:
+        log.debug("inspect timestamp %r normalised to %r still failed parse", raw, iso)
+        return None
+    # podman emits Go zero time ``0001-01-01 00:00:00 +0000 UTC`` for
+    # containers that exist but never started -- treat as unknown.
+    if parsed.year < 2000:
+        return None
+    return parsed
+
+
+def _container_uptime_secs(cli: str, name: str) -> int | None:
+    """Probe ``<cli> inspect`` for container uptime, in seconds, or None.
+
+    ``cli`` is the binary (``podman`` or ``docker``); ``name`` is the
+    container name we expect (cfg.pod.container_name). We also try the
+    two common compose-prefixed variants because podman-compose 1.x
+    sometimes overrides the explicit ``container_name:`` with the
+    project prefix -- ``is_running`` uses a regex match on ``ps`` so it
+    succeeds either way, but ``inspect <name>`` is strict.
+
+    The ``--format '{{json ...}}'`` payload always shapes the timestamp
+    as RFC3339Nano even on podman / docker versions whose bare
+    ``-f '{{.State.StartedAt}}'`` would emit Go's ``time.Time.String()``
+    default -- saves us from having to parse the Go shape on the wire.
+    """
+    candidates = [name, f"winpodx_{name}", f"winpodx_{name}_1"]
+    raw = ""
+    last_stderr = ""
+    for candidate in candidates:
+        try:
+            result = subprocess.run(
+                [cli, "inspect", "--format", "{{json .State.StartedAt}}", candidate],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return None
+        if result.returncode == 0 and result.stdout.strip():
+            raw = result.stdout.strip()
+            break
+        last_stderr = (result.stderr or "").strip()
+
+    if not raw:
+        log.debug(
+            "%s inspect StartedAt failed for all candidates %r: %s",
+            cli,
+            candidates,
+            last_stderr,
+        )
+        return None
+    # Strip JSON quoting if present; fall through to the regex parser
+    # for either shape.
+    try:
+        raw = json.loads(raw)
+        if not isinstance(raw, str):
+            return None
+    except (json.JSONDecodeError, TypeError):
+        pass  # already a bare string
+
+    started = _parse_inspect_timestamp(raw)
+    if started is None:
+        return None
+    now = datetime.datetime.now(tz=started.tzinfo)
+    return max(0, int((now - started).total_seconds()))
 
 
 class Backend(ABC):

--- a/src/winpodx/backend/docker.py
+++ b/src/winpodx/backend/docker.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 import time
 
-from winpodx.backend.base import Backend
+from winpodx.backend.base import Backend, _container_uptime_secs
 from winpodx.utils.paths import config_dir
 
 log = logging.getLogger(__name__)
@@ -91,54 +91,8 @@ class DockerBackend(Backend):
         return "paused" in self._container_state()
 
     def uptime_secs(self) -> int | None:
-        """Seconds since the container was last started, or None on probe failure.
-
-        Falls back to compose-prefixed names the same way the podman
-        backend does — ``docker compose`` follows the same naming
-        convention so the candidate list is identical.
-        """
-        import datetime
-        import subprocess
-
-        candidates = [
-            self.cfg.pod.container_name,
-            f"winpodx_{self.cfg.pod.container_name}",
-            f"winpodx_{self.cfg.pod.container_name}_1",
-        ]
-        ts = ""
-        for name in candidates:
-            try:
-                result = subprocess.run(
-                    ["docker", "inspect", "-f", "{{.State.StartedAt}}", name],
-                    capture_output=True,
-                    text=True,
-                    timeout=5,
-                    check=False,
-                )
-            except (FileNotFoundError, subprocess.TimeoutExpired):
-                return None
-            if result.returncode == 0 and result.stdout.strip():
-                ts = result.stdout.strip()
-                break
-
-        if not ts:
-            return None
-        ts = ts.replace("Z", "+00:00")
-        if "." in ts:
-            head, _, tail = ts.partition(".")
-            frac, _, tz = tail.partition("+")
-            if tz:
-                ts = f"{head}.{frac[:6]}+{tz}"
-            else:
-                ts = f"{head}.{frac[:6]}"
-        try:
-            started = datetime.datetime.fromisoformat(ts)
-        except ValueError:
-            return None
-        if started.year < 2000:
-            return None
-        now = datetime.datetime.now(tz=started.tzinfo)
-        return max(0, int((now - started).total_seconds()))
+        """Seconds since the container was last started, or None on probe failure."""
+        return _container_uptime_secs("docker", self.cfg.pod.container_name)
 
     def get_ip(self) -> str:
         return self.cfg.rdp.ip or "127.0.0.1"

--- a/src/winpodx/backend/podman.py
+++ b/src/winpodx/backend/podman.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 import time
 
-from winpodx.backend.base import Backend
+from winpodx.backend.base import Backend, _container_uptime_secs
 from winpodx.utils.paths import config_dir
 
 log = logging.getLogger(__name__)
@@ -96,78 +96,8 @@ class PodmanBackend(Backend):
         return "paused" in self._container_state()
 
     def uptime_secs(self) -> int | None:
-        """Seconds since the container was last started, or None on probe failure.
-
-        Tries inspect first by the configured container name and falls
-        back to the compose-prefixed name (``{project}_{name}``) +
-        ``--format`` variants. podman-compose sometimes overrides the
-        explicit ``container_name:`` directive with the project prefix,
-        so a bare inspect on ``cfg.pod.container_name`` will fail with
-        ``no such object`` even though the container is running. The
-        legacy ``is_running`` uses ``ps -a --filter name=^X$`` which
-        does a regex match, so it succeeds with either naming.
-        """
-        import datetime
-        import subprocess
-
-        candidates = [
-            self.cfg.pod.container_name,
-            # podman-compose project-prefixed variants (project name is
-            # `name:` in compose.yaml = "winpodx").
-            f"winpodx_{self.cfg.pod.container_name}",
-            f"winpodx_{self.cfg.pod.container_name}_1",
-        ]
-        ts = ""
-        last_stderr = ""
-        for name in candidates:
-            try:
-                result = subprocess.run(
-                    ["podman", "inspect", "-f", "{{.State.StartedAt}}", name],
-                    capture_output=True,
-                    text=True,
-                    timeout=5,
-                    check=False,
-                )
-            except (FileNotFoundError, subprocess.TimeoutExpired):
-                return None
-            if result.returncode == 0 and result.stdout.strip():
-                ts = result.stdout.strip()
-                break
-            last_stderr = (result.stderr or "").strip()
-
-        if not ts:
-            log.debug(
-                "podman inspect StartedAt failed for all candidates %r: %s",
-                candidates,
-                last_stderr,
-            )
-            return None
-        # podman prints RFC3339 (`2026-05-20T14:00:00.123456789Z`). Python's
-        # fromisoformat handles `+00:00` but not bare `Z` until 3.11, and
-        # the nanoseconds suffix until 3.11 either — strip both for the
-        # 3.9 / 3.10 fallback path.
-        ts = ts.replace("Z", "+00:00")
-        if "." in ts:
-            head, _, tail = ts.partition(".")
-            # Truncate fractional seconds to microseconds (6 digits) so
-            # the parser accepts it across Python versions.
-            frac, _, tz = tail.partition("+")
-            if tz:
-                ts = f"{head}.{frac[:6]}+{tz}"
-            else:
-                ts = f"{head}.{frac[:6]}"
-        try:
-            started = datetime.datetime.fromisoformat(ts)
-        except ValueError:
-            log.debug("Could not parse podman StartedAt timestamp %r", ts)
-            return None
-        # Guard against the Go zero time ``0001-01-01T00:00:00Z`` that
-        # podman emits for containers that never started.
-        if started.year < 2000:
-            return None
-        now = datetime.datetime.now(tz=started.tzinfo)
-        delta = (now - started).total_seconds()
-        return max(0, int(delta))
+        """Seconds since the container was last started, or None on probe failure."""
+        return _container_uptime_secs("podman", self.cfg.pod.container_name)
 
     def get_ip(self) -> str:
         return self.cfg.rdp.ip or "127.0.0.1"


### PR DESCRIPTION
User's v0.5.5 smoke showed every pod_status poll logging "returned no uptime from inspect" because podman's `-f '{{.State.StartedAt}}'` calls `time.Time.String()` which emits Go-native shape (`2026-05-21 07:55:40.190529036 +0900 KST`), not RFC3339. Auto-recovery never fired because the probe always returned None -> STARTING fallback.

Two fixes:
- Switch the inspect command to `--format '{{json .State.StartedAt}}'` -- routes through Go's `encoding/json` which always emits RFC3339Nano on every podman / docker version on every distro.
- Defensive `_parse_inspect_timestamp` regex parser handles all three on-the-wire shapes (JSON-quoted RFC3339Nano, bare RFC3339, Go default) so the timestamp parses regardless of which podman flavour or future format change shows up.

Both fixes extracted into `backend/base.py` helpers and shared by the podman + docker backends. Bundled in v0.5.5.