### PR TITLE
feat(disk): Windows disk auto-grow + manual grow-disk / disk-usage (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ verbatim.
 ### Fixed
 -->
 
+### Added
+
+- **Windows disk auto-grow + manual grow (#318).** The Windows C: drive now grows on its own: when the system volume fills past `disk_autogrow_threshold_pct` (default 80%) and the pod is idle, winpodx grows the virtual disk *enough to restore `disk_autogrow_target_free_pct` free space* (default 30%, in whole `disk_autogrow_increment` steps — not a flat bump), recreates the container so dockur grows the image, then extends C: to fill via `Resize-Partition` — no manual Disk Management step. The grow is bounded by the host's free space (minus a safety reserve); `disk_max_size` is now an *optional* explicit ceiling (empty by default) rather than a fixed cap. The same operation is exposed manually: `winpodx pod grow-disk` (add one increment), `winpodx pod grow-disk 128G` (absolute target), `winpodx pod grow-disk --extend-only` (just extend C: into existing unallocated space), and `winpodx pod disk-usage` (size / free / used%). The GUI Tools page gains a **Grow Disk** action. Auto-grow runs only while idle so it never interrupts a live RemoteApp session, and the guest-side work reuses the agent `/exec` path (no agent change). Default-on; set `disk_autogrow = false` to manage size manually. Note: dockur has no online disk resize, so each grow recreates the container (a quick guest reboot) — winpodx schedules auto-grows during idle for exactly this reason. Reported by @drjwhitty (Linux Mint 22.2).
+
 ## [0.5.8] - 2026-05-24
 
 Reliability + reach release: fixes the two big fresh-install failures users reported (#269 agent can't bind 8765, #287 install.bat never runs), ships a distro-agnostic fat AppImage, and rounds out the setup wizard so a standalone `winpodx setup` provisions end-to-end.

--- a/docs/USAGE.ko.md
+++ b/docs/USAGE.ko.md
@@ -38,6 +38,10 @@ winpodx pod multi-session on      # bundled rdprrap 멀티세션 RDP 토글
 winpodx pod multi-session status
 winpodx pod wait-ready --logs     # Windows 첫 부팅 대기 + 진행 + 컨테이너 로그 (느린 ISO 다운로드 시 자동 연장)
 winpodx pod recover-oem           # dockur 첫 부팅 OEM 복사 실패 시 C:\OEM 재stage + install.bat 실행 (#287)
+winpodx pod disk-usage            # Windows C: 크기 / 여유 / 사용% + 자동확장 상태 (#318)
+winpodx pod grow-disk             # 자동확장 increment(기본 32G) 만큼 디스크 확장 + C: extend (#318)
+winpodx pod grow-disk 128G        # 절대 크기로 확장
+winpodx pod grow-disk --extend-only   # 기존 미할당 공간으로 C: 만 확장
 
 # 전원 관리
 winpodx power --suspend           # 컨테이너 pause (CPU 해제, 메모리 유지)
@@ -233,7 +237,12 @@ auto_start = true                                # 앱 실행 시 pod 자동 시
 idle_timeout = 0                                 # 자동 suspend 까지 초 (0 = 비활성)
 boot_timeout = 300                               # 첫 부팅 unattended 설치 대기 초
 image = "docker.io/dockurr/windows:latest"       # 컨테이너 이미지 (에어갭 미러용 override)
-disk_size = "64G"                                # dockur 에 전달하는 가상 디스크 크기
+disk_size = "64G"                                # dockur 에 전달하는 가상 디스크 크기 (`pod grow-disk` 로 확장)
+disk_autogrow = true                             # C: 가 임계 넘으면 자동 확장 (idle 일 때만)
+disk_autogrow_threshold_pct = 80                 # 자동 확장 트리거 사용% (50-99)
+disk_autogrow_target_free_pct = 30               # 확장 후 회복할 여유 비율 (고정 step 아님)
+disk_autogrow_increment = "32G"                  # 확장 granularity / 최소 step
+disk_max_size = ""                               # 선택적 상한; 빈값 = host 여유공간만이 한계
 
 [reverse_open]
 enabled = true                                   # v0.5.0 부터 기본 활성

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -38,6 +38,10 @@ winpodx pod multi-session on      # Toggle bundled rdprrap multi-session RDP
 winpodx pod multi-session status
 winpodx pod wait-ready --logs     # Wait for Windows first-boot with progress + container logs (auto-extends on slow ISO download)
 winpodx pod recover-oem           # Re-stage C:\OEM + run install.bat when dockur's first-boot OEM copy failed (#287)
+winpodx pod disk-usage            # Show Windows C: size / free / used% + auto-grow status (#318)
+winpodx pod grow-disk             # Add the auto-grow increment (default 32G) to the disk + extend C: (#318)
+winpodx pod grow-disk 128G        # Grow to an absolute size
+winpodx pod grow-disk --extend-only   # Just extend C: into existing unallocated space
 
 # Power management
 winpodx power --suspend           # Pause container (free CPU, keep memory)
@@ -233,7 +237,12 @@ auto_start = true                                # Start pod automatically when 
 idle_timeout = 0                                 # Seconds before auto-suspend (0 = disabled)
 boot_timeout = 300                               # Seconds to wait for first-boot unattended install
 image = "docker.io/dockurr/windows:latest"       # Container image (override for air-gapped mirror)
-disk_size = "64G"                                # Virtual disk size passed to dockur
+disk_size = "64G"                                # Virtual disk size passed to dockur (grows via `pod grow-disk`)
+disk_autogrow = true                             # Auto-grow C: when it fills past the threshold (idle only)
+disk_autogrow_threshold_pct = 80                 # Used-% that triggers an auto-grow (50-99)
+disk_autogrow_target_free_pct = 30               # Grow is sized to restore this much free (not a flat step)
+disk_autogrow_increment = "32G"                  # Grow granularity / minimum step
+disk_max_size = ""                               # Optional hard ceiling; empty = bounded only by host free space
 
 [reverse_open]
 enabled = true                                   # Default since v0.5.0

--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -210,6 +210,51 @@ def cli(argv: list[str] | None = None) -> None:
         ),
     )
 
+    grow_p = pod_sub.add_parser(
+        "grow-disk",
+        help=(
+            "Grow the Windows virtual disk and extend C: to fill it (#318). "
+            "Bumps disk_size (capped at disk_max_size), recreates the "
+            "container so dockur grows the image, then extends C:. Windows "
+            "data is preserved. podman/docker backends only."
+        ),
+    )
+    grow_p.add_argument(
+        "size",
+        nargs="?",
+        default=None,
+        metavar="SIZE",
+        help=(
+            "Absolute target size (e.g. 128G). Omit to add the auto-grow "
+            "increment (default 32G) to the current size."
+        ),
+    )
+    grow_p.add_argument(
+        "--increment",
+        default=None,
+        metavar="SIZE",
+        help="Amount to add to the current size instead of the configured default (e.g. 64G).",
+    )
+    grow_p.add_argument(
+        "--extend-only",
+        action="store_true",
+        help=(
+            "Skip the resize; only extend C: into existing unallocated space "
+            "(finishes a grow whose guest wasn't responsive yet)."
+        ),
+    )
+    grow_p.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Skip the confirmation prompt.",
+    )
+
+    pod_sub.add_parser(
+        "disk-usage",
+        help="Show the Windows C: drive size / free / used%% and auto-grow status (#318).",
+    )
+
     # --- config ---
     cfg_parser = sub.add_parser("config", help="Manage configuration")
     cfg_sub = cfg_parser.add_subparsers(dest="config_command")

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -39,11 +39,20 @@ def handle_pod(args: argparse.Namespace) -> None:
         sys.exit(handle_install_resume(args))
     elif cmd == "recover-oem":
         _recover_oem()
