### PR TITLE
fix(install): require podman-compose proper, don't trust `podman compose` delegation (#288)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -396,7 +396,18 @@ if ! command -v podman >/dev/null 2>&1; then
     MISSING+=("podman")
 fi
 
-if ! command -v podman-compose >/dev/null 2>&1 && ! podman compose version >/dev/null 2>&1; then
+# Require podman-compose proper. `podman compose` (the subcommand)
+# delegates to whatever compose provider it finds first, and on systems
+# that have the docker-compose CLI plugin installed (Fedora / Nobara
+# default) that delegation succeeds while silently routing through
+# docker-compose. docker-compose does not understand podman's
+# `group_add: [keep-groups]` magic value (required for rootless
+# /dev/kvm access), so the container fails to start with:
+#   "looking up supplemental groups for container ...: Unable to find
+#    group keep-groups: no matching entries in group file"
+# See #288 (magicdiablo, Nobara). Don't rely on `podman compose
+# version` succeeding -- it lies via delegation.
+if ! command -v podman-compose >/dev/null 2>&1; then
     MISSING+=("podman-compose")
 fi
 

--- a/src/winpodx/backend/podman.py
+++ b/src/winpodx/backend/podman.py
@@ -18,12 +18,29 @@ class PodmanBackend(Backend):
         return str(config_dir() / "compose.yaml")
 
     def _compose_cmd(self) -> list[str]:
-        # Prefer podman-compose directly (avoids docker-compose plugin hijacking)
+        # We require podman-compose proper -- the `podman compose`
+        # subcommand delegates to whatever compose provider it finds,
+        # and on Fedora-family systems with the docker-compose CLI
+        # plugin installed (Nobara default) it routes through
+        # docker-compose. docker-compose does not understand podman's
+        # `group_add: [keep-groups]` magic value (which we need for
+        # rootless /dev/kvm access), so the container start fails with
+        # "looking up supplemental groups ... Unable to find group
+        # keep-groups". See #288 (magicdiablo).
         import shutil
 
         if shutil.which("podman-compose"):
             return ["podman-compose", "-f", self._compose_file()]
-        return ["podman", "compose", "-f", self._compose_file()]
+        raise RuntimeError(
+            "podman-compose not found on PATH. winpodx requires podman-compose "
+            "(not the `podman compose` subcommand, which delegates to "
+            "docker-compose and breaks our keep-groups extension -- see #288). "
+            "Install it with your package manager: "
+            "Fedora/Nobara: `sudo dnf install podman-compose`, "
+            "Debian/Ubuntu: `sudo apt install podman-compose`, "
+            "Arch: `sudo pacman -S podman-compose`, "
+            "openSUSE: `sudo zypper install podman-compose`."
+        )
 
     def start(self) -> None:
         try:


### PR DESCRIPTION
## Summary

@magicdiablo on Nobara hit a container start failure (#288):

```
Error response from daemon: looking up supplemental groups for container ...:
Unable to find group keep-groups: no matching entries in group file
```

**Root cause**: our compose template emits `group_add: [keep-groups]` + `run.oci.keep_original_groups: "1"` to pass the caller's supplemental groups (notably the KVM group) through to the rootless container. `keep-groups` is a **podman-specific magic value**, not a real Linux group.

On Fedora-family systems with the docker-compose CLI plugin installed (Nobara default), `podman compose` **delegates** to docker-compose. docker-compose treats `keep-groups` as a literal group name to look up, finds nothing, and the container start fails.

Our existing presence check in `install.sh` allowed this state through:

```bash
if ! command -v podman-compose >/dev/null 2>&1 && ! podman compose version >/dev/null 2>&1; then
    MISSING+=("podman-compose")
fi
```

`podman compose version` succeeds via docker-compose delegation -- it lies about being a working compose provider while actually routing through one that breaks our extras.

## Changes

1. **`install.sh`**: drop the `|| podman compose version` clause. Always require the standalone `podman-compose` binary.
2. **`backend.podman._compose_cmd`**: raise a clear `RuntimeError` naming the distro install commands instead of silently falling back to `podman compose` (which would hit the same trap).

## Workaround for affected users

```bash
# Fedora/Nobara
sudo dnf install podman-compose

# Debian/Ubuntu
sudo apt install podman-compose

# Arch
sudo pacman -S podman-compose

# openSUSE
sudo zypper install podman-compose
```

## Test plan

- [x] `pytest tests/test_backend.py tests/test_audit5_core.py -q` -> 44 passed
- [x] `ruff check src/winpodx/backend/podman.py` -> clean
- [ ] @magicdiablo re-runs `install.sh` on Nobara after `dnf install podman-compose` (verifies workaround)
- [ ] Fresh install on a Fedora VM without podman-compose pre-installed -> install.sh detects + suggests it