### PR TITLE
fix(guest-sync): pull OEM via the guest's default gateway, not hardcoded 10.0.2.2

### DIFF
--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -1269,8 +1269,13 @@ def _recover_oem() -> None:
     print()
     print("  noVNC URL: http://127.0.0.1:8007/")
     print()
-    print("  # Download OEM bundle from container (10.0.2.2 = QEMU NAT gateway)")
-    print("  Invoke-WebRequest http://10.0.2.2:8766/oem.tar.gz -OutFile C:\\oem.tar.gz")
+    print("  # Download OEM bundle from the container via the guest's default")
+    print("  # gateway (QEMU slirp = 10.0.2.2, podman bridge = 10.89.0.1, etc.)")
+    print(
+        "  $gw = (Get-NetRoute -DestinationPrefix '0.0.0.0/0' | "
+        "Sort-Object RouteMetric | Select-Object -First 1).NextHop"
+    )
+    print('  Invoke-WebRequest "http://${gw}:8766/oem.tar.gz" -OutFile C:\\oem.tar.gz')
     print()
     print("  # Extract to C:\\OEM\\ (Windows 10/11 ships bsdtar in System32)")
     print("  cd C:\\")

--- a/src/winpodx/core/guest_sync.py
+++ b/src/winpodx/core/guest_sync.py
@@ -250,16 +250,26 @@ def _stop_oem_server(cfg: Config) -> None:
         pass
 
 
-# PowerShell run in the guest: pull oem.tar.gz from the container gateway and
-# extract over C:\OEM (refreshes agent.ps1, rdprrap, shim, rcedit, scripts).
+# PowerShell run in the guest: pull oem.tar.gz from the container over the
+# guest's *default gateway* and extract over C:\OEM (refreshes agent.ps1,
+# rdprrap, shim, rcedit, scripts).
+#
+# The gateway is discovered at runtime, NOT hardcoded: dockur's network mode
+# decides what the guest sees -- QEMU slirp gives 10.0.2.2, but a podman
+# bridge gives e.g. 10.89.0.1 (verified on @drjwhitty's host) and other
+# setups give 20.20.20.1. The container's http.server (0.0.0.0:8766) is
+# reachable from the guest at whatever its default route's NextHop is.
 _PULL_OEM_PS = (
-    rf"Invoke-WebRequest http://10.0.2.2:{_OEM_HTTP_PORT}/oem.tar.gz "
-    r"-OutFile C:\oem.tar.gz -UseBasicParsing; "
+    r"$gw = (Get-NetRoute -DestinationPrefix '0.0.0.0/0' -ErrorAction Stop | "
+    r"Sort-Object RouteMetric | Select-Object -First 1).NextHop; "
+    r"if (-not $gw) { throw 'no default gateway' }; "
+    f'Invoke-WebRequest "http://${{gw}}:{_OEM_HTTP_PORT}/oem.tar.gz" '
+    r"-OutFile C:\oem.tar.gz -UseBasicParsing -TimeoutSec 120; "
     r"if (-not (Test-Path C:\oem.tar.gz)) { throw 'download failed' }; "
     r"cmd /c 'cd /d C:\ && tar -xzf C:\oem.tar.gz'; "
     r"Remove-Item C:\oem.tar.gz -ErrorAction SilentlyContinue; "
     r"if (-not (Test-Path C:\OEM\agent.ps1)) { throw 'extract failed: agent.ps1 missing' }; "
-    r"Write-Output 'oem-refreshed'"
+    r'Write-Output "oem-refreshed via $gw"'
 )
 
 


### PR DESCRIPTION
Live-tested #323 on real podman networking and the OEM delivery failed: `oem_delivery: failed: guest OEM pull failed: Unable to connect to the remote server`.

## Root cause
The guest pulls `oem.tar.gz` from `http://10.0.2.2:8766` — the QEMU **slirp** gateway recover-oem assumed. But under podman bridge networking the guest's default gateway is **10.89.0.1**, so 10.0.2.2 is unreachable. Confirmed in-guest:

```
default gateway = 10.89.0.1
http://10.89.0.1:8766/oem.tar.gz  -> OK (2254437 bytes)
http://10.89.0.2:8766/oem.tar.gz  -> FAIL (container IP not directly routable)
```

## Fix
Discover the gateway at runtime and pull from it:
```powershell
$gw = (Get-NetRoute -DestinationPrefix "0.0.0.0/0" | Sort RouteMetric | Select -First 1).NextHop
Invoke-WebRequest "http://${gw}:8766/oem.tar.gz" ...
```
Works for any dockur network mode (slirp 10.0.2.2 / podman 10.89.0.1 / dockur bridge 20.20.20.1). Same fix applied to the recover-oem noVNC instructions.

## Verified end-to-end (live, this host)
`sync_guest(force=True)` →
```
oem_delivery: ok   urlacl: ok   fix:*: ok (all 5)   agent_restart: ok   stamp: ok
```
guest stamp written `{0.5.8, 25}`, `guest_sync_needed` now False (idempotent), and the agent stayed reachable through its restart task. **Smoke-passed.**