### PR TITLE
fix(uninstall+tray): match venv entry-point cmdlines too

### DIFF
--- a/src/winpodx/desktop/tray.py
+++ b/src/winpodx/desktop/tray.py
@@ -448,18 +448,22 @@ def run_tray() -> None:
             log.debug("stop_pod during tray-quit failed: %s", e)
 
         # 2. Close any winpodx GUI / dashboard process the user may
-        #    have open. The wrapper script execs into ``python3 -m
-        #    winpodx gui``; the regex matches that shape. An earlier
-        #    anchored variant tried to avoid hypothetical false
-        #    positives (``vim winpodx-gui.md``) but missed real wrapper
-        #    invocations and the Quit silently no-op'd -- realistic
-        #    false positives are approximately zero, and Quit is an
-        #    explicit user click, so over-killing is the safer mode.
+        #    have open. Three launcher cmdline shapes exist:
+        #      (a) install.sh wrapper:  python -m winpodx gui
+        #      (b) pip / venv entry pt: python /.../venv/bin/winpodx gui
+        #      (c) source path-style:   python /.../src/winpodx/__main__.py gui
+        #    A "python ... winpodx ... gui" pattern catches all three.
+        #    Earlier we tried to anchor to ``-m winpodx gui`` only --
+        #    that missed the venv entry-point shape and Quit silently
+        #    no-op'd against a tray running under dev install. Quit is
+        #    an explicit user click, so over-killing (the worst case is
+        #    a stray pytest run that happens to have ``winpodx`` and
+        #    ``gui`` in argv) is the safer failure mode.
         try:
             import subprocess as _sp
 
             _sp.run(
-                ["pkill", "-f", r"python.*-m[[:space:]]+winpodx[[:space:]]+gui"],
+                ["pkill", "-f", r"python.*winpodx.*gui"],
                 capture_output=True,
                 timeout=5,
                 check=False,

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -71,19 +71,27 @@ fi
 # recovery-attempt notifications fire against a now-gone container.
 #
 # Uninstall is intentional + user-initiated, so kill every winpodx
-# Python process broadly via the launcher cmdline shape ``python ... -m
-# winpodx ...`` (covers gui / tray / app / host-open / setup -- all
-# subcommands). The earlier attempt at narrow anchored regexes missed
-# wrapper-script invocations whose cmdline didn't include the ``app``
-# token, so live tray + GUI survived the uninstall and held the
-# install dir open. Listing the pids first makes the kill observable.
-WINPODX_PROCS=$(pgrep -fa 'python.*-m[[:space:]]+winpodx' 2>/dev/null || true)
+# Python process broadly. Three launcher cmdline shapes exist in the
+# wild:
+#   (a) install.sh wrapper:   python -m winpodx tray
+#   (b) pip / venv entry pt:  python /.../venv/bin/winpodx tray
+#   (c) source path-style:    python /.../src/winpodx/__main__.py tray
+# Common substring: "python" ... "winpodx" ... <subcommand>. The
+# pattern below matches all three. False positives (e.g. pytest
+# tests/test_winpodx_*.py) are acceptable -- uninstall is explicit
+# and ``--purge`` is the expected mode, so over-killing is the
+# safer failure shape than leaving FDs open into the dir we're
+# about to rm -rf.
+#
+# Listing the matched pids before the kill makes the action
+# observable so a surprise hit is at least obvious in the output.
+WINPODX_PROCS=$(pgrep -fa 'python.*winpodx' 2>/dev/null || true)
 if [[ -n "$WINPODX_PROCS" ]]; then
     log "Stopping winpodx processes:"
     while IFS= read -r line; do
         log "  $line"
     done <<<"$WINPODX_PROCS"
-    pkill -f 'python.*-m[[:space:]]+winpodx' 2>/dev/null || true
+    pkill -f 'python.*winpodx' 2>/dev/null || true
     REMOVED=$((REMOVED + 1))
 fi
 # Brief grace so the killed processes release their file handles


### PR DESCRIPTION
Previous pattern only matched `python -m winpodx tray` (install.sh wrapper). Missed venv entry-point (`python /.../venv/bin/winpodx tray`) and source path-style (`python /.../src/winpodx/__main__.py tray`). v0.5.5 smoke caught it: user's tray was launched from dev venv, Quit + uninstall pkill silently no-op'd.

Broaden to `python.*winpodx[.*<subcmd>]`. Three legit shapes covered. Bundled in v0.5.5.