### PR TITLE
fix(install): flatpak-first FreeRDP label + always-regen compose on upgrade

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -592,17 +592,18 @@ if [ "$FLATPAK_PRESENT" = true ] \
 fi
 # Any client (native or Flatpak) satisfies the requirement, so we never pull a
 # redundant native package when a client is already present (#269). winpodx's
-# launcher prefers the NATIVE xfreerdp when both are present (core/rdp.py) —
-# the Flatpak sandbox has RAIL / multi-display / DPI rough edges — so the
-# reported "kind" mirrors that: native wins the label when both exist.
+# launcher prefers the FLATPAK client when both are present (core/rdp.py
+# auto order is flatpak-first, #401) — so the reported "kind" mirrors that:
+# flatpak wins the label when both exist, so it matches the client the
+# launcher will actually use.
 FREERDP_PRESENT=false
 FREERDP_KIND=""
-if [ "$FREERDP_NATIVE_PRESENT" = true ]; then
-    FREERDP_PRESENT=true
-    FREERDP_KIND="native"
-elif [ "$FREERDP_FLATPAK_PRESENT" = true ]; then
+if [ "$FREERDP_FLATPAK_PRESENT" = true ]; then
     FREERDP_PRESENT=true
     FREERDP_KIND="flatpak (com.freerdp.FreeRDP)"
+elif [ "$FREERDP_NATIVE_PRESENT" = true ]; then
+    FREERDP_PRESENT=true
+    FREERDP_KIND="native"
 fi
 PYTHON3_PRESENT=false
 command -v python3 >/dev/null 2>&1 && PYTHON3_PRESENT=true
@@ -944,13 +945,13 @@ esac
 
 # FreeRDP is required for every backend (the launcher shells out to it).
 # Source resolution (auto | native | flatpak). Custom mode may set
-# WINPODX_FREERDP_SOURCE; default auto. winpodx's launcher prefers the NATIVE
-# xfreerdp (RAIL-proven; the Flatpak sandbox has RAIL / multi-display / DPI
-# rough edges), so auto installs the native package when no client is present.
-# An already-present Flatpak is reused at runtime (find_freerdp falls back to
-# it when there's no native), so we never install a redundant client. Only an
-# explicit `--freerdp-source flatpak` (Custom) installs the Flatpak. The
-# resolved value is handed to `winpodx setup --freerdp-source` -> cfg.rdp.
+# WINPODX_FREERDP_SOURCE; default auto. winpodx's launcher prefers the FLATPAK
+# client when present (flatpak-first auto order, #401). install.sh still
+# installs the lightweight NATIVE package when NO client is present at all --
+# pulling the whole Flatpak runtime during install is heavy, and the launcher
+# uses whatever is there. An already-present Flatpak is reused (never install a
+# redundant client). Only an explicit `--freerdp-source flatpak` (Custom)
+# installs the Flatpak. The resolved value -> `winpodx setup --freerdp-source`.
 WINPODX_FREERDP_SOURCE="${WINPODX_FREERDP_SOURCE:-auto}"
 INSTALL_FREERDP_FLATPAK=false
 case "$WINPODX_FREERDP_SOURCE" in
@@ -961,8 +962,10 @@ case "$WINPODX_FREERDP_SOURCE" in
             [ "$FLATPAK_PRESENT" = false ] && MISSING+=("flatpak")
         fi
         ;;
-    *)  # auto + native: native preferred. Install native only when NO client
-        # (native or Flatpak) is present; an existing Flatpak is reused.
+    *)  # auto: the launcher prefers an existing Flatpak (flatpak-first), but
+        # install the lightweight native package only when NO client (native
+        # or Flatpak) is present — an existing Flatpak is reused, never a
+        # redundant install.
         [ "$FREERDP_PRESENT" = false ] && MISSING+=("freerdp")
         ;;
 esac

