### PR TITLE
feat(freerdp): selectable client source + prefer Flatpak when both present (#269, #366, #393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Changed
+
+- **FreeRDP client source is now selectable, and the launcher prefers the Flatpak when both are present (#269, #366, #393).** Previously `install.sh` always installed the native `freerdp3` package even when the Flatpak `com.freerdp.FreeRDP` was already there (redundant — #269), and the launcher always picked native first. Now: (1) **the launcher prefers the Flatpak when both clients are present** (`core/rdp.find_freerdp` auto order is Flatpak-first), the better client on distros whose native `freerdp3-x11` is broken; this applies to existing installs too, with `cfg.rdp.freerdp_source = native` as the escape hatch. (2) **`install.sh` never installs a redundant client** — if any FreeRDP (native or Flatpak) is present it installs nothing; when none is present `auto` installs the Flatpak if the flatpak runtime is available, else the native package (best-effort, with native fallback). (3) **Custom install mode now lets you choose each major dependency's source** — container backend (podman/docker/libvirt), **FreeRDP client (auto / native / flatpak)**, and the GUI — and `winpodx setup --freerdp-source <auto|native|flatpak>` persists the choice to `cfg.rdp.freerdp_source`.
+
 ### Fixed
 
 - **The install-mode menu (R/A/C/N) now works under `curl … | bash`.** The interactive mode prompt — and the Custom-mode backend/GUI sub-prompts and the dependency-install confirm — were gated on `[ -t 0 ]` and read from stdin, so under the canonical `curl … | bash` install (where stdin is the script pipe, not a terminal) they were silently skipped and the install always defaulted to Recommended. install.sh now also detects a reachable controlling terminal via `/dev/tty` and reads every prompt from it, so a `curl … | bash` run in an attended terminal shows the mode menu and lets you choose (the same `/dev/tty` trick the live progress line already uses for output). Fully non-interactive runs (CI / cron / stdin and `/dev/tty` both absent) stay non-interactive and default to Recommended, and `--mode` / `WINPODX_MODE` still preselect without prompting.

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **FreeRDP 클라이언트 소스를 선택 가능하게 했고, 둘 다 있으면 런처가 Flatpak 을 우선 사용합니다 (#269, #366, #393).** 기존엔 `install.sh` 가 Flatpak `com.freerdp.FreeRDP` 이 이미 있어도 네이티브 `freerdp3` 패키지를 항상 설치했고(중복 — #269), 런처도 항상 네이티브를 먼저 골랐습니다. 이제: (1) **둘 다 있으면 런처가 Flatpak 우선** (`core/rdp.find_freerdp` auto 순서가 Flatpak-first) — 네이티브 `freerdp3-x11` 이 깨진 distro 에서 더 나은 클라이언트; **기존 설치에도 적용**되며 `cfg.rdp.freerdp_source = native` 로 되돌릴 수 있음. (2) **`install.sh` 가 중복 클라이언트를 설치하지 않음** — FreeRDP(네이티브든 Flatpak 이든) 가 하나라도 있으면 아무것도 안 깖; 둘 다 없으면 `auto` 는 flatpak 런타임이 있으면 Flatpak 을, 없으면 네이티브 패키지를 설치(best-effort, 실패 시 네이티브 fallback). (3) **Custom 설치 모드에서 주요 의존성마다 소스를 선택** — 컨테이너 백엔드(podman/docker/libvirt), **FreeRDP 클라이언트(auto / native / flatpak)**, GUI — 그리고 `winpodx setup --freerdp-source <auto|native|flatpak>` 가 선택을 `cfg.rdp.freerdp_source` 에 저장.
+
 ### Fixed
 
 - **설치 모드 메뉴(R/A/C/N)가 이제 `curl … | bash` 에서도 동작합니다.** 대화형 모드 프롬프트(+ Custom 모드의 백엔드/GUI 서브프롬프트, 의존성 설치 확인)가 `[ -t 0 ]` 으로 게이트되고 stdin 에서 읽어서, 표준 `curl … | bash` 설치(stdin 이 스크립트 파이프지 터미널이 아님)에선 조용히 스킵되고 항상 Recommended 로 기본 처리됐습니다. 이제 install.sh 가 제어 터미널 `/dev/tty` 도 감지하고 모든 프롬프트를 거기서 읽으므로, 터미널에서 실행한 `curl … | bash` 는 모드 메뉴를 띄우고 선택할 수 있습니다(라이브 진행 라인이 출력에 이미 쓰는 `/dev/tty` 트릭과 동일). 완전 비대화형 실행(CI / cron / stdin 과 `/dev/tty` 둘 다 없음)은 비대화형으로 남아 Recommended 기본, `--mode` / `WINPODX_MODE` 는 여전히 프롬프트 없이 미리 선택합니다.

--- a/install.sh
+++ b/install.sh
@@ -567,10 +567,34 @@ DOCKER_PRESENT=false
 command -v docker >/dev/null 2>&1 && DOCKER_PRESENT=true
 LIBVIRT_PRESENT=false
 command -v virsh >/dev/null 2>&1 && LIBVIRT_PRESENT=true
-FREERDP_PRESENT=false
-for _c in xfreerdp3 xfreerdp wlfreerdp3 wlfreerdp; do
-    if command -v "$_c" >/dev/null 2>&1; then FREERDP_PRESENT=true; break; fi
+# FreeRDP detection — track native client, Flatpak client, and the Flatpak
+# runtime separately so the install policy + Custom mode can choose a source.
+# Mirrors core/rdp.py:find_freerdp's accepted native set.
+FREERDP_NATIVE_PRESENT=false
+for _c in xfreerdp3 xfreerdp sdl-freerdp3 sdl-freerdp wlfreerdp3 wlfreerdp; do
+    if command -v "$_c" >/dev/null 2>&1; then FREERDP_NATIVE_PRESENT=true; break; fi
 done
+FLATPAK_PRESENT=false
+command -v flatpak >/dev/null 2>&1 && FLATPAK_PRESENT=true
+FREERDP_FLATPAK_PRESENT=false
+if [ "$FLATPAK_PRESENT" = true ] \
+    && flatpak list --app --columns=application 2>/dev/null | grep -qx 'com.freerdp.FreeRDP'; then
+    FREERDP_FLATPAK_PRESENT=true
+fi
+# Any client (native or Flatpak) satisfies the requirement. winpodx's launcher
+# prefers the Flatpak when both are present (core/rdp.py), and on distros whose
+# native freerdp3-x11 is broken the Flatpak is the better client (#366, #393);
+# #269 showed both present with the native install adding nothing. So we never
+# pull the native package when a Flatpak client is already there.
+FREERDP_PRESENT=false
+FREERDP_KIND=""
+if [ "$FREERDP_FLATPAK_PRESENT" = true ]; then
+    FREERDP_PRESENT=true
+    FREERDP_KIND="flatpak (com.freerdp.FreeRDP)"
+elif [ "$FREERDP_NATIVE_PRESENT" = true ]; then
+    FREERDP_PRESENT=true
+    FREERDP_KIND="native"
+fi
 PYTHON3_PRESENT=false
 command -v python3 >/dev/null 2>&1 && PYTHON3_PRESENT=true
 KVM_PRESENT=false
@@ -609,7 +633,7 @@ print_system_check() {
     fi
     echo "  docker:        $(yesno "$DOCKER_PRESENT")  $(tool_version docker)"
     echo "  libvirt/virsh: $(yesno "$LIBVIRT_PRESENT")  $(tool_version virsh)"
-    echo "  freerdp:       $(yesno "$FREERDP_PRESENT")  $(tool_version freerdp)"
+    echo "  freerdp:       $(yesno "$FREERDP_PRESENT")  ${FREERDP_KIND:+$FREERDP_KIND }$(tool_version freerdp)"
     echo "  /dev/kvm:      $(yesno "$KVM_PRESENT")"
     echo "======================================================"
     if [ "$PODMAN_TOO_OLD" = true ]; then
@@ -682,11 +706,16 @@ if [ "$INSTALL_MODE" = "n" ]; then
     exit 0
 fi
 
-# --- Custom mode: interactively pick backend + GUI ---
+# --- Custom mode: interactively pick the source of each major dependency ---
+# Components with a real source choice: the container backend (podman / docker
+# / libvirt), the FreeRDP client (native package / Flatpak), and the GUI
+# (PySide6 yes/no). Everything else is a plain distro package with no
+# meaningful alternative. Each prompt has a sensible default so just hitting
+# Enter reproduces the Recommended stack.
 if [ "$INSTALL_MODE" = "c" ]; then
     if [ -z "$WINPODX_BACKEND" ]; then
         if [ "$INTERACTIVE" = true ]; then
-            echo -n "Backend? [podman/docker/libvirt] (default podman): "
+            echo -n "Container backend? [podman/docker/libvirt] (default podman): "
             read -r be_answer < "$TTY_DEV"
             case "$(echo "${be_answer:-podman}" | tr '[:upper:]' '[:lower:]')" in
                 docker)  WINPODX_BACKEND="docker" ;;
@@ -696,6 +725,19 @@ if [ "$INSTALL_MODE" = "c" ]; then
         else
             WINPODX_BACKEND="podman"
         fi
+    fi
+    if [ -z "${WINPODX_FREERDP_SOURCE:-}" ] && [ "$INTERACTIVE" = true ]; then
+        echo    "FreeRDP client source?"
+        echo    "  [A]uto     prefer the Flatpak when present, else native (recommended)"
+        echo    "  [N]ative   distro freerdp3 package"
+        echo    "  [F]latpak  com.freerdp.FreeRDP via Flatpak (better on distros with a broken native freerdp3-x11)"
+        echo -n "Choice [A/n/f]: "
+        read -r fr_answer < "$TTY_DEV"
+        case "$(echo "${fr_answer:-a}" | tr '[:upper:]' '[:lower:]' | cut -c1)" in
+            n) WINPODX_FREERDP_SOURCE="native" ;;
+            f) WINPODX_FREERDP_SOURCE="flatpak" ;;
+            *) WINPODX_FREERDP_SOURCE="auto" ;;
+        esac
     fi
     if [ -z "$WINPODX_NO_GUI" ] && [ "$INTERACTIVE" = true ]; then
         echo -n "Install the GUI (PySide6)? [Y/n]: "
