### PR TITLE
docs(readme): add dedicated 'First-time setup' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,34 @@ chmod +x winpodx-*-x86_64.AppImage
 
 See [docs/INSTALL.md](docs/INSTALL.md) for offline / air-gapped builds, source installs, version pinning, and uninstall.
 
+## First-time setup
+
+If you used the `curl install.sh` one-liner, setup already ran and the Windows VM is booting -- skip to [Launch](#launch). For every other install path (package managers, AppImage, source, pip) run setup once before the first app launch:
+
+```bash
+# Auto setup -- host-detected defaults, no prompts
+winpodx setup
+
+# Interactive wizard -- pick backend, cores, RAM, edition, language, timezone, debloat preset
+winpodx setup --customize
+```
+
+Setup writes `~/.config/winpodx/winpodx.toml` + `compose.yaml`, registers the GUI launcher, and confirms the host has FreeRDP + Podman / Docker + KVM. If any of those are missing, the output ends with a per-distro install command (e.g. `sudo apt install xfreerdp3 podman podman-compose` on Debian / Ubuntu, `sudo dnf install ...` on Fedora) -- run it and re-run `winpodx setup`.
+
+The first app launch then provisions the pod, pulls the dockur image, runs the Windows ISO download + Sysprep + OEM apply, and reaches a usable RDP session in ~5-10 min. `winpodx pod wait-ready --logs` tails container progress live so you can watch each phase:
+
+```bash
+winpodx app run desktop          # First launch -- ~5-10 min, subsequent launches near-instant
+winpodx pod wait-ready --logs    # Optional: watch first-boot progress live
+```
+
+Run `winpodx doctor` any time afterwards to re-check host state and surface the next fix command if something drifts:
+
+```bash
+winpodx doctor                   # Read-only -- prints what would need fixing
+winpodx pod apply-fixes          # Re-applies guest-side runtime fixes (RDP timeouts, NIC power-save, etc.)
+```
+
 ## Launch
 
 ```bash

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -111,6 +111,34 @@ chmod +x winpodx-*-x86_64.AppImage
 
 오프라인 / 에어갭 빌드, 소스 설치, 버전 pin, 언인스톨은 [docs/INSTALL.ko.md](INSTALL.ko.md) 참조.
 
+## 첫 실행 설정
+
+`curl install.sh` 원라이너 썼으면 setup 이 이미 돌았고 Windows VM 부팅 중 — [실행](#실행) 으로 skip. 그 외 install 경로 (패키지 매니저, AppImage, source, pip) 는 첫 앱 실행 전에 setup 한번 돌려야 함:
+
+```bash
+# 자동 setup — 호스트 자동감지 기본값, 프롬프트 없음
+winpodx setup
+
+# 대화형 wizard — backend, cores, RAM, edition, language, timezone, debloat preset 선택
+winpodx setup --customize
+```
+
+Setup 이 `~/.config/winpodx/winpodx.toml` + `compose.yaml` 작성, GUI 런처 등록, 호스트의 FreeRDP + Podman / Docker + KVM 확인. 부족하면 출력 마지막에 distro 별 설치 명령 (예: Debian / Ubuntu 면 `sudo apt install xfreerdp3 podman podman-compose`, Fedora 면 `sudo dnf install ...`) — 실행 후 `winpodx setup` 재실행.
+
+첫 앱 실행이 pod provision, dockur 이미지 pull, Windows ISO 다운로드 + Sysprep + OEM apply 거쳐 사용 가능한 RDP 세션까지 ~5-10분. `winpodx pod wait-ready --logs` 가 컨테이너 진행 라이브 출력:
+
+```bash
+winpodx app run desktop          # 첫 실행 ~5-10분, 이후 실행은 거의 즉시
+winpodx pod wait-ready --logs    # 선택: 첫 부팅 진행상황 라이브 보기
+```
+
+이후 언제든 `winpodx doctor` 로 호스트 상태 재확인 + drift 시 다음 fix 명령 surface:
+
+```bash
+winpodx doctor                   # read-only — 필요한 fix 만 출력
+winpodx pod apply-fixes          # guest 측 런타임 fix 재적용 (RDP timeout, NIC power-save 등)
+```
+
 ## 실행
 
 ```bash

--- a/tests/test_compose_arch.py
+++ b/tests/test_compose_arch.py
@@ -255,9 +255,7 @@ def test_compose_287_workaround_no_longer_needed(monkeypatch):
     for profile in ("off", "safe", "auto", "performance", "manual"):
         cfg.pod.tuning_profile = profile
         content = _build_compose_content(cfg)
-        assert "-msg timestamp=on" not in content, (
-            f"marker leaked back in under profile={profile}"
-        )
+        assert "-msg timestamp=on" not in content, f"marker leaked back in under profile={profile}"
         # And -cpu host, never appears in ARGUMENTS (the whole point).
         # We only need to check that ARGUMENTS lines don't contain it.
         for line in content.splitlines():


### PR DESCRIPTION
## Summary

Promotes the post-install guidance from a one-line blockquote inside Quick install (easy to skim past) to a real H2 between Quick install and Launch.

## Why

AppImage / package-manager / pip users currently have to scan the Quick install \`>\` blockquote to find the canonical post-install sequence. The new section makes it impossible to miss:

- `winpodx setup` (auto vs `--customize`)
- Per-distro install hints when FreeRDP / Podman / KVM are missing
- First-app-launch ~5-10 min provisioning + `wait-ready --logs` for live progress
- `winpodx doctor` + `winpodx pod apply-fixes` for follow-up health

curl one-liner users still skip the section -- `install.sh` runs setup for them. The blockquote inside Quick install stays as a one-line fallback hint for users who only read the install code block.

## Mirrors

- `README.md` (English)
- `docs/README.ko.md` (Korean)

## Test plan

- [x] Markdown renders cleanly on GitHub (verified by inspection)
- [x] No broken anchors -- "Launch" anchor stays valid + new "First-time setup" anchor links cleanly