### PR TITLE
fix(devices): lift SELinux confinement so QEMU can open passed-through device nodes (#286)

### DIFF
--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -75,7 +75,7 @@ name: "winpodx"
     devices:
 {device_nodes}    cap_add:
       - NET_ADMIN
-"""
+{security_opt}"""
 
 _COMPOSE_PODMAN_EXTRAS = """\
     group_add:
@@ -403,14 +403,44 @@ def _extra_volumes_block(cfg: Config) -> str:
     usb-host``. We do NOT emit a ``device_cgroup_rules`` entry — the
     device-cgroup controller is unavailable to rootless Podman (winpodx's
     default; it errors "device cgroup rules are not supported in rootless
-    mode") and rootless has no cgroup device gate anyway, so the bind-mount +
-    dockur's root QEMU (the host session user via the userns) opening the node
-    is what grants access. No QMP socket is wired here — live attach reuses
-    dockur's own ``-monitor`` (see core/devices). Empty when usb_live=False.
+    mode") and rootless has no cgroup device gate anyway.
+
+    The bind alone is NOT enough on SELinux hosts (openSUSE Tumbleweed,
+    Fedora, RHEL): the container's ``container_t`` domain is denied read on
+    the host ``usb_device_t`` nodes even when the uid/ACL match (verified —
+    ``keep-id`` running as the exact ACL-holder uid still got EACCES). The
+    accompanying ``security_opt: label=disable`` (see :func:`_security_opt_block`)
+    lifts that confinement so QEMU can open the node. No QMP socket is wired
+    here — live attach reuses dockur's own ``-monitor`` (see core/devices).
+    Empty when usb_live=False.
     """
     if not getattr(cfg.pod, "usb_live", True):
         return ""
     return "      - /dev/bus/usb:/dev/bus/usb\n"
+
+
+def _security_opt_block(cfg: Config) -> str:
+    """Build the indented YAML ``security_opt:`` body for device passthrough.
+
+    On SELinux hosts the container's ``container_t`` domain cannot open the
+    bind-mounted ``/dev/bus/usb`` usbfs nodes (USB) or ``/dev/vfio/vfio``
+    (PCI) — the denial is at the MAC layer, independent of uid/ACL/userns
+    (confirmed empirically: a ``keep-id`` container running as the exact
+    ACL-holder uid still got "Permission denied"; ``label=disable`` made the
+    same read succeed). ``label=disable`` drops SELinux confinement for this
+    one container so QEMU can grab the device.
+
+    Scoped to when a passthrough device path is actually exposed (usb_live or
+    a PCI device), so a user who turns the feature off keeps full SELinux
+    confinement. Harmless no-op on non-SELinux hosts (AppArmor / none):
+    Podman just passes the flag through with no effect. Backend-agnostic —
+    Docker on SELinux hosts hits the same wall.
+    """
+    usb = getattr(cfg.pod, "usb_live", True)
+    pci = any(d.dtype == "pci" for d in parse_entries(cfg.pod.devices))
+    if not (usb or pci):
+        return ""
+    return "    security_opt:\n      - label=disable\n"
 
 
 def _build_compose_content(cfg: Config) -> str:
@@ -450,6 +480,7 @@ def _build_compose_content(cfg: Config) -> str:
         agent_port=AGENT_PORT,
         device_nodes=_device_nodes_block(cfg),
         extra_volumes=_extra_volumes_block(cfg),
+        security_opt=_security_opt_block(cfg),
     )
 
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -182,6 +182,10 @@ def test_compose_default_wires_usb_bus():
     out = _build_compose_content(Config())
     assert "- /dev/kvm" in out and "- /dev/net/tun" in out
     assert "- /dev/bus/usb:/dev/bus/usb" in out
+    # SELinux hosts (openSUSE Tumbleweed / Fedora / RHEL) deny container_t
+    # read on the usbfs nodes even with matching uid/ACL — label=disable
+    # lifts that confinement (scoped to this one container). See #286.
+    assert "security_opt:" in out and "- label=disable" in out
     assert "-qmp" not in out
     assert "device_cgroup_rules" not in out
     assert "usb-host" not in out  # never boot-added
@@ -197,6 +201,8 @@ def test_compose_usb_live_off_is_clean():
     out = _build_compose_content(c)
     assert "/dev/bus/usb" not in out
     assert "-qmp" not in out
+    # No device exposure -> keep full SELinux confinement on the container.
+    assert "label=disable" not in out
 
 
 def test_compose_usb_live_opt_in_wires_usb_bus_only():
@@ -212,11 +218,11 @@ def test_compose_usb_live_opt_in_wires_usb_bus_only():
     c.pod.__post_init__()
     out = _build_compose_content(c)
     assert "- /dev/bus/usb:/dev/bus/usb" in out
+    assert "- label=disable" in out  # SELinux confinement lifted for usbfs access
     assert "-qmp" not in out  # reuse dockur's monitor, no custom socket
     assert "qmp.sock" not in out  # no bind-mounted socket
     assert "device_cgroup_rules" not in out
     assert "usb-host" not in out  # USB never boot-added
-    assert "usb-host" not in out
 
 
 def test_compose_pci_boot_adds_vfio_usb_stays_live():
@@ -236,3 +242,20 @@ def test_compose_pci_boot_adds_vfio_usb_stays_live():
     assert "usb-host" not in out
     assert "- /dev/bus/usb:/dev/bus/usb" in out
     assert "-qmp" not in out
+    # PCI (vfio) also needs the SELinux lift to open /dev/vfio.
+    assert "- label=disable" in out
+
+
+def test_compose_pci_only_still_lifts_selinux():
+    # Even with usb_live off, an assigned PCI device exposes /dev/vfio/vfio,
+    # which container_t can't open on SELinux hosts -> label=disable applies.
+    from winpodx.core.config import Config
+    from winpodx.core.pod.compose import _build_compose_content
+
+    c = Config()
+    c.pod.usb_live = False
+    c.pod.devices = ["pci|0000:01:00.0|Card"]
+    c.pod.__post_init__()
+    out = _build_compose_content(c)
+    assert "- /dev/bus/usb" not in out  # usb off
+    assert "- label=disable" in out  # but PCI still needs the lift


### PR DESCRIPTION
On SELinux hosts (openSUSE Tumbleweed, Fedora, RHEL) the container `container_t` domain is denied read on the bind-mounted `/dev/bus/usb` usbfs nodes (USB) and `/dev/vfio/vfio` (PCI) **even when the uid/ACL match** — a `keep-id` container running as the exact ACL-holder uid still got `EACCES`. This was the real reason live USB hot-plug reached QEMUs monitor but QEMU could only build an empty redirector stub: it could never open the host device node. Not a uid/ACL/userns/nodev problem.

## Fix
Add `security_opt: [label=disable]` to the generated compose when a passthrough device path is exposed (`usb_live` or an assigned PCI device).

- Drops SELinux MAC confinement for **this one winpodx container only** — system SELinux stays `enforcing`, no host node is relabeled, every other container keeps full confinement.
- Scoped off when the feature is off; harmless no-op on non-SELinux hosts.
- Backend-agnostic (Docker hits the same wall on SELinux hosts).

## Verification
`label=disable` flips the usbfs node read from `EACCES` to `OK`. Plain bind, `idmap`, `--device`, and `keep-id` all failed without it.

Upgrades pick this up automatically: `winpodx migrate` regenerates compose and `podman-compose up -d` recreates on the diff (storage volume preserved, no ISO redownload) — verified with podman 5.8.2 / podman-compose 1.5.0.

Full suite: 1709 passed, 1 skipped. `ruff` clean.

Refs #286.