### PR TITLE
refactor(compose): timezone via dockur TZ env, restore _find_oem_dir fast path

### DIFF
--- a/config/oem/install.bat
+++ b/config/oem/install.bat
@@ -131,22 +131,12 @@ reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" /v TargetReleas
 reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" /v DeferFeatureUpdates /t REG_DWORD /d 1 /f
 reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" /v DeferFeatureUpdatesPeriodInDays /t REG_DWORD /d 365 /f
 
-REM Timezone: prefer C:\OEM\timezone.txt (winpodx host-detected, #254),
-REM fall back to UTC. The file is single-line, contains a literal Windows
-REM TZ ID like "Korea Standard Time". winpodx skips writing it when host
-REM autodetect resolves to UTC, so the guest stays on whatever default
-REM Windows picked rather than being forced onto UTC.
-if exist "C:\OEM\timezone.txt" (
-    set "WINPODX_TZ="
-    for /f "usebackq delims=" %%T in ("C:\OEM\timezone.txt") do if not defined WINPODX_TZ set "WINPODX_TZ=%%T"
-    if defined WINPODX_TZ (
-        tzutil /s "%WINPODX_TZ%"
-    ) else (
-        tzutil /s "UTC"
-    )
-) else (
-    tzutil /s "UTC"
-)
+REM Timezone is handled upstream now: winpodx sets the dockur TZ env var
+REM in compose.yaml from cfg.pod.timezone (or host autodetect), and
+REM dockur writes the <TimeZone> element into the Sysprep unattend.xml
+REM on first boot. No tzutil call needed here -- Windows reads the
+REM Sysprep value during OOBE. Leaving this block as a no-op marker so
+REM the OEM script structure stays predictable across releases.
 
 reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Windows Search" /v AllowCortana /t REG_DWORD /d 0 /f
 

--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -54,6 +54,7 @@ name: "winpodx"
       LANGUAGE: "{language}"
       REGION: "{region}"
       KEYBOARD: "{keyboard}"
+      TZ: "{timezone}"
       ARGUMENTS: "{qemu_arguments}"
       USER_PORTS: "8765"
     volumes:
@@ -139,138 +140,77 @@ def _yaml_escape(val: str) -> str:
 def _find_oem_dir() -> str:
     """Return a user-writable OEM directory for the compose bind mount.
 
-    Back-compat wrapper around :func:`_prepare_oem_dir` for callers
-    that don't have a Config in hand (e.g. setup_cmd's agent-token
-    staging before the wizard has finished). Equivalent to
-    ``_prepare_oem_dir(cfg=None)``.
-    """
-    return _prepare_oem_dir(cfg=None)
+    Two regimes:
 
+    1. **Bundle dir is user-writable** (curl install, source checkout,
+       Nix profile install -- anything where the user owns the bundle
+       tree). Return bundle path directly. No copy needed: Podman's
+       ``:Z`` relabel works fine because the user owns the source.
+       Avoids the parent-dir traversal problem ``~/.config/winpodx/``
+       under umask 077 introduces -- dockur's in-container OEM-copy
+       step runs as a non-root sub-UID that can't traverse a 0700
+       ancestor (PR #95 / #266 / #267 history).
 
-def _prepare_oem_dir(cfg: Config | None) -> str:
-    """Return a user-writable OEM directory, populated for *cfg*.
+    2. **Bundle dir is read-only to current user** (RPM/wheel install
+       under ``/usr/share/winpodx/`` -- root-owned, world-readable
+       only). Copy the OEM tree into ``~/.config/winpodx/oem/`` and
+       return that. Necessary because rootless Podman can't lsetxattr
+       root-owned files for ``:Z`` (pgarciaq's GH-93). Files are
+       chmod'd 0644 + dirs 0755 after copy so dockur's in-container
+       ``cp`` can read regardless of the user's umask.
 
-    Always uses ``~/.config/winpodx/oem`` and copies the bundle OEM
-    tree in (idempotent via ``dirs_exist_ok``). Pre-#254 the function
-    had a fast-path that returned the bundle dir directly when it was
-    user-writable, but #254 needs to drop per-config files into the
-    OEM dir (``timezone.txt`` for the OEM ``tzutil`` step) without
-    touching the source bundle, so the always-copy path is now the
-    single regime.
+    #254's original P1 (timezone wiring) collapsed both regimes into a
+    single always-copy path so we could drop ``timezone.txt`` next to
+    the OEM scripts. That re-introduced the parent-dir traversal
+    problem on hosts with a 0700 ``~/.config/winpodx/`` (#266 / #267
+    user report). Switched to dockur's native ``TZ`` env var for
+    timezone wiring instead, which means the OEM dir no longer needs
+    per-config content -- so we can restore the two-regime layout.
 
-    With *cfg* provided, also writes:
-
-    * ``timezone.txt`` -- single line, Windows TZ ID resolved from
-      ``cfg.pod.timezone`` via :func:`utils.locale.resolve_timezone_for_oem`.
-      Empty when resolution returns ``"UTC"`` AND ``cfg.pod.timezone``
-      was explicitly empty (host autodetect found nothing usable) -- we
-      skip the file in that case so install.bat short-circuits past
-      the tzutil step instead of forcing UTC on guests that may have
-      a sensible default.
-
-    Permissions on copied files: 0644 / 0755. Necessary because dockur's
-    in-container ``cp`` runs as a non-root user the first time it pulls
-    /oem into C:\\OEM; a default 0600 umask blocks the copy and
-    install.bat never runs.
-
-    Falls back to the empty user OEM path when the bundle OEM dir is
+    Falls back to the user OEM path string when the bundle OEM dir is
     missing (broken install), so callers still get a path for error
     messages.
     """
     bundle_oem = bundle_dir() / "config" / "oem"
+
+    # Case 1 -- user owns the bundle. Use it directly.
+    if bundle_oem.is_dir() and os.access(bundle_oem, os.R_OK | os.W_OK):
+        return str(bundle_oem)
+
+    # Case 2 -- bundle is read-only (or missing). Copy into user space.
     user_oem = config_dir() / "oem"
+    if not bundle_oem.is_dir():
+        return str(user_oem)
 
     user_oem.mkdir(parents=True, exist_ok=True, mode=0o755)
-    # Explicit chmod on user_oem AND its parent ``~/.config/winpodx/``.
-    # ``mkdir(mode=0o755)`` is umask-adjusted, so on a host with the
-    # default umask 077 we'd get 0o700 and dockur's in-container ``cp``
-    # (running as a non-root user) couldn't traverse the parent to
-    # reach /oem at all -- the symptom is ``cp: cannot stat
-    # '/oem/./<file>': Permission denied`` for every file at first
-    # boot. PR #95 originally dodged this by returning the bundle dir
-    # directly when user-writable; #254 P1 had to drop that fast path
-    # to land per-config files (timezone.txt) without polluting the
-    # bundle, so we re-establish the traversal perms explicitly.
     try:
         os.chmod(user_oem, 0o755)
     except OSError:
         pass
-    try:
-        os.chmod(user_oem.parent, 0o755)
-    except OSError:
-        pass
 
-    if bundle_oem.is_dir():
-        for item in bundle_oem.iterdir():
-            dest = user_oem / item.name
-            if item.is_dir():
-                shutil.copytree(item, dest, dirs_exist_ok=True)
-                for root_dir, _dirs, files in os.walk(dest):
-                    root_path = Path(root_dir)
-                    try:
-                        os.chmod(root_path, 0o755)
-                    except OSError:
-                        pass
-                    for f in files:
-                        try:
-                            os.chmod(root_path / f, 0o644)
-                        except OSError:
-                            pass
-            else:
-                shutil.copy2(item, dest)
+    for item in bundle_oem.iterdir():
+        dest = user_oem / item.name
+        if item.is_dir():
+            shutil.copytree(item, dest, dirs_exist_ok=True)
+            for root_dir, _dirs, files in os.walk(dest):
+                root_path = Path(root_dir)
                 try:
-                    os.chmod(dest, 0o644)
+                    os.chmod(root_path, 0o755)
                 except OSError:
                     pass
-
-    if cfg is not None:
-        _write_oem_timezone(user_oem, cfg)
+                for f in files:
+                    try:
+                        os.chmod(root_path / f, 0o644)
+                    except OSError:
+                        pass
+        else:
+            shutil.copy2(item, dest)
+            try:
+                os.chmod(dest, 0o644)
+            except OSError:
+                pass
 
     return str(user_oem)
-
-
-def _write_oem_timezone(oem_dir: Path, cfg: Config) -> None:
-    """Drop ``oem_dir/timezone.txt`` with the Windows TZ ID for install.bat.
-
-    Resolution rules and skip-conditions live in
-    :func:`utils.locale.resolve_timezone_for_oem`. We treat
-    ``cfg.pod.timezone == ""`` AND a resolved value of ``"UTC"`` as
-    "host detection failed; let install.bat skip the tzutil step
-    rather than force UTC", because most users on UTC-via-detection-
-    failure are actually on a real zone and we'd rather not silently
-    change their system clock to UTC. An explicit ``timezone = "UTC"``
-    in the TOML, or any other resolved value, is written verbatim.
-    """
-    from winpodx.utils.locale import resolve_timezone_for_oem
-
-    configured = (cfg.pod.timezone or "").strip()
-    win_tz = resolve_timezone_for_oem(configured)
-
-    target = oem_dir / "timezone.txt"
-    # Detection fell all the way back to UTC: don't write the file so
-    # install.bat skips the tzutil call. Users on UTC who *want* UTC
-    # set it explicitly in the TOML and we honour that.
-    if not configured and win_tz == "UTC":
-        try:
-            target.unlink()
-        except FileNotFoundError:
-            pass
-        return
-
-    try:
-        target.write_text(win_tz + "\n", encoding="utf-8")
-        os.chmod(target, 0o644)
-    except OSError as e:
-        # Non-fatal: install.bat will skip tzutil if the file is
-        # missing, and the guest stays on its current TZ. Surface
-        # the failure to the user in logs so they can diagnose.
-        import logging
-
-        logging.getLogger(__name__).warning(
-            "could not write %s: %s; Windows guest TZ will stay on its current value",
-            target,
-            e,
-        )
 
 
 def _render_storage_blocks(cfg: Config) -> tuple[str, str]:
@@ -312,6 +252,29 @@ def _render_storage_blocks(cfg: Config) -> tuple[str, str]:
     return "", f"{expanded}:/storage:Z"
 
 
+def _resolve_timezone_for_compose(cfg: Config) -> str:
+    """Resolve ``cfg.pod.timezone`` to the value passed to dockur's TZ env.
+
+    dockur's ``TZ`` env var accepts an IANA name and translates it
+    internally to the Windows ``<TimeZone>`` element written into the
+    Sysprep unattend.xml. We just hand it whatever the user configured
+    (or autodetect from the host if the field is empty).
+
+    Empty string in -> host autodetect via :func:`utils.locale.detect_timezone`.
+    Non-empty IANA name in -> pass through verbatim.
+    Non-empty Windows TZ ID in (no ``/``) -> pass through. dockur tolerates
+    Windows TZ IDs directly; older dockur builds may not, in which case
+    users on niche territories the CLDR 001 wildcard doesn't cover need
+    to set an IANA name instead.
+    """
+    raw = (cfg.pod.timezone or "").strip()
+    if raw:
+        return raw
+    from winpodx.utils.locale import detect_timezone
+
+    return detect_timezone()
+
+
 def _build_compose_content(cfg: Config) -> str:
     """Build and return compose YAML content string for *cfg*."""
     password = cfg.rdp.password or generate_password()
@@ -337,9 +300,10 @@ def _build_compose_content(cfg: Config) -> str:
         language=_yaml_escape(cfg.pod.language),
         region=_yaml_escape(cfg.pod.region),
         keyboard=_yaml_escape(cfg.pod.keyboard),
+        timezone=_yaml_escape(_resolve_timezone_for_compose(cfg)),
         rdp_port=cfg.rdp.port,
         vnc_port=cfg.pod.vnc_port,
-        oem_dir=_prepare_oem_dir(cfg),
+        oem_dir=_find_oem_dir(),
         top_volumes=top_volumes,
         storage_mount=storage_mount,
         qemu_arguments=_qemu_arguments_for_host(cfg),

--- a/tests/test_compose_timezone.py
+++ b/tests/test_compose_timezone.py
@@ -1,17 +1,13 @@
 # SPDX-License-Identifier: MIT
-"""Tests for #254 timezone wiring in compose._prepare_oem_dir."""
+"""Tests for #254 timezone wiring via the dockur TZ env var."""
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from winpodx.core.config import Config
-from winpodx.core.pod.compose import _prepare_oem_dir
+from winpodx.core.pod.compose import _build_compose_content, _resolve_timezone_for_compose
 
 
 def _make_cfg(monkeypatch, tmp_path, *, timezone: str) -> Config:
-    """Build a Config with XDG_CONFIG_HOME pointed at tmp_path and a
-    specific cfg.pod.timezone value."""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
     cfg = Config()
@@ -19,89 +15,73 @@ def _make_cfg(monkeypatch, tmp_path, *, timezone: str) -> Config:
     return cfg
 
 
-class TestPrepareOemDirTimezone:
-    def test_explicit_iana_is_translated_and_written(self, tmp_path, monkeypatch):
+class TestResolveTimezoneForCompose:
+    def test_explicit_iana_passes_through(self, tmp_path, monkeypatch):
         cfg = _make_cfg(monkeypatch, tmp_path, timezone="Asia/Seoul")
-        result = Path(_prepare_oem_dir(cfg))
-
-        tz_file = result / "timezone.txt"
-        assert tz_file.exists(), "timezone.txt should be dropped into user OEM dir"
-        assert tz_file.read_text().strip() == "Korea Standard Time"
+        assert _resolve_timezone_for_compose(cfg) == "Asia/Seoul"
 
     def test_explicit_windows_id_passes_through(self, tmp_path, monkeypatch):
-        cfg = _make_cfg(monkeypatch, tmp_path, timezone="Russia Time Zone 11")
-        result = Path(_prepare_oem_dir(cfg))
+        cfg = _make_cfg(monkeypatch, tmp_path, timezone="Korea Standard Time")
+        assert _resolve_timezone_for_compose(cfg) == "Korea Standard Time"
 
-        tz_file = result / "timezone.txt"
-        assert tz_file.exists()
-        assert tz_file.read_text().strip() == "Russia Time Zone 11"
-
-    def test_explicit_utc_is_written(self, tmp_path, monkeypatch):
-        """Explicit ``UTC`` in TOML -> write the file. Distinguishes
-        deliberate UTC from detection-failure UTC (which doesn't write)."""
-        cfg = _make_cfg(monkeypatch, tmp_path, timezone="UTC")
-        result = Path(_prepare_oem_dir(cfg))
-
-        tz_file = result / "timezone.txt"
-        assert tz_file.exists()
-        assert tz_file.read_text().strip() == "UTC"
-
-    def test_empty_timezone_with_failed_detection_skips_file(self, tmp_path, monkeypatch):
-        """When cfg.pod.timezone is empty AND host detection falls back
-        to UTC, we don't write the file -- install.bat skips the tzutil
-        call and the guest keeps its current TZ rather than being forced
-        onto UTC."""
-        monkeypatch.setattr("winpodx.utils.locale.detect_timezone", lambda: "UTC")
-        cfg = _make_cfg(monkeypatch, tmp_path, timezone="")
-        result = Path(_prepare_oem_dir(cfg))
-
-        tz_file = result / "timezone.txt"
-        assert not tz_file.exists(), "no file should be written on detection-failure UTC"
-
-    def test_empty_timezone_with_real_host_value_is_written(self, tmp_path, monkeypatch):
-        """When cfg.pod.timezone is empty but host detection returns a
-        real zone, we write that zone's Windows ID."""
-        monkeypatch.setattr("winpodx.utils.locale.detect_timezone", lambda: "Asia/Tokyo")
-        cfg = _make_cfg(monkeypatch, tmp_path, timezone="")
-        result = Path(_prepare_oem_dir(cfg))
-
-        tz_file = result / "timezone.txt"
-        assert tz_file.exists()
-        assert tz_file.read_text().strip() == "Tokyo Standard Time"
-
-    def test_changing_timezone_overwrites_file(self, tmp_path, monkeypatch):
-        """Subsequent compose generations with a different timezone
-        must overwrite the previous file, not leave it stale."""
-        cfg = _make_cfg(monkeypatch, tmp_path, timezone="Asia/Seoul")
-        _prepare_oem_dir(cfg)
-
-        cfg.pod.timezone = "Europe/Paris"
-        result = Path(_prepare_oem_dir(cfg))
-
-        tz_file = result / "timezone.txt"
-        assert tz_file.read_text().strip() == "Romance Standard Time"
-
-    def test_changing_to_detection_failure_removes_stale_file(self, tmp_path, monkeypatch):
-        """If a previous run wrote the file and a subsequent run resolves
-        to detection-failure-UTC, the stale file must be removed so
-        install.bat doesn't apply an outdated TZ."""
-        cfg = _make_cfg(monkeypatch, tmp_path, timezone="Asia/Seoul")
-        result_first = Path(_prepare_oem_dir(cfg))
-        assert (result_first / "timezone.txt").exists()
-
-        monkeypatch.setattr("winpodx.utils.locale.detect_timezone", lambda: "UTC")
-        cfg.pod.timezone = ""
-        result_second = Path(_prepare_oem_dir(cfg))
-
-        assert not (result_second / "timezone.txt").exists(), (
-            "stale tz file should be removed on detection-failure run"
+    def test_empty_triggers_host_detect(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "winpodx.utils.locale.detect_timezone",
+            lambda: "Europe/Berlin",
         )
+        cfg = _make_cfg(monkeypatch, tmp_path, timezone="")
+        assert _resolve_timezone_for_compose(cfg) == "Europe/Berlin"
 
-    def test_no_cfg_skips_timezone_write(self, tmp_path, monkeypatch):
-        """Back-compat path: _prepare_oem_dir(cfg=None) is callable from
-        the legacy _find_oem_dir alias and must not touch timezone.txt."""
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
-        result = Path(_prepare_oem_dir(cfg=None))
+    def test_whitespace_is_stripped(self, tmp_path, monkeypatch):
+        cfg = _make_cfg(monkeypatch, tmp_path, timezone="  Asia/Tokyo  ")
+        assert _resolve_timezone_for_compose(cfg) == "Asia/Tokyo"
 
-        tz_file = result / "timezone.txt"
-        assert not tz_file.exists(), "no cfg -> no timezone.txt write"
+
+class TestComposeContainsTzEnv:
+    """The generated compose YAML must carry a ``TZ:`` line whose value
+    matches whatever cfg.pod.timezone resolves to. dockur reads TZ at
+    Sysprep time and writes the <TimeZone> element into unattend.xml."""
+
+    def test_explicit_iana_lands_in_tz_env(self, tmp_path, monkeypatch):
+        cfg = _make_cfg(monkeypatch, tmp_path, timezone="Asia/Seoul")
+        content = _build_compose_content(cfg)
+        assert 'TZ: "Asia/Seoul"' in content
+
+    def test_host_detect_lands_in_tz_env(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "winpodx.utils.locale.detect_timezone",
+            lambda: "America/Los_Angeles",
+        )
+        cfg = _make_cfg(monkeypatch, tmp_path, timezone="")
+        content = _build_compose_content(cfg)
+        assert 'TZ: "America/Los_Angeles"' in content
+
+    def test_utc_detect_fallback_still_lands(self, tmp_path, monkeypatch):
+        """Even when host detect returns the UTC fallback, the TZ env
+        still gets that value. This differs from the pre-refactor
+        OEM-file approach, where we skipped writing the file on a
+        detection-failure UTC to avoid forcing the guest onto UTC.
+        Now we just hand whatever we resolve to dockur and let dockur
+        decide; dockur's own fallback is also UTC, so the net effect
+        is identical."""
+        monkeypatch.setattr("winpodx.utils.locale.detect_timezone", lambda: "UTC")
+        cfg = _make_cfg(monkeypatch, tmp_path, timezone="")
+        content = _build_compose_content(cfg)
+        assert 'TZ: "UTC"' in content
+
+
+class TestNoStaleTimezoneFile:
+    """The pre-refactor design dropped a ``timezone.txt`` into the OEM
+    dir for install.bat to consume. That code path is gone -- compose
+    generation must not create the file, and the OEM dir must not
+    contain one after a fresh compose run."""
+
+    def test_compose_does_not_write_timezone_txt(self, tmp_path, monkeypatch):
+        cfg = _make_cfg(monkeypatch, tmp_path, timezone="Asia/Seoul")
+        _build_compose_content(cfg)
+
+        # User OEM dir may not even exist (case-1 fast path uses bundle
+        # dir directly); when it does exist, timezone.txt must not.
+        user_oem = tmp_path / "config" / "winpodx" / "oem"
+        if user_oem.is_dir():
+            assert not (user_oem / "timezone.txt").exists()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -54,29 +54,33 @@ class TestBundleDir:
 
 
 class TestFindOemDir:
-    """_find_oem_dir() / _prepare_oem_dir() always return the user OEM
-    dir under ~/.config/winpodx/oem/, populated by copy from the bundle
-    OEM tree. Pre-#254 the function had a fast-path that returned the
-    bundle dir directly when it was user-writable, but #254 needs to
-    drop per-config files (timezone.txt) into the OEM dir without
-    polluting the source bundle, so the always-copy path is now the
-    single regime. Both call shapes are covered."""
+    """_find_oem_dir() returns the bundle path directly when user-owned,
+    otherwise copies the OEM tree into ~/.config/winpodx/oem/ and
+    returns that. Two regimes; both regression-tested.
 
-    def test_returns_user_oem_path_always(self, tmp_path, monkeypatch):
-        """Even when the bundle is user-writable, the function returns
-        a copy under ``~/.config/winpodx/oem/`` rather than the bundle
-        path. Lets the compose generator safely drop ``timezone.txt``
-        (and future per-config files) without touching the source
-        checkout."""
+    The two-regime split exists because dockur's in-container OEM cp
+    runs as a non-root sub-UID that can't traverse a 0700 ancestor;
+    using the bundle path directly avoids the ``~/.config/winpodx/``
+    parent-perm trap that #254 P1's always-copy approach re-introduced
+    (#267 user report). Timezone wiring -- the original reason P1
+    needed always-copy -- moved to the dockur TZ env var, so the
+    two-regime layout is once again the right model."""
+
+    def test_returns_bundle_path_when_user_writable(self, tmp_path, monkeypatch):
+        """Common case (curl install / source checkout / Nix profile):
+        the user owns the bundle dir, so we use it directly without
+        copying."""
         from winpodx.core.pod.compose import _find_oem_dir
 
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
         result = Path(_find_oem_dir())
 
+        # Returned path must NOT be under tmp_path/winpodx/oem -- the
+        # user_oem fallback shouldn't fire when the bundle is writable.
         user_oem = tmp_path / "winpodx" / "oem"
-        assert result == user_oem, "expected always-copy path under user_oem"
-        # Bundle OEM contents must be present under the user_oem copy.
-        assert (result / "install.bat").exists(), "bundle OEM files should be copied"
+        assert result != user_oem, "user_oem fallback fired despite bundle being user-writable"
+        # Returned path must be the actual bundle OEM dir on disk.
+        assert (result / "install.bat").exists(), "bundle OEM not at returned path"
 
     def test_copies_to_user_dir_when_bundle_readonly(self, tmp_path, monkeypatch):
         """Fedora/RPM case: bundle dir is root-owned + read-only to


### PR DESCRIPTION
## Root cause

#254 P1 dropped `timezone.txt` into the OEM bind-mount dir and added a tzutil block to install.bat to consume it. That forced an always-copy OEM dir path so we could land per-config files without touching the source bundle -- which re-introduced the parent-dir traversal problem PR #95 originally dodged: dockur's in-container OEM cp runs as a non-root sub-UID that can't traverse a 0700 `~/.config` or `~/.local` ancestor, producing `cp: cannot stat /oem/./<file>: Permission denied` for every OEM file at first boot (user-reported).

## Simpler design

dockur natively supports a `TZ` env var that drives the `<TimeZone>` element in its Sysprep unattend.xml. winpodx hands `cfg.pod.timezone` (or the host-detected fallback) to dockur via compose env -- no OEM-side file, no tzutil call, no always-copy requirement.

## Changes

- Compose template gains `TZ: "{timezone}"` env line.
- New helper `_resolve_timezone_for_compose(cfg)` -- returns configured timezone or host-detected fallback verbatim. dockur handles IANA->Windows TZ ID translation internally; we just pass through.
- `_find_oem_dir` restored to the two-regime layout (bundle-direct when user-writable / copy to user OEM when read-only). `_prepare_oem_dir` + `_write_oem_timezone` removed.
- `config/oem/install.bat`: tzutil block stripped, short comment points at the compose TZ env approach.
- `tests/test_compose_timezone.py` rewritten: checks TZ env line in generated compose YAML + asserts no stale timezone.txt is dropped under user OEM. `tests/test_paths.py` restored to pre-P1 two-regime expectation.
- `utils/locale.py` kept as-is -- still drives GUI dropdown's 'Auto (detected: ...)' label + wizard prompt default + mapping table available for future code paths.

## Tests

Targeted: tests/test_compose_timezone.py (12) + tests/test_paths.py + tests/test_locale.py (29) + tests/test_config.py (105 total) all pass. Ruff clean.

## User-visible

Fixes the regression where `winpodx app run desktop` / fresh installs fail at dockur's OEM-copy step with permission-denied cascades when `~/.config/winpodx/` or any home-dir ancestor is 0700.