@@ -813,7 +855,35 @@ case "${WINPODX_BACKEND:-podman}" in
 esac
 
 # FreeRDP is required for every backend (the launcher shells out to it).
-[ "$FREERDP_PRESENT" = false ] && MISSING+=("freerdp")
+# Source resolution (auto | native | flatpak). Custom mode may set
+# WINPODX_FREERDP_SOURCE; default auto. winpodx's launcher prefers the Flatpak
+# when both clients are present (core/rdp.py), so auto mirrors that: when NO
+# client exists yet, install the Flatpak if the flatpak runtime is available,
+# else the native package. An explicit native/flatpak choice forces that
+# source. The resolved value is handed to `winpodx setup` (--freerdp-source)
+# which writes cfg.rdp.freerdp_source.
+WINPODX_FREERDP_SOURCE="${WINPODX_FREERDP_SOURCE:-auto}"
+INSTALL_FREERDP_FLATPAK=false
+case "$WINPODX_FREERDP_SOURCE" in
+    native)
+        [ "$FREERDP_NATIVE_PRESENT" = false ] && MISSING+=("freerdp")
+        ;;
+    flatpak)
+        if [ "$FREERDP_FLATPAK_PRESENT" = false ]; then
+            INSTALL_FREERDP_FLATPAK=true
+            [ "$FLATPAK_PRESENT" = false ] && MISSING+=("flatpak")
+        fi
+        ;;
+    *)  # auto
+        if [ "$FREERDP_PRESENT" = false ]; then
+            if [ "$FLATPAK_PRESENT" = true ]; then
+                INSTALL_FREERDP_FLATPAK=true
+            else
+                MISSING+=("freerdp")
+            fi
+        fi
+        ;;
+esac
 
 # python3 is mandatory (venv host interpreter).
 [ "$PYTHON3_PRESENT" = false ] && MISSING+=("python3")
