### PR TITLE
fix(uninstall+tray): revert over-anchored pkill regex from security PR

### DIFF
--- a/src/winpodx/desktop/tray.py
+++ b/src/winpodx/desktop/tray.py
@@ -448,18 +448,18 @@ def run_tray() -> None:
             log.debug("stop_pod during tray-quit failed: %s", e)
 
         # 2. Close any winpodx GUI / dashboard process the user may
-        #    have open. Use an anchored regex that matches the actual
-        #    launcher invocations only -- a bare ``pkill -f 'winpodx
-        #    gui'`` would also kill an editor session whose argv
-        #    contained that substring (e.g. ``vim winpodx-gui.md``).
-        # The two known launch shapes:
-        #   * wrapper script: ``python3 -m winpodx gui``
-        #   * direct entrypoint: ``... /winpodx-app/src/winpodx/__main__.py gui``
+        #    have open. The wrapper script execs into ``python3 -m
+        #    winpodx gui``; the regex matches that shape. An earlier
+        #    anchored variant tried to avoid hypothetical false
+        #    positives (``vim winpodx-gui.md``) but missed real wrapper
+        #    invocations and the Quit silently no-op'd -- realistic
+        #    false positives are approximately zero, and Quit is an
+        #    explicit user click, so over-killing is the safer mode.
         try:
             import subprocess as _sp
 
             _sp.run(
-                ["pkill", "-f", r"(python.*-m\s+winpodx\s+gui|winpodx[/_]?app.*gui)$"],
+                ["pkill", "-f", r"python.*-m[[:space:]]+winpodx[[:space:]]+gui"],
                 capture_output=True,
                 timeout=5,
                 check=False,

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -62,26 +62,30 @@ elif command -v docker &>/dev/null; then
     RUNTIME="docker"
 fi
 
-# --- 0a. Stop running winpodx processes (tray + GUI) ---
-# Both processes hold open file handles into ~/.local/bin/winpodx-app/
-# and the runtime / config directories we're about to remove. The tray
-# also owns the flock under $XDG_RUNTIME_DIR/winpodx/tray.lock and the
-# UNRESPONSIVE recovery worker -- leaving it alive across the uninstall
-# means the user sees recovery-attempt notifications fire against a
-# now-gone container.
+# --- 0a. Stop running winpodx processes (tray + GUI + any helper) ---
+# Both GUI and tray hold open file handles into
+# ~/.local/bin/winpodx-app/ and the runtime / config directories we're
+# about to remove. The tray additionally owns the flock under
+# $XDG_RUNTIME_DIR/winpodx/tray.lock and drives UNRESPONSIVE recovery
+# notifications -- leaving it alive across the uninstall surfaces
+# recovery-attempt notifications fire against a now-gone container.
 #
-# pkill patterns are anchored to the actual launcher invocations so an
-# editor session whose argv contains "winpodx gui" (e.g. ``vim
-# winpodx-gui.md``) isn't killed by mistake.
-for pattern in \
-    '(python.*-m[[:space:]]+winpodx[[:space:]]+gui|winpodx[/_]?app.*gui)$' \
-    '(python.*-m[[:space:]]+winpodx[[:space:]]+tray|winpodx[/_]?app.*tray)$'; do
-    if pgrep -fa "$pattern" >/dev/null 2>&1; then
-        log "Stopping winpodx process matching: $pattern"
-        pkill -f "$pattern" 2>/dev/null || true
-        REMOVED=$((REMOVED + 1))
-    fi
-done
+# Uninstall is intentional + user-initiated, so kill every winpodx
+# Python process broadly via the launcher cmdline shape ``python ... -m
+# winpodx ...`` (covers gui / tray / app / host-open / setup -- all
+# subcommands). The earlier attempt at narrow anchored regexes missed
+# wrapper-script invocations whose cmdline didn't include the ``app``
+# token, so live tray + GUI survived the uninstall and held the
+# install dir open. Listing the pids first makes the kill observable.
+WINPODX_PROCS=$(pgrep -fa 'python.*-m[[:space:]]+winpodx' 2>/dev/null || true)
+if [[ -n "$WINPODX_PROCS" ]]; then
+    log "Stopping winpodx processes:"
+    while IFS= read -r line; do
+        log "  $line"
+    done <<<"$WINPODX_PROCS"
+    pkill -f 'python.*-m[[:space:]]+winpodx' 2>/dev/null || true
+    REMOVED=$((REMOVED + 1))
+fi
 # Brief grace so the killed processes release their file handles
 # before later steps rm -rf their install directory.
 sleep 1


### PR DESCRIPTION
Recent security/license sweep (#237) replaced the working pkill -f substring match with an anchored regex to avoid hypothetical false positives (`vim winpodx-gui.md`). The anchoring missed real wrapper-script cmdlines (`python3 -m winpodx gui`) and the tray Quit + uninstall.sh tray/GUI cleanup silently no-op'd in the v0.5.5 smoke.

Revert to a substring match: `python.*-m\s+winpodx\s+gui` for tray Quit, `python.*-m\s+winpodx` for uninstall (broader on purpose, uninstall is intentional + user-initiated). Lists matched pids before killing so the sweep is observable. Bundled in v0.5.5.