### PR TITLE
chore: dockur v5.15 + install.sh trap exit + migrate non-interactive

### DIFF
--- a/config/oem/VERSIONS.txt
+++ b/config/oem/VERSIONS.txt
@@ -18,7 +18,7 @@
 # describes what winpodx deliberately uses.
 #
 # Format: <key>=<value>
-dockur=v5.14
-dockur-digest=sha256:272b42c66e7377dc68e5da5d06d011308cf48f7a62201bc63f3caf973b87cdd9
-dockur-arm=v5.14
-dockur-arm-digest=sha256:a19114b03bed6433d95f61df39ea7ef249c953647973968b8f1fda495975f821
+dockur=v5.15
+dockur-digest=sha256:32abe0836aeeb744b8ff8af25688fcd348cc66016a1378fe1bd0768c8c67022c
+dockur-arm=v5.15
+dockur-arm-digest=sha256:5775bcfd335bad14fe35001460dd6640e131eb660601c2f3c90af43005a9532a

--- a/install.sh
+++ b/install.sh
@@ -173,7 +173,19 @@ chmod 600 "$WINPODX_INSTALL_MARKER" 2>/dev/null || true
 cleanup_install_marker() {
     rm -f "$WINPODX_INSTALL_MARKER"
 }
-trap cleanup_install_marker EXIT INT TERM
+# Ctrl+C / SIGTERM has to actually abort the rest of install.sh, not
+# just clean up the marker and fall through to the next command in
+# the script. Pre-fix behaviour: Ctrl+C during ``[1/4]`` wait-ready
+# killed the foreground winpodx process, the trap ran, then install
+# proceeded straight into the migrate step + apply-fixes prompt --
+# user saw "Start the pod now and apply?" against a pod that was
+# mid-install. Explicit ``exit 130`` (SIGINT) / ``143`` (SIGTERM) so
+# the script stops where the user asked.
+cleanup_and_exit_int() { cleanup_install_marker; exit 130; }
+cleanup_and_exit_term() { cleanup_install_marker; exit 143; }
+trap cleanup_install_marker EXIT
+trap cleanup_and_exit_int INT
+trap cleanup_and_exit_term TERM
 
 # Detect host architecture. winpodx ships two dockur image variants:
 #
@@ -792,7 +804,12 @@ export WINPODX_REQUIRE_AGENT=1
 # `|| true` keeps install.sh's exit code clean if migrate fails.
 if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_MIGRATE:-}" != "1" ]; then
     log "Running post-upgrade migration wizard..."
-    "$HOME/.local/bin/winpodx" migrate || mark_pending "migrate"
+    # ``--non-interactive`` so migrate doesn't prompt mid-install --
+    # install.sh runs its own confirmation up top and the user shouldn't
+    # have to answer "Start the pod now and apply?" / "Run app discovery
+    # now?" again from a subprocess. The wizard still records the
+    # version stamp + applies the idempotent runtime-fix chain.
+    "$HOME/.local/bin/winpodx" migrate --non-interactive || mark_pending "migrate"
 fi
 
 # --- Wait for agent to settle after migrate's apply chain ---

--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -87,10 +87,10 @@ _DISK_SIZE_RE = re.compile(r"^[1-9][0-9]{0,4}[KMGTkmgt]?$")
 # current ``:latest`` digest, paste below. See ``winpodx setup --update
 # -image`` for the runtime equivalent users invoke explicitly.
 #
-# As of 2026-05-02:
+# As of 2026-05-21 (dockur/windows v5.15):
 DOCKUR_IMAGE_PIN = (
     "docker.io/dockurr/windows@sha256:"
-    "20b398ab935465f97ec8ab06489f7a85a5ad58e74e036ce66cc3c9172e7dbea8"
+    "32abe0836aeeb744b8ff8af25688fcd348cc66016a1378fe1bd0768c8c67022c"
 )
 
 # Pinned dockur/windows-arm image — used as the default ``cfg.pod.image``
@@ -100,10 +100,10 @@ DOCKUR_IMAGE_PIN = (
 # OCI index, so container runtimes pick the right platform manifest
 # (amd64 or arm64) automatically.
 #
-# As of 2026-05-13:
+# As of 2026-05-21 (dockur/windows-arm v5.15):
 DOCKUR_IMAGE_ARM_PIN = (
     "docker.io/dockurr/windows-arm@sha256:"
-    "9c13f28f484bdf129fb8d951efb3fe3ff0cff20828efa5ed4b62ff1597a62611"
+    "5775bcfd335bad14fe35001460dd6640e131eb660601c2f3c90af43005a9532a"
 )
 
 


### PR DESCRIPTION
Three bundled changes for v0.5.5. Closes #223 #224.

dockur v5.14 -> v5.15: VERSIONS.txt + DOCKUR_IMAGE_PIN + DOCKUR_IMAGE_ARM_PIN refreshed.

install.sh Ctrl+C aborts properly: EXIT trap cleanup only; INT/TERM traps cleanup + exit 130/143.

migrate called with --non-interactive from install.sh so the wizard does not prompt mid-install.