### PR TITLE
fix(rpm): widen License tag to `MIT AND Apache-2.0`

### DIFF
--- a/packaging/rpm/winpodx.spec
+++ b/packaging/rpm/winpodx.spec
@@ -8,7 +8,12 @@ Name:           %{pypi_name}
 Version:        0.1.5
 Release:        0
 Summary:        Windows app integration for Linux desktop
-License:        MIT
+# MIT covers winpodx + bundled rdprrap (same MIT terms).
+# Apache-2.0 covers stascorp/rdpwrap, ported into rdprrap and
+# redistributed inside config/oem/rdprrap-*-windows-x64.zip. See
+# debian/copyright + THIRD_PARTY_LICENSES.md for the full breakdown.
+# Combined SPDX expression follows Fedora packaging guidelines.
+License:        MIT AND Apache-2.0
 URL:            https://github.com/kernalix7/winpodx
 Source0:        %{name}-%{version}.tar.gz
 


### PR DESCRIPTION
## Summary

`packaging/rpm/winpodx.spec` declared `License: MIT`, but `config/oem/rdprrap-*-windows-x64.zip` bundles **stascorp/rdpwrap**, which is **Apache-2.0** licensed. Fedora packaging guidelines require the `License:` tag to enumerate every license that applies to the redistributed binary content -- the previous tag was strictly incomplete.

## Changes

- `packaging/rpm/winpodx.spec`: `License: MIT` -> `License: MIT AND Apache-2.0` (SPDX expression form).
- Added a comment block explaining which component contributes each license.

## Why this matters

A Fedora reviewer running `rpmlint` on the spec, or a downstream OBS project linter, would flag the missing Apache-2.0 declaration once `config/oem/rdprrap-*.zip` is opened and the vendored `LICENSE.rdpwrap.Apache-2.0` is seen.

Already correctly handled in `debian/copyright` (rdprrap's `Apache-2.0` vendored components are explicitly broken out) and `THIRD_PARTY_LICENSES.md` (full upstream attribution). This PR brings the RPM spec in line.

## Test plan

- [x] `rpmlint packaging/rpm/winpodx.spec` -- no License-tag warnings
- [ ] OBS rebuild on next tag push (verifies the OBS spec inherits the corrected tag)