### PR TITLE
feat(pod): add `pod recover-oem` for failed first-boot OEM copy (#287)

### DIFF
--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -199,6 +199,17 @@ def cli(argv: list[str] | None = None) -> None:
     add_install_status(pod_sub)
     add_install_resume(pod_sub)
 
+    pod_sub.add_parser(
+        "recover-oem",
+        help=(
+            "Re-stage C:\\OEM in the Windows guest when dockur's automatic "
+            "first-boot OEM copy failed (#287). Tars /oem inside the "
+            "container, starts an HTTP server, and prints the noVNC "
+            "PowerShell commands the user must paste to download + run "
+            "install.bat manually. podman/docker backends only."
+        ),
+    )
+
     # --- config ---
     cfg_parser = sub.add_parser("config", help="Manage configuration")
     cfg_sub = cfg_parser.add_subparsers(dest="config_command")

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -1017,7 +1017,7 @@ def _recover_oem() -> None:
        present inside the container (i.e. host-side OEM mount is OK
        and only the guest-side copy is what failed).
     2. Tars ``/oem`` to ``/storage/oem.tar.gz`` inside the container.
-    3. Starts a one-shot Python HTTP server on container port 9999
+    3. Starts a one-shot Python HTTP server on container port 8766
        (reachable from the Windows guest via QEMU's NAT gateway
        ``10.0.2.2``).
     4. Prints the exact PowerShell commands the user must paste into
@@ -1116,8 +1116,12 @@ def _recover_oem() -> None:
         print("Error: tar timed out (60s).")
         sys.exit(1)
 
-    print("[winpodx] Starting HTTP server on container port 9999...")
-    # Best-effort cleanup of any prior server on 9999.
+    # Port 8766: one above the winpodx agent port (8765) so anyone
+    # debugging with `lsof -i :876*` sees both. Container-internal only;
+    # not forwarded to the host. Reachable from the Windows guest via
+    # QEMU's NAT gateway 10.0.2.2:8766.
+    print("[winpodx] Starting HTTP server on container port 8766...")
+    # Best-effort cleanup of any prior server on 8766.
     subprocess.run(
         [
             cmd,
@@ -1125,7 +1129,7 @@ def _recover_oem() -> None:
             container,
             "sh",
             "-c",
-            "pkill -f 'http.server 9999' 2>/dev/null; true",
+            "pkill -f 'http.server 8766' 2>/dev/null; true",
         ],
         capture_output=True,
         timeout=5,
@@ -1140,7 +1144,7 @@ def _recover_oem() -> None:
             container,
             "sh",
             "-c",
-            "cd /storage && nohup python3 -m http.server 9999 >/tmp/recover-oem-http.log 2>&1 &",
+            "cd /storage && nohup python3 -m http.server 8766 >/tmp/recover-oem-http.log 2>&1 &",
         ],
         timeout=10,
     )
@@ -1153,7 +1157,7 @@ def _recover_oem() -> None:
     print("  noVNC URL: http://127.0.0.1:8007/")
     print()
     print("  # Download OEM bundle from container (10.0.2.2 = QEMU NAT gateway)")
-    print("  Invoke-WebRequest http://10.0.2.2:9999/oem.tar.gz -OutFile C:\\oem.tar.gz")
+    print("  Invoke-WebRequest http://10.0.2.2:8766/oem.tar.gz -OutFile C:\\oem.tar.gz")
     print()
     print("  # Extract to C:\\OEM\\ (Windows 10/11 ships bsdtar in System32)")
     print("  cd C:\\")
@@ -1172,4 +1176,4 @@ def _recover_oem() -> None:
     print("  winpodx check")
     print()
     print("To stop the HTTP server when finished:")
-    print(f"  {cmd} exec {container} pkill -f 'http.server 9999'")
+    print(f"  {cmd} exec {container} pkill -f 'http.server 8766'")

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -36,10 +36,13 @@ def handle_pod(args: argparse.Namespace) -> None:
         from winpodx.cli.pod_install_resume import handle as handle_install_resume
 
         sys.exit(handle_install_resume(args))