@@ -883,6 +953,32 @@ if [ ${#MISSING[@]} -gt 0 ]; then
     log "All dependencies installed successfully"
 else
     log "All dependencies OK"
+fi
+
+# Install the Flatpak FreeRDP when that's the resolved source (auto with a
+# flatpak runtime but no client yet, or an explicit --freerdp-source flatpak).
+# Best-effort: if the Flatpak install fails (no flathub remote, offline, …)
+# fall back to the native package so the user still ends up with a client.
+if [ "$INSTALL_FREERDP_FLATPAK" = true ]; then
+    log "Installing FreeRDP via Flatpak (com.freerdp.FreeRDP)..."
+    flatpak remote-add --if-not-exists --user flathub \
+        https://dl.flathub.org/repo/flathub.flatpakrepo >/dev/null 2>&1 || true
+    if flatpak install -y --user flathub com.freerdp.FreeRDP >/dev/null 2>&1 \
+        || flatpak install -y flathub com.freerdp.FreeRDP >/dev/null 2>&1; then
+        log "  Flatpak FreeRDP installed."
+        FREERDP_PRESENT=true
+        WINPODX_FREERDP_SOURCE="flatpak"
+    else
+        warn "  Flatpak FreeRDP install failed — falling back to the native package."
+        WINPODX_FREERDP_SOURCE="auto"
+        if [ "$FREERDP_NATIVE_PRESENT" = false ]; then
+            if install_pkg freerdp; then
+                FREERDP_PRESENT=true
+            else
+                warn "  Native FreeRDP install also failed — install a FreeRDP 3 client manually."
+            fi
+        fi
+    fi
 fi
 
 # Re-verify /dev/kvm after the install loop. Installing the qemu /
@@ -1146,6 +1242,12 @@ else
     if [ -n "$WINPODX_WIN_VERSION" ]; then
         SETUP_ARGS+=(--win-version "$WINPODX_WIN_VERSION")
         log "Installing Windows edition: $WINPODX_WIN_VERSION"
+    fi
+    # Persist the resolved FreeRDP source so the launcher honours it
+    # (cfg.rdp.freerdp_source). Skip "auto" — that's the default.
+    if [ -n "${WINPODX_FREERDP_SOURCE:-}" ] && [ "$WINPODX_FREERDP_SOURCE" != "auto" ]; then
+        SETUP_ARGS+=(--freerdp-source "$WINPODX_FREERDP_SOURCE")
+        log "FreeRDP source: $WINPODX_FREERDP_SOURCE"
     fi
     # WINPODX_NO_PROVISION=1: setup creates the container but skips its own
     # full-provision tail; install.sh runs the chain once via the explicit

--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -321,6 +321,16 @@ def cli(argv: list[str] | None = None) -> None:
     # --- setup ---
     setup_p = sub.add_parser("setup", help="Run setup wizard")
     setup_p.add_argument("--backend", choices=["podman", "docker", "libvirt", "manual"])
+    setup_p.add_argument(
+        "--freerdp-source",
+        choices=["auto", "native", "flatpak"],
+        default=None,
+        help=(
+            "Which FreeRDP client the launcher prefers: auto (Flatpak when "
+            "present, else native), native, or flatpak. Stored in "
+            "cfg.rdp.freerdp_source."
+        ),
+    )
     # Curated edition list pulled from winpodx.core.config.WIN_VERSION_LABELS
     # so the help text stays in sync with the validator and the GUI dropdown.
     from winpodx.core.config import known_win_version_codes

--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -660,8 +660,19 @@ def handle_setup(args: argparse.Namespace) -> None:
             # the user picks "Auto", setup short-circuits on this branch,
             # returns without marking initialized, and the prompt comes back
             # next time. Persist only when it actually changes.
+            # A targeted `winpodx setup --freerdp-source <x>` on an existing
+            # config still persists the preference (this branch otherwise
+            # short-circuits before the main apply below).
+            _fr_src = getattr(args, "freerdp_source", None)
+            changed = False
             if not cfg.pod.initialized:
                 cfg.pod.initialized = True
+                changed = True
+            if _fr_src and _fr_src != cfg.rdp.freerdp_source:
+                cfg.rdp.freerdp_source = _fr_src
+                cfg.rdp.__post_init__()
+                changed = True
+            if changed:
                 cfg.save()
             _ensure_oem_token_staged()
             # Half-uninstalled detection. If cfg points at a podman/docker
@@ -718,6 +729,15 @@ def handle_setup(args: argparse.Namespace) -> None:
     if win_version_arg:
         cfg.pod.win_version = win_version_arg
         cfg.pod.__post_init__()
+
+    # Persist the FreeRDP source preference (native / flatpak / auto) chosen in
+    # install.sh Custom mode or via `winpodx setup --freerdp-source`. "auto"
+    # (the default) prefers the Flatpak when present; an explicit value forces
+    # that client. RDPConfig.__post_init__ validates the value.
+    freerdp_source_arg = getattr(args, "freerdp_source", None)
+    if freerdp_source_arg:
+        cfg.rdp.freerdp_source = freerdp_source_arg
+        cfg.rdp.__post_init__()
 
     _resolve_credentials(cfg, non_interactive=non_interactive, config_existed=config_existed)
 

--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -157,12 +157,18 @@ class RDPConfig:
     scale: int = 100
     dpi: int = 0  # Windows DPI %, 0 = auto-detect from Linux
     extra_flags: str = ""
+    # Which FreeRDP client to prefer: "auto" (Flatpak when installed, else
+    # native — see core/rdp.find_freerdp), "native", or "flatpak". Lets a user
+    # force the native client if the Flatpak's sandbox is a problem for them.
+    freerdp_source: str = "auto"
 
     def __post_init__(self) -> None:
         self.port = max(1, min(65535, int(self.port)))
         self.scale = max(100, min(500, int(self.scale)))
         self.dpi = max(0, min(500, int(self.dpi)))
         self.password_max_age = max(0, int(self.password_max_age))
+        if self.freerdp_source not in ("auto", "native", "flatpak"):
+            self.freerdp_source = "auto"
 
 
 @dataclass
@@ -673,6 +679,7 @@ class Config:
                 "scale": self.rdp.scale,
                 "dpi": self.rdp.dpi,
                 "extra_flags": self.rdp.extra_flags,
+                "freerdp_source": self.rdp.freerdp_source,
             },
             "pod": {
                 "backend": self.pod.backend,

--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -155,8 +155,9 @@ def _media_redirect_base() -> Path:
     return placeholder
 
 
-# Success-only cache; a miss is not cached so a mid-session install is picked up.
-_FREERDP_CACHE: tuple[str, str] | None = None
+# Success-only cache, keyed by preference; a miss is not cached so a
+# mid-session install is picked up.
+_FREERDP_CACHE: dict[str, tuple[str, str]] = {}
 _FREERDP_MAJOR_CACHE: int | None = None
 
 
@@ -210,8 +211,8 @@ def freerdp_major_version() -> int:
     return _FREERDP_MAJOR_CACHE
 
 
-def find_freerdp() -> tuple[str, str] | None:
-    """Locate a FreeRDP 3+ binary on the system.
+def _find_native_freerdp() -> tuple[str, str] | None:
+    """First available native FreeRDP binary.
 
     ``xfreerdp`` first: it is the only client with working RAIL.
     ``sdl-freerdp`` has none (FreeRDP #9078) and ``wlfreerdp`` is
@@ -219,39 +220,68 @@ def find_freerdp() -> tuple[str, str] | None:
     substitute -- pure-Wayland needs XWayland. SDL stays as a
     full-desktop-only fallback.
     """
-    global _FREERDP_CACHE
-    if _FREERDP_CACHE is not None:
-        return _FREERDP_CACHE
-
     probes: tuple[tuple[tuple[str, ...], str], ...] = (
         (("xfreerdp3", "xfreerdp"), "xfreerdp"),
         (("sdl-freerdp3", "sdl-freerdp"), "sdl"),
     )
-    found: tuple[str, str] | None = None
     for names, kind in probes:
         for name in names:
             path = shutil.which(name)
             if path:
-                found = (path, kind)
-                break
-        if found is not None:
-            break
+                return (path, kind)
+    return None
 
-    if found is None:
-        try:
-            result = subprocess.run(
-                ["flatpak", "list", "--app", "--columns=application"],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-            if result.returncode == 0 and "com.freerdp.FreeRDP" in result.stdout:
-                found = ("flatpak run com.freerdp.FreeRDP", "flatpak")
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            pass
+
+def _find_flatpak_freerdp() -> tuple[str, str] | None:
+    """The Flatpak FreeRDP (``com.freerdp.FreeRDP``) if installed.
+
+    The Flatpak ships ``xfreerdp``, so it has working RAIL just like the
+    native ``xfreerdp`` — it's a first-class client, not a degraded fallback.
+    """
+    try:
+        result = subprocess.run(
+            ["flatpak", "list", "--app", "--columns=application"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0 and "com.freerdp.FreeRDP" in result.stdout:
+            return ("flatpak run com.freerdp.FreeRDP", "flatpak")
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+def find_freerdp(prefer: str = "auto") -> tuple[str, str] | None:
+    """Locate a FreeRDP 3+ client, honouring a source preference.
+
+    ``prefer``:
+      * ``"auto"`` (default) — **prefer the Flatpak when it's installed**, else
+        native. The Flatpak ``com.freerdp.FreeRDP`` is RAIL-capable and is the
+        more reliable client on distros whose native ``freerdp3-x11`` is broken
+        (e.g. Ubuntu 26.04, #393), so when both are present we use the Flatpak.
+      * ``"native"`` — force the native binary (fall back to Flatpak only if no
+        native is present).
+      * ``"flatpak"`` — force the Flatpak (fall back to native only if the
+        Flatpak isn't installed).
+
+    Override per install via ``cfg.rdp.freerdp_source``. Returns ``(path_or_cmd,
+    kind)`` or ``None``. Success is cached per-preference; a miss is not cached
+    so a mid-session install is still picked up.
+    """
+    pref = prefer if prefer in ("auto", "native", "flatpak") else "auto"
+    cached = _FREERDP_CACHE.get(pref)
+    if cached is not None:
+        return cached
+
+    if pref == "native":
+        found = _find_native_freerdp() or _find_flatpak_freerdp()
+    else:
+        # auto + flatpak: try the Flatpak first, fall back to native.
+        found = _find_flatpak_freerdp() or _find_native_freerdp()
 
     if found is not None:
-        _FREERDP_CACHE = found
+        _FREERDP_CACHE[pref] = found
     return found
 
 
@@ -297,7 +327,7 @@ def build_rdp_command(
     ``/wm-class`` (exe stem) so the Linux window lines up with the
     discovered app's desktop entry rather than ``explorer``.
     """
-    found = find_freerdp()
+    found = find_freerdp(prefer=getattr(cfg.rdp, "freerdp_source", "auto"))
     if not found:
         raise RuntimeError("FreeRDP 3+ not found. Install xfreerdp3 or xfreerdp.")
 
@@ -775,7 +805,7 @@ def launch_app(
 
     # See find_freerdp(): only xfreerdp has working RAIL, and it needs $DISPLAY.
     is_remoteapp = launch_uri is not None or app_executable is not None
-    found = find_freerdp()
+    found = find_freerdp(prefer=getattr(cfg.rdp, "freerdp_source", "auto"))
     kind = found[1] if found else ""
     if is_remoteapp and kind == "xfreerdp" and not os.environ.get("DISPLAY"):
         raise RuntimeError(

--- a/tests/test_audit5_core.py
+++ b/tests/test_audit5_core.py
@@ -168,7 +168,7 @@ def test_sec_tls_applied_for_all_backends(backend_name, monkeypatch):
 
     monkeypatch.setattr(
         "winpodx.core.rdp.find_freerdp",
-        lambda: ("/usr/bin/xfreerdp3", "xfreerdp"),
+        lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
     )
     cfg = Config()
     cfg.rdp.user = "User"
@@ -274,7 +274,7 @@ def test_check_freerdp_accepts_sdl(monkeypatch):
 
     monkeypatch.setattr(
         "winpodx.core.rdp.find_freerdp",
-        lambda: ("/usr/bin/sdl-freerdp3", "sdl"),
+        lambda *a, **k: ("/usr/bin/sdl-freerdp3", "sdl"),
     )
     result = deps.check_freerdp()
     assert result.found is True
@@ -285,7 +285,7 @@ def test_check_freerdp_accepts_sdl(monkeypatch):
 def test_check_freerdp_reports_missing(monkeypatch):
     from winpodx.utils import deps
 
-    monkeypatch.setattr("winpodx.core.rdp.find_freerdp", lambda: None)
+    monkeypatch.setattr("winpodx.core.rdp.find_freerdp", lambda *a, **k: None)
     result = deps.check_freerdp()
     assert result.found is False
     assert "FreeRDP 3+" in result.note

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,19 @@ def test_rdp_config_scale_clamping():
     assert rdp.scale == 500
 
 
+def test_rdp_config_freerdp_source_default_is_auto():
+    assert RDPConfig().freerdp_source == "auto"
+
+
+def test_rdp_config_freerdp_source_accepts_valid():
+    assert RDPConfig(freerdp_source="native").freerdp_source == "native"
+    assert RDPConfig(freerdp_source="flatpak").freerdp_source == "flatpak"
+
+
+def test_rdp_config_freerdp_source_invalid_falls_back_to_auto():
+    assert RDPConfig(freerdp_source="bogus").freerdp_source == "auto"
+
+
 def test_pod_config_backend_validation():
     pod = PodConfig(backend="invalid")
     assert pod.backend == "podman"

--- a/tests/test_install_sh_provision.py
+++ b/tests/test_install_sh_provision.py
@@ -135,6 +135,25 @@ def test_mode_prompt_reads_from_tty_so_curl_bash_can_choose(script: str) -> None
     assert script.count('read -r mode_answer < "$TTY_DEV"') == 1
 
 
+def test_custom_mode_picks_freerdp_source(script: str) -> None:
+    # Custom mode lets the user pick the FreeRDP client source (native/flatpak/
+    # auto), not just the backend + GUI.
+    assert "WINPODX_FREERDP_SOURCE" in script
+    assert '[ "$INSTALL_MODE" = "c" ]' in script
+    # The resolved source is handed to setup so the launcher honours it.
+    assert "--freerdp-source" in script
+
+
+def test_freerdp_flatpak_not_installed_redundantly(script: str) -> None:
+    # When a FreeRDP client (native or Flatpak) is already present, the native
+    # package is not pulled; when neither is present, auto installs the Flatpak
+    # if the flatpak runtime exists, else native.
+    assert "FREERDP_FLATPAK_PRESENT" in script
+    assert "FREERDP_NATIVE_PRESENT" in script
+    assert "INSTALL_FREERDP_FLATPAK" in script
+    assert "com.freerdp.FreeRDP" in script
+
+
 def test_no_inline_chain_steps_survive(script: str) -> None:
     """After `winpodx setup`, the post-create chain is driven by ONE winpodx
     command (provision on fresh, migrate on upgrade, both via PROVISION_CMD).

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -67,7 +67,7 @@ def test_launch_app_remoteapp_without_display_raises(monkeypatch, tmp_path):
     # No $DISPLAY -> xfreerdp would die post-detach; launch_app must raise.
     from winpodx.core import rdp as rdp_mod
 
-    monkeypatch.setattr(rdp_mod, "find_freerdp", lambda: ("/usr/bin/xfreerdp", "xfreerdp"))
+    monkeypatch.setattr(rdp_mod, "find_freerdp", lambda *a, **k: ("/usr/bin/xfreerdp", "xfreerdp"))
     monkeypatch.setattr(rdp_mod, "runtime_dir", lambda: tmp_path)
     monkeypatch.setattr("winpodx.core.process.runtime_dir", lambda: tmp_path)
     monkeypatch.delenv("DISPLAY", raising=False)
@@ -81,6 +81,58 @@ def test_find_freerdp_returns_tuple_or_none():
 
     result = find_freerdp()
     assert result is None or (isinstance(result, tuple) and len(result) == 2)
+
+
+def _patch_freerdp_probes(monkeypatch, *, native, flatpak):
+    """Stub the native + Flatpak FreeRDP probes independently."""
+    import winpodx.core.rdp as rdp_mod
+
+    rdp_mod._FREERDP_CACHE.clear()
+    monkeypatch.setattr(
+        rdp_mod,
+        "_find_native_freerdp",
+        lambda: ("/usr/bin/xfreerdp3", "xfreerdp") if native else None,
+    )
+    monkeypatch.setattr(
+        rdp_mod,
+        "_find_flatpak_freerdp",
+        lambda: ("flatpak run com.freerdp.FreeRDP", "flatpak") if flatpak else None,
+    )
+
+
+def test_find_freerdp_auto_prefers_flatpak_when_both_present(monkeypatch):
+    from winpodx.core.rdp import find_freerdp
+
+    _patch_freerdp_probes(monkeypatch, native=True, flatpak=True)
+    assert find_freerdp("auto") == ("flatpak run com.freerdp.FreeRDP", "flatpak")
+
+
+def test_find_freerdp_auto_falls_back_to_native(monkeypatch):
+    from winpodx.core.rdp import find_freerdp
+
+    _patch_freerdp_probes(monkeypatch, native=True, flatpak=False)
+    assert find_freerdp("auto") == ("/usr/bin/xfreerdp3", "xfreerdp")
+
+
+def test_find_freerdp_native_forced_ignores_flatpak(monkeypatch):
+    from winpodx.core.rdp import find_freerdp
+
+    _patch_freerdp_probes(monkeypatch, native=True, flatpak=True)
+    assert find_freerdp("native") == ("/usr/bin/xfreerdp3", "xfreerdp")
+
+
+def test_find_freerdp_native_forced_falls_back_to_flatpak(monkeypatch):
+    from winpodx.core.rdp import find_freerdp
+
+    _patch_freerdp_probes(monkeypatch, native=False, flatpak=True)
+    assert find_freerdp("native") == ("flatpak run com.freerdp.FreeRDP", "flatpak")
+
+
+def test_find_freerdp_flatpak_forced(monkeypatch):
+    from winpodx.core.rdp import find_freerdp
+
+    _patch_freerdp_probes(monkeypatch, native=True, flatpak=True)
+    assert find_freerdp("flatpak") == ("flatpak run com.freerdp.FreeRDP", "flatpak")
 
 
 def test_find_existing_session_rejects_non_freerdp_pid(tmp_path, monkeypatch):
@@ -179,14 +231,14 @@ class TestBuildRdpCommand:
         return c
 
     def test_raises_without_freerdp(self, cfg, monkeypatch):
-        monkeypatch.setattr("winpodx.core.rdp.find_freerdp", lambda: None)
+        monkeypatch.setattr("winpodx.core.rdp.find_freerdp", lambda *a, **k: None)
         with pytest.raises(RuntimeError, match="FreeRDP 3\\+ not found"):
             build_rdp_command(cfg)
 
     def test_basic_command_structure(self, cfg, monkeypatch):
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
-            lambda: ("/usr/bin/xfreerdp3", "xfreerdp"),
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
         )
         cmd, password = build_rdp_command(cfg)
         assert password == ""  # password embedded in /p: flag
@@ -200,7 +252,7 @@ class TestBuildRdpCommand:
     def test_remote_ip_uses_tofu(self, cfg, monkeypatch):
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
-            lambda: ("/usr/bin/xfreerdp3", "xfreerdp"),
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
         )
         cfg.rdp.ip = "192.168.1.100"
         cmd, _ = build_rdp_command(cfg)
@@ -216,7 +268,7 @@ class TestBuildRdpCommand:
         3.24.1 (2026-05-14)."""
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
-            lambda: ("/usr/bin/xfreerdp3", "xfreerdp"),
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
         )
         monkeypatch.setattr("winpodx.core.rdp.freerdp_major_version", lambda: 3)
         cmd, _ = build_rdp_command(cfg, app_executable="notepad.exe")
@@ -234,7 +286,7 @@ class TestBuildRdpCommand:
         Microsoft Store handler (#158, reported by @poetman)."""
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
-            lambda: ("/usr/bin/xfreerdp", "xfreerdp"),
+            lambda *a, **k: ("/usr/bin/xfreerdp", "xfreerdp"),
         )
         monkeypatch.setattr("winpodx.core.rdp.freerdp_major_version", lambda: 2)
         cmd, _ = build_rdp_command(cfg, app_executable="notepad.exe")
@@ -248,7 +300,7 @@ class TestBuildRdpCommand:
         ``/app:`` arg, with comma-to-space sanitisation."""
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
-            lambda: ("/usr/bin/xfreerdp3", "xfreerdp"),
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
         )
         monkeypatch.setattr("winpodx.core.rdp.freerdp_major_version", lambda: 3)
         cmd, _ = build_rdp_command(
@@ -265,7 +317,7 @@ class TestBuildRdpCommand:
         its own argv entry."""
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
-            lambda: ("/usr/bin/xfreerdp", "xfreerdp"),
+            lambda *a, **k: ("/usr/bin/xfreerdp", "xfreerdp"),
         )
         monkeypatch.setattr("winpodx.core.rdp.freerdp_major_version", lambda: 2)
         cmd, _ = build_rdp_command(
@@ -278,7 +330,7 @@ class TestBuildRdpCommand:
     def test_dpi_flag_when_set(self, cfg, monkeypatch):
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
-            lambda: ("/usr/bin/xfreerdp3", "xfreerdp"),
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
         )
         cfg.rdp.dpi = 150
         cmd, _ = build_rdp_command(cfg)
@@ -287,7 +339,7 @@ class TestBuildRdpCommand:
     def test_dynamic_resolution_flag(self, cfg, monkeypatch):
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
-            lambda: ("/usr/bin/xfreerdp3", "xfreerdp"),
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
         )
         cmd, _ = build_rdp_command(cfg)
         assert "/dynamic-resolution" in cmd
@@ -295,7 +347,7 @@ class TestBuildRdpCommand:
     def test_dynamic_resolution_not_in_app_launch(self, cfg, monkeypatch):
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
-            lambda: ("/usr/bin/xfreerdp3", "xfreerdp"),
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
         )
         cmd, _ = build_rdp_command(
             cfg,
@@ -308,7 +360,7 @@ class TestBuildRdpCommand:
     def test_dpi_flag_omitted_when_zero(self, cfg, monkeypatch):
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
-            lambda: ("/usr/bin/xfreerdp3", "xfreerdp"),
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
         )
         cfg.rdp.dpi = 0
         cmd, _ = build_rdp_command(cfg)
@@ -317,7 +369,7 @@ class TestBuildRdpCommand:
     def test_no_password_no_stdin(self, cfg, monkeypatch):
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
-            lambda: ("/usr/bin/xfreerdp3", "xfreerdp"),
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
         )
         cfg.rdp.password = ""
         cmd, password = build_rdp_command(cfg)
@@ -327,7 +379,7 @@ class TestBuildRdpCommand:
     def test_domain_flag(self, cfg, monkeypatch):
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
-            lambda: ("/usr/bin/xfreerdp3", "xfreerdp"),
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
         )
         cfg.rdp.domain = "WORKGROUP"
         cmd, _ = build_rdp_command(cfg)
@@ -336,7 +388,7 @@ class TestBuildRdpCommand:
     def test_extra_flags_filtered(self, cfg, monkeypatch):
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
-            lambda: ("/usr/bin/xfreerdp3", "xfreerdp"),
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
         )
         cfg.rdp.extra_flags = "/sound:sys:alsa /exec:evil"
         cmd, _ = build_rdp_command(cfg)
