### PR TITLE
feat(tray): always-running tray + Dashboard shortcut + confirmed Quit

### DIFF
--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -283,6 +283,24 @@ def cli(argv: list[str] | None = None) -> None:
         parser.print_help()
         return
 
+    # Best-effort: ensure the tray subprocess is up before dispatching
+    # any CLI command. The tray is the only driver for the UNRESPONSIVE
+    # auto-recovery flow, so even users who only ever touch winpodx via
+    # the CLI get the same idle-stall recovery the GUI users get.
+    # ``setup`` / ``gui`` / ``tray`` skip this:
+    #   * ``setup`` runs during install before the tray is wanted;
+    #   * ``gui`` spawns the tray itself from run_gui();
+    #   * ``tray`` IS the tray -- spawning a second copy is what
+    #     tray_spawn's pgrep + tray.py's flock are guarding against, but
+    #     short-circuiting here is cheaper than relying on those.
+    if args.command not in ("setup", "gui", "tray"):
+        try:
+            from winpodx.desktop.tray_spawn import maybe_spawn_tray
+
+            maybe_spawn_tray()
+        except Exception:  # noqa: BLE001 — best-effort, never crash CLI
+            pass
+
     _dispatch(args)
 
 

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -103,10 +103,26 @@ def ensure_ready(cfg: Config | None = None, timeout: int = 300) -> Config:
     # itself is dead while VNC is fine. Probe and try to revive TermService
     # before handing the cfg to the caller — the alternative is the FreeRDP
     # launch failing with a connection-refused that the user has to debug.
-    from winpodx.core.pod import recover_rdp_if_needed
-
+    #
+    # Two-stage recovery (cheap before expensive):
+    #   1. Agent-driven TermService cycle (try_recover_rdp). Costs ~5-30 s
+    #      and keeps the container + Windows uptime; the right fix when the
+    #      stall is just a wedged RDP listener.
+    #   2. Whole-container restart via recover_rdp_if_needed. Costs ~30 s
+    #      pod restart and resets Windows uptime; the fallback when the
+    #      agent isn't reachable or stage 1 didn't bring RDP back.
     if not check_rdp_port(cfg.rdp.ip, cfg.rdp.port, timeout=1.0):
-        recover_rdp_if_needed(cfg)
+        from winpodx.core.pod import recover_rdp_if_needed
+        from winpodx.core.pod.recovery import try_recover_rdp
+
+        result = try_recover_rdp(cfg)
+        log.info(
+            "ensure_ready: agent recovery returned action=%s success=%s",
+            result.action.value,
+            result.success,
+        )
+        if not result.success:
+            recover_rdp_if_needed(cfg)
 
     # Discovery is no longer auto-fired here (Step 3 of the redesign).
     # The "populate the menu on first boot" UX is owned by install.sh

--- a/src/winpodx/desktop/tray.py
+++ b/src/winpodx/desktop/tray.py
@@ -8,8 +8,55 @@ import sys
 log = logging.getLogger(__name__)
 
 
+_TRAY_LOCK_FH = None  # held for the lifetime of the tray process
+
+
+def _acquire_tray_lock() -> bool:
+    """Return True if we got the tray flock, False if another tray owns it.
+
+    The lockfile lives under ``$XDG_RUNTIME_DIR/winpodx/`` (falls back to
+    ``~/.config/winpodx/``); the file handle is kept on the module so
+    the lock survives until the process exits. ``GUI`` calls
+    ``_maybe_spawn_tray`` which already does a ``pgrep`` pre-check, so
+    this lock is the second line of defence -- catches the case where
+    pgrep is unavailable or the user manually runs `winpodx tray` while
+    one is already up.
+    """
+    import fcntl
+    import os
+    from pathlib import Path
+
+    global _TRAY_LOCK_FH
+    runtime = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime and Path(runtime).is_dir():
+        lock_dir = Path(runtime) / "winpodx"
+    else:
+        from winpodx.utils.paths import config_dir
+
+        lock_dir = config_dir()
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_dir / "tray.lock"
+    try:
+        fh = open(lock_path, "w")
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (OSError, BlockingIOError):
+        return False
+    try:
+        fh.truncate(0)
+        fh.write(str(os.getpid()))
+        fh.flush()
+    except OSError:
+        pass
+    _TRAY_LOCK_FH = fh
+    return True
+
+
 def run_tray() -> None:
     """Launch the system tray icon application."""
