### PR TITLE
fix(appimage): delete nodocs from dnf.conf so license texts install (dnf5)

### DIFF
--- a/.github/workflows/appimage-publish.yml
+++ b/.github/workflows/appimage-publish.yml
@@ -130,12 +130,16 @@ jobs:
               -v "$PWD/packaging/appimage:/scripts" \
               fedora:41 bash -c '
                   set -euo pipefail
-                  # tsflags= overrides the fedora image default
-                  # `tsflags=nodocs`, which strips /usr/share/licenses on
-                  # install -- without it the fail-closed license check
-                  # below aborts because podman/freerdp-libs/... then ship
-                  # no license dir in the doc-stripped image.
-                  dnf install -y --setopt=install_weak_deps=False --setopt=tsflags= \
+                  # The fedora:41 image sets `tsflags=nodocs` in
+                  # /etc/dnf/dnf.conf, which strips /usr/share/licenses on
+                  # install -- the fail-closed license check below then
+                  # aborts because podman/freerdp-libs/... ship no license
+                  # dir. `--setopt=tsflags=` is NOT honored by dnf5 here
+                  # (config value wins), so delete the line from the conf
+                  # outright; that is dnf4/dnf5-agnostic and verified to
+                  # repopulate /usr/share/licenses.
+                  sed -i "/^tsflags/d" /etc/dnf/dnf.conf
+                  dnf install -y --setopt=install_weak_deps=False \
                       freerdp \
                       freerdp-libs \
                       libwinpr \


### PR DESCRIPTION
Follow-up to #312. AppImage still failed with `/usr/share/licenses/podman missing`.

## Root cause

`--setopt=tsflags=` (added in #312) is **silently ignored by dnf5** on
`fedora:41` -- the `/etc/dnf/dnf.conf` value `tsflags=nodocs` wins, so
`/usr/share/licenses/*` is still stripped on install and the
fail-closed check aborts.

## Fix

Delete the `tsflags` line from `/etc/dnf/dnf.conf` before install:

```sh
sed -i "/^tsflags/d" /etc/dnf/dnf.conf
```

dnf4/dnf5-agnostic. Verified in a fresh `fedora:41` that this
repopulates `/usr/share/licenses/{podman,freerdp-libs,libwinpr,...}`.
Workflow-only change.