### PR TITLE
fix(setup): stop the first-run prompt firing on every run with an existing config (#341)

### DIFF
--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -664,6 +664,16 @@ def handle_setup(args: argparse.Namespace) -> None:
         cfg = Config.load()
         if non_interactive:
             print(tr("Existing config found at {path}, skipping setup.").format(path=Config.path()))
+            # #341: an existing config IS a completed setup -- flip the
+            # first-run flag here too. Without this, a config written before
+            # the `initialized` flag existed (or any config with it still
+            # False) makes the first-run prompt fire on *every* invocation:
+            # the user picks "Auto", setup short-circuits on this branch,
+            # returns without marking initialized, and the prompt comes back
+            # next time. Persist only when it actually changes.
+            if not cfg.pod.initialized:
+                cfg.pod.initialized = True
+                cfg.save()
             _ensure_oem_token_staged()
             # Half-uninstalled detection. If cfg points at a podman/docker
             # pod but the container is gone (user did `uninstall.sh`

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -138,6 +138,34 @@ class TestHalfUninstalledGuard:
             "ensure_ready must not run when container is healthy"
         )
 
+    def test_marks_initialized_on_existing_config_skip(self, tmp_path, monkeypatch):
+        """#341: non-interactive setup over an existing config whose
+        `initialized` flag is still False must flip it True (and persist),
+        so the first-run prompt stops firing on every invocation."""
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr("sys.stdin", MagicMock(isatty=lambda: False))
+        cfg = _make_existing_config(tmp_path)
+        assert cfg.pod.initialized is False  # precondition: the buggy state
+
+        with (
+            patch("winpodx.cli.setup_cmd.check_all", return_value=_mock_freerdp_ok()),
+            patch("winpodx.cli.setup_cmd.import_winapps_config", return_value=None),
+            patch("winpodx.cli.setup_cmd._ensure_oem_token_staged"),
+            patch(
+                "winpodx.cli.setup_cmd._container_exists_on_backend",
+                return_value=True,
+            ),
+        ):
+            from winpodx.cli.setup_cmd import handle_setup
+
+            handle_setup(_setup_args(non_interactive=True))
+
+        from winpodx.core.config import Config
+
+        assert Config.load().pod.initialized is True, (
+            "existing-config skip path must mark the install initialized (#341)"
+        )
+
     def test_calls_ensure_ready_when_container_missing(self, tmp_path, monkeypatch):
         """Half-uninstalled: config present, container gone → ensure_ready
         is called to recreate the container from compose.yaml."""


### PR DESCRIPTION
The first-run prompt ("winpodx has not been set up yet on this account") fires on **every** invocation for some users even though a config exists and works — they pick "Auto", setup says "Existing config found, skipping setup", and the prompt is back next time.

## Cause
The prompt gates on `cfg.pod.initialized`. The non-interactive existing-config branch in `handle_setup` printed "skipping setup" and `return`ed **before** the `initialized = True` flip (which only runs at the end of a full setup). So a config whose flag is still `False` — one created via install.sh's own skip path, or written before the flag existed (#255) — never gets marked, and the prompt loops forever.

## Fix
Flip `cfg.pod.initialized = True` (and persist, only when it changes) on the existing-config skip branch too — an existing config is a completed setup. Regression test added.

Note: the reporter also saw a secondary "pod alive but not responding to RDP / agent unreachable [Errno 104]" symptom on Fedora 44 — that is a separate agent-health issue, tracked apart from this prompt-loop fix.

Reported by @ntruhan (Fedora 44).