+    if not _acquire_tray_lock():
+        log.info("winpodx tray already running; exiting.")
+        return
+
     try:
         from PySide6.QtCore import QTimer
         from PySide6.QtGui import QAction
@@ -29,10 +76,27 @@ def run_tray() -> None:
     app.setApplicationName("winpodx")
     app.setQuitOnLastWindowClosed(False)
 
+    # Resolve the bundled SVG so the system-tray icon actually shows up.
+    # Without ``tray.setIcon`` Qt logs ``QSystemTrayIcon::setVisible: No
+    # Icon set`` and most DEs (KDE Plasma, GNOME extensions) just don't
+    # render the indicator at all.
+    from PySide6.QtGui import QIcon
+
+    from winpodx.desktop.icons import bundled_data_path
+
+    icon_path = bundled_data_path("winpodx-icon.svg")
+    tray_icon = QIcon(str(icon_path)) if icon_path is not None else QIcon.fromTheme("computer")
+    app.setWindowIcon(tray_icon)
+
     tray = QSystemTrayIcon()
+    tray.setIcon(tray_icon)
     tray.setToolTip("winpodx - Windows App Integration")
 
     menu = QMenu()
+
+    dashboard_action = QAction("Open Dashboard")
+    menu.addAction(dashboard_action)
+    menu.addSeparator()
 
     status_action = QAction("Status: checking...")
     status_action.setEnabled(False)
@@ -47,6 +111,39 @@ def run_tray() -> None:
     start_action = QAction("Start Pod")
     stop_action = QAction("Stop Pod")
     restart_action = QAction("Restart Pod")
+
+    def _open_dashboard() -> None:
+        """Launch the main GUI window as a detached subprocess.
+
+        Single-process GUI + tray would be ideal but the GUI's
+        QApplication lifecycle clashes with the tray's
+        ``setQuitOnLastWindowClosed(False)``. Spawning is the cleanest
+        win until we unify the two into one process.
+        """
+        import os
+        import shutil as _shutil
+        import subprocess as _sp
+
+        cmd = _shutil.which("winpodx") or sys.executable
+        args = [cmd, "gui"] if cmd != sys.executable else [cmd, "-m", "winpodx", "gui"]
+        try:
+            _sp.Popen(
+                args,
+                stdin=_sp.DEVNULL,
+                stdout=_sp.DEVNULL,
+                stderr=_sp.DEVNULL,
+                start_new_session=True,
+                close_fds=True,
+                env=os.environ.copy(),
+            )
+        except OSError as e:
+            tray.showMessage(
+                "winpodx",
+                f"Could not open dashboard: {e}",
+                QSystemTrayIcon.MessageIcon.Warning,
+            )
+
+    dashboard_action.triggered.connect(_open_dashboard)
 
     # Cache the previous state across refresh ticks so the tray can drive
     # state-transition behaviour — currently the RUNNING → UNRESPONSIVE
@@ -304,8 +401,59 @@ def run_tray() -> None:
 
     menu.addSeparator()
 
