### PR TITLE
fix(guest-sync): never auto-sync on a fresh install (absent stamp)

### DIFF
--- a/src/winpodx/core/guest_sync.py
+++ b/src/winpodx/core/guest_sync.py
@@ -393,14 +393,32 @@ def sync_guest(cfg: Config, *, force: bool = False) -> dict[str, str]:
 
 def maybe_autosync(cfg: Config) -> bool:
     """Trigger hook: sync the guest when the host is newer. Returns True when
-    a sync ran. Honours ``pod.guest_autosync``; safe no-op when current."""
+    a sync ran. Honours ``pod.guest_autosync``; safe no-op when current.
+
+    Crucially, this only auto-syncs when a stamp is **present and older**. An
+    *absent* stamp is treated as "fresh install or pre-stamp pod": we record
+    the current version but do NOT sync. Auto-syncing on a fresh install
+    would fire mid-first-boot and the agent restart races install.bat's own
+    agent bring-up, leaving the agent down (observed on a fresh opensuse
+    install). A genuinely stale pre-stamp pod can be refreshed once with
+    ``winpodx pod sync-guest --force``; after that its stamp drives future
+    auto-syncs.
+    """
     if not getattr(cfg.pod, "guest_autosync", True):
         return False
     if cfg.pod.backend not in ("podman", "docker"):
         return False
-    if not guest_sync_needed(cfg):
+
+    guest = read_guest_version(cfg)
+    if guest is None:
+        # No stamp -> fresh install / pre-stamp. Record version, never sync.
+        if write_guest_version(cfg, host_version()):
+            log.info("guest has no version stamp; recorded %s without syncing", host_version())
         return False
-    log.info("guest is older than host (%s); auto-syncing", host_version())
+    if guest == host_version():
+        return False
+
+    log.info("guest %s older than host %s; auto-syncing", guest, host_version())
     try:
         sync_guest(cfg)
     except GuestSyncError as e:

--- a/tests/test_guest_sync.py
+++ b/tests/test_guest_sync.py
@@ -70,7 +70,7 @@ def test_maybe_autosync_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_maybe_autosync_skips_when_current(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("winpodx.core.guest_sync.guest_sync_needed", lambda cfg: False)
+    monkeypatch.setattr("winpodx.core.guest_sync.read_guest_version", lambda cfg: host_version())
     monkeypatch.setattr(
         "winpodx.core.guest_sync.sync_guest",
         lambda *a, **k: pytest.fail("sync should not run when current"),
@@ -78,8 +78,11 @@ def test_maybe_autosync_skips_when_current(monkeypatch: pytest.MonkeyPatch) -> N
     assert maybe_autosync(_cfg()) is False
 
 
-def test_maybe_autosync_runs_when_needed(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("winpodx.core.guest_sync.guest_sync_needed", lambda cfg: True)
+def test_maybe_autosync_runs_when_stamp_older(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "winpodx.core.guest_sync.read_guest_version",
+        lambda cfg: GuestVersion(winpodx="0.0.1", oem_bundle="1"),
+    )
     calls = {"n": 0}
     monkeypatch.setattr(
         "winpodx.core.guest_sync.sync_guest",
@@ -87,6 +90,23 @@ def test_maybe_autosync_runs_when_needed(monkeypatch: pytest.MonkeyPatch) -> Non
     )
     assert maybe_autosync(_cfg()) is True
     assert calls["n"] == 1
+
+
+def test_maybe_autosync_absent_stamp_records_no_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Fresh install / pre-stamp pod: must NOT sync (would disrupt first-boot
+    # agent bring-up) -- just record the version.
+    monkeypatch.setattr("winpodx.core.guest_sync.read_guest_version", lambda cfg: None)
+    wrote = {"n": 0}
+    monkeypatch.setattr(
+        "winpodx.core.guest_sync.write_guest_version",
+        lambda *a, **k: wrote.__setitem__("n", wrote["n"] + 1) or True,
+    )
+    monkeypatch.setattr(
+        "winpodx.core.guest_sync.sync_guest",
+        lambda *a, **k: pytest.fail("sync must not run when stamp absent (fresh install)"),
+    )
+    assert maybe_autosync(_cfg()) is False
+    assert wrote["n"] == 1
 
 
 def test_maybe_autosync_skips_unsupported_backend(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
A fresh `--main` install showed the guest agent never coming up (`agent /health didn't answer within 180s`, discovery deferred, migrate skipped — everything degraded to FreeRDP-only).

## Cause
The `wait-ready` auto-sync hook fired **during install.bat's first boot**: a fresh guest has no version stamp → `guest_sync_needed` True → `sync_guest` ran → its agent restart raced install.bat's own agent bring-up, killing the agent before it bound 8765. The `cfg.pod.initialized` gate was ineffective (setup flips it True before `wait-ready` runs).

## Fix
`maybe_autosync` now only syncs when the stamp is **present and older**. An **absent** stamp = fresh install / pre-stamp pod → record the version, **do not sync**. A genuinely stale pre-stamp pod gets refreshed once with `winpodx pod sync-guest --force`; its stamp then drives future auto-syncs. The manual `sync-guest` path is unchanged.

Tests updated (12 pass): absent stamp records-no-sync, present-older syncs, present-equal no-ops.