### PR TITLE
feat(provision): unify post-create chain into winpodx provision (0.6.0 B+I)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1119,10 +1119,13 @@ if [ "${WINPODX_MANUAL:-0}" = "1" ]; then
     log "  Run 'winpodx' (CLI or GUI) to finish setup. Prompt will offer auto, customize, or skip."
 else
     log "Running winpodx setup..."
-    # --create-only: install.sh orchestrates wait-ready / migrate /
-    # discovery / reverse-open itself (below), so setup should stop after
-    # creating the container.
-    SETUP_ARGS=(--non-interactive --create-only)
+    # 0.6.0 item B: --create-only is gone. setup writes config + creates the
+    # container; the post-create chain runs once via `winpodx provision`
+    # (below) — the single source of truth shared with setup_cmd / migrate /
+    # pending.resume. WINPODX_NO_PROVISION makes setup itself skip its own
+    # full-provision tail so install.sh's explicit `winpodx provision` is the
+    # only run (setup would otherwise also run finish_provisioning).
+    SETUP_ARGS=(--non-interactive)
     if [ -n "$WINPODX_BACKEND" ] && [ "$WINPODX_BACKEND" != "manual" ]; then
         SETUP_ARGS+=(--backend "$WINPODX_BACKEND")
         log "Backend: $WINPODX_BACKEND"
@@ -1131,7 +1134,10 @@ else
         SETUP_ARGS+=(--win-version "$WINPODX_WIN_VERSION")
         log "Installing Windows edition: $WINPODX_WIN_VERSION"
     fi
-    "$VENV_PY" -m winpodx setup "${SETUP_ARGS[@]}" 2>/dev/null || true
+    # WINPODX_NO_PROVISION=1: setup creates the container but skips its own
+    # full-provision tail; install.sh runs the chain once via the explicit
+    # `winpodx provision` call below (0.6.0 item B, replaces --create-only).
+    WINPODX_NO_PROVISION=1 "$VENV_PY" -m winpodx setup "${SETUP_ARGS[@]}" 2>/dev/null || true
 fi
 
 # --- Install winpodx GUI desktop entry & icon ---
@@ -1194,147 +1200,69 @@ if [ "${WINPODX_MANUAL:-0}" = "1" ]; then
     exit 0
 fi
 
-# --- Wait for Windows VM to finish first-boot setup ---
-# v0.2.0.5: dockur Windows first-boot can take 5-10 minutes (Sysprep,
-# OEM apply, account password set, RDP listener up). wait-ready surfaces
-# the wait up-front with progress + tailed container logs.
-# Skip with WINPODX_NO_WAIT=1 (CI / non-interactive setups).
-# v0.2.1: track which steps haven't completed so the next CLI / GUI
-# launch can auto-resume them. .pending_setup is a newline-separated
-# list of step IDs (wait_ready, migrate, discovery).
+# --- Finish provisioning the Windows VM (0.6.0 item B) ---
+# The wait-ready → agent-settle → apply-fixes → discovery → reverse-open
+# chain used to be ~140 lines of bash here (with its own /health curl poll,
+# 6× `app refresh` retry loop, and host-open listener-start). It is now the
+# single `winpodx provision` command — the same chain setup_cmd, migrate,
+# and pending.resume run — so there is exactly one place to fix a bug and
+# one shared progress surface. install.sh just forwards $WINPODX_VERBOSE.
+#
+# `winpodx provision` exit codes:
+#   0  — full chain succeeded
+#   4  — Windows guest didn't become responsive in time (wait-ready timeout)
+#   5  — provisioning deferred (only when --require-agent; we don't pass it)
+# Both 4 and 5 are non-fatal: the .pending_setup machinery (utils/pending.py)
+# is the safety net — the next `winpodx` CLI / GUI launch resumes the chain.
+# Skip the whole step with WINPODX_NO_WAIT=1 (CI / non-interactive setups).
 PENDING_FILE="$HOME/.config/winpodx/.pending_setup"
-PENDING_STEPS=""
-mark_pending() {
-    PENDING_STEPS="${PENDING_STEPS}${1}
-"
-}
 
 if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_WAIT:-}" != "1" ]; then
-    log "Waiting for Windows VM to finish first-boot (60 min default, auto-extends to match observed ISO download speed)..."
-    log "  Fresh install downloads ~7.5GB Windows ISO + runs Sysprep + OEM apply."
+    log "Finishing Windows provisioning (wait-ready + apply-fixes + discovery + reverse-open)..."
+    log "  Fresh install downloads ~7.5GB Windows ISO + runs Sysprep + OEM apply (auto-extends on slow links)."
     log "  Subsequent installs reuse the cached ISO and finish in 2-5 min."
-    WAIT_READY_OUT="$(mktemp)"
-    # PYTHONUNBUFFERED=1 forces Python's stdout to line-buffered even
-    # when piped. Disable ``set -e`` for the pipeline so we can inspect
-    # the wait-ready rc + tee'd output below; capture PIPESTATUS while
-    # it's still the pipeline's.
+    PROVISION_OUT="$(mktemp)"
+    PROVISION_ARGS=()
+    [ -n "$WINPODX_VERBOSE" ] && PROVISION_ARGS+=(--verbose)
+    # PYTHONUNBUFFERED=1 keeps the streamed per-stage progress line-buffered
+    # when piped. Disable ``set -e`` so we can inspect the rc; tee the output
+    # so the `no such container` partial-uninstall case is still detectable.
     set +e
-    WAIT_READY_VERBOSE=()
-    [ -n "$WINPODX_VERBOSE" ] && WAIT_READY_VERBOSE=(--verbose)
-    PYTHONUNBUFFERED=1 "$SYMLINK" pod wait-ready --timeout 3600 --logs \
-        "${WAIT_READY_VERBOSE[@]}" 2>&1 \
-        | tee "$WAIT_READY_OUT"
-    WAIT_READY_RC="${PIPESTATUS[0]}"
+    PYTHONUNBUFFERED=1 "$SYMLINK" provision "${PROVISION_ARGS[@]}" 2>&1 \
+        | tee "$PROVISION_OUT"
+    PROVISION_RC="${PIPESTATUS[0]}"
     set -e
-    # Ctrl+C / SIGTERM: bail out. The traps also fire in the parent shell,
-    # but the check here covers the case where the child winpodx died from
-    # the signal and the parent didn't get it directly (piped install).
-    if [ "$WAIT_READY_RC" -eq 130 ] || [ "$WAIT_READY_RC" -eq 143 ]; then
-        err "Install cancelled (winpodx pod wait-ready returned $WAIT_READY_RC)."
+    # Ctrl+C / SIGTERM: bail out. The traps fire in the parent shell too, but
+    # this covers the piped-install case where the child died from the signal
+    # and the parent didn't see it directly.
+    if [ "$PROVISION_RC" -eq 130 ] || [ "$PROVISION_RC" -eq 143 ]; then
+        err "Install cancelled (winpodx provision returned $PROVISION_RC)."
         err "Re-run install.sh to continue from where you left off."
-        rm -f "$WAIT_READY_OUT"
-        # This is a deliberate user cancel mid-provisioning. On an upgrade,
-        # rollback() is a no-op (leaves the working install). On a fresh
-        # install the binary + venv are valid and re-runnable, so don't
-        # nuke them — just clean the marker and exit with the signal rc.
+        rm -f "$PROVISION_OUT"
         ROLLBACK_ARMED=0
         cleanup_install_marker
         trap - EXIT ERR INT TERM
-        exit "$WAIT_READY_RC"
+        exit "$PROVISION_RC"
     fi
-    if [ "$WAIT_READY_RC" -ne 0 ]; then
-        if grep -q "no such container" "$WAIT_READY_OUT"; then
+    if [ "$PROVISION_RC" -ne 0 ]; then
+        if grep -q "no such container" "$PROVISION_OUT"; then
             warn "Container is missing — likely from a partial uninstall."
             warn "Recover with a full reinstall:"
             warn '  curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh | bash -s -- --purge'
             warn '  curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash -s -- --main'
         else
-            warn "Windows first-boot didn't complete in time (default 60min,"
-            warn "auto-extended based on observed wget ETA -- see #126)."
-            warn "Marking remaining steps as pending — they will auto-resume on next"
-            warn "\`winpodx\` CLI invocation or when you open \`winpodx gui\`."
-            mark_pending "wait_ready"
+            warn "Provisioning didn't complete in time (Windows first-boot can run long"
+            warn "on slow links -- see #126). Marking remaining steps as pending — they"
+            warn "auto-resume on the next \`winpodx\` CLI invocation or when you open the GUI."
+            mkdir -p "$HOME/.config/winpodx"
+            # wait_ready first so pending.resume re-runs the full chain.
+            printf 'wait_ready\nmigrate\ndiscovery\n' > "$PENDING_FILE"
+            warn "Pending steps recorded at $PENDING_FILE."
         fi
+    else
+        rm -f "$PENDING_FILE"
     fi
