### PR TITLE
feat(pod): dynamic wait-ready timeout based on dockur wget ETA (#126)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -774,7 +774,7 @@ mark_pending() {
 }
 
 if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_WAIT:-}" != "1" ]; then
-    log "Waiting for Windows VM to finish first-boot (up to 60 min, auto-extends to 4h on slow ISO downloads)..."
+    log "Waiting for Windows VM to finish first-boot (60 min default, auto-extends to match observed ISO download speed)..."
     log "  Fresh install downloads ~7.5GB Windows ISO + runs Sysprep + OEM apply."
     log "  Subsequent installs reuse the cached ISO and finish in 2-5 min."
     # Capture wait-ready output so we can discriminate the "no such
@@ -824,7 +824,7 @@ if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_WAIT:-}" != "1
             warn '  curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash -s -- --main'
         else
             warn "Windows first-boot didn't complete in time (default 60min,"
-            warn "extended automatically up to 4h on slow downloads -- see #126)."
+            warn "auto-extended based on observed wget ETA -- see #126)."
             warn "Marking remaining steps as pending — they will auto-resume on next"
             warn "\`winpodx\` CLI invocation or when you open \`winpodx gui\`."
             mark_pending "wait_ready"

--- a/install.sh
+++ b/install.sh
@@ -774,7 +774,7 @@ mark_pending() {
 }
 
 if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_WAIT:-}" != "1" ]; then
-    log "Waiting for Windows VM to finish first-boot (up to 60 min)..."
+    log "Waiting for Windows VM to finish first-boot (up to 60 min, auto-extends to 4h on slow ISO downloads)..."
     log "  Fresh install downloads ~7.5GB Windows ISO + runs Sysprep + OEM apply."
     log "  Subsequent installs reuse the cached ISO and finish in 2-5 min."
     # Capture wait-ready output so we can discriminate the "no such
@@ -823,7 +823,8 @@ if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_WAIT:-}" != "1
             warn '  curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh | bash -s -- --purge'
             warn '  curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash -s -- --main'
         else
-            warn "Windows first-boot didn't complete in 60 minutes."
+            warn "Windows first-boot didn't complete in time (default 60min,"
+            warn "extended automatically up to 4h on slow downloads -- see #126)."
             warn "Marking remaining steps as pending — they will auto-resume on next"
             warn "\`winpodx\` CLI invocation or when you open \`winpodx gui\`."
             mark_pending "wait_ready"

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 
 
@@ -821,6 +822,31 @@ def _wait_for_oem_reboot(cfg, timeout: int) -> bool:  # type: ignore[no-untyped-
     return False
 
 
+# Wget progress line format dockur prints during Windows ISO download:
+#
+#   6488064K ........ ........ ........ ........ 78% 4.55M 21m22s
+#                                                %    speed remaining
+#
+# We only match the "remaining" form (space-separated time after speed),
+# not the "= elapsed" form (4.55M=21m22s) that wget prints when it
+# hasn't seen enough samples for an ETA yet. The space anchor before
+# the time group is load-bearing -- it discriminates the two forms.
+_WGET_ETA_RE = re.compile(r"\d+%\s+\d+\.?\d*[KMG]?\s+(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?\s*$")
+
+
+def _parse_wget_eta_secs(line: str) -> int | None:
+    """Extract wget's "remaining time" estimate (seconds) from a dockur
+    progress line. Returns None if the line doesn't carry a usable ETA
+    (no match, or all-zero groups).
+    """
+    m = _WGET_ETA_RE.search(line)
+    if m is None:
+        return None
+    h, mn, s = m.groups()
+    secs = (int(h) if h else 0) * 3600 + (int(mn) if mn else 0) * 60 + (int(s) if s else 0)
+    return secs if secs > 0 else None
+
+
 def _wait_ready(timeout: int, show_logs: bool) -> None:
     """v0.2.0.5: multi-phase wait for the Windows VM to finish first-boot.
 
@@ -836,6 +862,13 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
     and surfaced as ``[container] ...`` lines so the user can see Windows
     actually doing work (Sysprep, OEM apply, etc.) instead of a black
     box.
+
+    The deadline is dynamic when ``--logs`` is on: wget's ETA from the
+    Windows ISO download is parsed in the log-drain thread and used to
+    extend the wait window if the user's connection is slow enough that
+    the static timeout would expire mid-download (xiyeming #126: 86min
+    ISO download exceeded the 60min default). Capped at 4h to bound
+    runaway extensions on broken networks. No-op for fast connections.
     """
     import threading
     import time as _time
