### PR TITLE
fix(rdp): Flatpak FreeRDP does per-app RemoteApp, not full desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Flatpak FreeRDP now does per-app RemoteApp instead of opening the full desktop.** `flatpak run com.freerdp.FreeRDP` runs the app's *default* command — the **SDL** client, which has no RAIL (FreeRDP #9078) — so launching a single app via the Flatpak opened the whole Windows desktop / login screen instead of one app window. winpodx now invokes the Flatpak as `flatpak run --command=xfreerdp … com.freerdp.FreeRDP`, forcing the X11 `xfreerdp` binary (the only client with working RAIL), and grants the sandbox the holes every winpodx RDP flag needs so the Flatpak behaves like a native client: `--share=network` (localhost RDP), `--socket=x11`/`--socket=wayland` (RAIL + clipboard), `--socket=pulseaudio` (sound), `--socket=cups` (printer), `--device=dri` (display), and `--filesystem=home` + the removable-media mount roots (`\\tsclient\home` + `\\tsclient\media` drive redirection). Surfaced after 0.6.0 started preferring the Flatpak when present.
+
 ### Changed
 
 - **`install.sh` prints an install plan before it touches the system.** Once the mode (R/A/C/N) and every dependency source are resolved, the installer shows a short plan that lists **every major component evenly** — `python3`, the `venv` probe, the container backend, FreeRDP, `/dev/kvm`, and the GUI — each with its detected state and the action this run will take (use existing / install / host-requirement), plus the exact packages it will install via the distro package manager and the Windows-VM provisioning steps — *before* any package install or `sudo`. The run is transparent instead of jumping straight from the mode prompt into installing things.

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Flatpak FreeRDP 가 이제 풀데스크탑이 아니라 앱별 RemoteApp 을 띄웁니다.** `flatpak run com.freerdp.FreeRDP` 는 앱의 *기본* 명령 — RAIL 없는 **SDL** 클라이언트(FreeRDP #9078) — 를 실행해서, Flatpak 으로 앱 하나를 띄우면 단일 앱 창 대신 Windows 전체 데스크탑/로그인 화면이 떴습니다. 이제 winpodx 가 Flatpak 을 `flatpak run --command=xfreerdp … com.freerdp.FreeRDP` 로 호출해 RAIL 되는 유일한 클라이언트인 X11 `xfreerdp` 바이너리를 강제하고, winpodx 의 모든 RDP 플래그가 필요로 하는 샌드박스 권한을 부여해서 Flatpak 이 네이티브 클라이언트처럼 동작합니다: `--share=network`(로컬 RDP), `--socket=x11`/`--socket=wayland`(RAIL + 클립보드), `--socket=pulseaudio`(사운드), `--socket=cups`(프린터), `--device=dri`(디스플레이), `--filesystem=home` + 이동식 미디어 마운트 루트(`\\tsclient\home` + `\\tsclient\media` 드라이브 리다이렉션). 0.6.0 이 Flatpak 우선 사용을 시작한 뒤 드러났습니다.
+
 ### Changed
 
 - **`install.sh` 가 시스템을 건드리기 전에 설치 플랜을 출력합니다.** 모드(R/A/C/N) 와 모든 의존성 소스가 결정되면, 인스톨러가 **주요 컴포넌트를 균등하게** 나열한 짧은 플랜 — `python3`, `venv` 프로브, 컨테이너 백엔드, FreeRDP, `/dev/kvm`, GUI — 을 각각 감지 상태 + 이번 실행의 동작(기존 사용 / 설치 / 호스트 요구사항)과 함께, 그리고 배포판 패키지 매니저로 설치할 정확한 패키지 목록 + Windows VM 프로비저닝 단계까지 — *어떤 패키지 설치/`sudo` 전에* 보여줍니다. 모드 프롬프트에서 바로 설치로 직행하지 않고 진행 내용이 투명합니다.

--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -232,11 +232,42 @@ def _find_native_freerdp() -> tuple[str, str] | None:
     return None
 
 
+# Flatpak `run` options for com.freerdp.FreeRDP. Two things have to be right or
+# the client silently degrades inside the sandbox:
+#   * --command=xfreerdp — the app's DEFAULT command is the SDL client, which
+#     has NO RAIL (FreeRDP #9078); without this, a RemoteApp launch opens the
+#     full Windows desktop / login screen instead of a single app window. We
+#     force the X11 xfreerdp binary, the only one with working RAIL.
+#   * the sockets / device / network / filesystem holes every winpodx RDP flag
+#     needs, so clipboard / sound / printer / display / drive-redirection
+#     (\\tsclient\home + \\tsclient\media) and the localhost RDP connection all
+#     work the same as a native client:
+#       /v:127.0.0.1     -> --share=network
+#       RAIL + +clipboard -> --socket=x11 (RAIL needs X11/XWayland) + --socket=wayland
+#       /sound           -> --socket=pulseaudio
+#       /printer         -> --socket=cups
+#       /scale + display -> --device=dri
+#       /drive:media + \\tsclient\home -> --filesystem=home + the media mount roots
+_FLATPAK_RUN_OPTS = (
+    "--command=xfreerdp "
+    "--share=network "
+    "--socket=x11 --socket=wayland "
+    "--socket=pulseaudio "
+    "--socket=cups "
+    "--device=dri "
+    "--filesystem=home "
+    "--filesystem=/run/media --filesystem=/media --filesystem=/mnt"
+)
+_FLATPAK_FREERDP_CMD = f"flatpak run {_FLATPAK_RUN_OPTS} com.freerdp.FreeRDP"
+
+
 def _find_flatpak_freerdp() -> tuple[str, str] | None:
     """The Flatpak FreeRDP (``com.freerdp.FreeRDP``) if installed.
 
-    The Flatpak ships ``xfreerdp``, so it has working RAIL just like the
-    native ``xfreerdp`` — it's a first-class client, not a degraded fallback.
+    Returns the full ``flatpak run`` invocation that forces the RAIL-capable
+    ``xfreerdp`` binary and opens the sandbox holes winpodx's RDP flags need
+    (clipboard / sound / printer / display / drive redirection / network) — so
+    the Flatpak behaves like a native client, not a degraded full-desktop one.
     """
     try:
         result = subprocess.run(
@@ -246,7 +277,7 @@ def _find_flatpak_freerdp() -> tuple[str, str] | None:
             timeout=10,
         )
         if result.returncode == 0 and "com.freerdp.FreeRDP" in result.stdout:
-            return ("flatpak run com.freerdp.FreeRDP", "flatpak")
+            return (_FLATPAK_FREERDP_CMD, "flatpak")
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
     return None

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -135,6 +135,27 @@ def test_find_freerdp_flatpak_forced(monkeypatch):
     assert find_freerdp("flatpak") == ("flatpak run com.freerdp.FreeRDP", "flatpak")
 
 
+def test_flatpak_invocation_forces_xfreerdp_and_grants_perms():
+    # The Flatpak default command is the SDL client (no RAIL) -> a RemoteApp
+    # launch would open the full desktop. We must force xfreerdp and open the
+    # sandbox holes winpodx's RDP flags need.
+    from winpodx.core.rdp import _FLATPAK_FREERDP_CMD
+
+    assert _FLATPAK_FREERDP_CMD.startswith("flatpak run ")
+    assert "--command=xfreerdp" in _FLATPAK_FREERDP_CMD  # RAIL-capable client
+    assert _FLATPAK_FREERDP_CMD.endswith(" com.freerdp.FreeRDP")  # app id last
+    for perm in (
+        "--share=network",  # /v: localhost RDP
+        "--socket=x11",  # RAIL + clipboard
+        "--socket=wayland",
+        "--socket=pulseaudio",  # /sound
+        "--socket=cups",  # /printer
+        "--filesystem=home",  # \\tsclient\home + drive redirect
+        "--filesystem=/run/media",  # \\tsclient\media (USB)
+    ):
+        assert perm in _FLATPAK_FREERDP_CMD, f"missing sandbox permission: {perm}"
+
+
 def test_find_existing_session_rejects_non_freerdp_pid(tmp_path, monkeypatch):
     # A non-freerdp process with 'winpodx' in its cmdline must not look like a live RDP session.
     import shutil


### PR DESCRIPTION
## The regression (0.6.0 smoke)
After 0.6.0 started preferring the Flatpak FreeRDP when present, launching a single app via the Flatpak opened the **full Windows desktop / login screen** instead of one app window.

## Root cause
`flatpak run com.freerdp.FreeRDP` runs the app's **default command** — the **SDL** client — which has **no RAIL** (FreeRDP #9078). RemoteApp (per-app windows) only works with `xfreerdp`. The default-command invocation silently used the wrong client.

## Fix
Invoke the Flatpak as `flatpak run --command=xfreerdp … com.freerdp.FreeRDP`, forcing the X11 `xfreerdp` binary, and grant the sandbox the holes every winpodx RDP flag needs so it behaves like a native client:

| winpodx flag | flatpak permission |
|---|---|
| `/v:127.0.0.1:3390` | `--share=network` |
| RAIL `/app:` + `+clipboard` | `--socket=x11` (RAIL needs X11/XWayland) + `--socket=wayland` |
| `/sound:sys:alsa` | `--socket=pulseaudio` |
| `/printer` | `--socket=cups` |
| `/scale` + display | `--device=dri` |
| `/drive:media` + `\\tsclient\home` | `--filesystem=home` + `/run/media` `/media` `/mnt` |

Session tracking is unaffected — `core/process.py` still recognises the cmdline (`com.freerdp.freerdp` present).

## Test plan
- [x] `ruff check` + `ruff format --check` clean.
- [x] `core.process._cmdline_is_freerdp` still recognises the new flatpak cmdline.
- [x] New test pins the forced `--command=xfreerdp` + every granted permission.
- [x] `pytest tests/test_rdp.py tests/test_process.py tests/test_windows_exec.py tests/test_transport/` — passed; full suite running.
- [ ] Maintainer smoke: app launches as a single window via the Flatpak (not full desktop); clipboard / file-open (`\\tsclient`) work.