-    rm -f "$WAIT_READY_OUT"
-fi
-
-# --- Post-install / upgrade migration wizard + discovery ---
-#
-# WINPODX_REQUIRE_AGENT=1 makes both migrate and app refresh refuse to
-# fall back to FreeRDP RemoteApp when the guest agent isn't up yet. They
-# exit "deferred"; install.sh marks them pending so the next CLI / GUI
-# launch resumes them once the agent has come up cleanly.
-export WINPODX_REQUIRE_AGENT=1
-
-# If an existing config is present this is an upgrade, not a fresh
-# install. Run the migrate wizard. Opt out with WINPODX_NO_MIGRATE=1.
-if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_MIGRATE:-}" != "1" ]; then
-    log "Running post-upgrade migration wizard..."
-    "$SYMLINK" migrate --non-interactive || mark_pending "migrate"
-fi
-
-# --- Wait for agent to settle after migrate's apply chain ---
-# migrate's apply chain ends with `_apply_multi_session`, which cycles
-# TermService and bounces the agent's own RDP session. Polling /health
-# here means refresh runs against the resurrected agent.
-if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_WAIT_AGENT:-}" != "1" ]; then
-    log "Waiting for guest agent to settle after apply chain..."
-    # Port 8765: paired with src/winpodx/core/agent.py:AGENT_PORT (Python SoT) and
-    # config/oem/agent/agent.ps1 (guest SoT). Shell can't import the constant;
-    # changing the port means editing here AND those two files.
-    for _ in $(seq 1 30); do
-        if curl -fsS --max-time 2 http://127.0.0.1:8765/health >/dev/null 2>&1; then
-            break
-        fi
-        sleep 2
-    done
-fi
-
-# --- Auto-discover apps ---
-# Retry up to 6 times with 10s spacing (~50s window) to ride out the
-# agent's transient "responsive but not yet stable" state right after
-# install.bat's final TermService cycle. Final failure records the step
-# as pending so pending-resume stays as a safety net.
-if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_DISCOVERY:-}" != "1" ]; then
-    log "Discovering installed Windows apps..."
-    discovery_ok=
-    for attempt in 1 2 3 4 5 6; do
-        if "$SYMLINK" app refresh 2>/dev/null; then
-            discovery_ok=1
-            break
-        fi
-        if [ "$attempt" -lt 6 ]; then
-            log "  discovery attempt $attempt deferred (agent transitioning); retrying in 10s..."
-            sleep 10
-        fi
-    done
-    if [ -z "$discovery_ok" ]; then
-        mark_pending "discovery"
-    fi
-fi
-
-# --- Reverse-open auto-setup ---
-# Linux apps in the Windows guest's "Open with..." menu (#48). Ships
-# default-on. Opt out via WINPODX_NO_REVERSE_OPEN=1.
-if [ -f "$HOME/.config/winpodx/winpodx.toml" ] && [ "${WINPODX_NO_REVERSE_OPEN:-}" != "1" ]; then
-    log "Setting up reverse-open (Linux apps in Windows 'Open with')..."
-    "$SYMLINK" host-open start-listener 2>/dev/null || \
-        warn "  reverse-open listener didn't start; the feature will activate on next \`winpodx pod start\`"
-    if ! "$SYMLINK" host-open refresh 2>&1 | sed 's/^/  /'; then
-        warn "  reverse-open refresh failed; retry manually with \`winpodx host-open refresh\` once the pod is up"
-    fi
-fi
-
-unset WINPODX_REQUIRE_AGENT
-
-# Persist the pending list so resume_install_work() can pick it up.
-if [ -n "$PENDING_STEPS" ]; then
-    mkdir -p "$HOME/.config/winpodx"
-    printf '%s' "$PENDING_STEPS" > "$PENDING_FILE"
-    warn "Pending steps recorded at $PENDING_FILE — auto-resume will run on next winpodx invocation."
-else
-    rm -f "$PENDING_FILE"
+    rm -f "$PROVISION_OUT"
 fi
 
 # --- Done. Disarm rollback (success). ---

--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -359,17 +359,12 @@ def cli(argv: list[str] | None = None) -> None:
             "auto setup; use this flag to opt into the wizard."
         ),
     )
-    setup_p.add_argument(
-        "--create-only",
-        action="store_true",
-        help=(
-            "Stop after writing config + creating the container. Skip the "
-            "full provision flow (wait-ready, apply-fixes, app discovery, "
-            "reverse-open). install.sh passes this because it orchestrates "
-            "those steps itself; a standalone `winpodx setup` runs the full "
-            "flow so it finishes like a complete install."
-        ),
-    )
+    # --create-only was removed in 0.6.0 (item B). The post-create
+    # provisioning chain (wait-ready → apply-fixes → discovery →
+    # reverse-open) is now the single `winpodx provision` command, so
+    # install.sh runs `winpodx setup ... && winpodx provision --verbose`
+    # instead of carrying its own bash copy. A standalone `winpodx setup`
+    # always finishes the full flow.
     setup_p.add_argument(
         "--update-image",
         action="store_true",
@@ -583,6 +578,57 @@ def cli(argv: list[str] | None = None) -> None:
         help="Disable all prompts (for automation / CI)",
     )
 
+    # --- provision (post-create provisioning chain, 0.6.0 item B) ---
+    # The single source of truth for wait-ready → agent-settle → apply-fixes
+    # → discovery → reverse-open. Replaces install.sh's ~140 lines of bash,
+    # setup_cmd's _run_full_provision, and (via the helper) feeds migrate /
+    # pending.resume. Run with no flags it reproduces the install.sh defaults
+    # so an AppImage's first run can just `winpodx provision`.
+    provision_p = sub.add_parser(
+        "provision",
+        help=(
+            "Finish provisioning a created pod: wait for Windows first-boot, "
+            "apply runtime fixes, discover apps, set up reverse-open. Run with "
+            "no flags it reproduces install.sh's post-create behaviour."
+        ),
+    )
+    provision_p.add_argument(
+        "--wait-timeout",
+        type=int,
+        default=3600,
+        help="Seconds to wait for the Windows guest to become responsive (default 3600).",
+    )
+    provision_p.add_argument(
+        "--require-agent",
+        action="store_true",
+        help=(
+            "Hard-gate on the in-guest agent /health and fail (don't fall "
+            "back to FreeRDP) if it never answers. Off by default."
+        ),
+    )
+    provision_p.add_argument(
+        "--no-discovery",
+        action="store_true",
+        help="Skip the app-discovery stage (on by default).",
+    )
+    provision_p.add_argument(
+        "--no-reverse-open",
+        action="store_true",
+        help=("Skip reverse-open setup (on by default when cfg.reverse_open.enabled)."),
+    )
+    provision_p.add_argument(
+        "--retries",
+        type=int,
+        default=6,
+        help="Discovery retry attempts with exponential backoff (default 6).",
+    )
+    provision_p.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Stream raw per-stage progress to stderr.",
+    )
+
     # --- host-open (reverse file associations, #48) ---
     from winpodx.cli.host_open import add_subcommand as add_host_open
 
@@ -698,10 +744,78 @@ def _dispatch(args: argparse.Namespace) -> None:
         from winpodx.cli.migrate import run_migrate
 
         sys.exit(run_migrate(args))
+    elif cmd == "provision":
+        sys.exit(_cmd_provision(args))
     elif cmd == "host-open":
         from winpodx.cli.host_open import handle as handle_host_open
 
         sys.exit(handle_host_open(args))
+
+
+def _cmd_provision(args: argparse.Namespace) -> int:
+    """Drive ``core.provisioner.finish_provisioning`` from the CLI (item B).
+
+    Flags map 1:1 onto the helper parameters. Run with no flags it
+    reproduces install.sh's post-create defaults (wait 3600s, soft agent
+    settle, discovery on with 6× retry, reverse-open on when enabled), so
+    an AppImage first run can simply ``winpodx provision`` for the
+    install.sh UX without re-implementing it (item I AppImage parity).
+    """
+    from winpodx.core.config import Config
+    from winpodx.core.provisioner import (
+        ProvisionAgentUnavailable,
+        finish_provisioning,
+    )
+
+    cfg = Config.load()
+
+    if cfg.pod.backend not in ("podman", "docker"):
+        print(
+            tr("provision not supported for backend {backend} (podman/docker only).").format(
+                backend=repr(cfg.pod.backend)
+            )
+        )
+        return 2
+
+    verbose = bool(getattr(args, "verbose", False))
+
+    def _on_progress(stage: str, detail: str) -> None:
+        # Always surface stage transitions; --verbose just keeps the raw
+        # detail lines flowing without buffering.
+        print(f"  [{stage}] {detail}", file=sys.stderr, flush=verbose)
+
+    with_reverse_open = not bool(getattr(args, "no_reverse_open", False))
+    with_discovery = not bool(getattr(args, "no_discovery", False))
+
+    try:
+        results = finish_provisioning(
+            cfg,
+            wait_timeout=int(getattr(args, "wait_timeout", 3600)),
+            require_agent=bool(getattr(args, "require_agent", False)),
+            with_reverse_open=with_reverse_open,
+            with_discovery=with_discovery,
+            retries=int(getattr(args, "retries", 6)),
+            on_progress=_on_progress,
+        )
+    except ProvisionAgentUnavailable as e:
+        print(tr("provision deferred: {error}").format(error=e), file=sys.stderr)
+        return 5
+
+    if results.get("wait_ready") == "timeout":
+        print(
+            tr(
+                "provision: Windows guest did not become responsive in time. "
+                "Re-run `winpodx provision` once `winpodx pod status` reports the "
+                "pod is fully up."
+            ),
+            file=sys.stderr,
+        )
+        return 4
+
+    print(tr("Provisioning complete."))
+    for stage, status in results.items():
+        print(f"  {stage}: {status}")
+    return 0
 
 
 def _cmd_language(code: str | None) -> None:

--- a/src/winpodx/cli/migrate.py
+++ b/src/winpodx/cli/migrate.py
@@ -699,7 +699,6 @@ def _apply_runtime_fixes_to_existing_guest(non_interactive: bool) -> None:
     try:
         from winpodx.core.config import Config
         from winpodx.core.pod import PodState, pod_status
-        from winpodx.core.provisioner import apply_windows_runtime_fixes
     except ImportError as e:
         print(f"  warning: cannot load provisioner helpers ({e}); skipping.")
         return
@@ -735,58 +734,48 @@ def _apply_runtime_fixes_to_existing_guest(non_interactive: bool) -> None:
             print(f"  warning: pod start failed ({e}). Try `winpodx pod start --wait`.")
         return
 
