### PR TITLE
fix(ci): AppImage workflow_dispatch `tag` input is optional

### DIFF
--- a/.github/workflows/appimage-publish.yml
+++ b/.github/workflows/appimage-publish.yml
@@ -7,8 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g. v0.5.7)"
-        required: true
+        description: "Optional release tag to build from (e.g. v0.5.8). Leave empty to build from the selected ref (usually main) -- useful for verifying the recipe before cutting a tag."
+        required: false
+        default: ""
 
 permissions:
   contents: write


### PR DESCRIPTION
Required-input trap: dispatching with the latest tag (v0.5.7) checked out a commit that predates packaging/appimage/, so the 'Pin recipe' step bombed with `packaging/appimage/recipe/requirements.txt: No such file or directory`. Making the input optional + defaulting to empty lets dispatch runs use `github.ref` (the branch selected in the UI, usually main) and still honors an explicit tag when rebuilding a published release. Tag pushes (`v*.*.*`) keep working unchanged.