### PR TITLE
fix(timeouts): activity-based compose up + generous bumps across the board

### DIFF
--- a/src/winpodx/backend/docker.py
+++ b/src/winpodx/backend/docker.py
@@ -21,20 +21,24 @@ class DockerBackend(Backend):
         return ["docker", "compose", "-f", self._compose_file()]
 
     def start(self) -> None:
+        # Match podman backend: large hard cap so first-run image pull
+        # on slow connections doesn't fail. Docker doesn't need the
+        # activity-based wrapper because the docker daemon handles its
+        # own pull progress; only the wall-clock timeout is at risk.
         try:
             subprocess.run(
                 [*self._compose_cmd(), "up", "-d"],
                 check=True,
                 capture_output=True,
                 text=True,
-                timeout=120,
+                timeout=4 * 3600,
             )
             log.info("Pod started (docker)")
         except subprocess.CalledProcessError as e:
             log.error("docker compose up failed: %s", e.stderr.strip())
             raise
         except subprocess.TimeoutExpired:
-            log.error("docker compose up timed out (120s)")
+            log.error("docker compose up timed out (4h hard cap)")
             raise
 
     def stop(self) -> None:
@@ -43,7 +47,7 @@ class DockerBackend(Backend):
                 [*self._compose_cmd(), "down"],
                 capture_output=True,
                 text=True,
-                timeout=60,
+                timeout=180,
             )
             if result.returncode != 0:
                 log.warning(
@@ -52,7 +56,7 @@ class DockerBackend(Backend):
                     result.stderr.strip(),
                 )
         except subprocess.TimeoutExpired:
-            log.error("docker compose down timed out (60s)")
+            log.error("docker compose down timed out (180s)")
 
     def _container_state(self) -> str:
         """Return the lower-cased container state, or empty string if unavailable."""

--- a/src/winpodx/backend/podman.py
+++ b/src/winpodx/backend/podman.py
@@ -43,21 +43,93 @@ class PodmanBackend(Backend):
         )
 
     def start(self) -> None:
+        # Activity-based timeout: as long as podman is printing progress
+        # lines (image pull layers, container creation, etc.) we let it
+        # keep going. Only fail when the output goes silent for too long.
+        # The previous fixed 120s budget failed on slow connections during
+        # the first-run dockur image pull (#288-class issue). Idle limit
+        # 5min absorbs network blips while still failing cleanly on a
+        # genuinely stalled pull.
         try:
-            subprocess.run(
+            self._run_streaming(
                 [*self._compose_cmd(), "up", "-d"],
-                check=True,
-                capture_output=True,
-                text=True,
-                timeout=120,
+                idle_limit=300,
+                hard_cap=4 * 3600,
+                description="podman compose up",
             )
             log.info("Pod started (podman)")
         except subprocess.CalledProcessError as e:
-            log.error("podman compose up failed: %s", e.stderr.strip())
+            log.error("podman compose up failed: %s", e.stderr.strip() if e.stderr else "")
             raise
         except subprocess.TimeoutExpired:
-            log.error("podman compose up timed out (120s)")
+            log.error("podman compose up went idle for >300s")
             raise
+
+    def _run_streaming(
+        self,
+        cmd: list[str],
+        *,
+        idle_limit: int,
+        hard_cap: int,
+        description: str,
+    ) -> None:
+        """Run a subprocess while watching its output for activity.
+
+        Kills the process when its combined stdout+stderr stream goes
+        silent for ``idle_limit`` seconds, or when total wall time
+        exceeds ``hard_cap``. Raises ``CalledProcessError`` on non-zero
+        exit, ``TimeoutExpired`` on idle or cap.
+        """
+        import threading
+        import time
+
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        last_activity = [time.monotonic()]
+        captured: list[str] = []
+
+        def _drain() -> None:
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                last_activity[0] = time.monotonic()
+                captured.append(line)
+
+        t = threading.Thread(target=_drain, daemon=True)
+        t.start()
+        start = time.monotonic()
+        while True:
+            try:
+                rc = proc.wait(timeout=2)
+                break
+            except subprocess.TimeoutExpired:
+                now = time.monotonic()
+                if now - last_activity[0] > idle_limit:
+                    proc.kill()
+                    proc.wait(timeout=5)
+                    raise subprocess.TimeoutExpired(
+                        cmd=cmd,
+                        timeout=idle_limit,
+                        output="".join(captured),
+                        stderr=None,
+                    ) from None
+                if now - start > hard_cap:
+                    proc.kill()
+                    proc.wait(timeout=5)
+                    raise subprocess.TimeoutExpired(
+                        cmd=cmd,
+                        timeout=hard_cap,
+                        output="".join(captured),
+                        stderr=None,
+                    ) from None
+        t.join(timeout=5)
+        out = "".join(captured)
+        if rc != 0:
+            raise subprocess.CalledProcessError(returncode=rc, cmd=cmd, output=out, stderr=out)
 
     def stop(self) -> None:
         try:
@@ -65,7 +137,7 @@ class PodmanBackend(Backend):
                 [*self._compose_cmd(), "down"],
                 capture_output=True,
                 text=True,
-                timeout=60,
+                timeout=180,
             )
             if result.returncode != 0:
                 log.warning(
@@ -74,7 +146,7 @@ class PodmanBackend(Backend):
                     result.stderr.strip(),
                 )
         except subprocess.TimeoutExpired:
