### PR TITLE
fix(compose): chmod parent dir 0755 for OEM bind-mount traversal

### DIFF
--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -181,8 +181,22 @@ def _prepare_oem_dir(cfg: Config | None) -> str:
     user_oem = config_dir() / "oem"
 
     user_oem.mkdir(parents=True, exist_ok=True, mode=0o755)
+    # Explicit chmod on user_oem AND its parent ``~/.config/winpodx/``.
+    # ``mkdir(mode=0o755)`` is umask-adjusted, so on a host with the
+    # default umask 077 we'd get 0o700 and dockur's in-container ``cp``
+    # (running as a non-root user) couldn't traverse the parent to
+    # reach /oem at all -- the symptom is ``cp: cannot stat
+    # '/oem/./<file>': Permission denied`` for every file at first
+    # boot. PR #95 originally dodged this by returning the bundle dir
+    # directly when user-writable; #254 P1 had to drop that fast path
+    # to land per-config files (timezone.txt) without polluting the
+    # bundle, so we re-establish the traversal perms explicitly.
     try:
         os.chmod(user_oem, 0o755)
+    except OSError:
+        pass
+    try:
+        os.chmod(user_oem.parent, 0o755)
     except OSError:
         pass
 


### PR DESCRIPTION
User hit `cp: cannot stat '/oem/./<file>': Permission denied` for every OEM file during dockur's first-boot OEM-copy on a fresh install.

## Root cause

#254 P1 (PR #257) dropped `_find_oem_dir`'s bundle-direct fast path so per-config files (timezone.txt) could land under `~/.config/winpodx/oem/` without polluting the source bundle. The fallback path always copies OEM into the user OEM dir -- which PR #95 originally avoided because `~/.config/winpodx/` may be 0700 under umask 077, and dockur's in-container `cp` (running as a non-root user) needs traversal permission on every parent dir along the bind-mount path.

## Fix

`_prepare_oem_dir` now explicitly `chmod 0755` on both the user OEM dir AND its parent (`~/.config/winpodx/`). The parent chmod is the missing piece -- `mkdir(mode=0755)` is umask-adjusted so on a host with umask 077 we'd otherwise end up with 0700 and the same Permission denied cascade.

The chmod is a no-op when perms are already 0755+; on hosts that genuinely need 0700 on `~/.config/winpodx/` for some other reason (unlikely -- it's standard XDG_CONFIG_HOME content), users can post-chmod to taste, but the OEM bind mount would break again.

Ruff clean. Targeted tests (test_compose_timezone.py + test_paths.py) all pass.