@@ -353,7 +405,7 @@ class TestBuildRdpCommand:
         misleading flag never reaches xfreerdp3."""
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
-            lambda: ("/usr/bin/xfreerdp3", "xfreerdp"),
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
         )
         cfg.rdp.extra_flags = "-gfx-h264 +gfx-h264 -rfx +rfx -nsc +nsc -jpeg +jpeg -avc444 +avc444"
         cmd, _ = build_rdp_command(cfg)
@@ -368,7 +420,7 @@ class TestBuildRdpCommand:
         xfreerdp3."""
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
-            lambda: ("/usr/bin/xfreerdp3", "xfreerdp"),
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
         )
         # FreeRDP 3.x cmdline split:
         #   - BOOL flags (`+/-name`): the genuine bare toggles below.
@@ -406,7 +458,7 @@ class TestBuildRdpCommand:
         unsafe."""
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
-            lambda: ("/usr/bin/xfreerdp3", "xfreerdp"),
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
         )
         cfg.rdp.extra_flags = "+gfx-progressive"  # global says: enable
         cmd, _ = build_rdp_command(cfg, extra_args="-gfx-progressive /not-a-real-flag:bad")
@@ -426,7 +478,7 @@ class TestBuildRdpCommand:
         up as an empty-string arg in the FreeRDP command."""
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
-            lambda: ("/usr/bin/xfreerdp3", "xfreerdp"),
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
         )
         cmd_no_extra, _ = build_rdp_command(cfg)
         cmd_empty, _ = build_rdp_command(cfg, extra_args="")

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -166,6 +166,33 @@ class TestHalfUninstalledGuard:
             "existing-config skip path must mark the install initialized (#341)"
         )
 
