### PR TITLE
fix(appimage): invoke winpodx via python3 -m, not broken-shebang console script

### DIFF
--- a/.github/workflows/appimage-publish.yml
+++ b/.github/workflows/appimage-publish.yml
@@ -81,7 +81,13 @@ jobs:
           export PATH="$APPDIR/usr/bin:$APPDIR/opt/python/bin:$PATH"
           export LD_LIBRARY_PATH="$APPDIR/usr/lib:$APPDIR/opt/python/lib:$LD_LIBRARY_PATH"
           export PYTHONPATH="$APPDIR/opt/python/lib/python3.11/site-packages:$PYTHONPATH"
-          exec "$APPDIR/opt/python/bin/winpodx" "$@"
+          # Invoke via `python3 -m winpodx`, NOT the pip-generated
+          # bin/winpodx console script. pip bakes an absolute build-time
+          # shebang (#!/home/runner/work/.../AppDir/opt/python/bin/python3)
+          # into bin/winpodx that doesn't exist at AppImage-extract time
+          # -> "bad interpreter". The -m form runs the module through the
+          # bundled interpreter directly and ignores the broken shebang.
+          exec "$APPDIR/opt/python/bin/python3" -m winpodx "$@"
           APPRUN
           chmod +x AppDir/AppRun
           # Desktop + icon -- appimagetool expects them in AppDir root.


### PR DESCRIPTION
## Summary

Smoke-testing the built fat AppImage (artifact from the #306 build) surfaced a bad-interpreter crash on **every** invocation:

```
AppRun: .../opt/python/bin/winpodx: /home/runner/work/winpodx/winpodx/AppDir/opt/python/bin/python3: bad interpreter: No such file or directory
```

pip bakes an absolute build-time shebang into the generated `bin/winpodx` console script (`#!/home/runner/work/.../AppDir/opt/python/bin/python3`). That path only exists on the CI runner during the build; at AppImage-extract time the interpreter lives elsewhere, so the shebang points at nothing.

## Fix

AppRun now execs `python3 -m winpodx` through the bundled interpreter, which ignores the console-script shebang entirely. `src/winpodx/__main__.py` already exists, so the `-m` form is supported.

## Verification (against the built #306 artifact)

Extracted the broken AppImage + ran via the bundled interpreter:

- `opt/python/bin/python3 -m winpodx --version` -> `winpodx 0.5.7` ✓
- `python3 -m winpodx setup-host --status` -> full host-state report ✓
- `usr/bin/` contains all bundled binaries: xfreerdp, wlfreerdp, sdl-freerdp, podman, podman-compose, conmon, crun, netavark, slirp4netns, passt, pasta ✓

So the fat bundling from #306 was correct -- this was purely the launch shim. Original (broken) AppImage 295 MB.

## Test plan

- [x] Bundled `python3 -m winpodx --version` + `setup-host --status` work (verified against artifact)
- [ ] Manual AppImage workflow_dispatch on this branch produces a runnable AppImage (the fix's real test)
- [ ] Next release tag auto-builds + attaches the corrected AppImage