-    # v0.2.0.1: container can be RUNNING while the Windows VM inside
-    # QEMU is still booting — that's the fresh-install scenario where
-    # `setup` recreates the container then `migrate` runs immediately
-    # and every apply collapses with rc=147 connection-reset / rc=131
-    # activation-timeout. Wait for the RDP listener to actually accept
-    # FreeRDP RemoteApp before firing applies.
-    from winpodx.core.provisioner import wait_for_windows_responsive
+    # 0.6.0 item B: delegate the wait-ready → agent-gate → apply-fixes →
+    # discovery chain to the single source of truth
+    # ``core.provisioner.finish_provisioning``. The migrate-specific gating
+    # the old inline code carried is preserved via parameters:
+    #
+    #   * require_agent=True — the hard agent gate. Every apply helper goes
+    #     through dispatch(cfg), which prefers AgentTransport (HTTP to
+    #     127.0.0.1:8765) and silently falls back to FreerdpTransport when
+    #     /health doesn't answer. On a freshly-booted pod rdprrap multi-
+    #     session is NOT yet active (install.bat is still mid-script cycling
+    #     TermService), so a new FreeRDP login would KICK the autologon
+    #     session install.bat runs in and kill the install mid-stage
+    #     (kernalix7's 2026-05-02..04 smoke failures). require_agent=True
+    #     makes finish_provisioning raise ProvisionAgentUnavailable rather
+    #     than race FreeRDP; we catch it and skip with the same "deferred
+    #     until next launch" guidance the old gate printed. The apply chain
+    #     is purely additive on a fresh install (OEM v22+ already applied
+    #     everything), so skipping is strictly safer than racing.
+    #
+    #   * with_discovery=True, retries=3 — migrate now folds discovery into
+    #     the chain (previously a separate interactive prompt). retries=3
+    #     rather than install.sh's 6× because migrate runs against an
+    #     already-settled agent more often than not.
+    #
+    #   * with_reverse_open=False — migrate never set up reverse-open; that
+    #     stays install.sh / setup_cmd's job.
+    from winpodx.core.provisioner import (
+        ProvisionAgentUnavailable,
+        finish_provisioning,
+    )
 