--- a/src/winpodx/cli/migrate.py
+++ b/src/winpodx/cli/migrate.py
@@ -657,17 +657,23 @@ def _ensure_canonical_image_pin(non_interactive: bool) -> None:
     from winpodx.core.config import DOCKUR_IMAGE_PIN, Config
 
     cfg = Config.load()
-    if cfg.pod.image == DOCKUR_IMAGE_PIN:
-        return  # already aligned with what a fresh install would write
     if cfg.pod.backend not in ("podman", "docker"):
-        return  # libvirt / manual backends don't use the dockur image
+        return  # the manual backend doesn't use the dockur image / compose
 
-    print("\nAligning container image with this winpodx version...")
-    print(f"  was: {cfg.pod.image}")
-    print(f"  now: {DOCKUR_IMAGE_PIN}")
-    cfg.pod.image = DOCKUR_IMAGE_PIN
-    cfg.save()
+    pin_changed = cfg.pod.image != DOCKUR_IMAGE_PIN
+    if pin_changed:
+        print("\nAligning container image with this winpodx version...")
+        print(f"  was: {cfg.pod.image}")
+        print(f"  now: {DOCKUR_IMAGE_PIN}")
+        cfg.pod.image = DOCKUR_IMAGE_PIN
+        cfg.save()
 
+    # Always regenerate compose.yaml on upgrade — NOT just when the image pin
+    # changed. compose-template features that land in a release without a pin
+    # bump (e.g. the live-USB QMP/cgroup infra, #286) must reach an existing
+    # guest too. generate_compose is idempotent + atomic; the next `pod start`
+    # recreates the container only when the rendered compose actually differs
+    # (storage volume preserved — no ISO redownload, no Sysprep, ~30 s).
     try:
         from winpodx.core.compose import generate_compose
 
@@ -676,13 +682,14 @@ def _ensure_canonical_image_pin(non_interactive: bool) -> None:
         print(f"  warning: compose.yaml regenerate failed ({e})")
         return
 
-    print(
-        "  cfg.pod.image + compose.yaml updated.\n"
-        "  Next `winpodx pod start` will recreate the container so the new\n"
-        "  image pin takes effect (~30 s, storage volume preserved — no ISO\n"
-        "  redownload, no Sysprep). Future dockur :latest pushes won't\n"
-        "  trigger automatic recreates."
-    )
+    if pin_changed:
+        print(
+            "  cfg.pod.image + compose.yaml updated.\n"
+            "  Next `winpodx pod start` will recreate the container so the new\n"
+            "  image pin takes effect (~30 s, storage volume preserved — no ISO\n"
+            "  redownload, no Sysprep). Future dockur :latest pushes won't\n"
+            "  trigger automatic recreates."
+        )
 
 
 def _apply_runtime_fixes_to_existing_guest(non_interactive: bool, *, verbose: bool = False) -> None:


### PR DESCRIPTION
Two install/upgrade-correctness fixes from smoke:

- **FreeRDP label**: `install.sh`'s `FREERDP_KIND` + comments still said the launcher prefers the NATIVE client and labelled "native" when both clients are present. The launcher flipped to flatpak-first in #401, so the install plan showed "native" while the launcher actually used the Flatpak. The label is now flatpak-first (flatpak wins when both present) to match `core/rdp.find_freerdp`. (Installing the native package when NO client is present stays — pulling the Flatpak runtime at install is heavy; the launcher uses whatever is there.)

- **Upgrade picks up compose-template changes automatically**: `winpodx migrate` now ALWAYS regenerates `compose.yaml`, not just when the dockur image pin changed. compose-template features that ship without a pin bump (e.g. the live-USB QMP/cgroup infra, #286) must reach an existing guest too; the next `pod start` (`podman-compose up -d`) recreates the container when the rendered compose differs. So a normal upgrade picks up the live-USB infra with no manual `pod recreate`.

## Tests
91 migrate/install pass; ruff clean. (Full suite running.)