### PR TITLE
fix(devices): auto-migrate recovery-era usb_live=false; surface GUI errors (#286)

### DIFF
--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -33,7 +33,7 @@ from winpodx.utils.toml_writer import dumps as toml_dumps
 # transforms land -- it is a no-op today (0.6.0 introduced the marker without
 # changing the layout) and starts doing real work in 0.7.0+ as the structure
 # evolves. See docs/design/ROADMAP-0.6.0.md item J.
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 # "libvirt" was dropped in 0.6.0 (dockur is QEMU/KVM in a container and now
 # covers device passthrough — #286). An existing config with backend="libvirt"
@@ -1024,7 +1024,15 @@ def _migrate_config(data: dict[str, Any], from_version: int) -> dict[str, Any]:
     Each guarded block is idempotent so a migration that fails halfway and is
     re-run on the next load completes cleanly.
     """
-    # No migrations needed for SCHEMA_VERSION 1; this hook is the marker.
+    if from_version < 2:
+        # usb_live (#286) was briefly defaulted False during a hotfix for a
+        # since-fixed boot crash (the QMP-socket bind / cgroup-rule path). The
+        # field is unreleased, so any persisted ``usb_live = false`` is that
+        # recovery-era artifact rather than a deliberate choice — drop it so the
+        # (now boot-safe) default-on applies automatically on upgrade.
+        pod = data.get("pod")
+        if isinstance(pod, dict) and pod.get("usb_live") is False:
+            pod.pop("usb_live", None)
     return data
 
 

--- a/src/winpodx/gui/_main_window_devices.py
+++ b/src/winpodx/gui/_main_window_devices.py
@@ -218,7 +218,13 @@ class DevicesMixin:
                     D.live_attach(cfg.pod.backend, cfg.pod.container_name, dc)
                     msg += tr("Hot-plugged live.")
                 except D.HmpError as e:
-                    msg += tr("Live attach failed: ") + str(e)
+                    msg += tr("Live attach failed.")
+                    # Surface the failure loudly — don't bury it in the status line.
+                    QMessageBox.critical(
+                        self,
+                        tr("USB hot-plug failed"),
+                        tr("Couldn't hot-plug ") + f"{dc.did}:\n\n{e}",
+                    )
             else:
                 msg += tr("Applies when the guest is running.")
         else:
@@ -244,7 +250,12 @@ class DevicesMixin:
                     D.live_detach(cfg.pod.backend, cfg.pod.container_name, dc)
                     msg += tr("Unplugged live.")
                 except D.HmpError as e:
-                    msg += tr("Live detach failed: ") + str(e)
+                    msg += tr("Live detach failed.")
+                    QMessageBox.critical(
+                        self,
+                        tr("USB unplug failed"),
+                        tr("Couldn't unplug ") + f"{dc.did}:\n\n{e}",
+                    )
         else:
             msg += tr("Restart the pod to apply.")
         self._render_devices()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -111,6 +111,30 @@ def test_pod_config_usb_live_non_bool_coerced():
     assert PodConfig(usb_live=False).usb_live is False
 
 
+def test_migrate_drops_recovery_era_usb_live_false(tmp_path, monkeypatch):
+    # A pre-schema-2 config with the recovery-era `usb_live = false` is
+    # migrated to the (now boot-safe) default-on automatically on load — the
+    # user shouldn't have to flip it back by hand after upgrade.
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    path = Config.path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("schema_version = 1\n\n[pod]\nusb_live = false\n", encoding="utf-8")
+    assert Config.load().pod.usb_live is True
+
+
+def test_migrate_keeps_explicit_usb_live_false_at_current_schema(tmp_path, monkeypatch):
+    # At the current schema, an explicit usb_live=false is a real choice — kept.
+    from winpodx.core.config import SCHEMA_VERSION
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    path = Config.path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"schema_version = {SCHEMA_VERSION}\n\n[pod]\nusb_live = false\n", encoding="utf-8"
+    )
+    assert Config.load().pod.usb_live is False
+
+
 def test_pod_config_backend_validation():
     pod = PodConfig(backend="invalid")
     assert pod.backend == "podman"


### PR DESCRIPTION
Two smoke follow-ups: (1) config migration (schema 1->2) drops a recovery-era `usb_live = false` (from the earlier boot-crash hotfix — unreleased field, not a real choice) so an in-place upgrade auto-restores default-on live USB; an explicit false at the current schema is kept. (2) the GUI Devices tab now pops a QMessageBox on live attach/detach failure instead of burying it in the status line. 1708 tests pass.