### PR TITLE
fix(ci/obs): filter downloaded RPMs by current tag version

### DIFF
--- a/.github/workflows/obs-publish.yml
+++ b/.github/workflows/obs-publish.yml
@@ -134,6 +134,7 @@ jobs:
       - name: Discover repos and download RPMs
         run: |
           mkdir -p dist-rpms
+          version="${{ steps.tag.outputs.version }}"
 
           # Parse enabled repos from project _meta (public, no auth)
           meta=$(curl -sS -f "$OBS_PUBLIC_API/source/$OBS_PROJECT/_meta")
@@ -172,7 +173,14 @@ jobs:
               # directly instead of anchoring on `href="winpodx-`.
               listing=$(curl -sSL "$base/" || true)
               [ -z "$listing" ] && continue
-              rpms=$(echo "$listing" | grep -oE 'winpodx-[^"]+\.rpm' | sort -u)
+              # Anchor the filename match to the current tag's version so a
+              # stale older RPM still in the OBS publish index (Tumbleweed /
+              # Slowroll rolling-release repos are slow to garbage-collect)
+              # doesn't get downloaded and re-uploaded as a v${version}
+              # release asset. The release-asset rename further down would
+              # otherwise produce e.g. winpodx-0.5.4-...openSUSE_Tumbleweed.rpm
+              # alongside the real 0.5.5 RPMs, which already happened on v0.5.5.
+              rpms=$(echo "$listing" | grep -oE "winpodx-${version}-[^\"]+\.rpm" | sort -u)
               for f in $rpms; do
                 case "$f" in
                   *debuginfo*|*debugsource*|*.src.rpm) continue ;;


### PR DESCRIPTION
v0.5.5 release picked up two stale v0.5.4 RPMs from openSUSE Tumbleweed and Slowroll. Root cause: the discover-and-download step greps the OBS publish index for 'winpodx-*.rpm' with no version anchor, so any older RPM still in the index (Tumbleweed and Slowroll are rolling-release repos where OBS prunes published artefacts only lazily) gets pulled into dist-rpms/, renamed with the repo-slug suffix, and uploaded to the GitHub release.

Fix: pin the grep pattern to the current tag's version (already exported as steps.tag.outputs.version above). Other shipping repos (Leap 15.6/16.0, Fedora 42/43/44) didn't show the bug because their build targets rebuild less frequently and the new publish displaces the old before the workflow runs.

Will not retroactively clean v0.5.5's two stale assets - cosmetic, and removing them risks breaking anyone who already downloaded the URL.