### PR TITLE
fix(uninstall): suppress tray respawn via WINPODX_NO_TRAY_SPAWN env

### DIFF
--- a/src/winpodx/desktop/tray_spawn.py
+++ b/src/winpodx/desktop/tray_spawn.py
@@ -84,6 +84,14 @@ def maybe_spawn_tray() -> bool:
     tray downgrades to "no auto-recovery on idle stall" but never breaks
     the GUI / CLI itself.
     """
+    # Caller explicitly opted out of tray spawn via env var. uninstall.sh
+    # sets this so the ``winpodx host-open stop-listener`` /
+    # ``unregister-guest`` calls it runs to tear down reverse-open don't
+    # auto-respawn a fresh tray right after the pkill in section 0a.
+    if os.environ.get("WINPODX_NO_TRAY_SPAWN"):
+        log.debug("WINPODX_NO_TRAY_SPAWN set; skipping tray auto-spawn")
+        return False
+
     if _install_in_progress():
         log.debug("install.sh in progress; skipping tray auto-spawn")
         return False

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -2,6 +2,17 @@
 # SPDX-License-Identifier: MIT
 set -euo pipefail
 
+# Suppress auto-spawn of the system tray during uninstall. install.sh
+# uses a marker file for this; uninstall.sh uses an env var instead
+# because the marker would block tray spawn far longer than we want
+# (uninstall is expected to be short, and leaving a stale marker would
+# leak into the next install / GUI session). Every ``winpodx`` CLI call
+# this script makes (host-open stop-listener, unregister-guest, etc.)
+# inherits the env, so ``maybe_spawn_tray`` short-circuits cleanly --
+# without this the section-0a pkill below was promptly undone by the
+# next CLI subcommand auto-spawning a fresh tray.
+export WINPODX_NO_TRAY_SPAWN=1
+
 ###############################################################################
 # winpodx uninstaller
 #


### PR DESCRIPTION
Section 0a pkill'd the tray, then section 0b ran 'winpodx host-open stop-listener / unregister-guest' to tear down reverse-open. cli/main.py auto-spawns the tray for every subcommand outside the {setup, gui, tray} skiplist, so host-open triggered a fresh tray spawn and section 0a's work was immediately undone.

uninstall.sh now exports WINPODX_NO_TRAY_SPAWN=1. maybe_spawn_tray() short-circuits when set. Every winpodx CLI subprocess uninstall.sh runs inherits the env and skips the spawn. Bundled in v0.5.5.