### PR TITLE
fix(rdp): redirect a live media parent so a late-inserted USB shows on refresh

### DIFF
--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -99,10 +99,31 @@ class RDPSession:
 
 
 def _find_media_base() -> Path | None:
-    """Find the user's removable media base directory."""
+    """Find a live removable-media parent dir to expose as ``\\tsclient\\media``.
+
+    Returns the *deepest existing* media-parent so a USB plugged in **after**
+    the FreeRDP session starts still shows up on a refresh: FreeRDP's drive
+    redirection passes the host directory through live (each guest enumeration
+    re-reads the host fs), and xfreerdp runs in the host mount namespace (no
+    ``unshare`` since #214), so a submount appearing under the redirected dir
+    propagates and a guest Explorer refresh (F5) reveals it.
+
+    The per-user dirs (``/run/media/$USER``, ``/media/$USER``) are preferred so
+    the shortcut lands one level above the volume (``\\media\\<LABEL>``). They
+    only exist once udisks has mounted something for this user, so we also
+    accept the persistent parents (``/run/media``, ``/media``) — that catches
+    the case where nothing is mounted *yet* at launch but a USB is inserted
+    later (it then appears at ``\\media\\$USER\\<LABEL>`` on refresh). Returns
+    None only when no media subsystem dir exists at all.
+    """
     user = os.environ.get("USER", "")
 
-    for base in (Path("/run/media") / user, Path("/media") / user):
+    for base in (
+        Path("/run/media") / user,
+        Path("/media") / user,
+        Path("/run/media"),
+        Path("/media"),
+    ):
         if base.is_dir():
             return base
 
@@ -115,10 +136,11 @@ def _media_redirect_base() -> Path:
     install.bat always drops a ``USB`` desktop shortcut pointing at
     ``\\tsclient\\media``. If we only redirected the drive when removable
     media is mounted, clicking that shortcut with no USB plugged in failed
-    with "``\\tsclient\\media`` is not accessible ... invalid address"
-    (reported by @camegone-style setups). So always redirect *something*:
-    the real media base when present, otherwise an empty placeholder dir so
-    the shortcut opens to an empty folder instead of erroring.
+    with "``\\tsclient\\media`` is not accessible ... invalid address". So
+    always redirect *something*: a live media parent when one exists (see
+    ``_find_media_base`` — chosen so a late-inserted USB shows on refresh),
+    otherwise an empty placeholder dir so the shortcut opens to an empty
+    folder instead of erroring.
     """
     from winpodx.utils.paths import data_dir
 

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -40,6 +40,29 @@ def test_linux_to_unc_media_path(monkeypatch, tmp_path):
     assert result == "\\\\tsclient\\media\\USB\\report.docx"
 
 
+def test_find_media_base_prefers_user_then_persistent_parent(monkeypatch):
+    # A live media parent is preferred over the placeholder so a USB inserted
+    # AFTER the session starts shows on refresh. Per-user dir wins; the
+    # persistent parent is the fallback for the not-mounted-yet-at-launch case.
+    from winpodx.core import rdp
+
+    monkeypatch.setenv("USER", "alice")
+    present: set[str] = set()
+    monkeypatch.setattr(rdp.Path, "is_dir", lambda self: str(self) in present)
+
+    # Nothing mounted, no media subsystem dir -> None (caller uses placeholder).
+    assert rdp._find_media_base() is None
+
+    # USB inserted while no per-user dir existed yet: the persistent parent
+    # exists, so we redirect it (USB shows at \\media\alice\<LABEL> on F5).
+    present.add("/run/media")
+    assert str(rdp._find_media_base()) == "/run/media"
+
+    # Once udisks has made the per-user dir, prefer it (\\media\<LABEL>).
+    present.add("/run/media/alice")
+    assert str(rdp._find_media_base()) == "/run/media/alice"
+
+
 def test_launch_app_remoteapp_without_display_raises(monkeypatch, tmp_path):
     # No $DISPLAY -> xfreerdp would die post-detach; launch_app must raise.
     from winpodx.core import rdp as rdp_mod


### PR DESCRIPTION
Follow-up to #342. A USB mounted **after** the FreeRDP session started never appeared under the guest `USB` shortcut, even on refresh.

## Cause
`#342` made `\\tsclient\media` always resolve, but with no media mounted at launch it redirected an empty placeholder (`~/.local/share/winpodx/media`). FreeRDP `/drive` is fixed at connect, and a later USB lands at `/run/media/$USER/<LABEL>` — a different path than the placeholder — so it can never show in that session, refresh or not. (Confirmed: the live session redirected the placeholder while the USB was mounted at `/run/media/kernalix7/A533-A768`.)

## Fix
`_find_media_base()` now returns the **deepest existing live media parent**:
- `/run/media/$USER` or `/media/$USER` when present → USB shows at `\\media\<LABEL>`
- else the persistent parents `/run/media` / `/media` → USB shows at `\\media\$USER\<LABEL>`

These are the real dirs udisks mounts into, and xfreerdp runs in the host mount namespace (no `unshare` since #214), so a submount appearing under the redirected dir propagates — a guest Explorer **F5** reveals it. The empty placeholder is used only when no media subsystem dir exists at all (keeps #342's no-error guarantee).

**Note:** a session started before this fix still redirects the old path — relaunch the app to pick up the live parent. New test covers the user/parent/placeholder selection order. 27 rdp tests pass.