### PR TITLE
feat(rdp): allow multi-monitor / repaint flags in --extra-args (RAIL window-move corruption)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added
+
+- **`--extra-args` / `cfg.rdp.extra_flags` now allow the multi-monitor + repaint knobs** (`/multimon`, `/multimon:force`, `/span`, `/gdi:sw|hw`, `/smart-sizing[:WxH]`, `/monitors:0,1`), each value-validated. These are the levers for the RAIL window-move corruption some multi-display setups hit (a remote app window blurs / breaks when dragged between monitors of different resolution or DPI) — e.g. `winpodx app run <app> --extra-args="/multimon"` advertises the full host monitor layout to the session so the window stays inside a geometry the guest knows. Override-only for now; a default may be baked in once the winning combination is confirmed.
+
 ### Fixed
 
 - **Upgrades no longer prompt for an install mode or replay the old first-boot log.** Two upgrade/re-run UX warts: (1) `install.sh` showed the `[R]ecommended / [A]utomatic / [C]ustom / [N]o` mode menu even when a winpodx config already existed — pointless, since an upgrade reuses the existing backend/config and runs `migrate`. It now detects the existing install and resolves to Automatic without prompting. (2) `pod wait-ready --logs` (used by the upgrade's migrate path) tailed `podman logs --tail 100`, which on an already-running container replays the *original* first-boot ISO-download + image-build output — under `--verbose` that looked alarmingly like Windows was being re-downloaded on every update. wait-ready now replays no history (`--tail 0`) when the pod is already up (RDP reachable), keeping `--tail 100` only for a genuine fresh boot where the in-progress download is worth showing.

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`--extra-args` / `cfg.rdp.extra_flags` 가 이제 멀티모니터 + 리페인트 knob 을 허용합니다** (`/multimon`, `/multimon:force`, `/span`, `/gdi:sw|hw`, `/smart-sizing[:WxH]`, `/monitors:0,1`), 각각 값 검증됨. 일부 멀티디스플레이 환경의 RAIL 창-이동 깨짐(해상도/DPI 다른 모니터 사이로 창을 끌면 뭉개지거나 깨짐) 해결 레버 — 예: `winpodx app run <app> --extra-args="/multimon"` 는 전체 호스트 모니터 레이아웃을 세션에 광고해 창이 게스트가 아는 geometry 안에 머물게 함. 지금은 override 전용; 최적 조합 확정되면 기본값으로 넣을 수 있음.
+
 ### Fixed
 
 - **업그레이드 시 더 이상 설치 모드를 묻거나 옛 첫부팅 로그를 재생하지 않습니다.** 업그레이드/재실행 UX 두 가지: (1) `install.sh` 가 winpodx config 가 이미 있어도 `[R]ecommended / [A]utomatic / [C]ustom / [N]o` 모드 메뉴를 띄웠음 — 업그레이드는 기존 backend/config 를 재사용하고 `migrate` 를 돌리므로 무의미. 이제 기존 설치를 감지해 프롬프트 없이 Automatic 으로 해결. (2) `pod wait-ready --logs`(업그레이드의 migrate 경로가 사용)가 `podman logs --tail 100` 으로 tail 했는데, 이미 떠있는 컨테이너에선 *원래* 첫부팅 ISO 다운로드 + 이미지 빌드 출력을 재생 — `--verbose` 에선 매 업데이트마다 Windows 를 다시 받는 것처럼 보였음. 이제 pod 가 이미 떠있으면(RDP 도달 가능) 기록을 재생하지 않고(`--tail 0`), 진행 중 다운로드를 보여줄 가치가 있는 진짜 첫부팅에만 `--tail 100` 유지.

--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -603,6 +603,16 @@ _BARE_FLAGS: frozenset[str] = frozenset(
         "-offscreen-cache",
         "+glyph-cache",
         "-glyph-cache",
+        # Multi-monitor / repaint experiments (RAIL window-move corruption,
+        # 2026-05-30). Bare forms; the value forms (/multimon:force, /gdi:sw,
+        # /smart-sizing:WxH, /monitors:0,1) live in _SIMPLE_VALUE_FLAGS below.
+        # `/multimon` advertises the full host monitor layout to the session so
+        # a RAIL window dragged between monitors stays inside a geometry the
+        # guest knows; `/smart-sizing` rescales on the client to fight blur
+        # across mixed-DPI monitors.
+        "/multimon",
+        "/span",
+        "/smart-sizing",
     }
 )
 
@@ -626,6 +636,11 @@ _SIMPLE_VALUE_FLAGS: dict[str, re.Pattern[str]] = {
     "/rfx": re.compile(r"[a-zA-Z0-9_-]{1,32}"),
     # Documented log levels only; rejects wildcard scopes like TRACE:FOO.
     "/log-level": re.compile(r"(OFF|FATAL|ERROR|WARN|INFO|DEBUG|TRACE)", re.IGNORECASE),
+    # Multi-monitor / repaint experiments (RAIL window-move corruption).
+    "/multimon": re.compile(r"force"),  # /multimon:force
+    "/gdi": re.compile(r"(sw|hw)"),  # software vs hardware GDI repaint
+    "/monitors": re.compile(r"[0-9]{1,2}(,[0-9]{1,2}){0,7}"),  # /monitors:0,1
+    "/smart-sizing": re.compile(r"[1-9][0-9]{1,4}x[1-9][0-9]{1,4}"),  # /smart-sizing:WxH
 }
 
 # Device-redirection allowlist; empty set rejects all :value forms.


### PR DESCRIPTION
## Context
Multi-display setups hit RAIL **window-move corruption**: a remote-app window blurs / breaks when dragged between monitors of different resolution or DPI. It reproduces on **both** native and Flatpak xfreerdp → it's a RAIL multi-monitor issue, not a client-choice one (so native-first/flatpak-first doesn't fix it).

## What
Widen the `--extra-args` / `cfg.rdp.extra_flags` allowlist with the relevant, **value-validated** knobs so the fix can be A/B-tested without a code change:
- `/multimon`, `/multimon:force`, `/span` — advertise the full host monitor layout to the session so a RAIL window stays inside a geometry the guest knows.
- `/gdi:sw` | `/gdi:hw` — software vs hardware repaint.
- `/smart-sizing[:WxH]` — client-side rescale across mixed DPIs.
- `/monitors:0,1` — explicit monitor selection.

Each is validated (`/gdi` only `sw|hw`, `/monitors` only int lists, etc.) and injection attempts (`/gdi:sw;rm`, `/monitors:0,/etc`) are rejected.

Override-only for now; a default may be baked into the RAIL launch once the winning combination is confirmed on real hardware.

## Test plan
- [x] `ruff` clean; `pytest tests/test_rdp.py` — 33 passed.
- [x] Validation: the 8 new flag forms pass `_validate_flag`; 5 injection/typo variants are blocked.
- [ ] Maintainer A/B on the real multi-monitor rig (see below).