@@ -852,6 +885,41 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
 
     timeout = max(60, min(7200, int(timeout)))
     start = _time.monotonic()
+
+    # Mutable deadline so the log-drain thread can extend it when slow
+    # download progress is observed. Ceiling at 4h to bound the
+    # extension on stuck / aborted downloads.
+    _DEADLINE_CEILING = start + 4 * 3600
+    _BOOT_BUFFER_SECS = 600  # 10min after download for Sysprep / OEM apply
+    _ANNOUNCE_STEP_SECS = 600  # only re-announce when deadline jumps 10min+
+    deadline_state = {
+        "value": start + timeout,
+        "last_announced": None,
+    }
+
+    def _maybe_extend_deadline(eta_remaining_secs: int) -> None:
+        """Extend deadline if wget ETA suggests the current one will
+        expire before the download finishes. Idempotent + threadsafe
+        enough (single-key dict writes are atomic under the GIL; we
+        accept eventual consistency)."""
+        now = _time.monotonic()
+        projected_done = now + eta_remaining_secs + _BOOT_BUFFER_SECS
+        if projected_done <= deadline_state["value"]:
+            return
+        new_deadline = min(projected_done, _DEADLINE_CEILING)
+        if new_deadline <= deadline_state["value"]:
+            return
+        deadline_state["value"] = new_deadline
+        last = deadline_state["last_announced"]
+        if last is None or new_deadline - last >= _ANNOUNCE_STEP_SECS:
+            total_min = int((new_deadline - start) / 60)
+            eta_min = max(1, eta_remaining_secs // 60)
+            print(
+                f"[winpodx] Slow Windows ISO download detected "
+                f"(~{eta_min}m remaining). "
+                f"Extending wait to {total_min}m total."
+            )
+            deadline_state["last_announced"] = new_deadline
 
     def elapsed() -> str:
         s = int(_time.monotonic() - start)
@@ -916,6 +984,12 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
                         and "you are using the BTRFS filesystem for /storage" in line
                     ):
                         line = "(btrfs warning suppressed: NoCoW bind mount in use)"
+                    # Watch dockur's wget progress for slow downloads --
+                    # extend the wait deadline when the ETA suggests the
+                    # static timeout would expire mid-download (#126).
+                    eta_secs = _parse_wget_eta_secs(line)
+                    if eta_secs is not None:
+                        _maybe_extend_deadline(eta_secs)
                     print(f"       [container] {_rewrite_vnc_url(line)}")
 
             threading.Thread(target=_drain, args=(log_proc.stdout,), daemon=True).start()
@@ -927,8 +1001,7 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
     try:
         # --- [1/4] Container running ---
         print(f"[1/4] Waiting for container to start...      ({elapsed()})")
-        deadline = start + timeout
-        while _time.monotonic() < deadline:
+        while _time.monotonic() < deadline_state["value"]:
             try:
                 if pod_status(cfg).state == PodState.RUNNING:
                     print(f"      OK Container running                   ({elapsed()})")
@@ -942,7 +1015,7 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
 
         # --- [2/4] RDP port open ---
         print(f"[2/4] Waiting for Windows RDP service...     ({elapsed()})")
-        while _time.monotonic() < deadline:
+        while _time.monotonic() < deadline_state["value"]:
             if check_rdp_port(cfg.rdp.ip, cfg.rdp.port, timeout=1.0):
                 print(f"      OK RDP port {cfg.rdp.port} open                  ({elapsed()})")
                 break
@@ -953,7 +1026,7 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
 
         # --- [3/4] FreeRDP RemoteApp activation ---
         print(f"[3/4] Waiting for Windows activation...      ({elapsed()})")
-        remaining = max(60, int(deadline - _time.monotonic()))
+        remaining = max(60, int(deadline_state["value"] - _time.monotonic()))
         if wait_for_windows_responsive(cfg, timeout=remaining):
             print(f"      OK Windows ready                         ({elapsed()})")
         else:
@@ -981,7 +1054,7 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
         # silently — `apply-fixes` will surface the pending-reboot
         # condition separately if it matters.
         print(f"[4/4] Waiting for OEM reboot pass...         ({elapsed()})")
