### PR TITLE
feat(setup): complete --customize wizard + full standalone provision flow

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -704,7 +704,11 @@ if [ "${WINPODX_MANUAL:-0}" = "1" ]; then
     log "  Run 'winpodx' (CLI or GUI) to finish setup. Prompt will offer auto, customize, or skip."
 else
     log "Running winpodx setup..."
-    SETUP_ARGS=(--non-interactive)
+    # --create-only: install.sh orchestrates wait-ready / migrate /
+    # discovery / reverse-open itself (below), so setup should stop after
+    # creating the container. A standalone `winpodx setup` (no
+    # --create-only) runs that full flow on its own.
+    SETUP_ARGS=(--non-interactive --create-only)
     if [ -n "$WINPODX_WIN_VERSION" ]; then
         SETUP_ARGS+=(--win-version "$WINPODX_WIN_VERSION")
         log "Installing Windows edition: $WINPODX_WIN_VERSION"

--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -279,6 +279,17 @@ def cli(argv: list[str] | None = None) -> None:
         ),
     )
     setup_p.add_argument(
+        "--create-only",
+        action="store_true",
+        help=(
+            "Stop after writing config + creating the container. Skip the "
+            "full provision flow (wait-ready, apply-fixes, app discovery, "
+            "reverse-open). install.sh passes this because it orchestrates "
+            "those steps itself; a standalone `winpodx setup` runs the full "
+            "flow so it finishes like a complete install."
+        ),
+    )
+    setup_p.add_argument(
         "--update-image",
         action="store_true",
         help=(

--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -473,7 +473,7 @@ def _prompt_edition_locale_tuning(cfg: Config) -> None:
     # reserved.
     tuning = (
         _ask(
-            f"Tuning profile (auto / performance / safe / off / manual) [{cfg.pod.tuning_profile}]: ",
+            f"Tuning profile (auto/performance/safe/off/manual) [{cfg.pod.tuning_profile}]: ",
             default=cfg.pod.tuning_profile,
         )
         .strip()

--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -429,6 +429,136 @@ def _resolve_credentials(cfg: Config, *, non_interactive: bool, config_existed: 
         cfg.rdp.ip = _ask("Windows IP [127.0.0.1]: ", default="127.0.0.1")
 
 
+def _prompt_edition_locale_tuning(cfg: Config) -> None:
+    """Wizard prompts for the knobs the GUI Settings page exposes but the
+    CLI wizard historically skipped (#255 PR 7): Windows edition, UI
+    language, regional format, keyboard layout, and the host tuning
+    profile. Each reaches dockur as an env var and only takes effect on
+    the initial Windows install. Enter accepts the shown default.
+    """
+    print("\n--- Edition / locale / tuning (Enter = keep default) ---")
+
+    # Windows edition. Bare-token list mirrors _KNOWN_WIN_VERSIONS; the
+    # common picks are surfaced inline, the rest accepted if typed.
+    edition = _ask(
+        f"Windows edition (11, 10, ltsc11, iot11, tiny11, 2025, ...) [{cfg.pod.win_version}]: ",
+        default=cfg.pod.win_version,
+    )
+    cfg.pod.win_version = edition
+
+    # UI language (dockur LANGUAGE env). Full English name, e.g. "English",
+    # "German", "Korean". dockur maps it to the matching ISO at download.
+    cfg.pod.language = _ask(
+        f"Windows UI language [{cfg.pod.language}]: ",
+        default=cfg.pod.language,
+    )
+
+    # Regional format (dockur REGION env). BCP-47, e.g. en-US, en-GB,
+    # ko-KR. Default en-001 = "English (World)"; suggest the more common
+    # en-US for US date / number formatting (#293).
+    cfg.pod.region = _ask(
+        f"Regional format (BCP-47, e.g. en-US) [{cfg.pod.region}]: ",
+        default=cfg.pod.region,
+    )
+
+    # Keyboard layout (dockur KEYBOARD env). BCP-47, e.g. en-US, de-DE.
+    cfg.pod.keyboard = _ask(
+        f"Keyboard layout (BCP-47, e.g. en-US) [{cfg.pod.keyboard}]: ",
+        default=cfg.pod.keyboard,
+    )
+
+    # Host tuning profile (#215 / #245). auto = detect + apply every safe
+    # KVM tweak the host supports; performance = auto + force CPU pinning
+    # / no-balloon; safe = Tier-1 only; off = dockur defaults; manual =
+    # reserved.
+    tuning = (
+        _ask(
+            f"Tuning profile (auto / performance / safe / off / manual) [{cfg.pod.tuning_profile}]: ",
+            default=cfg.pod.tuning_profile,
+        )
+        .strip()
+        .lower()
+    )
+    if tuning in ("auto", "performance", "safe", "off", "manual"):
+        cfg.pod.tuning_profile = tuning
+    else:
+        print(f"  unknown profile {tuning!r}, keeping {cfg.pod.tuning_profile!r}")
+
+    # Re-run validation so any normalization (win_version casing, etc.)
+    # lands before compose generation.
+    cfg.pod.__post_init__()
+
+
+def _run_full_provision(cfg: Config) -> None:
+    """Drive the same post-container-create provisioning that install.sh
+    orchestrates in bash, so a standalone `winpodx setup` finishes like a
+    complete install instead of stopping at "container created".
+
+    Sequence (each step tolerant of the guest still booting):
+      1. wait-ready -- block until the Windows first-boot + OEM apply +
+         reboot pass complete (auto-extends on slow ISO downloads).
+      2. apply-fixes -- idempotent Windows-side runtime fixes.
+      3. app discovery -- scan the guest + register desktop entries.
+      4. reverse-open -- stage host apps into the guest "Open with" menu
+         (only when cfg.reverse_open.enabled).
+
+    Skipped for non-podman/docker backends and when --create-only is set
+    (install.sh path -- it runs its own bash version of these steps).
+    """
+    if cfg.pod.backend not in ("podman", "docker"):
+        return
+
+    print("\n" + "=" * 40)
+    print(" Provisioning Windows (first boot)")
+    print("=" * 40)
+    print("First install downloads ~7.5GB ISO + runs Sysprep + OEM apply.")
+    print("This can take ~5-10 min (longer on slow connections).\n")
+
+    # 1. wait-ready -- reuse the CLI implementation with live logs.
+    from winpodx.cli.pod import _wait_ready
+
+    try:
+        _wait_ready(timeout=3600, show_logs=True)
+    except SystemExit as e:
+        # _wait_ready exits non-zero on timeout. Don't abort the whole
+        # setup -- the pending-steps machinery + next `winpodx app run`
+        # will resume. Surface it and stop the provision chain.
+        print(
+            f"\n  wait-ready did not complete (exit {e.code}). "
+            "Remaining steps will auto-resume on your next "
+            "`winpodx app run` / `winpodx gui`."
+        )
+        return
+
+    # 2. apply-fixes -- idempotent guest runtime fixes.
+    try:
+        from winpodx.core.provisioner import apply_windows_runtime_fixes
+
+        print("\nApplying Windows-side runtime fixes...")
+        apply_windows_runtime_fixes(cfg)
+    except Exception as e:  # noqa: BLE001 -- best-effort, never fatal
+        print(f"  apply-fixes skipped ({e})")
+
+    # 3. discovery -- populate the app menu from the running guest.
+    try:
+        from winpodx.cli.app import _refresh_apps
+
+        print("\nDiscovering installed Windows apps...")
+        _refresh_apps(as_json=False, timeout=120)
+    except Exception as e:  # noqa: BLE001
+        print(f"  discovery skipped ({e}) -- run `winpodx app refresh` later")
+
+    # 4. reverse-open -- host apps into the guest "Open with" menu.
+    if getattr(cfg.reverse_open, "enabled", False):
+        try:
+            from winpodx.cli.host_open import _cmd_refresh
+
+            print("\nSetting up reverse-open (Linux apps in Windows 'Open with')...")
+            _cmd_refresh(argparse.Namespace(include_nodisplay=False, skip_icons=False, json=False))
+        except Exception as e:  # noqa: BLE001
+            print(f"  reverse-open setup skipped ({e})")
+
+
 def handle_setup(args: argparse.Namespace) -> None:
     """Run the setup wizard."""
     import sys
@@ -594,6 +724,14 @@ def handle_setup(args: argparse.Namespace) -> None:
             cfg.pod.timezone = tz_input
             cfg.pod.__post_init__()
 
+        # Edition / locale / tuning wizard (#255 PR 7 -- the knobs the
+        # GUI Settings page already exposes, now reachable from the CLI
+        # wizard too). All reach dockur as env vars and apply on the
+        # initial Windows install that _recreate_container triggers
+        # below. Non-interactive mode leaves the cfg defaults untouched.
+        if not non_interactive and cfg.pod.backend in ("podman", "docker"):
+            _prompt_edition_locale_tuning(cfg)
+
         # Pick a storage mode for podman/docker before compose is
         # rendered. Three cases:
         #   1. cfg.pod.storage_path already set → keep it (returning user
@@ -689,8 +827,25 @@ def handle_setup(args: argparse.Namespace) -> None:
         compose_path = config_dir() / "compose.yaml"
         print(f"  Compose:  {compose_path}")
     print()
-    print("Apps are now in your application menu.")
-    print("Just click any app. winpodx handles the rest automatically.")
+
+    # Full-provision flow: a standalone `winpodx setup` should finish
+    # like a complete install (wait for Windows first-boot + discover
+    # apps + reverse-open), not stop at "container created". install.sh
+    # passes --create-only because it drives those steps itself in bash;
+    # skipping here avoids doing the work twice.
+    create_only = bool(getattr(args, "create_only", False))
+    if create_only or cfg.pod.backend not in ("podman", "docker"):
+        print("Apps are now in your application menu.")
+        print("Just click any app. winpodx handles the rest automatically.")
+        if cfg.pod.backend in ("podman", "docker") and create_only:
+            print(
+                "\nWindows is booting in the background. "
+                "Run `winpodx pod wait-ready --logs` to watch, or just "
+                "`winpodx app run desktop` (it waits on first launch)."
+            )
+    else:
+        _run_full_provision(cfg)
+        print("\nSetup + provisioning complete. Launch with `winpodx app run desktop`.")
 
 
 def _recreate_container(cfg: Config) -> None:

--- a/tests/test_setup_wizard_prompts.py
+++ b/tests/test_setup_wizard_prompts.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the extended setup wizard (#255 PR 7 completion):
+edition / locale / tuning prompts + the --create-only provision gate.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from winpodx.cli.setup_cmd import _prompt_edition_locale_tuning, _run_full_provision
+from winpodx.core.config import Config
+
+
+def _cfg() -> Config:
+    cfg = Config()
+    cfg.pod.backend = "podman"
+    return cfg
+
+
+def test_wizard_prompts_set_all_locale_edition_tuning_fields() -> None:
+    """Each answered prompt maps to the matching cfg.pod field."""
+    cfg = _cfg()
+    answers = iter(
+        [
+            "ltsc11",  # edition / win_version
+            "German",  # language
+            "en-US",  # region
+            "de-DE",  # keyboard
+            "performance",  # tuning_profile
+        ]
+    )
+    with patch("builtins.input", lambda _prompt: next(answers)):
+        _prompt_edition_locale_tuning(cfg)
+
+    assert cfg.pod.win_version == "ltsc11"
+    assert cfg.pod.language == "German"
+    assert cfg.pod.region == "en-US"
+    assert cfg.pod.keyboard == "de-DE"
+    assert cfg.pod.tuning_profile == "performance"
+
+
+def test_wizard_prompts_enter_keeps_defaults() -> None:
+    """Empty input (Enter) keeps the existing cfg defaults."""
+    cfg = _cfg()
+    before = (
+        cfg.pod.win_version,
+        cfg.pod.language,
+        cfg.pod.region,
+        cfg.pod.keyboard,
+        cfg.pod.tuning_profile,
+    )
+    with patch("builtins.input", lambda _prompt: ""):
+        _prompt_edition_locale_tuning(cfg)
+
+    after = (
+        cfg.pod.win_version,
+        cfg.pod.language,
+        cfg.pod.region,
+        cfg.pod.keyboard,
+        cfg.pod.tuning_profile,
+    )
+    assert before == after
+
+
+def test_wizard_rejects_unknown_tuning_profile_keeps_default() -> None:
+    """A bogus tuning profile is rejected, default preserved."""
+    cfg = _cfg()
+    cfg.pod.tuning_profile = "auto"
+    answers = iter(["11", "English", "en-001", "en-US", "turbo-nonsense"])
+    with patch("builtins.input", lambda _prompt: next(answers)):
+        _prompt_edition_locale_tuning(cfg)
+    assert cfg.pod.tuning_profile == "auto"
+
+
+def test_full_provision_noop_for_non_container_backend() -> None:
+    """libvirt / manual backends have no container provision flow -- the
+    helper must return immediately without touching wait-ready etc."""
+    cfg = _cfg()
+    cfg.pod.backend = "manual"
+    # If it tried to import/run _wait_ready it'd need a real pod; the
+    # early return keeps it a pure no-op. No exception = pass.
+    _run_full_provision(cfg)


### PR DESCRIPTION
## Summary

Two gaps surfaced running `winpodx setup --customize`:

### 1. `--customize` wizard was incomplete

It only prompted backend / user / pass / IP / CPU / RAM / timezone. **Edition, UI language, regional format, keyboard layout, and tuning profile** -- all exposed in the GUI Settings page + via `config set` -- were never wired into the CLI wizard (#255 deferred them to "PR 7", which never landed).

New `_prompt_edition_locale_tuning()` asks for all five with the current value pre-filled; Enter keeps the default. Maps to `cfg.pod.win_version` / `.language` / `.region` / `.keyboard` / `.tuning_profile`.

### 2. Standalone `winpodx setup` stopped at "container created"

The Windows first-boot wait + app discovery + reverse-open only ran when install.sh drove them in bash. A user running `winpodx setup` directly got a half-finished install with no hint Windows was still booting.

New `_run_full_provision()` runs the same post-create flow: `wait-ready --logs` → `apply-fixes` → app discovery → reverse-open. So a direct `winpodx setup` finishes like a complete install.

### Avoiding double work

New `--create-only` flag: install.sh passes it (it orchestrates the post-steps itself in bash), so setup stops after container create on that path. Standalone setup runs the full flow. `--create-only` also prints a "Windows is booting, run `pod wait-ready --logs`" hint.

## Reuse

`cli.pod._wait_ready`, `provisioner.apply_windows_runtime_fixes`, `cli.app._refresh_apps`, `cli.host_open._cmd_refresh`. Every provision step is best-effort -- a guest still booting / a failed discovery never aborts setup; the pending-steps machinery + next `winpodx app run` resume.

## Test plan

- [x] 4 new cases: wizard prompt → cfg field mapping, Enter-keeps-default, bad-tuning rejection, non-container backend no-op
- [x] existing 70 setup/oem/install_config tests pass
- [x] `ruff check` + `ruff format` clean
- [x] `winpodx setup --help` shows `--create-only`
- [ ] Manual: `winpodx setup --customize` on a real host walks all knobs + runs full provision to a launchable guest
- [ ] Manual: `install.sh` still works end-to-end (setup --create-only + bash orchestration, no double provision)