+    elif cmd == "recover-oem":
+        _recover_oem()
     else:
         print(
             "Usage: winpodx pod {start|stop|status|restart|recreate|apply-fixes|"
-            "sync-password|multi-session|wait-ready|install-status|install-resume}"
+            "sync-password|multi-session|wait-ready|install-status|install-resume|"
+            "recover-oem}"
         )
         sys.exit(1)
 
@@ -998,3 +1001,175 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
                     log_proc.kill()
                 except Exception:  # noqa: BLE001
                     pass
+
+
+def _recover_oem() -> None:
+    """Recover from a failed dockur OEM-copy by re-staging C:\\OEM\\ manually.
+
+    Workaround for #287: in some host environments dockur's first-boot
+    ``/oem -> C:\\OEM\\`` copy silently fails, leaving the guest with
+    no ``install.bat``, no agent, and no rdprrap. The host then sees
+    port 8765 RST and ``winpodx pod wait-ready`` times out.
+
+    This command:
+
+    1. Verifies the container is running and ``/oem/install.bat`` is
+       present inside the container (i.e. host-side OEM mount is OK
+       and only the guest-side copy is what failed).
+    2. Tars ``/oem`` to ``/storage/oem.tar.gz`` inside the container.
+    3. Starts a one-shot Python HTTP server on container port 9999
+       (reachable from the Windows guest via QEMU's NAT gateway
+       ``10.0.2.2``).
+    4. Prints the exact PowerShell commands the user must paste into
+       the noVNC console to download, extract, and run ``install.bat``.
+
+    We do not push to the guest automatically because the failure mode
+    of #287 leaves the agent dead -- there is no working host->guest
+    channel. noVNC PowerShell paste is the only reliable path until the
+    agent is up.
+    """
+    import shutil as _shutil
+    import subprocess
+    import time
+
+    from winpodx.core.provisioner import _ensure_config
+
+    cfg = _ensure_config()
+    container = cfg.pod.container_name
+    backend_name = cfg.pod.backend
+
+    if backend_name not in ("podman", "docker"):
+        print(
+            f"Error: recover-oem only supports podman/docker backends "
+            f"(current: {backend_name}). For libvirt/manual backends, "
+            f"copy /oem into the guest manually."
+        )
+        sys.exit(1)
+
+    cmd = backend_name
+    if not _shutil.which(cmd):
+        print(f"Error: {cmd} not found on PATH.")
+        sys.exit(1)
+
+    print(f"[winpodx] Checking container '{container}' is running...")
+    try:
+        result = subprocess.run(
+            [
+                cmd,
+                "ps",
+                "--filter",
+                f"name={container}",
+                "--filter",
+                "status=running",
+                "--format",
+                "{{.Names}}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"Error: '{cmd} ps' timed out (10s).")
+        sys.exit(1)
+    if container not in result.stdout:
+        print(
+            f"Error: container '{container}' not running. Start it first with 'winpodx pod start'."
+        )
+        sys.exit(1)
+
+    print("[winpodx] Verifying /oem/install.bat exists inside container...")
+    try:
+        check = subprocess.run(
+            [cmd, "exec", container, "sh", "-c", "test -f /oem/install.bat"],
+            capture_output=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        print("Error: container exec timed out (10s).")
+        sys.exit(1)
+    if check.returncode != 0:
+        print(
+            "Error: /oem/install.bat not found inside container. "
+            "The host-side OEM mount itself is missing -- recreate "
+            "the pod with 'winpodx pod recreate' before retrying."
+        )
+        sys.exit(1)
+
+    print("[winpodx] Tarring /oem into /storage/oem.tar.gz inside container...")
+    try:
+        subprocess.run(
+            [
+                cmd,
+                "exec",
+                container,
+                "sh",
+                "-c",
+                "cd / && tar czf /storage/oem.tar.gz oem && ls -la /storage/oem.tar.gz",
+            ],
+            check=True,
+            timeout=60,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error: tar failed (rc={e.returncode}).")
+        sys.exit(1)
+    except subprocess.TimeoutExpired:
+        print("Error: tar timed out (60s).")
+        sys.exit(1)
+
+    print("[winpodx] Starting HTTP server on container port 9999...")
+    # Best-effort cleanup of any prior server on 9999.
+    subprocess.run(
+        [
+            cmd,
+            "exec",
+            container,
+            "sh",
+            "-c",
+            "pkill -f 'http.server 9999' 2>/dev/null; true",
+        ],
+        capture_output=True,
+        timeout=5,
+    )
+    time.sleep(1)
+    # `-d` detaches the exec so the server keeps running after we return.
+    subprocess.run(
+        [
+            cmd,
+            "exec",
+            "-d",
+            container,
+            "sh",
+            "-c",
+            "cd /storage && nohup python3 -m http.server 9999 >/tmp/recover-oem-http.log 2>&1 &",
+        ],
+        timeout=10,
+    )
+    time.sleep(2)
+
+    print()
+    print("=" * 70)
+    print("Paste these commands into the Windows guest via noVNC PowerShell:")
+    print()
+    print("  noVNC URL: http://127.0.0.1:8007/")
+    print()
+    print("  # Download OEM bundle from container (10.0.2.2 = QEMU NAT gateway)")
+    print("  Invoke-WebRequest http://10.0.2.2:9999/oem.tar.gz -OutFile C:\\oem.tar.gz")
+    print()
+    print("  # Extract to C:\\OEM\\ (Windows 10/11 ships bsdtar in System32)")
+    print("  cd C:\\")
+    print("  tar -xzf C:\\oem.tar.gz")
+    print()
+    print("  # Verify: should list install.bat, agent\\, rdprrap\\, scripts\\, etc.")
+    print("  dir C:\\OEM")
+    print()
+    print("  # Run install.bat -- guest will reboot at the end")
+    print("  C:\\OEM\\install.bat")
+    print()
+    print("=" * 70)
+    print()
+    print("After the post-install reboot, on this host:")
+    print("  winpodx pod wait-ready")
+    print("  winpodx check")
+    print()
+    print("To stop the HTTP server when finished:")
+    print(f"  {cmd} exec {container} pkill -f 'http.server 9999'")


### PR DESCRIPTION
## Summary

Adds `winpodx pod recover-oem`, a host-side command that recovers from dockur's silent first-boot `/oem -> C:\OEM\` copy failure (#287 -- @ankranidiotis on Linux Mint 22 / Podman 4.9.3).

When this failure hits, the guest ends up with **no `install.bat`, no agent, no rdprrap** -- port 8765 RSTs and `pod wait-ready` times out at 60 minutes.

@ankranidiotis attempted a manual workaround (container HTTP server + download `install.bat` alone), which fell short because `install.bat` expects sibling files inside `C:\OEM\`: `agent\agent.ps1`, `rdprrap\*`, `scripts\*`. Running it alone silently skips the agent install step.

This PR automates the **complete** workaround:

1. Verifies the container is running and `/oem/install.bat` exists inside the container (i.e. host-side OEM mount is OK -- only the guest-side copy failed; if not, suggests `pod recreate`).
2. Tars `/oem` -> `/storage/oem.tar.gz` inside the container.
3. Starts a one-shot Python HTTP server on container port 9999 (reachable from the guest via QEMU's NAT gateway `10.0.2.2`).
4. Prints the exact noVNC PowerShell commands the user pastes to download, extract, and run `install.bat` from the full OEM tree.

### Why we don't push to the guest automatically

The failure mode of #287 leaves the agent dead -- there is no working host->guest channel (RDP, agent /exec, all RST). noVNC PowerShell paste is the only reliable path until `install.bat` brings the agent up.

### Backend support

- `podman` / `docker`: full support
- `libvirt` / `manual`: clear error pointing the user at manual copy

## Test plan

- [ ] `winpodx pod recover-oem` with no pod started -> clear error
- [ ] `winpodx pod recover-oem` on libvirt backend -> clear error
- [ ] `winpodx pod recover-oem` with pod running but `/oem/install.bat` missing -> suggests `pod recreate`
- [ ] `winpodx pod recover-oem` on a healthy pod (smoke check that the tar + HTTP server steps actually fire and exit cleanly)
- [ ] @ankranidiotis dry-run of the printed PowerShell paste block against his #287 pod (eventual user verification)

## Notes

- Does NOT modify install.bat, OEM bundle version, or any guest-side path. Pure host-side recovery helper.
- HTTP server runs detached via `nohup` inside the container; cleanup command is printed at the end of the output.
- Tests: 188 cli/pod tests pass (`pytest -k 'pod or cli or main'`).