+    def test_freerdp_source_persisted_on_existing_config(self, tmp_path, monkeypatch):
+        """`winpodx setup --freerdp-source flatpak` on an existing config must
+        persist the preference even on the skip path."""
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr("sys.stdin", MagicMock(isatty=lambda: False))
+        _make_existing_config(tmp_path)
+
+        args = _setup_args(non_interactive=True)
+        args.freerdp_source = "flatpak"
+
+        with (
+            patch("winpodx.cli.setup_cmd.check_all", return_value=_mock_freerdp_ok()),
+            patch("winpodx.cli.setup_cmd.import_winapps_config", return_value=None),
+            patch("winpodx.cli.setup_cmd._ensure_oem_token_staged"),
+            patch(
+                "winpodx.cli.setup_cmd._container_exists_on_backend",
+                return_value=True,
+            ),
+        ):
+            from winpodx.cli.setup_cmd import handle_setup
+
+            handle_setup(args)
+
+        from winpodx.core.config import Config
+
+        assert Config.load().rdp.freerdp_source == "flatpak"
+
     def test_calls_ensure_ready_when_container_missing(self, tmp_path, monkeypatch):
         """Half-uninstalled: config present, container gone → ensure_ready
         is called to recreate the container from compose.yaml."""

--- a/tests/test_transport/test_freerdp.py
+++ b/tests/test_transport/test_freerdp.py
@@ -40,7 +40,7 @@ def patch_freerdp_present(monkeypatch):
 @pytest.fixture
 def patch_freerdp_missing(monkeypatch):
     """find_freerdp() returns None — config error path."""