-    quit_action = QAction("Quit")
-    quit_action.triggered.connect(app.quit)
+    quit_action = QAction("Quit winpodx")
+
+    def _confirmed_quit() -> None:
+        """Tear down GUI + pod before closing the tray.
+
+        User asked the tray Quit to be a real exit -- stop the Windows
+        pod, close any dashboard window the user may have open, then
+        exit the tray itself. A QMessageBox confirms first so a stray
+        click doesn't cycle the pod (~30s recreate cost + RDP session
+        loss).
+        """
+        from PySide6.QtWidgets import QMessageBox
+
+        reply = QMessageBox.question(
+            None,
+            "winpodx",
+            "winpodx 를 완전히 종료할까요?\n\nWindows 컨테이너를 멈추고 "
+            "열려 있는 dashboard 창도 닫습니다.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        # 1. Stop the Windows pod (best-effort -- a running session
+        #    survives a tray-quit only if the user explicitly chose to,
+        #    which is what the confirmation above is for).
+        try:
+            from winpodx.core.pod import stop_pod
+
+            stop_pod(Config.load())
+        except Exception as e:  # noqa: BLE001
+            log.debug("stop_pod during tray-quit failed: %s", e)
+
+        # 2. Close any winpodx GUI / dashboard process the user may
+        #    have open. pkill matches both ``python3 -m winpodx gui``
+        #    and the wrapper launcher's ``winpodx gui`` line.
+        try:
+            import subprocess as _sp
+
+            _sp.run(
+                ["pkill", "-f", "winpodx gui"],
+                capture_output=True,
+                timeout=5,
+                check=False,
+            )
+        except (FileNotFoundError, _sp.TimeoutExpired):
+            pass
+
+        # 3. Quit the tray itself.
+        app.quit()
+
+    quit_action.triggered.connect(_confirmed_quit)
     menu.addAction(quit_action)
 
     tray.setContextMenu(menu)

--- a/src/winpodx/desktop/tray_spawn.py
+++ b/src/winpodx/desktop/tray_spawn.py
@@ -1,0 +1,70 @@
+"""Shared helper for launching the winpodx tray as a detached subprocess.
+
+The tray icon is the only place where UNRESPONSIVE auto-recovery runs
+(see ``desktop/tray.py``), so any winpodx entry point the user actually
+exercises -- GUI window, ``winpodx`` CLI subcommand, the OEM-token tap
+inside install.sh -- should make sure the tray is up. This module
+centralises the spawn so the GUI + CLI dispatch + future entry points
+all share the same pgrep / flock pattern.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+
+log = logging.getLogger(__name__)
+
+
+def _tray_already_running() -> bool:
+    """Cheap pre-check via pgrep. Returns False when pgrep isn't usable."""
+    try:
+        result = subprocess.run(
+            ["pgrep", "-fa", "winpodx tray"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def maybe_spawn_tray() -> bool:
+    """Launch ``winpodx tray`` detached if not already running.
+
+    Returns True on a fresh spawn, False when the tray was already up or
+    the spawn failed. The caller is expected to be best-effort: a missing
+    tray downgrades to "no auto-recovery on idle stall" but never breaks
+    the GUI / CLI itself.
+    """
+    if _tray_already_running():
+        return False
+
+    cmd = shutil.which("winpodx")
+    if cmd is None:
+        # Source checkout fallback: ``python -m winpodx tray`` works as
+        # long as PYTHONPATH already includes ``src/``.
+        cmd = sys.executable
+        args = [cmd, "-m", "winpodx", "tray"]
+    else:
+        args = [cmd, "tray"]
+
+    try:
+        subprocess.Popen(
+            args,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+            env=os.environ.copy(),
+        )
+    except (FileNotFoundError, OSError) as e:
+        log.debug("Could not spawn tray subprocess: %s", e)
+        return False
+    return True

--- a/src/winpodx/gui/main_window.py
+++ b/src/winpodx/gui/main_window.py
@@ -193,4 +193,14 @@ def run_gui() -> None:
 
     window = WinpodxWindow()
     window.show()
+
+    # Spawn the tray subprocess so the user gets system-tray + auto-
+    # recovery (RUNNING -> UNRESPONSIVE detection + agent-driven RDP
+    # repair) without having to manually run `winpodx tray &`. tray.py
+    # acquires a flock on its lockfile, so a second invocation when one
+    # is already running exits silently instead of stacking icons.
+    from winpodx.desktop.tray_spawn import maybe_spawn_tray
+
+    maybe_spawn_tray()
+
     sys.exit(app.exec())


### PR DESCRIPTION
Four tray UX fixes from the v0.5.5 smoke:

1. **Auto-spawn from GUI + CLI** -- new `desktop/tray_spawn.maybe_spawn_tray` is called from `run_gui` and from `cli/main.py:cli` for every command except `setup` / `gui` / `tray` themselves. Any winpodx touch ensures the UNRESPONSIVE auto-recovery driver is up.
2. **Tray icon renders** -- bundled `winpodx-icon.svg` is now set on `QSystemTrayIcon` (with `computer` theme fallback). Fixes the `QSystemTrayIcon::setVisible: No Icon set` killing the indicator on KDE / GNOME.
3. **Open Dashboard tray menu item** -- one-click GUI from the tray.
4. **Quit confirms + cleans up** -- QMessageBox confirmation, then `stop_pod` + `pkill -f 'winpodx gui'` + `app.quit` so a stray Quit click doesn't cycle the pod's ~30 s restart.

Bonus: `ensure_ready` does two-stage RDP recovery -- cheap `try_recover_rdp` (agent TermService cycle) first, falling back to whole-container restart only when agent unreachable or stage 1 fails. CLI launches (`winpodx app run`) self-heal a stalled-RDP guest inline.

Bundled in v0.5.5.