-        remaining = max(60, int(deadline - _time.monotonic()))
+        remaining = max(60, int(deadline_state["value"] - _time.monotonic()))
         if _wait_for_oem_reboot(cfg, timeout=remaining):
             print(f"      OK OEM reboot pass complete             ({elapsed()})")
         else:

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -867,8 +867,11 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
     Windows ISO download is parsed in the log-drain thread and used to
     extend the wait window if the user's connection is slow enough that
     the static timeout would expire mid-download (xiyeming #126: 86min
-    ISO download exceeded the 60min default). Capped at 4h to bound
-    runaway extensions on broken networks. No-op for fast connections.
+    ISO download exceeded the 60min default). No upper bound -- we
+    trust the ETA wget itself reports. If the download genuinely
+    stalls, no new ETA arrives, the deadline stops moving, and the
+    wait expires naturally on the last extension. No-op for fast
+    connections (their ETA always fits inside the current deadline).
     """
     import threading
     import time as _time
@@ -887,9 +890,9 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
     start = _time.monotonic()
 
     # Mutable deadline so the log-drain thread can extend it when slow
-    # download progress is observed. Ceiling at 4h to bound the
-    # extension on stuck / aborted downloads.
-    _DEADLINE_CEILING = start + 4 * 3600
+    # download progress is observed. No ceiling -- we trust wget's
+    # ETA. A genuinely stalled download stops producing ETA lines, so
+    # the deadline stops advancing and the wait expires naturally.
     _BOOT_BUFFER_SECS = 600  # 10min after download for Sysprep / OEM apply
     _ANNOUNCE_STEP_SECS = 600  # only re-announce when deadline jumps 10min+
     deadline_state = {
@@ -903,10 +906,7 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
         enough (single-key dict writes are atomic under the GIL; we
         accept eventual consistency)."""
         now = _time.monotonic()
-        projected_done = now + eta_remaining_secs + _BOOT_BUFFER_SECS
-        if projected_done <= deadline_state["value"]:
-            return
-        new_deadline = min(projected_done, _DEADLINE_CEILING)
+        new_deadline = now + eta_remaining_secs + _BOOT_BUFFER_SECS
         if new_deadline <= deadline_state["value"]:
             return
         deadline_state["value"] = new_deadline

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -893,7 +893,12 @@ def _wait_ready(timeout: int, show_logs: bool) -> None:
     # download progress is observed. No ceiling -- we trust wget's
     # ETA. A genuinely stalled download stops producing ETA lines, so
     # the deadline stops advancing and the wait expires naturally.
