### PR TITLE
fix(appimage): harvest licenses from dnf cache (no second download)

### DIFF
--- a/.github/workflows/appimage-publish.yml
+++ b/.github/workflows/appimage-publish.yml
@@ -130,7 +130,10 @@ jobs:
               -v "$PWD/packaging/appimage:/scripts" \
               fedora:41 bash -c '
                   set -euo pipefail
-                  dnf install -y --setopt=install_weak_deps=False \
+                  # keepcache=1 keeps every installed .rpm under
+                  # /var/cache/libdnf5/.../packages so we can harvest license
+                  # texts straight out of the package payloads below.
+                  dnf install -y --setopt=install_weak_deps=False --setopt=keepcache=1 \
                       freerdp \
                       freerdp-libs \
                       libwinpr \
@@ -151,24 +154,23 @@ jobs:
                   # slirp4netns/passt; GPL-2.0: podman-compose).
                   #
                   # NB: the fedora image installs with `tsflags=nodocs`, which
-                  # strips /usr/share/licenses off the installed filesystem --
+                  # strips /usr/share/licenses off the installed filesystem,
                   # and overriding that (sed dnf.conf / --setopt) proved
                   # unreliable on the CI runner. The rpm *payload* always
                   # carries the %license files regardless of install-time
-                  # tsflags, so harvest them straight out of the downloaded
-                  # rpms via rpm2cpio. This is nodocs-proof and deterministic.
+                  # tsflags, so harvest them from the cached rpms (kept by
+                  # keepcache=1 above) via rpm2cpio -- no second download, no
+                  # dnf plugin, no network. nodocs-proof and deterministic.
                   dst=/AppDir/usr/share/doc/winpodx/third-party
                   mkdir -p "$dst"
                   harvest=$(mktemp -d)
                   ( cd "$harvest"
-                    dnf download --setopt=install_weak_deps=False \
-                        podman freerdp-libs libwinpr conmon crun netavark \
-                        passt slirp4netns >/dev/null 2>&1 || true
-                    for r in *.x86_64.rpm *.noarch.rpm; do
-                        [ -e "$r" ] || continue
+                    find /var/cache/libdnf5 -name "*.rpm" 2>/dev/null | while read -r r; do
                         rpm2cpio "$r" | cpio -idmu --quiet 2>/dev/null || true
                     done )
                   lic="$harvest/usr/share/licenses"
+                  echo "[provenance] harvested license dirs:"
+                  ls -1 "$lic" 2>/dev/null || echo "(none harvested)"
                   # REQUIRED license dirs fail the build if missing -- these
                   # carry the hard redistribution obligations of the primary
                   # bundled tools (Apache-2.0 NOTICE/LICENSE for Podman; the


### PR DESCRIPTION
Follow-up to #314. AppImage failed again -- `FATAL: license payload for podman not found`.

## Root cause

The #314 harvest used a second `dnf download`, which produced **zero
rpms on the CI runner** (output was suppressed → silent failure), even
though it works in a local `fedora:41` with the identical image digest.
This is the same maddening local-vs-CI divergence that defeated #312
(`--setopt=tsflags=`) and #313 (`sed dnf.conf`).

## Fix -- eliminate the second fetch

Set `keepcache=1` on the **main** `dnf install`, so every installed
`.rpm` stays in `/var/cache/libdnf5/.../packages`. Harvest the
`%license` trees straight from those cached payloads with `rpm2cpio`:

```sh
find /var/cache/libdnf5 -name "*.rpm" | while read -r r; do
    rpm2cpio "$r" | cpio -idmu --quiet
done
```

No second download, no dnf plugin, no network -- only local fs +
`rpm2cpio` (always present) + `cpio`. Removes every variable that kept
diverging between local and CI. Fail-closed required set
(podman / freerdp-libs / libwinpr + podman-compose dist-info GPL-2.0)
unchanged. Verified in `fedora:41` via docker. Workflow-only change.