### PR TITLE
fix(appimage): override fedora nodocs so third-party license texts install

### DIFF
--- a/.github/workflows/appimage-publish.yml
+++ b/.github/workflows/appimage-publish.yml
@@ -130,7 +130,12 @@ jobs:
               -v "$PWD/packaging/appimage:/scripts" \
               fedora:41 bash -c '
                   set -euo pipefail
-                  dnf install -y --setopt=install_weak_deps=False \
+                  # tsflags= overrides the fedora image default
+                  # `tsflags=nodocs`, which strips /usr/share/licenses on
+                  # install -- without it the fail-closed license check
+                  # below aborts because podman/freerdp-libs/... then ship
+                  # no license dir in the doc-stripped image.
+                  dnf install -y --setopt=install_weak_deps=False --setopt=tsflags= \
                       freerdp \
                       freerdp-libs \
                       libwinpr \


### PR DESCRIPTION
Follow-up to #311. The AppImage publish failed again with:

> FATAL: /usr/share/licenses/podman missing -- cannot ship a license-compliant AppImage without it. Aborting.

## Root cause

The `fedora:41` image ships `tsflags=nodocs` in `/etc/dnf/dnf.conf`,
which strips `/usr/share/licenses/*` on install. So even `podman` /
`freerdp-libs` / `libwinpr` -- which DO carry a license dir in a normal
install -- end up with none in the image, and the fail-closed check
(correctly) aborts.

## Fix

Add `--setopt=tsflags=` to the bundle-step `dnf install` to clear
`nodocs` for that transaction. Verified in a fresh `fedora:41`:

```
EXIST podman / freerdp-libs / libwinpr / conmon / crun / netavark / passt
MISSING slirp4netns / freerdp(metapackage)   <- genuinely ship none, stay best-effort
/usr/lib/python3.13/site-packages/podman_compose-1.4.1.dist-info/LICENSE   <- GPL-2.0, as before
```

Workflow-only change.