-    _BOOT_BUFFER_SECS = 600  # 10min after download for Sysprep / OEM apply
+    # The buffer is wider than the post-download Sysprep / OEM apply
+    # actually needs (typically 2-8min) because real-world downloads
+    # have brief network blips and a transient stall shouldn't fail
+    # the wait outright -- we'd rather wait an extra ~hour than mark
+    # a recoverable hiccup as a hard timeout.
+    _BOOT_BUFFER_SECS = 3600  # 60min slack for blips + post-download boot
     _ANNOUNCE_STEP_SECS = 600  # only re-announce when deadline jumps 10min+
     deadline_state = {
         "value": start + timeout,

--- a/tests/test_wait_ready_eta.py
+++ b/tests/test_wait_ready_eta.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+"""Tests for ``_parse_wget_eta_secs`` -- dockur download ETA parser used
+by ``winpodx pod wait-ready`` to extend its deadline on slow links
+(#126: 86min ISO download exceeded the 60min static timeout).
+"""
+
+from __future__ import annotations
+
+from winpodx.cli.pod import _parse_wget_eta_secs
+
+
+def test_eta_parser_minutes_seconds_form() -> None:
+    """``78% 4.55M 21m22s`` -- typical mid-download progress line."""
+    line = " 6488064K ........ ........ ........ ........ 78% 4.55M 21m22s"
+    assert _parse_wget_eta_secs(line) == 21 * 60 + 22
+
+
+def test_eta_parser_hours_minutes_form() -> None:
+    """``3%  389K 7h21m`` -- very slow connection."""
+    line = "  327680K ........ ........ ........ ........  4%  289K 7h21m"
+    assert _parse_wget_eta_secs(line) == 7 * 3600 + 21 * 60
+
+
+def test_eta_parser_seconds_only() -> None:
+    """``99% 33.3M 10s`` -- near-complete download."""
+    line = " 8224768K ........ ........ ........ ........ 99% 33.3M 10s"
+    assert _parse_wget_eta_secs(line) == 10
+
+
+def test_eta_parser_rejects_equals_elapsed_form() -> None:
+    """``100% 4.16M=86m43s`` is wget's "total elapsed" form, NOT a
+    remaining-time estimate. Must not be parsed as ETA -- otherwise
+    we'd try to extend the deadline at 100% complete.
+    """
+    line = " 8257536K ........ ....... 100% 4.16M=86m43s"
+    assert _parse_wget_eta_secs(line) is None
+
+
+def test_eta_parser_rejects_equals_elapsed_form_mid_download() -> None:
+    """``3%  484K=8m22s`` -- wget prints `=elapsed` form when it hasn't
+    seen enough samples for an ETA yet. Skipping these is correct;
+    we'd rather not extend on garbage data than extend wrongly.
+    """
+    line = "  294912K ....                                 3%  484K=8m22s"
+    assert _parse_wget_eta_secs(line) is None
+
+
+def test_eta_parser_rejects_non_progress_lines() -> None:
+    """Random container log lines must not match."""
+    assert _parse_wget_eta_secs("BdsDxe: starting Boot0004") is None
+    assert _parse_wget_eta_secs("[container] Sysprep specialize") is None
+    assert _parse_wget_eta_secs("") is None
+    assert _parse_wget_eta_secs("  0K ........") is None
+
+
+def test_eta_parser_rejects_zero_eta() -> None:
+    """Defensive: any all-zero parse (shouldn't happen with the regex
+    but cheap to guard against) returns None so we don't extend the
+    deadline by 0+buffer when something weird matches."""
+    # Synthetic line that matches structurally but parses to 0.
+    assert _parse_wget_eta_secs("99% 1M 0s") is None
+
+
+def test_eta_parser_handles_decimal_speed() -> None:
+    """Speed field can be ``4.55M`` or ``713`` (no unit) -- both shapes
+    must parse cleanly."""
+    assert _parse_wget_eta_secs("50% 1.5M 30s") == 30
+    assert _parse_wget_eta_secs("50% 713 30s") == 30


### PR DESCRIPTION
## Summary

@xiyeming on CachyOS (#126) hit a 60min `pod wait-ready` timeout while dockur's Windows ISO download was still in progress -- his connection delivered ~7.5GB in **86 minutes**, so the static 60min budget expired mid-download and install.sh marked the install as failed even though the container was making forward progress.

This extends the wait-ready deadline dynamically based on wget's own ETA, parsed from the container log stream that `--logs` already tails. Capped at 4h to bound runaway extensions on broken networks. Zero effect on fast connections.

## Mechanics

- **`_parse_wget_eta_secs`** -- lexes dockur progress lines for the `XX% speed remaining` form (e.g. `78% 4.55M 21m22s`). Deliberately rejects the `XX% speed=elapsed` form (e.g. `100% 4.16M=86m43s`) -- wget uses `=` for "total elapsed" not "remaining", and parsing it as ETA would mean trying to extend at 100% complete.
- **`_maybe_extend_deadline`** -- when an ETA + 10min boot buffer would exceed the current deadline, pushes the deadline out. Announces the extension once per 10min step so the user understands why the wait is longer, without log spam.
- **`deadline_state` dict** -- swaps the local `deadline` int for a mutable container so the drain thread can write while the main thread reads. Single-key dict writes are GIL-atomic; eventual consistency is sufficient.
- **`install.sh`** -- wording updated from "(up to 60 min)" to mention the auto-extension to 4h on slow downloads.

## Test plan

- [x] `pytest tests/test_wait_ready_eta.py -v` -> 8 passed (minutes/seconds, hours/minutes, seconds-only, `=elapsed` rejection, non-progress lines, zero-ETA, decimal/integer speed shapes)
- [x] `pytest -k 'pod or cli or wait' -q` -> 191 passed, 0 failed
- [x] `ruff check src/winpodx/cli/pod.py` -> clean
- [ ] Smoke: fresh install on a connection throttled to <1MB/s -> wait-ready survives + announces extension
- [ ] xiyeming verifies on his CachyOS connection (if he wants to reopen #126)

## Notes

- Only kicks in when `--logs` is on (install.sh always passes `--logs`). Without log tail there's no ETA stream to read, so the static timeout still applies -- that's the right default for direct `winpodx pod wait-ready` invocations from a TTY where the user is already watching.
- The 4h ceiling is a hard cap. If wget's ETA says "8h remaining", we stop at 4h. Users on multi-hour connections are better served by `WINPODX_NO_WAIT=1 ... install.sh && winpodx pod wait-ready --timeout 14400` than by us auto-extending past 4h.