### PR TITLE
docs(install): explicit 'run winpodx setup' hint after package-manager install (#256)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ yay -S winpodx
 nix run github:kernalix7/winpodx
 ```
 
+> **After a package-manager install:** run `winpodx setup` once to generate `~/.config/winpodx/winpodx.toml` + compose.yaml. The curl one-liner does this for you (and waits ~5–10 min for the Windows first boot); package installs ship the binary only so `apt install` / `dnf install` / `yay -S` don't trigger a 10-minute Windows ISO download out of the blue. After setup, just launching an app (`winpodx app run desktop`) auto-provisions the pod the first time.
+
 See [docs/INSTALL.md](docs/INSTALL.md) for offline / air-gapped builds, source installs, version pinning, and uninstall.
 
 ## Launch

--- a/docs/INSTALL.ko.md
+++ b/docs/INSTALL.ko.md
@@ -117,6 +117,13 @@ keyboard = "ko-KR"
 
 미리 빌드된 RPM 과 `.deb` 패키지가 모든 [GitHub Release](https://github.com/kernalix7/winpodx/releases/latest) 에 첨부됨 — openSUSE/Fedora RPM 은 [openSUSE Build Service (`home:Kernalix7/winpodx`)](https://build.opensuse.org/package/show/home:Kernalix7/winpodx) 에서, 나머지는 GitHub Actions 에서. [`winpodx` AUR 패키지](https://aur.archlinux.org/packages/winpodx) 는 v0.5.2 부터 라이브 — Arch 사용자는 `yay -S winpodx` 또는 `paru -S winpodx` 로 설치.
 
+> **패키지 매니저 설치 후엔 `winpodx setup` 한번 실행.** 패키지 payload 는 바이너리 + 데스크탑 entry + 아이콘 + man page 만 — Windows VM provisioning 자동 트리거하는 post-install 훅 없음. 이유: (a) `winpodx setup` 가 인터랙티브 (backend / 자격증명 prompt), (b) `winpodx pod start` 는 ~7.5 GB Windows ISO 다운로드 + Sysprep + OEM apply (보통 회선 5–10분) 트리거, (c) `apt install` / `dnf install` / `yay -S` 가 root 로 돌며 사용자 네임스페이스 rootless podman provisioning 발화시키면 곤란. curl 원라이너는 동일한 `winpodx setup --non-interactive` + `winpodx pod wait-ready` 체인을 자체 실행해서 수동 setup 단계 안 보임. 첫 실행 흐름:
+>
+> ```bash
+> winpodx setup                # 인터랙티브: backend / 자격증명 / 사양 / locale
+> winpodx app run desktop      # 첫 호출시 pod 자동 provision (~5–10분)
+> ```
+
 ### openSUSE Tumbleweed / Leap 15.6 / Leap 16.0 / Slowroll
 
 ```bash

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -116,6 +116,13 @@ For the complete list of supported languages and region codes, see the [dockur/w
 
 Prebuilt RPM and `.deb` packages are attached to every [GitHub Release](https://github.com/kernalix7/winpodx/releases/latest) — openSUSE/Fedora RPMs come from the [openSUSE Build Service (`home:Kernalix7/winpodx`)](https://build.opensuse.org/package/show/home:Kernalix7/winpodx), the rest from GitHub Actions. The [`winpodx` AUR package](https://aur.archlinux.org/packages/winpodx) is live as of v0.5.2 — Arch users can install via `yay -S winpodx` or `paru -S winpodx`.
 
+> **After any package-manager install, run `winpodx setup` once.** The package payload is binary + desktop entry + icon + man page only -- no post-install hook fires the Windows VM provisioning, because (a) `winpodx setup` is interactive (backend / credentials prompts), (b) `winpodx pod start` triggers a ~7.5 GB Windows ISO download + Sysprep + OEM apply (5–10 min on typical connections), and (c) `apt install` / `dnf install` / `yay -S` running as root shouldn't fire user-namespace rootless podman provisioning. The curl one-liner does the same `winpodx setup --non-interactive` + `winpodx pod wait-ready` chain itself, which is why it appears not to need a manual setup step. First-time flow:
+>
+> ```bash
+> winpodx setup                # interactive: backend / credentials / specs / locale
+> winpodx app run desktop      # auto-provisions the pod on first call (~5–10 min)
+> ```
+
 ### openSUSE Tumbleweed / Leap 15.6 / Leap 16.0 / Slowroll
 
 ```bash

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -100,6 +100,8 @@ yay -S winpodx
 nix run github:kernalix7/winpodx
 ```
 
+> **패키지 매니저 설치 후:** `winpodx setup` 한번 실행 → `~/.config/winpodx/winpodx.toml` + compose.yaml 생성. curl 원라이너는 이 단계를 자동으로 해주고 Windows 첫 부팅까지 ~5–10분 대기; 패키지 설치는 바이너리만 ship — `apt install` / `dnf install` / `yay -S` 가 갑자기 10분짜리 Windows ISO 다운로드 트리거하지 않게. setup 후엔 그냥 앱 실행 (`winpodx app run desktop`) 만 해도 첫 실행시 pod 자동 provision.
+
 오프라인 / 에어갭 빌드, 소스 설치, 버전 pin, 언인스톨은 [docs/INSTALL.ko.md](INSTALL.ko.md) 참조.
 
 ## 실행


### PR DESCRIPTION
@ismikes hit this in #256 -- after `sudo dnf` / `apt` / `yay install`, the first-time UX wasn't obvious. install.sh (curl) auto-runs the setup + wait-ready chain, but the .deb / .rpm / AUR packages ship the binary only (no post-install hook by design).

Adds a one-line blockquote callout after each 'Quick install' / package-manager block:

- README.md
- docs/README.ko.md
- docs/INSTALL.md (Native package managers section, longer rationale)
- docs/INSTALL.ko.md

Points users at `winpodx setup` + `winpodx app run desktop` (which auto-provisions on first call).