-    monkeypatch.setattr("winpodx.core.transport.freerdp.find_freerdp", lambda: None)
+    monkeypatch.setattr("winpodx.core.transport.freerdp.find_freerdp", lambda *a, **k: None)
 
 
 class TestHealth:


### PR DESCRIPTION
## Why
From #269 smoke: `install.sh` installed the native `freerdp3` package even when the Flatpak `com.freerdp.FreeRDP` was already present (redundant), and the launcher always picked native first — the wrong default on distros whose native `freerdp3-x11` is broken (#393), where the Flatpak is the working client (#366).

## What
**Runtime (existing installs switch too):**
- `core/rdp.find_freerdp(prefer="auto"|"native"|"flatpak")`. `auto` now **prefers the Flatpak when present**, else native. Split into `_find_native_freerdp` / `_find_flatpak_freerdp`; cache keyed per preference.
- New `cfg.rdp.freerdp_source` (auto/native/flatpak) + serialization; the launch path passes it. `cfg.rdp.freerdp_source = native` is the escape hatch for anyone who wants the native client.

**install.sh:**
- Detect native client / Flatpak client / flatpak runtime **separately**.
- Never install a redundant client — if any FreeRDP is present, install nothing. When none is present, `auto` installs the Flatpak if the flatpak runtime exists, else the native package (best-effort, native fallback if the Flatpak install fails).
- **Custom mode now picks each major dependency's source**: container backend (podman/docker/libvirt), FreeRDP client (auto/native/flatpak), GUI. The resolved source is handed to `winpodx setup --freerdp-source`.

**CLI:** `winpodx setup --freerdp-source <auto|native|flatpak>` persists the choice (fresh + existing-config skip paths).

Builds on the same branch's earlier `/dev/tty` fix that makes the install-mode menu reachable under `curl | bash`.

## Load-bearing note
The `auto` order flip changes FreeRDP selection for **all** installs (existing included) — by design, per maintainer request. Escape hatch: `cfg.rdp.freerdp_source = native`. Needs maintainer smoke.

## Test plan
- [x] Full suite: 1643 passed, 1 skipped.
- [x] `ruff check` + `bash -n install.sh` + `shellcheck -S warning install.sh` clean.
- [x] New tests: find_freerdp prefer matrix (auto-prefers-flatpak / fallbacks / forced native+flatpak), config field validation, `setup --freerdp-source` persistence, install.sh grep-guards (Custom freerdp prompt, no-redundant-install).
- [ ] Maintainer smoke: `curl | bash` Custom mode FreeRDP prompt + flatpak-preferred launch.