+    elif cmd == "grow-disk":
+        _grow_disk(
+            target_size=getattr(args, "size", None),
+            increment=getattr(args, "increment", None),
+            extend_only=getattr(args, "extend_only", False),
+            assume_yes=getattr(args, "yes", False),
+        )
+    elif cmd == "disk-usage":
+        _disk_usage()
     else:
         print(
             "Usage: winpodx pod {start|stop|status|restart|recreate|apply-fixes|"
             "sync-password|multi-session|wait-ready|install-status|install-resume|"
-            "recover-oem}"
+            "recover-oem|grow-disk|disk-usage}"
         )
         sys.exit(1)
 
@@ -1265,3 +1274,100 @@ def _recover_oem() -> None:
     print()
     print("To stop the HTTP server when finished:")
     print(f"  {cmd} exec {container} pkill -f 'http.server 8766'")
+
+
+def _disk_usage() -> None:
+    """Print the guest C: volume size / free / used%."""
+    from winpodx.core.config import Config
+    from winpodx.core.disk import get_guest_disk_usage
+
+    cfg = Config.load()
+    usage = get_guest_disk_usage(cfg)
+    if usage is None:
+        print(
+            "Could not read guest disk usage (is the pod running and the agent up?).\n"
+            "Try `winpodx pod wait-ready` first."
+        )
+        sys.exit(1)
+
+    def _gib(n: int) -> str:
+        return f"{n / (1024**3):.1f} GiB"
+
+    cap = cfg.pod.disk_max_size or "host free space"
+    print("Windows C: drive")
+    print(f"  configured disk_size : {cfg.pod.disk_size}  (max: {cap})")
+    print(f"  total                : {_gib(usage.total_bytes)}")
+    print(f"  free                 : {_gib(usage.free_bytes)}")
+    print(f"  used                 : {_gib(usage.used_bytes)}  ({usage.used_pct:.1f}%)")
+    if cfg.pod.disk_autogrow:
+        print(
+            f"  auto-grow            : on at {cfg.pod.disk_autogrow_threshold_pct}% "
+            f"(+{cfg.pod.disk_autogrow_increment} per step, idle only)"
+        )
+    else:
+        print("  auto-grow            : off")
+
+
+def _grow_disk(
+    *,
+    target_size: str | None,
+    increment: str | None,
+    extend_only: bool,
+    assume_yes: bool,
+) -> None:
+    """Grow the Windows virtual disk and extend C: to fill it (#318)."""
+    from winpodx.core.config import Config
+    from winpodx.core.disk import (
+        DiskError,
+        compute_grow_target,
+        extend_guest_system_volume,
+        grow_disk,
+    )
+
+    cfg = Config.load()
+
+    # --extend-only: skip the resize, just extend C: into existing
+    # unallocated space (used to finish a grow whose guest wasn't up yet).
+    if extend_only:
+        print("Extending C: into unallocated space...")
+        if extend_guest_system_volume(cfg):
+            print("C: extended (or already at max).")
+        else:
+            print("Failed to extend C: -- see logs; the guest may be unreachable.")
+            sys.exit(1)
+        return
+
+    try:
+        new_size = compute_grow_target(cfg, target_size=target_size, increment=increment)
+    except DiskError as e:
+        print(f"Cannot grow disk: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not assume_yes:
+        print(
+            f"Grow Windows disk {cfg.pod.disk_size} -> {new_size}?\n"
+            "This stops the pod, recreates the container so dockur grows the\n"
+            "virtual disk, then extends C: to fill it. Existing Windows data is\n"
+            "preserved. Type 'y' to continue: ",
+            end="",
+            flush=True,
+        )
+        try:
+            if input().strip().lower() not in ("y", "yes"):
+                print("Aborted.")
+                sys.exit(2)
+        except EOFError:
+            print("Aborted (no confirmation).")
+            sys.exit(2)
+
+    try:
+        result = grow_disk(cfg, target_size=target_size, increment=increment)
+    except DiskError as e:
+        print(f"Grow failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Disk grown {result.old_size} -> {result.new_size}.")
+    if result.partition_extended:
+        print("C: extended to fill the new space.")
+    elif result.note:
+        print(result.note)

--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -184,6 +184,29 @@ class PodConfig:
     image: str = field(default_factory=_default_pod_image)
     # Virtual disk size exposed in the compose template (e.g. "64G", "128G").
     disk_size: str = "64G"
+    # v0.5.x: disk auto-grow. When the Windows system volume fills past
+    # ``disk_autogrow_threshold_pct`` and the pod is idle, winpodx grows the
+    # virtual disk enough to restore ``disk_autogrow_target_free_pct`` free
+    # space (rounded up to whole ``disk_autogrow_increment`` steps),
+    # recreates the container so dockur grows the image, then extends the
+    # C: partition in the guest to fill it. Default-on; set
+    # ``disk_autogrow = false`` to manage size manually. The same grow op
+    # backs ``winpodx pod grow-disk`` (manual) and the GUI button.
+    disk_autogrow: bool = True
+    # Used-space percentage that triggers an auto-grow. Clamped to [50, 99].
+    disk_autogrow_threshold_pct: int = 80
+    # After an auto-grow, aim to leave this much of the disk free (the grow
+    # is sized to hit it, not a flat step). Clamped to [10, 50].
+    disk_autogrow_target_free_pct: int = 30
+    # Minimum / granularity step for a grow (dockur size shape, e.g. "32G").
+    # Auto-grow rounds the computed target up to a whole multiple of this;
+    # bare ``winpodx pod grow-disk`` adds exactly one.
+    disk_autogrow_increment: str = "32G"
+    # Optional hard ceiling for auto + manual grow. Empty string (default)
+    # means no fixed cap -- the real limit is the host's free space (minus
+    # a safety reserve). Set a dockur size (e.g. "512G", "1T") to impose an
+    # explicit upper bound regardless of host capacity.
+    disk_max_size: str = ""
     # Maximum concurrent RemoteApp sessions. Writes
     # HKLM:\...\Terminal Server\WinStations\RDP-Tcp\MaxInstanceCount
     # + clears fSingleSessionPerUser in the guest so rdprrap can hand
@@ -299,6 +322,38 @@ class PodConfig:
             self.disk_size = "64G"
         else:
             self.disk_size = self.disk_size.strip()
+        # disk auto-grow knobs: validate the size-shaped strings the same
+        # way as disk_size, clamp the threshold, coerce the bool.
+        if not isinstance(self.disk_autogrow, bool):
+            self.disk_autogrow = True
+        try:
+            self.disk_autogrow_threshold_pct = max(
+                50, min(99, int(self.disk_autogrow_threshold_pct))
+            )
+        except (TypeError, ValueError):
+            self.disk_autogrow_threshold_pct = 80
+        try:
+            self.disk_autogrow_target_free_pct = max(
+                10, min(50, int(self.disk_autogrow_target_free_pct))
+            )
+        except (TypeError, ValueError):
+            self.disk_autogrow_target_free_pct = 30
+        if not isinstance(self.disk_autogrow_increment, str) or not _DISK_SIZE_RE.match(
+            self.disk_autogrow_increment.strip()
+            if isinstance(self.disk_autogrow_increment, str)
+            else ""
+        ):
+            self.disk_autogrow_increment = "32G"
+        else:
+            self.disk_autogrow_increment = self.disk_autogrow_increment.strip()
+        # disk_max_size is optional: empty string = no fixed cap (host free
+        # space is the real bound). A non-empty value must be a valid size.
+        if not isinstance(self.disk_max_size, str):
+            self.disk_max_size = ""
+        else:
+            self.disk_max_size = self.disk_max_size.strip()
+            if self.disk_max_size and not _DISK_SIZE_RE.match(self.disk_max_size):
+                self.disk_max_size = ""
         # storage_path: keep empty (named-volume mode) or coerce to a
         # safe absolute string under the user's home or under a known
         # winpodx-managed root. The caller responsible for materialising
@@ -551,6 +606,11 @@ class Config:
                 "boot_timeout": self.pod.boot_timeout,
                 "image": self.pod.image,
                 "disk_size": self.pod.disk_size,
+                "disk_autogrow": self.pod.disk_autogrow,
+                "disk_autogrow_threshold_pct": self.pod.disk_autogrow_threshold_pct,
+                "disk_autogrow_target_free_pct": self.pod.disk_autogrow_target_free_pct,
+                "disk_autogrow_increment": self.pod.disk_autogrow_increment,
+                "disk_max_size": self.pod.disk_max_size,
                 "max_sessions": self.pod.max_sessions,
                 "storage_path": self.pod.storage_path,
                 "language": self.pod.language,

--- a/src/winpodx/core/daemon.py
+++ b/src/winpodx/core/daemon.py
@@ -194,6 +194,11 @@ def run_idle_monitor(
 
     log.info("Idle monitor started (timeout=%ds)", idle_timeout)
     idle_since: float | None = None
+    # Throttle the disk auto-grow probe: checking C: usage hits the guest
+    # over /exec, so only do it every ~10 min while idle (a grow drops
+    # usage well below the threshold, so it won't re-fire next tick).
+    autogrow_interval = 600.0
+    last_autogrow_check: float | None = None
 
     while not stop_event.is_set():
         sessions = list_active_sessions()
@@ -201,6 +206,29 @@ def run_idle_monitor(
         if sessions:
             idle_since = None  # Reset idle timer
         else:
+            # Disk auto-grow runs only while idle so a grow (which recreates
+            # the container) never interrupts a live RemoteApp session.
+            if (
+                cfg.pod.disk_autogrow
+                and not is_pod_paused(cfg)
+                and (
+                    last_autogrow_check is None
+                    or time.monotonic() - last_autogrow_check >= autogrow_interval
+                )
+            ):
+                last_autogrow_check = time.monotonic()
+                try:
+                    from winpodx.core.disk import maybe_autogrow
+
+                    if maybe_autogrow(cfg):
+                        # Pod was recreated -- restart the idle timer so the
+                        # freshly-grown pod isn't suspended immediately.
+                        idle_since = None
+                        stop_event.wait(30)
+                        continue
+                except Exception as e:  # noqa: BLE001 -- never kill the monitor
+                    log.warning("auto-grow check failed: %s", e)
+
             if idle_since is None:
                 idle_since = time.monotonic()
                 log.debug("No active sessions, starting idle timer")

--- a/src/winpodx/core/disk.py
+++ b/src/winpodx/core/disk.py
@@ -1,0 +1,426 @@
+# SPDX-License-Identifier: MIT
+"""Windows guest disk auto-grow + manual grow (#318).
+
+The Windows system volume sits on dockur's virtual disk, whose ceiling is
+``cfg.pod.disk_size``. dockur grows the underlying image when ``disk_size``
+increases and the container is recreated, but it never extends the guest's
+C: partition for an *existing* install -- the extra space lands as
+unallocated. This module closes that gap:
+
+- :func:`get_guest_disk_usage` probes C: size / free via the agent ``/exec``
+  (PowerShell ``Get-Volume``), no agent change required.
+- :func:`grow_disk` bumps ``disk_size`` (bounded by the effective cap --
+  the optional ``disk_max_size`` and/or host free space minus a reserve),
+  recreates the container so dockur grows the image, waits for the guest,
+  then extends C: to fill via ``Resize-Partition``.
+- :func:`maybe_autogrow` is the daemon hook: when ``disk_autogrow`` is on,
+  the pod is idle, and used space crosses ``disk_autogrow_threshold_pct``,
+  it grows just enough to restore ``disk_autogrow_target_free_pct`` free
+  (in whole ``disk_autogrow_increment`` steps), never past the cap.
+
+dockur's virtual disk is sparse, so raising the ceiling doesn't consume
+host space up front -- the host fills only as Windows writes -- and the
+host reserve keeps the ceiling within what the host can actually back, so
+a later guest fill can't ENOSPC the host. dockur has no online resize, so
+each grow recreates the container (a quick guest reboot); auto-grow runs
+only while idle for that reason.
+
+All guest-side work goes through ``windows_exec.run_in_windows`` (agent
+``/exec`` with FreeRDP fallback) -- there is no new agent endpoint.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from winpodx.core.config import Config
+
+log = logging.getLogger(__name__)
+
+# dockur size shape: <integer><unit?> where unit is K/M/G/T (default bytes
+# per dockur, but winpodx always emits an explicit unit). Mirrors
+# ``config._DISK_SIZE_RE`` but captures the parts for arithmetic.
+_SIZE_RE = re.compile(r"^\s*([1-9][0-9]{0,4})\s*([KMGTkmgt]?)\s*$")
+_UNIT_BYTES = {
+    "": 1,
+    "K": 1024,
+    "M": 1024**2,
+    "G": 1024**3,
+    "T": 1024**4,
+}
+
+
+class DiskError(Exception):
+    """Raised when a grow operation can't proceed (validation / lifecycle)."""
+
+
+@dataclass
+class DiskUsage:
+    """Snapshot of the guest C: volume."""
+
+    total_bytes: int
+    free_bytes: int
+
+    @property
+    def used_bytes(self) -> int:
+        return max(0, self.total_bytes - self.free_bytes)
+
+    @property
+    def used_pct(self) -> float:
+        if self.total_bytes <= 0:
+            return 0.0
+        return 100.0 * self.used_bytes / self.total_bytes
+
+
+@dataclass
+class GrowResult:
+    old_size: str
+    new_size: str
+    partition_extended: bool
+    note: str = ""
+
+
+def parse_size(value: str) -> int:
+    """Parse a dockur size string (e.g. ``"64G"``) to bytes.
+
+    Raises :class:`DiskError` on anything that isn't a valid size shape.
+    """
+    m = _SIZE_RE.match(value or "")
+    if not m:
+        raise DiskError(f"invalid disk size {value!r}")
+    n, unit = m.group(1), m.group(2).upper()
+    return int(n) * _UNIT_BYTES[unit]
+
+
+def format_size(num_bytes: int) -> str:
+    """Format bytes back to the largest whole dockur unit (e.g. ``"96G"``).
+
+    Rounds *up* to the next whole unit so a grow never produces a target
+    smaller than requested. Falls back to the next unit down only when the
+    value isn't a whole multiple of the larger one.
+    """
+    if num_bytes <= 0:
+        raise DiskError(f"non-positive size {num_bytes!r}")
+    for unit in ("T", "G", "M", "K"):
+        factor = _UNIT_BYTES[unit]
+        if num_bytes >= factor and num_bytes % factor == 0:
+            return f"{num_bytes // factor}{unit}"
+    # Not a whole multiple of any unit -- round up to the next whole GiB
+    # (disk_size never needs finer granularity than that in practice).
+    gib = (num_bytes + _UNIT_BYTES["G"] - 1) // _UNIT_BYTES["G"]
+    return f"{gib}G"
+
+
+# Auto-grow must never consume the last of the host disk -- keep a reserve
+# free so the host stays healthy. Whichever is larger: a flat floor or a
+# fraction of the host filesystem.
+_HOST_RESERVE_FLOOR = 10 * (1024**3)  # 10 GiB
+_HOST_RESERVE_FRACTION = 0.10  # or 10% of the host filesystem
+
+
+def _host_free_and_total(cfg: Config) -> tuple[int, int] | None:
+    """(free, total) bytes of the filesystem backing the Windows disk image.
+
+    Returns None when the storage path can't be resolved (named-volume mode
+    on an unknown root) -- callers treat None as "can't verify host capacity".
+    """
+    sp = cfg.pod.storage_path
+    if not sp:
+        return None
+    try:
+        path = Path(sp).expanduser()
+        # Walk up to the nearest existing parent so statvfs succeeds even
+        # before the storage dir is materialised.
+        while not path.exists() and path != path.parent:
+            path = path.parent
+        usage = shutil.disk_usage(path)
+        return usage.free, usage.total
+    except OSError as e:  # noqa: BLE001
+        log.debug("host free-space probe failed for %r: %s", sp, e)
+        return None
+
+
+def effective_max_bytes(cfg: Config, current_bytes: int) -> int | None:
+    """Largest disk size a grow may target, in bytes.
+
+    The bound is the *minimum* of:
+      * the explicit ``disk_max_size`` cap, if the user set one; and
+      * what the host can actually back -- ``current + (host_free - reserve)``
+        so auto-grow can't fill the host disk.
+
+    Returns None when neither bound applies (no explicit cap and the host
+    capacity can't be probed) -- i.e. unbounded, host-trusted.
+    """
+    caps: list[int] = []
+    if cfg.pod.disk_max_size:
+        try:
+            caps.append(parse_size(cfg.pod.disk_max_size))
+        except DiskError:
+            pass
+    ht = _host_free_and_total(cfg)
+    if ht is not None:
+        free, total = ht
+        reserve = max(_HOST_RESERVE_FLOOR, int(total * _HOST_RESERVE_FRACTION))
+        headroom = free - reserve
+        # Even with no headroom the disk can't shrink below its current size.
+        caps.append(current_bytes + max(0, headroom))
+    if not caps:
+        return None
+    return min(caps)
+
+
+# PowerShell: emit C: total + free as JSON. ``Get-Volume`` is present on
+# every supported Windows edition; SizeRemaining is free bytes.
+_USAGE_PS = (
+    "$v = Get-Volume -DriveLetter C -ErrorAction Stop; "
+    "[Console]::Out.Write((ConvertTo-Json -Compress "
+    "@{ total = [int64]$v.Size; free = [int64]$v.SizeRemaining }))"
+)
+
+# PowerShell: extend C: to the maximum contiguous size the disk now offers.
+# No-op (returns success) when C: is already at the supported max.
+_EXTEND_PS = (
+    "$max = (Get-PartitionSupportedSize -DriveLetter C -ErrorAction Stop).SizeMax; "
+    "$cur = (Get-Partition -DriveLetter C -ErrorAction Stop).Size; "
+    "if ($max -gt $cur) { "
+    "Resize-Partition -DriveLetter C -Size $max -ErrorAction Stop; "
+    "Write-Output 'extended' } else { Write-Output 'already-max' }"
+)
+
+
+def get_guest_disk_usage(cfg: Config, *, timeout: int = 30) -> DiskUsage | None:
+    """Probe the guest C: volume. Returns None when the guest is unreachable
+    or the output can't be parsed (callers treat None as "skip this round")."""
+    from winpodx.core.windows_exec import WindowsExecError, run_in_windows
+
+    try:
+        result = run_in_windows(cfg, _USAGE_PS, timeout=timeout, description="disk-usage")
+    except WindowsExecError as e:
+        log.debug("disk-usage probe exec failed: %s", e)
+        return None
+    if not result.ok:
+        log.debug("disk-usage probe rc=%s stderr=%s", result.rc, result.stderr)
+        return None
+    try:
+        data = json.loads(result.stdout.strip())
+        total = int(data["total"])
+        free = int(data["free"])
+    except (ValueError, KeyError, TypeError) as e:
+        log.debug("disk-usage probe unparseable %r: %s", result.stdout, e)
+        return None
+    if total <= 0:
+        return None
+    return DiskUsage(total_bytes=total, free_bytes=free)
+
+
+def extend_guest_system_volume(cfg: Config, *, timeout: int = 120) -> bool:
+    """Extend C: to fill the (now larger) virtual disk. Returns True on
+    success or when already at max; False when the guest call fails."""
+    from winpodx.core.windows_exec import WindowsExecError, run_in_windows
+
+    try:
+        result = run_in_windows(
+            cfg, _EXTEND_PS, timeout=timeout, description="extend-system-volume"
+        )
+    except WindowsExecError as e:
+        log.warning("partition extend exec failed: %s", e)
+        return False
+    if not result.ok:
+        log.warning("partition extend rc=%s stderr=%s", result.rc, result.stderr)
+        return False
+    log.info("partition extend: %s", result.stdout.strip() or "ok")
+    return True
+
+
+def compute_grow_target(
+    cfg: Config,
+    *,
+    target_size: str | None = None,
+    increment: str | None = None,
+) -> str:
+    """Resolve the new disk size for a grow, enforcing the effective cap.
+
+    ``target_size`` wins if given (absolute); otherwise current + ``increment``
+    (default ``cfg.pod.disk_autogrow_increment``). Raises :class:`DiskError`
+    if the result wouldn't grow the disk or exceeds the effective maximum
+    (explicit ``disk_max_size`` and/or host free space minus reserve).
+    """
+    current = parse_size(cfg.pod.disk_size)
+    if target_size is not None:
+        new = parse_size(target_size)
+    else:
+        inc = parse_size(increment or cfg.pod.disk_autogrow_increment)
+        new = current + inc
+    if new <= current:
+        raise DiskError(f"target {format_size(new)} is not larger than current {cfg.pod.disk_size}")
+    eff_max = effective_max_bytes(cfg, current)
+    if eff_max is not None and new > eff_max:
+        if eff_max <= current:
+            raise DiskError("not enough host free space to grow (would breach the host reserve)")
+        limit_reason = (
+            f"disk_max_size {cfg.pod.disk_max_size}"
+            if cfg.pod.disk_max_size
+            else "host free space minus reserve"
+        )
+        raise DiskError(
+            f"target {format_size(new)} exceeds the limit {format_size(eff_max)} ({limit_reason})"
+        )
+    return format_size(new)
+
+
+def compute_autogrow_target(cfg: Config, usage: DiskUsage) -> str | None:
+    """Size an auto-grow to restore the configured free-space headroom.
+
+    Rather than a flat step, grow just enough that ``used`` drops to
+    ``(100 - disk_autogrow_target_free_pct)%`` of the new disk -- rounded up
+    to whole ``disk_autogrow_increment`` units, floored at one increment, and
+    clamped to :func:`effective_max_bytes`. Returns the new size string, or
+    None when the disk can't grow by even one increment (at the cap / no host
+    room) so the caller skips this round.
+    """
+    current = parse_size(cfg.pod.disk_size)
+    inc = parse_size(cfg.pod.disk_autogrow_increment)
+    used = usage.used_bytes
+
+    # Disk size that lands ``used`` at the target utilisation:
+    #   used / new_total <= (100 - target_free)/100  =>  new_total >= used / frac
+    used_frac_target = (100 - cfg.pod.disk_autogrow_target_free_pct) / 100.0
+    needed_total = int(used / used_frac_target) + 1 if used_frac_target > 0 else current
+
+    # Grow in whole increments, at least one.
+    delta = max(inc, needed_total - current)
+    steps = (delta + inc - 1) // inc
+    new = current + steps * inc
+
+    eff_max = effective_max_bytes(cfg, current)
+    if eff_max is not None:
+        if eff_max < current + inc:
+            return None  # can't fit even one increment
+        if new > eff_max:
+            # Clamp down to the largest whole-increment size that fits.
+            fit_steps = (eff_max - current) // inc
+            new = current + fit_steps * inc
+    if new <= current:
+        return None
+    return format_size(new)
+
+
+def grow_disk(
+    cfg: Config,
+    *,
+    target_size: str | None = None,
+    increment: str | None = None,
+    extend_partition: bool = True,
+    wait_timeout: int = 600,
+) -> GrowResult:
+    """Grow the Windows virtual disk and extend C: to fill it.
+
+    Stops the pod, bumps ``disk_size`` (capped), regenerates compose so
+    dockur grows the image on the next boot, restarts, waits for the guest,
+    then runs the partition extend. Raises :class:`DiskError` on validation
+    or lifecycle failure; the config is only persisted once the new size is
+    validated, and is rolled back if the container won't come back up.
+    """
+    from winpodx.core.pod import PodState, start_pod, stop_pod
+    from winpodx.core.pod.compose import generate_compose
+    from winpodx.core.provisioner import wait_for_windows_responsive
+
+    if cfg.pod.backend not in ("podman", "docker"):
+        raise DiskError(f"grow-disk only supports podman/docker, not {cfg.pod.backend!r}")
+
+    old_size = cfg.pod.disk_size
+    # compute_grow_target enforces the effective cap (explicit disk_max_size
+    # and/or host free space minus the reserve), so no separate host guard.
+    new_size = compute_grow_target(cfg, target_size=target_size, increment=increment)
+
+    log.info("grow-disk: %s -> %s", old_size, new_size)
+    stop_pod(cfg)
+
+    cfg.pod.disk_size = new_size
+    cfg.save()
+    try:
+        generate_compose(cfg)
+    except Exception as e:  # noqa: BLE001 -- roll back size on compose failure
+        cfg.pod.disk_size = old_size
+        cfg.save()
+        raise DiskError(f"failed to regenerate compose: {e}") from e
+
+    status = start_pod(cfg)
+    if status.state not in (PodState.RUNNING, PodState.STARTING):
+        cfg.pod.disk_size = old_size
+        cfg.save()
+        generate_compose(cfg)
+        raise DiskError(
+            f"container did not come back up after grow (state={status.state}); "
+            "rolled disk_size back"
+        )
+
+    extended = False
+    note = ""
+    if extend_partition:
+        if wait_for_windows_responsive(cfg, timeout=wait_timeout):
+            extended = extend_guest_system_volume(cfg)
+            if not extended:
+                note = (
+                    "disk image grown but C: not extended -- run "
+                    "`winpodx pod grow-disk --extend-only` once the guest is up, "
+                    "or extend C: manually in Disk Management."
+                )
+        else:
+            note = (
+                "disk image grown but guest didn't become responsive in time; "
+                "C: not extended yet (retry with `winpodx pod grow-disk --extend-only`)."
+            )
+
+    return GrowResult(
+        old_size=old_size,
+        new_size=new_size,
+        partition_extended=extended,
+        note=note,
+    )
+
+
+def maybe_autogrow(cfg: Config) -> bool:
+    """Daemon hook: grow the disk if it's filling up and the pod is idle.
+
+    Returns True when a grow was performed. Caller (idle monitor) invokes
+    this only when there are no active sessions, so a grow never interrupts
+    a live RemoteApp session. The grow is sized to restore the configured
+    free-space headroom (not a flat step) and bounded by the effective cap.
+    """
+    if not cfg.pod.disk_autogrow:
+        return False
+
+    usage = get_guest_disk_usage(cfg)
+    if usage is None:
+        return False
+    if usage.used_pct < cfg.pod.disk_autogrow_threshold_pct:
+        return False
+
+    target = compute_autogrow_target(cfg, usage)
+    if target is None:
+        log.info(
+            "auto-grow wanted (C: %.1f%% used) but can't grow further (at cap / no host room)",
+            usage.used_pct,
+        )
+        return False
+
+    log.info(
+        "auto-grow trigger: C: %.1f%% used (>= %d%%), growing %s -> %s to restore ~%d%% free",
+        usage.used_pct,
+        cfg.pod.disk_autogrow_threshold_pct,
+        cfg.pod.disk_size,
+        target,
+        cfg.pod.disk_autogrow_target_free_pct,
+    )
+    try:
+        grow_disk(cfg, target_size=target)
+    except DiskError as e:
+        log.warning("auto-grow skipped: %s", e)
+        return False
+    return True

--- a/src/winpodx/gui/_main_window_maintenance.py
+++ b/src/winpodx/gui/_main_window_maintenance.py
@@ -116,6 +116,12 @@ class MaintenanceMixin:
                 "Re-apply RDP timeout / NIC / TermService recovery to existing pod",
                 self._on_apply_fixes,
             ),
+            (
+                "⊕",
+                "Grow Disk",
+                "Add space to the Windows disk and extend C: to fill it",
+                self._on_grow_disk,
+            ),
         ]
         for i, (icon, label, desc, handler) in enumerate(sys_tools):
             layout.addWidget(self._make_action_row(icon, label, desc, handler, i + 3))
@@ -238,6 +244,65 @@ class MaintenanceMixin:
         removed = cleanup_lock_files()
         msg = f"Removed {len(removed)} lock files" if removed else "No lock files found"
         self.info_label.setText(msg)
+
+    def _on_grow_disk(self) -> None:
+        """Grow the Windows virtual disk by one increment + extend C: (#318).
+
+        Mirrors ``winpodx pod grow-disk``: confirm, then run the stop /
+        recreate / extend lifecycle on a worker thread so the UI stays
+        responsive (the op reboots the guest and can take minutes).
+        """
+        from winpodx.core.disk import DiskError, compute_grow_target
+
+        cfg = Config.load()
+        if cfg.pod.backend not in ("podman", "docker"):
+            QMessageBox.information(
+                self,
+                "Grow Disk",
+                f"Disk grow is only supported on the podman / docker backends, "
+                f"not {cfg.pod.backend!r}.",
+            )
+            return
+        try:
+            new_size = compute_grow_target(cfg)
+        except DiskError as e:
+            QMessageBox.information(self, "Grow Disk", f"Cannot grow disk: {e}")
+            return
+
+        reply = QMessageBox.question(
+            self,
+            "Grow Disk",
+            f"Grow the Windows disk {cfg.pod.disk_size} → {new_size}?\n\n"
+            "This stops the pod, recreates the container so the virtual disk "
+            "grows, then extends C: to fill it. Windows data is preserved, but "
+            "the guest will reboot and this can take a few minutes.\n\nProceed?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        self.info_label.setText(f"Growing disk {cfg.pod.disk_size} → {new_size}...")
+
+        def _do() -> None:
+            from winpodx.core.disk import DiskError, grow_disk
+
+            try:
+                result = grow_disk(cfg)
+            except DiskError as e:
+                self.app_launch_failed.emit(f"Grow failed: {e}")
+                return
+            if result.partition_extended:
+                self.app_launched.emit(
+                    f"Disk grown {result.old_size} → {result.new_size}; C: extended to fill."
+                )
+            else:
+                self.app_launched.emit(
+                    f"Disk grown {result.old_size} → {result.new_size}. "
+                    + (result.note or "C: not extended yet.")
+                )
+
+        threading.Thread(target=_do, daemon=True).start()
 
     def _refresh_update_status(self) -> None:
         def _do() -> None:

--- a/tests/test_disk.py
+++ b/tests/test_disk.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: MIT
+"""Unit tests for disk auto-grow / manual grow helpers (#318).
+
+Pure host-side logic only -- the guest ``/exec`` calls (usage probe,
+partition extend) are mocked. The actual diskpart / Resize-Partition
+behaviour is covered by the real-Windows smoke gate, not here."""
+
+from __future__ import annotations
+
+import pytest
+
+from winpodx.core.config import Config
+from winpodx.core.disk import (
+    DiskError,
+    DiskUsage,
+    compute_autogrow_target,
+    compute_grow_target,
+    effective_max_bytes,
+    format_size,
+    maybe_autogrow,
+    parse_size,
+)
+
+GIB = 1024**3
+
+
+def test_parse_size_units() -> None:
+    assert parse_size("64G") == 64 * GIB
+    assert parse_size("1T") == 1024 * GIB
+    assert parse_size("512M") == 512 * 1024**2
+    assert parse_size(" 128G ") == 128 * GIB  # whitespace tolerated
+
+
+@pytest.mark.parametrize("bad", ["", "0G", "abc", "-5G", "64X", "G"])
+def test_parse_size_rejects_garbage(bad: str) -> None:
+    with pytest.raises(DiskError):
+        parse_size(bad)
+
+
+def test_format_size_roundtrips_whole_units() -> None:
+    assert format_size(64 * GIB) == "64G"
+    assert format_size(1024 * GIB) == "1T"
+    assert format_size(96 * GIB) == "96G"
+
+
+def test_format_size_rounds_up_partial_to_gib() -> None:
+    # Non-whole-unit byte counts round up to the next whole GiB so a grow
+    # never lands below the requested size.
+    assert format_size(64 * GIB + 1) == "65G"
+
+
+def test_compute_grow_target_increment() -> None:
+    cfg = Config()
+    cfg.pod.disk_size = "64G"
+    cfg.pod.disk_autogrow_increment = "32G"
+    assert compute_grow_target(cfg) == "96G"
+
+
+def test_compute_grow_target_explicit_size() -> None:
+    cfg = Config()
+    cfg.pod.disk_size = "64G"
+    assert compute_grow_target(cfg, target_size="200G") == "200G"
+
+
+def test_compute_grow_target_custom_increment() -> None:
+    cfg = Config()
+    cfg.pod.disk_size = "64G"
+    assert compute_grow_target(cfg, increment="64G") == "128G"
+
+
+def test_compute_grow_target_refuses_shrink_or_noop() -> None:
+    cfg = Config()
+    cfg.pod.disk_size = "128G"
+    with pytest.raises(DiskError):
+        compute_grow_target(cfg, target_size="64G")
+    with pytest.raises(DiskError):
+        compute_grow_target(cfg, target_size="128G")
+
+
+def test_compute_grow_target_enforces_explicit_cap() -> None:
+    cfg = Config()
+    cfg.pod.storage_path = ""  # no host probe -> cap is the explicit one
+    cfg.pod.disk_size = "480G"
+    cfg.pod.disk_max_size = "512G"
+    cfg.pod.disk_autogrow_increment = "64G"  # 480 + 64 = 544 > 512
+    with pytest.raises(DiskError):
+        compute_grow_target(cfg)
+
+
+def test_compute_grow_target_unbounded_without_cap_or_host() -> None:
+    # No explicit cap and no resolvable host path -> no ceiling.
+    cfg = Config()
+    cfg.pod.storage_path = ""
+    cfg.pod.disk_max_size = ""
+    cfg.pod.disk_size = "64G"
+    assert compute_grow_target(cfg, target_size="2000G") == "2000G"
+
+
+def test_effective_max_bytes_none_when_unbounded() -> None:
+    cfg = Config()
+    cfg.pod.storage_path = ""
+    cfg.pod.disk_max_size = ""
+    assert effective_max_bytes(cfg, 64 * GIB) is None
+
+
+def test_effective_max_bytes_uses_explicit_cap() -> None:
+    cfg = Config()
+    cfg.pod.storage_path = ""
+    cfg.pod.disk_max_size = "256G"
+    assert effective_max_bytes(cfg, 64 * GIB) == 256 * GIB
+
+
+def test_compute_autogrow_target_restores_headroom() -> None:
+    # 64G disk, 58G used (~91%), target 30% free -> need total >= 58/0.7
+    # ~= 82.9G -> round up to whole 32G increments from 64 -> 96G.
+    cfg = Config()
+    cfg.pod.storage_path = ""
+    cfg.pod.disk_max_size = ""
+    cfg.pod.disk_size = "64G"
+    cfg.pod.disk_autogrow_increment = "32G"
+    cfg.pod.disk_autogrow_target_free_pct = 30
+    usage = DiskUsage(total_bytes=64 * GIB, free_bytes=6 * GIB)
+    assert compute_autogrow_target(cfg, usage) == "96G"
+
+
+def test_compute_autogrow_target_clamped_to_cap() -> None:
+    cfg = Config()
+    cfg.pod.storage_path = ""
+    cfg.pod.disk_max_size = "80G"  # only one 32G step fits from 64G? no -> 64 only
+    cfg.pod.disk_size = "64G"
+    cfg.pod.disk_autogrow_increment = "32G"
+    usage = DiskUsage(total_bytes=64 * GIB, free_bytes=2 * GIB)
+    # 64 + 32 = 96 > 80 cap, and no whole increment fits under 80 -> None.
+    assert compute_autogrow_target(cfg, usage) is None
+
+
+def test_disk_usage_pct() -> None:
+    u = DiskUsage(total_bytes=100 * GIB, free_bytes=10 * GIB)
+    assert u.used_bytes == 90 * GIB
+    assert u.used_pct == pytest.approx(90.0)
+
+
+def test_disk_usage_zero_total_is_safe() -> None:
+    u = DiskUsage(total_bytes=0, free_bytes=0)
+    assert u.used_pct == 0.0
+
+
+def _cfg_autogrow() -> Config:
+    cfg = Config()
+    cfg.pod.backend = "podman"
+    cfg.pod.disk_size = "64G"
+    cfg.pod.disk_max_size = "512G"
+    cfg.pod.disk_autogrow = True
+    cfg.pod.disk_autogrow_threshold_pct = 80
+    cfg.pod.disk_autogrow_increment = "32G"
+    return cfg
+
+
+def test_maybe_autogrow_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg_autogrow()
+    cfg.pod.disk_autogrow = False
+    # Should never even probe when disabled.
+    monkeypatch.setattr(
+        "winpodx.core.disk.get_guest_disk_usage",
+        lambda *a, **k: pytest.fail("probe should not run when autogrow off"),
+    )
+    assert maybe_autogrow(cfg) is False
+
+
+def test_maybe_autogrow_below_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg_autogrow()
+    monkeypatch.setattr(
+        "winpodx.core.disk.get_guest_disk_usage",
+        lambda *a, **k: DiskUsage(total_bytes=100 * GIB, free_bytes=50 * GIB),
+    )
+    grew = {"called": False}
+    monkeypatch.setattr(
+        "winpodx.core.disk.grow_disk",
+        lambda *a, **k: grew.__setitem__("called", True),
+    )
+    assert maybe_autogrow(cfg) is False
+    assert grew["called"] is False
+
+
+def test_maybe_autogrow_triggers_above_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg_autogrow()  # disk_size 64G, max 512G
+    monkeypatch.setattr(
+        "winpodx.core.disk.get_guest_disk_usage",
+        lambda *a, **k: DiskUsage(total_bytes=64 * GIB, free_bytes=3 * GIB),
+    )
+    calls = {"n": 0}
+    monkeypatch.setattr(
+        "winpodx.core.disk.grow_disk",
+        lambda *a, **k: calls.__setitem__("n", calls["n"] + 1),
+    )
+    assert maybe_autogrow(cfg) is True
+    assert calls["n"] == 1
+
+
+def test_maybe_autogrow_skips_at_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg_autogrow()
+    cfg.pod.disk_size = "512G"  # already at the explicit cap
+    cfg.pod.disk_max_size = "512G"
+    monkeypatch.setattr(
+        "winpodx.core.disk.get_guest_disk_usage",
+        lambda *a, **k: DiskUsage(total_bytes=512 * GIB, free_bytes=5 * GIB),
+    )
+    grew = {"called": False}
+    monkeypatch.setattr(
+        "winpodx.core.disk.grow_disk",
+        lambda *a, **k: grew.__setitem__("called", True),
+    )
+    # Over threshold but can't grow past the cap -> no grow.
+    assert maybe_autogrow(cfg) is False
+    assert grew["called"] is False
+
+
+def test_maybe_autogrow_unreachable_guest(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg_autogrow()
+    monkeypatch.setattr("winpodx.core.disk.get_guest_disk_usage", lambda *a, **k: None)
+    assert maybe_autogrow(cfg) is False
+
+
+def test_config_validation_clamps_threshold() -> None:
+    cfg = Config()
+    cfg.pod.disk_autogrow_threshold_pct = 200
+    cfg.pod.__post_init__()
+    assert cfg.pod.disk_autogrow_threshold_pct == 99
+    cfg.pod.disk_autogrow_threshold_pct = 5
+    cfg.pod.__post_init__()
+    assert cfg.pod.disk_autogrow_threshold_pct == 50
+
+
+def test_config_validation_coerces_bad_sizes() -> None:
+    cfg = Config()
+    cfg.pod.disk_autogrow_increment = "garbage"
+    cfg.pod.disk_max_size = "0G"  # invalid -> empty (no cap)
+    cfg.pod.disk_autogrow_target_free_pct = 99  # out of range -> clamp to 50
+    cfg.pod.__post_init__()
+    assert cfg.pod.disk_autogrow_increment == "32G"
+    assert cfg.pod.disk_max_size == ""
+    assert cfg.pod.disk_autogrow_target_free_pct == 50
+
+
+def test_config_max_size_empty_default() -> None:
+    cfg = Config()
+    assert cfg.pod.disk_max_size == ""


### PR DESCRIPTION
Fixes #318 -- the Windows C: drive stayed at its install-time size even after raising `disk_size`, because dockur grows the virtual image on recreate but leaves the new space **unallocated** (it only auto-extends the partition on a *fresh* install). Reported by @drjwhitty (Linux Mint 22.2).

## What it does

**Auto-grow (default on, idle only).** When C: fills past `disk_autogrow_threshold_pct` (80%) and the pod is idle, winpodx grows the disk *just enough to restore `disk_autogrow_target_free_pct` free* (30%, in whole `disk_autogrow_increment` steps — adaptive, not a flat bump), recreates the container so dockur grows the image, then extends C: to fill via `Resize-Partition`. Idle-only so it never interrupts a live RemoteApp session.

**Manual.**
- `winpodx pod grow-disk` — add one increment (default 32G)
- `winpodx pod grow-disk 128G` — absolute target
- `winpodx pod grow-disk --extend-only` — just extend C: into existing unallocated space
- `winpodx pod disk-usage` — size / free / used% + auto-grow status
- GUI **Tools → Grow Disk** action

## Design notes (addressing the review questions)

- **`disk_max_size` is now optional** (empty by default). The real bound is **host free space minus a reserve** (10 GiB or 10% of the host fs), so auto-grow can never ENOSPC the host. Set an explicit `disk_max_size` only if you want a hard ceiling.
- **Sparse image** → raising the virtual ceiling does **not** consume host space up front; the host fills only as Windows writes. The reserve keeps the ceiling within what the host can actually back.
- **No online resize in dockur** → each grow recreates the container (a quick guest reboot); that is exactly why auto-grow is idle-gated.
- **No agent change** — usage probe + partition extend both go through the existing bearer-auth `/exec` (`run_in_windows`).

## Tests

`tests/test_disk.py` (29) cover size parsing/formatting, adaptive target sizing, the effective cap (explicit + host-bound + unbounded), and the autogrow gate. Lint + format clean; full suite green.

## ⚠️ Smoke gate

The guest-side `Resize-Partition` / `Get-Volume` run via `/exec` — per the project rule, **this needs a real-Windows smoke verification before merge/release** (pwsh-on-Linux Pester is not enough for a guest-side change). Holding merge until that passes.