-            log.error("podman compose down timed out (60s)")
+            log.error("podman compose down timed out (180s)")
 
     def _container_state(self) -> str:
         """Return the lower-cased container state, or empty string if unavailable."""

--- a/src/winpodx/cli/migrate.py
+++ b/src/winpodx/cli/migrate.py
@@ -527,7 +527,7 @@ def _probe_password_sync(non_interactive: bool) -> None:
     from winpodx.core.provisioner import wait_for_windows_responsive
 
     print("\nProbing Windows-side authentication...")
-    if not wait_for_windows_responsive(cfg, timeout=180):
+    if not wait_for_windows_responsive(cfg, timeout=600):
         print("  (probe deferred — guest still booting; will retry on next ensure_ready)")
         return
 
@@ -727,7 +727,7 @@ def _apply_runtime_fixes_to_existing_guest(non_interactive: bool) -> None:
     from winpodx.core.provisioner import wait_for_windows_responsive
 
     print("  Waiting for Windows guest to finish booting (up to 180s)...")
-    if not wait_for_windows_responsive(cfg, timeout=180):
+    if not wait_for_windows_responsive(cfg, timeout=600):
         print(
             "  Windows guest still booting after 180s — skipping runtime apply.\n"
             "  Run `winpodx pod apply-fixes` once `winpodx pod status` reports "
@@ -969,7 +969,7 @@ def _attempt_refresh() -> None:
     from winpodx.core.provisioner import wait_for_windows_responsive
 
     print("\n  Waiting for Windows guest to be ready (up to 180s)...")
-    if not wait_for_windows_responsive(cfg, timeout=180):
+    if not wait_for_windows_responsive(cfg, timeout=600):
         print(
             "  Windows guest still booting — skipping discovery for now.\n"
             "  Re-run later with: winpodx app refresh"

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -218,7 +218,7 @@ def _apply_fixes() -> None:
     from winpodx.core.provisioner import wait_for_windows_responsive
 
     print("Waiting for Windows guest to finish booting (up to 180s)...")
-    if not wait_for_windows_responsive(cfg, timeout=180):
+    if not wait_for_windows_responsive(cfg, timeout=600):
         print(
             "Windows guest still booting after 180s. Wait a bit longer, "
             "then re-run `winpodx pod apply-fixes`."
@@ -300,7 +300,7 @@ def _sync_password(non_interactive: bool) -> None:
     if transport is not None:
         print("Resetting Windows account password via agent...")
         try:
-            result = transport.exec(payload, description="sync-password", timeout=30)
+            result = transport.exec(payload, description="sync-password", timeout=90)
         except TransportAuthError as e:
             print(f"FAIL: agent rejected the request (auth): {e}")
             print(
@@ -354,7 +354,7 @@ def _sync_password(non_interactive: bool) -> None:
 
     print("Authenticating with recovery password and resetting Windows account...")
     try:
-        result = run_in_windows(rescue_cfg, payload, description="sync-password", timeout=45)
+        result = run_in_windows(rescue_cfg, payload, description="sync-password", timeout=120)
     except WindowsExecError as e:
         print(f"FAIL: channel failure with recovery password: {e}")
         print(
@@ -466,7 +466,7 @@ def _multi_session_enable(cfg) -> None:  # type: ignore[no-untyped-def]
 
     print("Queuing multi-session activation (detached)...")
     try:
-        result = run_via_transport(cfg, payload, description="multi-session-enable", timeout=20)
+        result = run_via_transport(cfg, payload, description="multi-session-enable", timeout=60)
     except WindowsExecError as e:
         print(f"FAIL: channel failure: {e}")
         sys.exit(3)
@@ -521,7 +521,7 @@ def _multi_session_disable(cfg) -> None:  # type: ignore[no-untyped-def]
 
     print("Disabling multi-session RDP via rdprrap...")
     try:
-        result = run_via_transport(cfg, payload, description="multi-session-disable", timeout=45)
+        result = run_via_transport(cfg, payload, description="multi-session-disable", timeout=120)
     except WindowsExecError as e:
         print(f"FAIL: channel failure: {e}")
         sys.exit(3)
@@ -573,7 +573,7 @@ def _multi_session_status(cfg) -> None:  # type: ignore[no-untyped-def]
 
     print("Querying multi-session status...")
     try:
-        result = run_via_transport(cfg, payload, description="multi-session-status", timeout=20)
+        result = run_via_transport(cfg, payload, description="multi-session-status", timeout=60)
     except WindowsExecError as e:
         print(f"FAIL: channel failure: {e}")
         sys.exit(3)

--- a/src/winpodx/core/agent.py
+++ b/src/winpodx/core/agent.py
@@ -88,7 +88,7 @@ class AgentClient:
     """HTTP client for the guest agent on ``127.0.0.1:8765``."""
 
     DEFAULT_BASE_URL = "http://127.0.0.1:8765"
-    HEALTH_TIMEOUT = 2.0
+    HEALTH_TIMEOUT = 5.0
 
     def __init__(
         self,

--- a/src/winpodx/core/checks.py
+++ b/src/winpodx/core/checks.py
@@ -139,7 +139,7 @@ def probe_guest_exec(cfg: Config) -> Probe:
 
         client = AgentClient(cfg)
         try:
-            result = client.exec("Write-Output ok\n", timeout=10.0)
+            result = client.exec("Write-Output ok\n", timeout=30.0)
         except AgentTimeoutError as e:
             return "warn", f"agent warming up or busy: {e}"
         except AgentError as e:
@@ -206,7 +206,7 @@ def probe_guest_summary(cfg: Config) -> Probe:
 
         client = AgentClient(cfg)
         try:
-            result = client.exec(script, timeout=15.0)
+            result = client.exec(script, timeout=45.0)
         except AgentTimeoutError as e:
             return "warn", f"agent warming up or busy: {e}"
         except AgentError as e:

--- a/src/winpodx/core/daemon.py
+++ b/src/winpodx/core/daemon.py
@@ -48,7 +48,7 @@ def suspend_pod(cfg: Config) -> bool:
     if cfg.pod.backend not in ("podman", "docker"):
         return False  # libvirt/manual don't support pause
     cmd = [cfg.pod.backend, "pause", cfg.pod.container_name]
-    result = _run_container_cmd(cfg, cmd, timeout=30, timeout_msg="Pod suspend timed out after 30s")
+    result = _run_container_cmd(cfg, cmd, timeout=90, timeout_msg="Pod suspend timed out after 90s")
     if result is None:
         return False
     if result.returncode == 0:
@@ -63,7 +63,7 @@ def resume_pod(cfg: Config) -> bool:
     if cfg.pod.backend not in ("podman", "docker"):
         return False
     cmd = [cfg.pod.backend, "unpause", cfg.pod.container_name]
-    result = _run_container_cmd(cfg, cmd, timeout=30, timeout_msg="Pod resume timed out after 30s")
+    result = _run_container_cmd(cfg, cmd, timeout=90, timeout_msg="Pod resume timed out after 90s")
     if result is None:
         return False
     if result.returncode == 0:
@@ -78,7 +78,7 @@ def is_pod_paused(cfg: Config) -> bool:
     if cfg.pod.backend not in ("podman", "docker"):
         return False
     cmd = [cfg.pod.backend, "inspect", "--format", "{{.State.Status}}", cfg.pod.container_name]
-    result = _run_container_cmd(cfg, cmd, timeout=10, timeout_msg="Pod inspect timed out after 10s")
+    result = _run_container_cmd(cfg, cmd, timeout=30, timeout_msg="Pod inspect timed out after 30s")
     if result is None:
         return False
     if result.returncode != 0:
@@ -161,7 +161,7 @@ def sync_windows_time(cfg: Config) -> bool:
     from winpodx.core.windows_exec import WindowsExecError, run_via_transport
 
     try:
-        result = run_via_transport(cfg, payload, description="sync-time", timeout=30)
+        result = run_via_transport(cfg, payload, description="sync-time", timeout=90)
     except WindowsExecError as e:
         log.warning("Time sync channel failure: %s", e)
         return False

--- a/src/winpodx/core/discovery/__init__.py
+++ b/src/winpodx/core/discovery/__init__.py
@@ -1385,7 +1385,7 @@ def run_if_first_boot(cfg: Config) -> None:
         # the guest is not yet activation-responsive.
         from winpodx.core.provisioner import wait_for_windows_responsive
 
-        if not wait_for_windows_responsive(cfg, timeout=180):
+        if not wait_for_windows_responsive(cfg, timeout=600):
             log.info("Windows guest still booting; deferring discovery to a later run.")
             return
         apps = scan(cfg)

--- a/src/winpodx/core/pod/recovery.py
+++ b/src/winpodx/core/pod/recovery.py
@@ -78,7 +78,7 @@ def try_recover_rdp(cfg: Config) -> RecoveryResult:
         )
 
     try:
-        result = transport.exec(_RESTART_TERMSERVICE, timeout=20)
+        result = transport.exec(_RESTART_TERMSERVICE, timeout=60)
     except (TransportUnavailable, TransportTimeoutError) as e:
         return RecoveryResult(
             success=False,

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -210,7 +210,7 @@ def _apply_max_sessions(cfg: Config) -> None:
     log.info("max_sessions: %s", result.stdout.strip())
 
 
-def wait_for_windows_responsive(cfg: Config, timeout: int = 90) -> bool:
+def wait_for_windows_responsive(cfg: Config, timeout: int = 300) -> bool:
     """Poll until the Windows guest is ready to accept commands.
 
     Two-stage readiness probe:

--- a/src/winpodx/core/rotation/__init__.py
+++ b/src/winpodx/core/rotation/__init__.py
@@ -103,11 +103,11 @@ def _change_windows_password(cfg: Config, new_password: str) -> bool:
 
     try:
         transport = dispatch(cfg, prefer="agent")
-        result = transport.exec(payload, description="rotate-password", timeout=30)
+        result = transport.exec(payload, description="rotate-password", timeout=90)
     except TransportUnavailable:
         log.info("Agent unavailable for password rotation; falling back to FreeRDP")
         try:
-            result = run_in_windows(cfg, payload, description="rotate-password", timeout=45)
+            result = run_in_windows(cfg, payload, description="rotate-password", timeout=120)
         except WindowsExecError as e:
             log.warning("Password change channel failure: %s", e)
             return False

--- a/src/winpodx/core/transport/freerdp.py
+++ b/src/winpodx/core/transport/freerdp.py
@@ -37,7 +37,7 @@ assert SPEC_VERSION == 1, "FreerdpTransport built against Transport spec v1"
 
 log = logging.getLogger(__name__)
 
-_HEALTH_PROBE_TIMEOUT = 2.0
+_HEALTH_PROBE_TIMEOUT = 5.0
 
 
 class FreerdpTransport(Transport):

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -72,7 +72,7 @@ class TestHealth:
         assert result == {"ok": True, "version": "0.2.2"}
         assert captured["url"] == "http://127.0.0.1:8765/health"
         assert captured["method"] == "GET"
-        assert captured["timeout"] == 2.0
+        assert captured["timeout"] == 5.0
         # No Authorization header on /health.
         header_keys = {k.lower() for k in captured["headers"]}
         assert "authorization" not in header_keys

--- a/tests/test_rotation/test_rotation_agent_first.py
+++ b/tests/test_rotation/test_rotation_agent_first.py
@@ -76,7 +76,7 @@ def test_agent_unavailable_falls_back_to_freerdp(_rotate_cfg, monkeypatch):
     assert args[0] is _rotate_cfg
     assert "net user" in args[1]
     assert kwargs.get("description") == "rotate-password"
-    assert kwargs.get("timeout") == 45
+    assert kwargs.get("timeout") == 120
 
 
 def test_agent_auth_error_does_not_fall_back(_rotate_cfg, monkeypatch, caplog):

--- a/tests/test_sync_password_agent_first.py
+++ b/tests/test_sync_password_agent_first.py
@@ -61,7 +61,7 @@ def test_agent_ok_skips_freerdp_and_recovery_prompt(_cfg, monkeypatch):
     transport.exec.assert_called_once()
     _, kwargs = transport.exec.call_args
     assert kwargs.get("description") == "sync-password"
-    assert kwargs.get("timeout") == 30
+    assert kwargs.get("timeout") == 90
     rin.assert_not_called()
 
 
@@ -89,7 +89,7 @@ def test_agent_unavailable_falls_back_to_freerdp(_cfg, monkeypatch):
     assert "net user" in args[1]
     assert "target-pw" in args[1]  # the value from cfg, not the recovery
     assert kwargs.get("description") == "sync-password"
-    assert kwargs.get("timeout") == 45
+    assert kwargs.get("timeout") == 120
 
 
 def test_agent_auth_error_does_not_fall_back(_cfg, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

Pairs with #297 (dynamic wait-ready timeout). Across-the-board widening of fixed timeouts so slow hosts / slow links don't fail ops that are still making progress.

## Changes

### Activity-based (no fixed wall-clock budget)

- **`PodmanBackend.start()`** -- new `_run_streaming()` wrapper kills the process when its output stream goes silent for **5min**, not when total time exceeds 120s. First-run image pull on slow connections no longer fails. 4h hard cap as a runaway guard.

### Generous fixed bumps

| Target | Old | New |
|---|---|---|
| `wait_for_windows_responsive` (default) | 90s | 300s |
| `wait_for_windows_responsive` (explicit callers) | 180s | 600s |
| `DockerBackend.start()` compose up | 120s | 4h hard cap |
| `compose down` (podman + docker) | 60s | 180s |
| agent `/health` `HEALTH_TIMEOUT` | 2.0s | 5.0s |
| FreeRDP RDP-port probe `_HEALTH_PROBE_TIMEOUT` | 2.0s | 5.0s |
| `transport.exec` sync-password | 30s | 90s |
| `transport.exec` rotate-password | 30s | 90s |
| `transport.exec` multi-session-enable | 20s | 60s |
| `transport.exec` multi-session-disable | 45s | 120s |
| `transport.exec` multi-session-status | 20s | 60s |
| `transport.exec` TermService restart (recovery) | 20s | 60s |
| `transport.exec` sync-time | 30s | 90s |
| `run_in_windows` sync-password | 45s | 120s |
| `run_in_windows` rotate-password | 45s | 120s |
| `check_pod` guest exec | 10s | 30s |
| `check_pod` summary | 15s | 45s |
| daemon suspend/resume | 30s | 90s |
| daemon inspect | 10s | 30s |

### Untouched on purpose

Tight TCP probe timeouts inside poll loops (`check_rdp_port` 1.0/2.0/3.0 in `pod_status`, `deps_quickcheck`) -- the short budget IS the poll interval. Bumping would slow the loop without helping correctness.

## Test plan

- [x] `pytest tests/ -q` -> 1328 passed, 1 skipped (3 originally-failing tests updated to match new timeout values: `test_agent.py`, `test_sync_password_agent_first.py`, `test_rotation_agent_first.py`)
- [x] `ruff check src/winpodx/` -> clean
- [x] `ruff format --check src/winpodx/` -> clean
- [ ] Smoke: fresh install on a connection throttled to <1MB/s -> `compose up` survives the slow image pull