-    print("  Waiting for Windows guest to finish booting (up to 180s)...")
-    if not wait_for_windows_responsive(cfg, timeout=600):
-        print(
-            "  Windows guest still booting after 180s — skipping runtime apply.\n"
-            "  Run `winpodx pod apply-fixes` once `winpodx pod status` reports "
-            "the pod is fully up, or just launch any app and the apply will "
-            "fire automatically."
+    print("  Waiting for Windows guest to finish booting + applying fixes...")
+    try:
+        results = finish_provisioning(
+            cfg,
+            wait_timeout=600,
+            require_agent=True,
+            with_reverse_open=False,
+            with_discovery=True,
+            retries=3,
         )
-        return
-
-    # v0.4.0 (post-rc1): require the in-guest agent before firing apply chain.
-    #
-    # Background: every apply helper goes through dispatch(cfg) which prefers
-    # AgentTransport (HTTP to 127.0.0.1:8765) and silently falls back to
-    # FreerdpTransport when the agent doesn't answer /health. FreerdpTransport
-    # opens a brand-new RDP login each call -- and on a freshly-booted pod
-    # rdprrap (multi-session) is NOT yet active because install.bat is still
-    # mid-script writing the registry patch and cycling TermService. Single-
-    # session enforcement means the new FreeRDP session KICKS the autologon
-    # User session -- and install.bat is running inside that session as a
-    # FirstLogonCommands child. Result: install.bat dies mid-extract /
-    # mid-rdprrap-installer / mid-launcher-stage, setup_done.txt never lands,
-    # agent never starts, every subsequent FreeRDP call cascades with rc=12
-    # ERRINFO_LOGOFF_BY_USER. kernalix7 hit this on every fresh-install
-    # smoke test from 2026-05-02 through 2026-05-04.
-    #
-    # Why a hard gate instead of "just bump phase 3 timeout": the apply
-    # chain is purely additive on a fresh install -- install.bat OEM v22+
-    # already does max_sessions / rdp_timeouts / oem_runtime_fixes /
-    # vbs_launchers / multi_session activation. Re-running them via FreeRDP
-    # at migrate time produces no behavior change (everything is idempotent),
-    # only the session-kick side effect. So skipping with a "deferred until
-    # next launch" message is strictly safer than racing.
-    #
-    # Why not just disable the FreeRDP fallback in dispatch(): GUI's
-    # explicit "Apply Windows Fixes" button + `winpodx pod apply-fixes` CLI
-    # may legitimately want FreeRDP (existing pod with broken agent). The
-    # gate is migrate-specific because migrate is the ONLY caller that
-    # reliably runs while install.bat is still in-flight -- install.sh
-    # invokes it 60s after RDP comes up, regardless of install.bat state.
-    from winpodx.core.transport.agent import AgentTransport
-
-    agent = AgentTransport(cfg)
-    if not agent.health().available:
+    except ProvisionAgentUnavailable:
         print(
             "  Agent not yet up (still on FreeRDP-only channel).\n"
             "  Skipping runtime apply to avoid kicking the autologon\n"
@@ -799,15 +788,18 @@ def _apply_runtime_fixes_to_existing_guest(non_interactive: bool) -> None:
         )
         return
 
-    # Delegate to the canonical apply chain in provisioner so install.sh's
-    # post-upgrade migrate path picks up new steps (e.g. vbs_launchers added
-    # in v0.3.0 post-RTM) automatically — duplicating the list here drifted
-    # silently when winpodx pod apply-fixes gained vbs_launchers but migrate
-    # didn't, causing C:\Users\Public\winpodx\launchers\ to never be staged
-    # on `curl install.sh --main` upgrades.
-    results = apply_windows_runtime_fixes(cfg)
+    if results.get("wait_ready") == "timeout":
+        print(
+            "  Windows guest still booting — skipping runtime apply.\n"
+            "  Run `winpodx pod apply-fixes` once `winpodx pod status` reports "
+            "the pod is fully up, or just launch any app and the apply will "
+            "fire automatically."
+        )
+        return
+
+    apply_results = results.get("apply_fixes", {})
     failures: list[str] = [
-        f"{name}: {status}" for name, status in results.items() if status != "ok"
+        f"{name}: {status}" for name, status in apply_results.items() if status != "ok"
     ]
 
     if failures:

--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -535,20 +535,20 @@ def _prompt_edition_locale_tuning(cfg: Config) -> None:
 
 
 def _run_full_provision(cfg: Config) -> None:
-    """Drive the same post-container-create provisioning that install.sh
-    orchestrates in bash, so a standalone `winpodx setup` finishes like a
-    complete install instead of stopping at "container created".
+    """Drive the post-container-create provisioning so a standalone
+    `winpodx setup` finishes like a complete install instead of stopping at
+    "container created".
 
-    Sequence (each step tolerant of the guest still booting):
-      1. wait-ready -- block until the Windows first-boot + OEM apply +
-         reboot pass complete (auto-extends on slow ISO downloads).
-      2. apply-fixes -- idempotent Windows-side runtime fixes.
-      3. app discovery -- scan the guest + register desktop entries.
-      4. reverse-open -- stage host apps into the guest "Open with" menu
-         (only when cfg.reverse_open.enabled).
+    0.6.0 item B: this is now a thin wrapper over the single source of truth
+    ``core.provisioner.finish_provisioning`` (the same chain ``winpodx
+    provision``, migrate, and pending.resume run). The manual per-stage
+    assembly that used to live here — wait-ready, apply-fixes, discovery,
+    reverse-open — moved into the helper, parameter-gated. We pass the same
+    parameters the old inline code used: 3600s wait, soft agent settle
+    (require_agent=False so a slow first boot doesn't crash setup), discovery
+    with 6× retry, reverse-open gated on cfg.reverse_open.enabled.
 
-    Skipped for non-podman/docker backends and when --create-only is set
-    (install.sh path -- it runs its own bash version of these steps).
+    Skipped for non-podman/docker backends (the helper short-circuits too).
     """
     if cfg.pod.backend not in ("podman", "docker"):
         return
@@ -559,53 +559,28 @@ def _run_full_provision(cfg: Config) -> None:
     print(tr("First install downloads ~7.5GB ISO + runs Sysprep + OEM apply."))
     print(tr("This can take ~5-10 min (longer on slow connections).\n"))
 
-    # 1. wait-ready -- reuse the CLI implementation with live logs.
-    from winpodx.cli.pod import _wait_ready
+    from winpodx.core.provisioner import finish_provisioning
 
-    try:
-        _wait_ready(timeout=3600, show_logs=True)
-    except SystemExit as e:
-        # _wait_ready exits non-zero on timeout. Don't abort the whole
-        # setup -- the pending-steps machinery + next `winpodx app run`
-        # will resume. Surface it and stop the provision chain.
+    def _on_progress(stage: str, detail: str) -> None:
+        print(tr("  [{stage}] {detail}").format(stage=stage, detail=detail))
+
+    results = finish_provisioning(
+        cfg,
+        wait_timeout=3600,
+        require_agent=False,
+        with_reverse_open=getattr(cfg.reverse_open, "enabled", False),
+        with_discovery=True,
+        retries=6,
+        on_progress=_on_progress,
+    )
+
+    if results.get("wait_ready") == "timeout":
         print(
             tr(
-                "\n  wait-ready did not complete (exit {code}). "
-                "Remaining steps will auto-resume on your next "
-                "`winpodx app run` / `winpodx gui`."
-            ).format(code=e.code)
+                "\n  wait-ready did not complete. Remaining steps will "
+                "auto-resume on your next `winpodx app run` / `winpodx gui`."
+            )
         )
-        return
-
-    # 2. apply-fixes -- idempotent guest runtime fixes.
-    try:
-        from winpodx.core.provisioner import apply_windows_runtime_fixes
-
-        print(tr("\nApplying Windows-side runtime fixes..."))
-        apply_windows_runtime_fixes(cfg)
-    except Exception as e:  # noqa: BLE001 -- best-effort, never fatal
-        print(tr("  apply-fixes skipped ({error})").format(error=e))
-
-    # 3. discovery -- populate the app menu from the running guest.
-    try:
-        from winpodx.cli.app import _refresh_apps
-
-        print(tr("\nDiscovering installed Windows apps..."))
-        _refresh_apps(as_json=False, timeout=120)
-    except Exception as e:  # noqa: BLE001
-        print(
-            tr("  discovery skipped ({error}) -- run `winpodx app refresh` later").format(error=e)
-        )
-
-    # 4. reverse-open -- host apps into the guest "Open with" menu.
-    if getattr(cfg.reverse_open, "enabled", False):
-        try:
-            from winpodx.cli.host_open import _cmd_refresh
-
-            print(tr("\nSetting up reverse-open (Linux apps in Windows 'Open with')..."))
-            _cmd_refresh(argparse.Namespace(include_nodisplay=False, skip_icons=False, json=False))
-        except Exception as e:  # noqa: BLE001
-            print(tr("  reverse-open setup skipped ({error})").format(error=e))
 
 
 def handle_setup(args: argparse.Namespace) -> None:
@@ -904,20 +879,29 @@ def handle_setup(args: argparse.Namespace) -> None:
     print()
 
     # Full-provision flow: a standalone `winpodx setup` should finish
-    # like a complete install (wait for Windows first-boot + discover
-    # apps + reverse-open), not stop at "container created". install.sh
-    # passes --create-only because it drives those steps itself in bash;
-    # skipping here avoids doing the work twice.
-    create_only = bool(getattr(args, "create_only", False))
-    if create_only or cfg.pod.backend not in ("podman", "docker"):
+    # like a complete install (wait for Windows first-boot + apply-fixes +
+    # discover apps + reverse-open), not stop at "container created".
+    #
+    # 0.6.0 item B: the `--create-only` flag is gone. install.sh now runs
+    # `winpodx setup ... && winpodx provision --verbose`: setup creates the
+    # container and the dedicated `provision` command runs the chain once.
+    # To avoid running the chain twice in that flow, install.sh exports
+    # WINPODX_NO_PROVISION=1 so setup skips its own provision tail and leaves
+    # it to the explicit `winpodx provision` call. A standalone `winpodx
+    # setup` (no env var) still finishes the full flow. Non-container
+    # backends short-circuit (the helper has nothing to do for libvirt/manual).
+    import os
+
+    skip_provision = os.environ.get("WINPODX_NO_PROVISION") == "1"
+    if cfg.pod.backend not in ("podman", "docker") or skip_provision:
         print(tr("Apps are now in your application menu."))
         print(tr("Just click any app. winpodx handles the rest automatically."))
-        if cfg.pod.backend in ("podman", "docker") and create_only:
+        if cfg.pod.backend in ("podman", "docker") and skip_provision:
             print(
                 tr(
                     "\nWindows is booting in the background. "
-                    "Run `winpodx pod wait-ready --logs` to watch, or just "
-                    "`winpodx app run desktop` (it waits on first launch)."
+                    "Run `winpodx provision` to finish (wait-ready + apply-fixes "
+                    "+ discovery + reverse-open), or just `winpodx app run desktop`."
                 )
             )
     else:

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 import time
 from datetime import datetime, timezone
+from typing import Any, Callable
 
 from winpodx.core.compose import generate_compose, generate_password
 from winpodx.core.config import Config
@@ -60,6 +61,17 @@ def _apply_via_transport(cfg: Config, payload: str, *, description: str, timeout
 
 class ProvisionError(Exception):
     """Raised when auto-provisioning fails."""
+
+
+class ProvisionAgentUnavailable(ProvisionError):
+    """Raised by ``finish_provisioning`` when ``require_agent=True`` but the
+    in-guest agent's ``/health`` never comes up within the wait budget.
+
+    Subclasses ``ProvisionError`` so callers that only catch the base type
+    (and treat any provisioning failure as "defer to next launch") keep
+    working, while migrate — the one caller that hard-gates on the agent —
+    can distinguish "agent never settled" from a generic failure.
+    """
 
 
 def ensure_ready(cfg: Config | None = None, timeout: int = 300) -> Config:
@@ -290,6 +302,234 @@ def wait_for_windows_responsive(cfg: Config, timeout: int = 300) -> bool:
         waited,
     )
     return True
+
+
+def finish_provisioning(
+    cfg: Config,
+    *,
+    wait_timeout: int = 3600,
+    require_agent: bool = False,
+    with_reverse_open: bool = True,
+    with_discovery: bool = True,
+    retries: int = 6,
+    on_progress: Callable[[str, str], None] | None = None,
+) -> dict[str, Any]:
+    """Run the post-pod-running provisioning chain in one place (0.6.0 item B).
+
+    This is the single source of truth for the ``wait-ready → agent-settle →
+    apply-fixes → discovery → reverse-open`` sequence that previously lived,
+    with subtly diverging ordering and gating, in ``install.sh``,
+    ``setup_cmd._run_full_provision``, ``migrate``, and ``pending.resume``.
+    It sits AFTER ``ensure_ready`` (which owns compose generation + pod
+    bring-up + RDP recovery); ``finish_provisioning`` only consolidates the
+    work each of those callers did once the pod was already running.
+
+    Every stage is parameter-gated so the four callers can request exactly
+    the behaviour they had before:
+
+    * ``wait_timeout`` — seconds for ``wait_for_windows_responsive``.
+      install.sh / setup_cmd use 3600; pending.resume uses 300.
+    * ``require_agent`` — when True, hard-gate on the agent ``/health`` and
+      raise :class:`ProvisionAgentUnavailable` if it never answers (migrate's
+      behaviour — it refuses to fall back to FreeRDP RemoteApp because a
+      fresh-boot FreeRDP connect can kick install.bat's autologon session).
+      When False, do a best-effort settle poll (install.sh's behaviour:
+      30 attempts × 2 s) and proceed silently regardless — this lets
+      setup_cmd's auto-provision use the chain without crashing on a slow
+      first boot.
+    * ``with_discovery`` — run the shared discovery path (discover_apps +
+      persist_discovered + _register_desktop_entries) with ``retries``
+      attempts and exponential backoff (install.sh's 6× behaviour).
+    * ``with_reverse_open`` — run the host-open listener-start + manifest
+      refresh, gated additionally on ``cfg.reverse_open.enabled``.
+    * ``on_progress(stage, detail)`` — optional callback so a GUI can mirror
+      the same stages onto a progress bar without re-running the chain.
+
+    Returns a results dict whose keys are the stage names and whose values
+    are short human-readable status strings, so callers can log / surface
+    them:
+    ``{"wait_ready": "ok", "agent_settle": "ok"|"skipped"|"not-up",
+    "apply_fixes": {...per-helper...}, "discovery": "12 apps"|"skipped",
+    "reverse_open": "ok"|"skipped"|"failed: ..."}``.
+    """
+    results: dict[str, Any] = {}
+
+    def _progress(stage: str, detail: str) -> None:
+        if on_progress is not None:
+            try:
+                on_progress(stage, detail)
+            except Exception:  # noqa: BLE001 — progress is best-effort, never fatal
+                log.debug("finish_provisioning on_progress(%s) raised", stage, exc_info=True)
+
+    # Backend gate: libvirt / manual have no Windows-side runtime apply,
+    # discovery channel, or reverse-open. Return early with a marker so the
+    # caller knows nothing was attempted (mirrors apply_windows_runtime_fixes).
+    if cfg.pod.backend not in ("podman", "docker"):
+        results["backend"] = f"skipped (backend={cfg.pod.backend} not supported)"
+        _progress("backend", results["backend"])
+        return results
+
+    # --- Stage 1: wait-ready ------------------------------------------------
+    _progress("wait_ready", f"up to {wait_timeout}s")
+    ready = wait_for_windows_responsive(cfg, timeout=wait_timeout)
+    results["wait_ready"] = "ok" if ready else "timeout"
+    _progress("wait_ready", results["wait_ready"])
+    if not ready:
+        # RDP never opened. Nothing downstream can succeed; let the caller
+        # decide whether to defer (pending machinery) or surface the timeout.
+        return results
+
+    # --- Stage 2: agent settle ---------------------------------------------
+    from winpodx.core.transport.agent import AgentTransport
+
+    transport = AgentTransport(cfg)
+    if require_agent:
+        # Hard gate (migrate's behaviour). ``wait_for_windows_responsive``
+        # already waited up to ``wait_timeout`` for /health and returned True
+        # regardless; re-probe once here so we can fail loudly rather than
+        # racing FreeRDP into install.bat's autologon session.
+        if not transport.health().available:
+            results["agent_settle"] = "not-up"
+            _progress("agent_settle", "agent /health never answered")
+            raise ProvisionAgentUnavailable(
+                "Guest agent /health did not answer; refusing FreeRDP fallback "
+                "(require_agent=True). Run `winpodx pod apply-fixes` once the "
+                "agent is up, or check C:\\winpodx\\setup.log via VNC."
+            )
+        results["agent_settle"] = "ok"
+        _progress("agent_settle", "ok")
+    else:
+        # Soft settle poll (install.sh's behaviour): 30 attempts × 2 s. Silent
+        # if it never lands — apply-fixes / discovery have their own agent
+        # gates + FreeRDP fallback, so we proceed either way.
+        _progress("agent_settle", "best-effort poll (up to 60s)")
+        settled = False
+        for _ in range(30):
+            if transport.health().available:
+                settled = True
+                break
+            time.sleep(2)
+        results["agent_settle"] = "ok" if settled else "not-up (proceeding)"
+        _progress("agent_settle", results["agent_settle"])
+
+    # --- Stage 3: apply-fixes ----------------------------------------------
+    # No gate — apply_windows_runtime_fixes is idempotent and surfaces its own
+    # per-helper success/failure map.
+    _progress("apply_fixes", "applying Windows-side runtime fixes")
+    apply_results = apply_windows_runtime_fixes(cfg)
+    results["apply_fixes"] = apply_results
+    _progress("apply_fixes", ", ".join(f"{k}: {v}" for k, v in apply_results.items()))
+
+    # --- Stage 4: discovery -------------------------------------------------
+    if with_discovery:
+        _progress("discovery", f"scanning guest (up to {retries} attempts)")
+        try:
+            count = _run_discovery_with_retry(cfg, retries=retries, on_progress=_progress)
+            results["discovery"] = f"{count} apps"
+            _progress("discovery", results["discovery"])
+        except Exception as e:  # noqa: BLE001 — best-effort; pending machinery is the net
+            results["discovery"] = f"failed: {e}"
+            _progress("discovery", results["discovery"])
+    else:
+        results["discovery"] = "skipped"
+        _progress("discovery", "skipped")
+
+    # --- Stage 5: reverse-open ---------------------------------------------
+    if with_reverse_open and getattr(cfg.reverse_open, "enabled", False):
+        _progress("reverse_open", "starting listener + pushing manifest")
+        try:
+            _run_reverse_open(cfg)
+            results["reverse_open"] = "ok"
+        except Exception as e:  # noqa: BLE001 — best-effort
+            results["reverse_open"] = f"failed: {e}"
+        _progress("reverse_open", results["reverse_open"])
+    else:
+        results["reverse_open"] = "skipped"
+        _progress("reverse_open", "skipped")
+
+    return results
+
+
+def _run_discovery_with_retry(
+    cfg: Config,
+    *,
+    retries: int,
+    on_progress: Callable[[str, str], None] | None = None,
+) -> int:
+    """Shared discovery path: discover_apps → persist_discovered → register.
+
+    This is the ONE discovery entrypoint the unified chain uses (0.6.0 item
+    B). It is the more-complete of the two historical forms: it not only
+    scans + persists but also installs the XDG .desktop entries AND prunes
+    stale ones + refreshes the icon cache (via ``cli.app._register_desktop_
+    entries``). install.sh's old ``app refresh`` and pending.resume's
+    ``discover_apps + persist + register`` both collapse onto this.
+
+    Retries up to ``retries`` attempts with exponential backoff (2, 4, 8…s,
+    capped at 30 s) to ride out the agent's transient "responsive but not
+    yet stable" window right after install.bat's final TermService cycle —
+    install.sh used a fixed 6× / 10 s loop; the backoff here is gentler at
+    the start and bounded above. Raises the last exception only if every
+    attempt fails so the caller can record it.
+
+    The ``cli.app`` imports are lazy + local: discovery wiring (persist +
+    desktop-entry registration) lives on the CLI side historically, and a
+    module-level import here would invert the core→cli layering. The same
+    lazy-import pattern is used by ``utils.pending.resume``.
+    """
+    from winpodx.cli.app import _register_desktop_entries
+    from winpodx.core.discovery import discover_apps, persist_discovered
+
+    last_exc: Exception | None = None
+    for attempt in range(1, max(1, retries) + 1):
+        try:
+            apps = discover_apps(cfg, timeout=180)
+            persist_discovered(apps)
+            if apps:
+                _register_desktop_entries(apps)
+            return len(apps)
+        except Exception as e:  # noqa: BLE001 — retry on any discovery failure
+            last_exc = e
+            if attempt < max(1, retries):
+                backoff = min(30, 2**attempt)
+                if on_progress is not None:
+                    on_progress(
+                        "discovery",
+                        f"attempt {attempt} deferred ({e}); retrying in {backoff}s",
+                    )
+                log.info(
+                    "discovery attempt %d deferred (%s); retrying in %ds",
+                    attempt,
+                    e,
+                    backoff,
+                )
+                time.sleep(backoff)
+    assert last_exc is not None  # loop always sets it before falling through
+    raise last_exc
+
+
+def _run_reverse_open(cfg: Config) -> None:
+    """Shared reverse-open path: start the listener, then push the manifest.
+
+    Mirrors install.sh's ``host-open start-listener`` + ``host-open refresh``
+    and setup_cmd's ``_cmd_refresh`` call. Both CLI handlers take an
+    ``argparse.Namespace``; we build the minimal shapes they read. Imports
+    are lazy + local for the same core→cli layering reason as discovery.
+
+    The listener start is best-effort (it activates on the next ``pod
+    start`` if it doesn't come up now); a refresh failure propagates so the
+    caller records ``reverse_open: failed``.
+    """
+    import argparse
+
+    from winpodx.cli.host_open import _cmd_refresh, _cmd_start_listener
+
+    try:
+        _cmd_start_listener(argparse.Namespace(json=False))
+    except Exception as e:  # noqa: BLE001 — listener is best-effort
+        log.warning("reverse-open listener did not start: %s", e)
+
+    _cmd_refresh(argparse.Namespace(include_nodisplay=False, skip_icons=False, json=False))
 
 
 def _apply_multi_session(cfg: Config) -> None:

--- a/src/winpodx/gui/_main_window_bringup.py
+++ b/src/winpodx/gui/_main_window_bringup.py
@@ -604,7 +604,41 @@ class BringUpMixin:
     # ----- worker --------------------------------------------------------
 
     def _bringup_worker(self) -> None:
-        """Run the 5-phase chain. Always exits via ``bringup_done.emit``."""
+        """Run the 5-phase chain. Always exits via ``bringup_done.emit``.
+
+        0.6.0 item I — DEFERRED, NOT migrated to ``finish_provisioning``.
+        ----------------------------------------------------------------
+        The roadmap folds this 5th copy of the wait → settle → apply →
+        discovery → reverse-open chain into ``core.provisioner.finish_
+        provisioning`` so there is one place to fix bugs. The unified helper
+        grew an ``on_progress(stage, detail)`` callback specifically so this
+        worker can wire its ``bringup_phase`` signal to it. BUT this worker
+        has three capabilities the helper does not yet expose, and the task
+        constraint is explicit: keep the legacy path rather than guess and
+        break it silently. Migrate once the helper grows the missing hooks:
+
+          1. Cooperative cancellation — every phase checks ``_is_cancelled``
+             and sleeps via ``_sleep_cancellable`` so the user's Cancel
+             button stops the chain promptly. ``finish_provisioning`` has no
+             cancel hook; routing through it would make Cancel a no-op until
+             the current blocking stage returns.
+          2. Per-attempt streaming with custom budgets — phases 1/2 stream
+             "Attempt N - ..." lines and use ``cfg.install.wait_ready_stage2
+             _secs`` / ``stage3_secs`` budgets, plus a token-readiness check
+             (``AgentClient.auth_ready``) the helper's soft settle poll
+             doesn't perform.
+          3. Distinct per-phase failure surfacing — each phase emits its own
+             ``bringup_done(False, "<phase> raised: ...")`` so the dialog
+             shows which stage broke.
+
+        TODO(0.6.x): add ``cancel_event`` + richer ``on_progress`` (attempt
+        index, budget) to ``finish_provisioning``, then replace this body
+        with a single ``finish_provisioning(self.cfg, wait_timeout=...,
+        require_agent=True, with_reverse_open=cfg.reverse_open.enabled,
+        with_discovery=True, retries=..., on_progress=self._on_provision_
+        progress, cancel_event=self._bringup_cancel)`` call and drop the
+        phase methods below.
+        """
         try:
             if not self._phase1_wait_pod_ready():
                 return

--- a/src/winpodx/utils/pending.py
+++ b/src/winpodx/utils/pending.py
@@ -109,50 +109,59 @@ def resume(printer=print) -> None:
         return
 
     from winpodx.core.config import Config
+    from winpodx.core.provisioner import finish_provisioning
 
     cfg = Config.load()
     printer(f"[winpodx] Resuming {len(pending)} pending setup step(s): {', '.join(pending)}")
 
-    if "wait_ready" in pending:
-        try:
-            from winpodx.core.provisioner import wait_for_windows_responsive
+    # 0.6.0 item B: the wait-ready → apply-fixes → discovery chain this used
+    # to assemble by hand (with discover_apps + persist + register inline)
+    # now lives in the single source of truth ``finish_provisioning``. The
+    # historical pending-step distinctions still drive which result we use
+    # to clear which marker:
+    #   * wait_ready  ← results["wait_ready"]
+    #   * migrate     ← results["apply_fixes"] (all helpers "ok")
+    #   * discovery   ← results["discovery"]
+    # Parameters preserve the old behaviour: 300s wait (NOT 3600), soft
+    # agent settle (require_agent=False), no reverse-open, discovery with a
+    # 3× retry. Discovery always runs in the helper; we only clear the
+    # discovery marker when it was actually pending.
+    def _on_progress(stage: str, detail: str) -> None:
+        printer(f"[winpodx] {stage}: {detail}")
 
-            printer("[winpodx] Waiting for Windows guest to be responsive (up to 5 min)...")
-            if wait_for_windows_responsive(cfg, timeout=300):
-                remove_step("wait_ready")
-                printer("[winpodx] Windows guest is ready.")
-            else:
-                printer("[winpodx] Guest still booting — leaving pending for next invocation.")
-                return  # No point trying migrate/discovery if guest isn't ready.
-        except Exception as e:  # noqa: BLE001
-            printer(f"[winpodx] wait_ready resume failed: {e}")
-            return
+    try:
+        results = finish_provisioning(
+            cfg,
+            wait_timeout=300,
+            require_agent=False,
+            with_reverse_open=False,
+            with_discovery=True,
+            retries=3,
+            on_progress=_on_progress,
+        )
+    except Exception as e:  # noqa: BLE001 — resume is best-effort, never raises
+        printer(f"[winpodx] resume failed: {e}")
+        return
+
+    if results.get("wait_ready") == "timeout":
+        printer("[winpodx] Guest still booting — leaving pending for next invocation.")
+        return  # No point clearing migrate/discovery if the guest isn't ready.
+    if "wait_ready" in pending:
+        remove_step("wait_ready")
+        printer("[winpodx] Windows guest is ready.")
 
     if "migrate" in pending:
-        try:
-            from winpodx.core.provisioner import apply_windows_runtime_fixes
-
-            printer("[winpodx] Re-running runtime apply...")
-            results = apply_windows_runtime_fixes(cfg)
-            if all(v == "ok" for v in results.values()):
-                remove_step("migrate")
-                printer("[winpodx] Runtime apply complete.")
-            else:
-                printer(f"[winpodx] Apply partial: {results} — leaving pending.")
-        except Exception as e:  # noqa: BLE001
-            printer(f"[winpodx] migrate resume failed: {e}")
+        apply_results = results.get("apply_fixes", {})
+        if apply_results and all(v == "ok" for v in apply_results.values()):
+            remove_step("migrate")
+            printer("[winpodx] Runtime apply complete.")
+        else:
+            printer(f"[winpodx] Apply partial: {apply_results} — leaving pending.")
 
     if "discovery" in pending:
-        try:
-            from winpodx.cli.app import _register_desktop_entries
-            from winpodx.core.discovery import discover_apps, persist_discovered
-
-            printer("[winpodx] Discovering installed Windows apps...")
-            apps = discover_apps(cfg, timeout=180)
-            persist_discovered(apps)
-            if apps:
-                _register_desktop_entries(apps)
+        discovery = results.get("discovery", "")
+        if isinstance(discovery, str) and discovery.startswith("failed:"):
+            printer(f"[winpodx] discovery resume failed ({discovery}) — leaving pending.")
+        else:
             remove_step("discovery")
-            printer(f"[winpodx] Discovery complete — {len(apps)} app(s) registered.")
-        except Exception as e:  # noqa: BLE001
-            printer(f"[winpodx] discovery resume failed: {e}")
+            printer(f"[winpodx] Discovery complete — {discovery}.")

--- a/tests/test_finish_provisioning.py
+++ b/tests/test_finish_provisioning.py
@@ -1,0 +1,478 @@
+# SPDX-License-Identifier: MIT
+"""Tests for ``core.provisioner.finish_provisioning`` (0.6.0 item B).
+
+The unified post-pod-running provisioning chain (wait-ready → agent-settle
+→ apply-fixes → discovery → reverse-open) and its ``winpodx provision`` CLI.
+Every stage is mocked so no real pod / FreeRDP / agent is touched; the tests
+pin each branch + parameter gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+from types import SimpleNamespace
+
+import pytest
+
+from winpodx.core import provisioner
+from winpodx.core.config import Config
+from winpodx.core.provisioner import (
+    ProvisionAgentUnavailable,
+    finish_provisioning,
+)
+
+
+def _cfg(*, backend: str = "podman", reverse_open: bool = True) -> Config:
+    cfg = Config()
+    cfg.pod.backend = backend
+    cfg.reverse_open.enabled = reverse_open
+    return cfg
+
+
+class _FakeTransport:
+    """Stand-in for AgentTransport whose /health is configurable."""
+
+    def __init__(self, available: bool) -> None:
+        self._available = available
+
+    def health(self):
+        return SimpleNamespace(available=self._available, detail="")
+
+
+def _patch_stages(
+    monkeypatch,
+    *,
+    wait_ready: bool = True,
+    agent_available: bool = True,
+    apply_results: dict | None = None,
+    discovery_count: int = 7,
+    discovery_raises: Exception | None = None,
+    reverse_open_raises: Exception | None = None,
+):
+    """Patch every finish_provisioning stage; return a call-record dict."""
+    calls: dict[str, object] = {
+        "wait": [],
+        "apply": 0,
+        "discovery": [],
+        "reverse": 0,
+        "sleep": 0,
+    }
+
+    monkeypatch.setattr(
+        provisioner,
+        "wait_for_windows_responsive",
+        lambda cfg, timeout: calls["wait"].append(timeout) or wait_ready,
+    )
+    monkeypatch.setattr(
+        "winpodx.core.transport.agent.AgentTransport",
+        lambda cfg: _FakeTransport(agent_available),
+    )
+    monkeypatch.setattr(
+        provisioner,
+        "apply_windows_runtime_fixes",
+        lambda cfg: (
+            (calls.__setitem__("apply", calls["apply"] + 1))
+            or (apply_results if apply_results is not None else {"max_sessions": "ok"})
+        ),
+    )
+
+    def fake_discovery(cfg, *, retries, on_progress=None):
+        calls["discovery"].append(retries)
+        if discovery_raises is not None:
+            raise discovery_raises
+        return discovery_count
+
+    monkeypatch.setattr(provisioner, "_run_discovery_with_retry", fake_discovery)
+
+    def fake_reverse(cfg):
+        calls["reverse"] = calls["reverse"] + 1
+        if reverse_open_raises is not None:
+            raise reverse_open_raises
+
+    monkeypatch.setattr(provisioner, "_run_reverse_open", fake_reverse)
+    # Make the soft-settle poll's sleep a no-op + counter (tests never block).
+    monkeypatch.setattr(
+        provisioner.time, "sleep", lambda s: calls.__setitem__("sleep", calls["sleep"] + 1)
+    )
+    return calls
+
+
+# --- backend gate --------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", ["libvirt", "manual"])
+def test_finish_provisioning_skips_non_container_backend(backend, monkeypatch):
+    calls = _patch_stages(monkeypatch)
+    results = finish_provisioning(_cfg(backend=backend))
+    assert "backend" in results
+    assert "skipped" in results["backend"]
+    # No stage ran.
+    assert calls["wait"] == []
+    assert calls["apply"] == 0
+    assert calls["discovery"] == []
+    assert calls["reverse"] == 0
+
+
+# --- stage 1: wait-ready -------------------------------------------------
+
+
+def test_wait_ready_timeout_short_circuits(monkeypatch):
+    calls = _patch_stages(monkeypatch, wait_ready=False)
+    results = finish_provisioning(_cfg(), wait_timeout=300)
+    assert results["wait_ready"] == "timeout"
+    assert calls["wait"] == [300]
+    # Nothing downstream runs once RDP never opens.
+    assert calls["apply"] == 0
+    assert calls["discovery"] == []
+    assert calls["reverse"] == 0
+
+
+def test_wait_timeout_is_forwarded(monkeypatch):
+    calls = _patch_stages(monkeypatch)
+    finish_provisioning(_cfg(), wait_timeout=1234)
+    assert calls["wait"] == [1234]
+
+
+# --- stage 2: agent settle ----------------------------------------------
+
+
+def test_require_agent_raises_when_health_down(monkeypatch):
+    calls = _patch_stages(monkeypatch, agent_available=False)
+    with pytest.raises(ProvisionAgentUnavailable):
+        finish_provisioning(_cfg(), require_agent=True)
+    # Hard gate fires before apply / discovery / reverse.
+    assert calls["apply"] == 0
+    assert calls["discovery"] == []
+    assert calls["reverse"] == 0
+
+
+def test_require_agent_ok_when_health_up(monkeypatch):
+    _patch_stages(monkeypatch, agent_available=True)
+    results = finish_provisioning(_cfg(), require_agent=True)
+    assert results["agent_settle"] == "ok"
+
+
+def test_soft_settle_proceeds_when_agent_never_up(monkeypatch):
+    calls = _patch_stages(monkeypatch, agent_available=False)
+    results = finish_provisioning(_cfg(), require_agent=False)
+    # Soft poll proceeds (no raise); records the not-up state but continues.
+    assert results["agent_settle"].startswith("not-up")
+    assert calls["apply"] == 1  # downstream stages still ran
+    # 30 poll attempts each slept once.
+    assert calls["sleep"] == 30
+
+
+def test_soft_settle_breaks_early_when_agent_up(monkeypatch):
+    calls = _patch_stages(monkeypatch, agent_available=True)
+    results = finish_provisioning(_cfg(), require_agent=False)
+    assert results["agent_settle"] == "ok"
+    assert calls["sleep"] == 0  # broke on first poll, no sleeps
+
+
+# --- stage 3: apply-fixes ------------------------------------------------
+
+
+def test_apply_fixes_always_runs_and_results_pass_through(monkeypatch):
+    custom = {"max_sessions": "ok", "rdp_timeouts": "failed: boom"}
+    calls = _patch_stages(monkeypatch, apply_results=custom)
+    results = finish_provisioning(_cfg())
+    assert calls["apply"] == 1
+    assert results["apply_fixes"] == custom
+
+
+# --- stage 4: discovery --------------------------------------------------
+
+
+def test_discovery_on_passes_retries_and_count(monkeypatch):
+    calls = _patch_stages(monkeypatch, discovery_count=12)
+    results = finish_provisioning(_cfg(), with_discovery=True, retries=3)
+    assert calls["discovery"] == [3]
+    assert results["discovery"] == "12 apps"
+
+
+def test_discovery_off_is_skipped(monkeypatch):
+    calls = _patch_stages(monkeypatch)
+    results = finish_provisioning(_cfg(), with_discovery=False)
+    assert calls["discovery"] == []
+    assert results["discovery"] == "skipped"
+
+
+def test_discovery_failure_is_recorded_not_raised(monkeypatch):
+    _patch_stages(monkeypatch, discovery_raises=RuntimeError("agent flaked"))
+    results = finish_provisioning(_cfg(), with_discovery=True)
+    assert results["discovery"].startswith("failed:")
+    # Reverse-open still runs after a discovery failure (best-effort chain).
+    assert results["reverse_open"] == "ok"
+
+
+# --- stage 5: reverse-open ----------------------------------------------
+
+
+def test_reverse_open_on_when_enabled(monkeypatch):
+    calls = _patch_stages(monkeypatch)
+    results = finish_provisioning(_cfg(reverse_open=True), with_reverse_open=True)
+    assert calls["reverse"] == 1
+    assert results["reverse_open"] == "ok"
+
+
+def test_reverse_open_flag_off_skips(monkeypatch):
+    calls = _patch_stages(monkeypatch)
+    results = finish_provisioning(_cfg(reverse_open=True), with_reverse_open=False)
+    assert calls["reverse"] == 0
+    assert results["reverse_open"] == "skipped"
+
+
+def test_reverse_open_gated_on_cfg_enabled(monkeypatch):
+    calls = _patch_stages(monkeypatch)
+    results = finish_provisioning(_cfg(reverse_open=False), with_reverse_open=True)
+    # Even with with_reverse_open=True, cfg.reverse_open.enabled=False skips.
+    assert calls["reverse"] == 0
+    assert results["reverse_open"] == "skipped"
+
+
+def test_reverse_open_failure_recorded(monkeypatch):
+    _patch_stages(monkeypatch, reverse_open_raises=RuntimeError("listener died"))
+    results = finish_provisioning(_cfg(reverse_open=True), with_reverse_open=True)
+    assert results["reverse_open"].startswith("failed:")
+
+
+# --- progress callback ---------------------------------------------------
+
+
+def test_on_progress_receives_every_stage(monkeypatch):
+    _patch_stages(monkeypatch)
+    stages: list[str] = []
+    finish_provisioning(_cfg(), on_progress=lambda stage, detail: stages.append(stage))
+    # All five stages emit at least one progress event.
+    for expected in (
+        "wait_ready",
+        "agent_settle",
+        "apply_fixes",
+        "discovery",
+        "reverse_open",
+    ):
+        assert expected in stages
+
+
+def test_on_progress_exception_is_swallowed(monkeypatch):
+    _patch_stages(monkeypatch)
+
+    def boom(stage, detail):
+        raise ValueError("callback blew up")
+
+    # A crashing callback must NOT abort provisioning.
+    results = finish_provisioning(_cfg(), on_progress=boom)
+    assert results["wait_ready"] == "ok"
+
+
+# --- discovery retry helper (the 6× behaviour) ---------------------------
+
+
+def test_discovery_retry_succeeds_after_transient_failures(monkeypatch):
+    attempts = {"n": 0}
+
+    def flaky(cfg, timeout=180):
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise RuntimeError("agent transitioning")
+        return ["app1", "app2"]
+
+    monkeypatch.setattr("winpodx.core.discovery.discover_apps", flaky)
+    monkeypatch.setattr("winpodx.core.discovery.persist_discovered", lambda apps: None)
+    monkeypatch.setattr("winpodx.cli.app._register_desktop_entries", lambda apps: None)
+    monkeypatch.setattr(provisioner.time, "sleep", lambda s: None)
+
+    count = provisioner._run_discovery_with_retry(_cfg(), retries=6)
+    assert count == 2
+    assert attempts["n"] == 3  # failed twice, succeeded on third
+
+
+def test_discovery_retry_raises_after_exhausting(monkeypatch):
+    def always_fail(cfg, timeout=180):
+        raise RuntimeError("never settles")
+
+    monkeypatch.setattr("winpodx.core.discovery.discover_apps", always_fail)
+    monkeypatch.setattr("winpodx.core.discovery.persist_discovered", lambda apps: None)
+    monkeypatch.setattr("winpodx.cli.app._register_desktop_entries", lambda apps: None)
+    monkeypatch.setattr(provisioner.time, "sleep", lambda s: None)
+
+    with pytest.raises(RuntimeError, match="never settles"):
+        provisioner._run_discovery_with_retry(_cfg(), retries=3)
+
+
+# --- ProvisionAgentUnavailable is a ProvisionError ----------------------
+
+
+def test_agent_unavailable_is_provision_error():
+    from winpodx.core.provisioner import ProvisionError
+
+    assert issubclass(ProvisionAgentUnavailable, ProvisionError)
+
+
+# === CLI: winpodx provision ==============================================
+
+
+def test_provision_cli_help_lists_every_flag(capsys):
+    from winpodx.cli.main import cli as main
+
+    with pytest.raises(SystemExit) as exc:
+        main(["provision", "--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    for flag in (
+        "--wait-timeout",
+        "--require-agent",
+        "--no-discovery",
+        "--no-reverse-open",
+        "--retries",
+        "--verbose",
+    ):
+        assert flag in out
+
+
+def test_provision_cli_maps_flags_to_helper(monkeypatch):
+    from winpodx.cli import main as main_mod
+
+    captured: dict = {}
+
+    def fake_finish(cfg, **kwargs):
+        captured.update(kwargs)
+        return {"wait_ready": "ok", "reverse_open": "skipped"}
+
+    monkeypatch.setattr("winpodx.core.config.Config.load", staticmethod(lambda: _cfg()))
+    monkeypatch.setattr("winpodx.core.provisioner.finish_provisioning", fake_finish)
+
+    rc = main_mod._cmd_provision(
+        argparse.Namespace(
+            wait_timeout=900,
+            require_agent=True,
+            no_discovery=True,
+            no_reverse_open=True,
+            retries=2,
+            verbose=False,
+        )
+    )
+    assert rc == 0
+    assert captured["wait_timeout"] == 900
+    assert captured["require_agent"] is True
+    assert captured["with_discovery"] is False
+    assert captured["with_reverse_open"] is False
+    assert captured["retries"] == 2
+
+
+def test_provision_cli_defaults_match_install_sh(monkeypatch):
+    """No flags == install.sh's post-create defaults (item I AppImage parity)."""
+    from winpodx.cli import main as main_mod
+
+    captured: dict = {}
+
+    def fake_finish(cfg, **kwargs):
+        captured.update(kwargs)
+        return {"wait_ready": "ok"}
+
+    monkeypatch.setattr("winpodx.core.config.Config.load", staticmethod(lambda: _cfg()))
+    monkeypatch.setattr("winpodx.core.provisioner.finish_provisioning", fake_finish)
+
+    rc = main_mod._cmd_provision(
+        argparse.Namespace(
+            wait_timeout=3600,
+            require_agent=False,
+            no_discovery=False,
+            no_reverse_open=False,
+            retries=6,
+            verbose=False,
+        )
+    )
+    assert rc == 0
+    assert captured["wait_timeout"] == 3600
+    assert captured["require_agent"] is False
+    assert captured["with_discovery"] is True
+    assert captured["with_reverse_open"] is True
+    assert captured["retries"] == 6
+
+
+def test_provision_cli_returns_5_on_agent_unavailable(monkeypatch):
+    from winpodx.cli import main as main_mod
+
+    def boom(cfg, **kwargs):
+        raise ProvisionAgentUnavailable("agent down")
+
+    monkeypatch.setattr("winpodx.core.config.Config.load", staticmethod(lambda: _cfg()))
+    monkeypatch.setattr("winpodx.core.provisioner.finish_provisioning", boom)
+
+    rc = main_mod._cmd_provision(
+        argparse.Namespace(
+            wait_timeout=3600,
+            require_agent=True,
+            no_discovery=False,
+            no_reverse_open=False,
+            retries=6,
+            verbose=False,
+        )
+    )
+    assert rc == 5
+
+
+def test_provision_cli_returns_4_on_wait_timeout(monkeypatch):
+    from winpodx.cli import main as main_mod
+
+    monkeypatch.setattr("winpodx.core.config.Config.load", staticmethod(lambda: _cfg()))
+    monkeypatch.setattr(
+        "winpodx.core.provisioner.finish_provisioning",
+        lambda cfg, **kwargs: {"wait_ready": "timeout"},
+    )
+
+    rc = main_mod._cmd_provision(
+        argparse.Namespace(
+            wait_timeout=3600,
+            require_agent=False,
+            no_discovery=False,
+            no_reverse_open=False,
+            retries=6,
+            verbose=False,
+        )
+    )
+    assert rc == 4
+
+
+def test_provision_cli_rejects_non_container_backend(monkeypatch):
+    from winpodx.cli import main as main_mod
+
+    monkeypatch.setattr(
+        "winpodx.core.config.Config.load", staticmethod(lambda: _cfg(backend="manual"))
+    )
+    rc = main_mod._cmd_provision(
+        argparse.Namespace(
+            wait_timeout=3600,
+            require_agent=False,
+            no_discovery=False,
+            no_reverse_open=False,
+            retries=6,
+            verbose=False,
+        )
+    )
+    assert rc == 2
+
+
+# === --create-only removal ===============================================
+
+
+def test_setup_help_no_longer_lists_create_only(capsys):
+    from winpodx.cli.main import cli as main
+
+    with pytest.raises(SystemExit) as exc:
+        main(["setup", "--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "--create-only" not in out
+
+
+def test_setup_rejects_create_only_flag(capsys):
+    from winpodx.cli.main import cli as main
+
+    with pytest.raises(SystemExit) as exc:
+        main(["setup", "--create-only"])
+    # argparse rejects unknown args with exit code 2.
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "create-only" in err

--- a/tests/test_install_sh_provision.py
+++ b/tests/test_install_sh_provision.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: MIT
+"""Parse-and-grep guard for install.sh's post-create provisioning (0.6.0 item B).
+
+After the provision-unify cleanup, install.sh's post-`winpodx setup`
+provisioning is the single ``winpodx provision`` command — NOT a bash copy
+of the wait-ready → /health poll → 6× discovery retry → host-open chain.
+These tests fail loudly if a regression reintroduces an inline bash copy,
+which is exactly the duplication the unification killed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_INSTALL_SH = Path(__file__).resolve().parent.parent / "install.sh"
+
+
+def _strip_comments(text: str) -> str:
+    """Drop comment lines so prose explaining the unification doesn't trip the
+    grep guards. A comment line is one whose first non-space char is ``#``
+    (the shebang counts as a comment too). Inline trailing comments are rare
+    in install.sh and not load-bearing for these assertions, so a line-level
+    strip is sufficient and avoids mangling quoted ``#`` inside strings."""
+    kept = []
+    for line in text.splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
+@pytest.fixture(scope="module")
+def script() -> str:
+    assert _INSTALL_SH.is_file(), f"install.sh not found at {_INSTALL_SH}"
+    return _strip_comments(_INSTALL_SH.read_text(encoding="utf-8"))
+
+
+def test_invokes_winpodx_provision(script: str) -> None:
+    # The unified call is the post-create provisioning step.
+    assert "provision" in script
+    # It runs through the installed symlink (same pattern as the old chain).
+    assert '"$SYMLINK" provision' in script
+
+
+def test_no_inline_health_curl_poll(script: str) -> None:
+    # The 30× `curl .../health` settle poll moved into finish_provisioning.
+    # (install.sh still uses curl elsewhere — e.g. the GitHub release check —
+    #  so we assert the absence of the agent /health endpoint specifically,
+    #  not curl in general.)
+    assert "/health" not in script
+    assert "127.0.0.1:8765" not in script
+    assert "8765/health" not in script
+
+
+def test_no_inline_six_times_discovery_retry(script: str) -> None:
+    # The 6× `app refresh` retry loop is gone from bash.
+    assert "for attempt in 1 2 3 4 5 6" not in script
+    assert '"$SYMLINK" app refresh' not in script
+
+
+def test_no_inline_host_open_listener_start(script: str) -> None:
+    # Reverse-open listener start + refresh moved into finish_provisioning.
+    assert "host-open start-listener" not in script
+    assert "host-open refresh" not in script
+
+
+def test_no_inline_migrate_in_provision_chain(script: str) -> None:
+    # The post-create `winpodx migrate --non-interactive` call (the old
+    # apply-fixes driver) is folded into finish_provisioning's apply stage.
+    assert "migrate --non-interactive" not in script
+
+
+def test_create_only_flag_is_gone(script: str) -> None:
+    # setup --create-only was removed; install.sh must not pass it.
+    assert "--create-only" not in script
+
+
+def test_setup_skips_its_own_provision_tail(script: str) -> None:
+    # install.sh runs the chain once via the explicit `winpodx provision`,
+    # so it tells `winpodx setup` to skip its own full-provision tail.
+    assert "WINPODX_NO_PROVISION=1" in script
+
+
+def test_provision_is_the_only_post_create_winpodx_step(script: str) -> None:
+    """After `winpodx setup`, the only chain-driving winpodx command is
+    `winpodx provision` (plus its non-provisioning siblings: the GUI
+    desktop-entry install isn't a winpodx subprocess). Assert none of the
+    individual chain commands the old bash copy invoked survive."""
+    forbidden = (
+        '"$SYMLINK" pod wait-ready',
+        '"$SYMLINK" migrate',
+        '"$SYMLINK" app refresh',
+        '"$SYMLINK" host-open',
+    )
+    for cmd in forbidden:
+        assert cmd not in script, f"inline bash chain step still present: {cmd!r}"

--- a/tests/test_setup_wizard_prompts.py
+++ b/tests/test_setup_wizard_prompts.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: MIT
 """Tests for the extended setup wizard (#255 PR 7 completion):
-edition / locale / tuning prompts + the --create-only provision gate.
+edition / locale / tuning prompts + the full-provision gate.
+
+0.6.0 item B: ``--create-only`` was removed; ``_run_full_provision`` is now
+a thin wrapper over ``core.provisioner.finish_provisioning``. The non-
+container short-circuit it kept is what ``test_full_provision_noop_*`` pins.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## 0.6.0 items B + I — unify the post-create provisioning chain

The `wait-ready → agent-settle → apply-fixes → discovery → reverse-open`
sequence lived in **five** places with subtly diverging ordering and gating:
`install.sh`, `setup_cmd._run_full_provision`, `migrate`, `pending.resume`,
and the Qt GUI bring-up. This PR consolidates it into one helper and routes
every caller through it.

### New single source of truth

`core.provisioner.finish_provisioning(cfg, *, wait_timeout, require_agent, with_reverse_open, with_discovery, retries, on_progress=None) -> dict[str, Any]`

Six parameter-gated stages, each preserving the exact behaviour of the copy
it replaced:

1. **wait-ready** — `wait_for_windows_responsive(cfg, timeout=wait_timeout)`.
2. **agent settle** — `require_agent=True` hard-gates on `AgentTransport.health()`
   and raises the new `ProvisionAgentUnavailable` (migrate's behaviour, refuses
   FreeRDP fallback to avoid kicking install.bat's autologon session).
   `require_agent=False` does install.sh's soft 30× × 2 s poll and proceeds
   silently if it never lands (lets setup_cmd's auto-provision survive a slow
   first boot).
3. **apply-fixes** — `apply_windows_runtime_fixes(cfg)`, ungated (idempotent).
4. **discovery** — `with_discovery` gates the shared discovery path with
   `retries` attempts + exponential backoff (install.sh's 6× behaviour, gentler
   ramp, capped at 30 s).
5. **reverse-open** — `with_reverse_open` + `cfg.reverse_open.enabled` gate the
   listener-start + manifest refresh.
6. **progress** — optional `on_progress(stage, detail)` callback.

Returns a results dict (`{"wait_ready": ..., "agent_settle": ..., "apply_fixes": {...}, "discovery": "N apps", "reverse_open": ...}`).

### New CLI: `winpodx provision`

Flags map 1:1: `--wait-timeout` (3600), `--require-agent` (off),
`--no-discovery`, `--no-reverse-open`, `--retries` (6), `--verbose`. Run with no
flags it reproduces install.sh's post-create defaults, so an AppImage first run
can simply `winpodx provision` and get the install.sh UX for free (item I
AppImage-parity goal). Exit codes: 0 ok, 2 unsupported backend, 4 wait-ready
timeout, 5 agent-deferred (`--require-agent`).

### Discovery entrypoint choice

**Chosen: `discover_apps` + `persist_discovered` + `cli.app._register_desktop_entries`**
(wrapped in the new `_run_discovery_with_retry`).

Why this one over `_refresh_apps`: `_refresh_apps` is a CLI wrapper around
*exactly* this trio but adds `sys.exit` / `print` and lives in `cli/` — not
callable from a core function. The trio is also the more complete form: it
installs *and* prunes stale `winpodx-*.desktop` entries and refreshes the icon
cache (bidirectional sync), whereas a bare scan+persist would leave stale menu
entries behind. install.sh's `app refresh` and `pending.resume`'s
`discover_apps+persist+register` both collapse onto it cleanly — they already
produced the same end state; the divergence was historical (CLI wrapper vs.
direct trio), not principled.

### Callers migrated

- **install.sh** — ~140 lines collapsed to `winpodx provision --verbose`
  (forwards `$WINPODX_VERBOSE`). Dropped: the inline 30× `curl /health` settle
  poll, the 6× `app refresh` retry loop, the `migrate --non-interactive` apply
  driver, the `host-open start-listener` + `host-open refresh`, and the
  per-step opt-out env vars. `winpodx setup` now runs with
  `WINPODX_NO_PROVISION=1` (replaces `--create-only`) so the chain runs exactly
  once, via the explicit `winpodx provision`. Kept: venv/cwd setup, Ctrl+C
  (rc 130/143) handling, `no such container` partial-uninstall detection, and a
  pending-marker fallback so `utils.pending.resume` stays the safety net.
- **setup_cmd._run_full_provision** — now a thin wrapper:
  `finish_provisioning(cfg, wait_timeout=3600, require_agent=False, with_reverse_open=cfg.reverse_open.enabled, with_discovery=True, retries=6)`.
- **setup --create-only** — flag removed from `cli/main.py`, dispatcher branch
  removed from `setup_cmd`, install.sh reference removed. argparse now rejects
  `--create-only` with exit 2 + a useful error.
- **migrate._apply_runtime_fixes_to_existing_guest** — wait/agent-gate/apply
  block replaced with
  `finish_provisioning(cfg, wait_timeout=600, require_agent=True, with_reverse_open=False, with_discovery=True, retries=3)`.
  Migrate-only bits kept around it (password-probe, image-pin, release notes,
  pod-state prompt, guest_sync). The old hard-gate's "agent not up, deferring"
  message is preserved via the `ProvisionAgentUnavailable` catch.
- **utils.pending.resume** — `discover_apps+persist+register` block dropped;
  routed through
  `finish_provisioning(cfg, wait_timeout=300, require_agent=False, with_reverse_open=False, with_discovery=True, retries=3)`.
  The per-step pending-marker removal semantics are preserved by mapping the
  results dict back to the `wait_ready` / `migrate` / `discovery` markers.

### Caller DEFERRED (item I) — GUI bring-up

`gui/_main_window_bringup.py` was **not** migrated. The roadmap (and the task
brief) pointed at lines 446-470 expecting a "podman logs -f follow + wait
loop" — that range is actually the optional pod-log expander. The real bring-up
is `_bringup_worker` + `_phase1..5`, a cancellable 5-phase Qt worker with
capabilities `finish_provisioning` does not yet expose:

1. **Cooperative cancellation** — every phase checks `_is_cancelled` /
   `_sleep_cancellable` so the user's Cancel button stops promptly. The helper
   has no cancel hook; routing through it would make Cancel a no-op until the
   current blocking stage returns.
2. **Per-attempt streaming with custom budgets** (`cfg.install.wait_ready_stage2_secs`
   / `stage3_secs`) plus a token-readiness check (`AgentClient.auth_ready`) the
   soft settle poll doesn't do.
3. **Distinct per-phase failure surfacing** to the dialog.

Per the task constraint ("if ambiguous, keep the legacy path behind a comment
rather than guess and break it silently"), the worker is left intact with a
`TODO(0.6.x)` documenting the exact migration once `finish_provisioning` grows a
`cancel_event` + richer `on_progress`. The helper already carries the
`on_progress(stage, detail)` callback for that wiring.

### Divergence the spec missed, accommodated here

- **GUI bring-up is not the chain the spec described.** Documented + deferred
  (above) instead of migrated blind.
- **`require_agent=True` needed a typed exception, not a bool return.** Migrate's
  old gate printed a specific "defer until next launch" message and returned.
  Added `ProvisionAgentUnavailable(ProvisionError)` so the hard-gate failure is
  distinguishable from a generic provisioning failure (migrate catches it; the
  CLI maps it to exit 5; base-class catchers still work).
- **`--create-only` had no clean replacement for the setup/provision double-run.**
  Added the `WINPODX_NO_PROVISION=1` env guard in `setup_cmd` so install.sh can
  run `setup` (container create) then `provision` (the chain) without running
  the chain twice. A standalone `winpodx setup` (no env var) still runs the full
  flow.

### Tests

New `tests/test_finish_provisioning.py` (33 tests) — pins all six branches with
mocked stages, parametrised over `require_agent` / `with_reverse_open` /
`with_discovery`; asserts each stage's args + skip-when-off; the discovery
retry helper (success-after-transient + exhaustion); the `--create-only` removal
(`setup --help` no longer lists it, dispatcher rejects it exit 2); and the
`winpodx provision` CLI (help lists every flag, flag→param mapping, exit codes).

New `tests/test_install_sh_provision.py` (8 tests) — parse-and-grep guard that
asserts `winpodx provision` is the only post-create step and fails loudly if a
bash copy of the chain (inline `/health` poll, 6× retry loop, host-open
listener-start, `migrate --non-interactive`, `--create-only`) is reintroduced.

Affected existing suites re-run green: test_provisioner, test_migrate,
test_pending, test_setup, test_setup_wizard_prompts, test_main_window_bringup,
test_pod, test_install_cli_stubs, test_install_config, test_uninstall_wrapper,
test_backend_select.

### Verification

- `ruff check src/ tests/` — clean.
- `ruff format --check src/ tests/` — clean.
- `bash -n install.sh` — clean.
- Affected test files green (full suite skipped locally per the podman-fixture
  /tmp constraint).

**Real-Windows smoke is the gate.** Not merging — the branch is ready for the
maintainer to run smoke against before merge.
