### PR TITLE
feat(devices): live USB passthrough via usbredir, bypassing frozen container libusb (#286)

### DIFF
--- a/docs/design/USB-PASSTHROUGH-INVESTIGATION.md
+++ b/docs/design/USB-PASSTHROUGH-INVESTIGATION.md
@@ -1,0 +1,139 @@
+<!-- SPDX-License-Identifier: MIT -->
+# USB passthrough investigation (#286)
+
+Why a YubiKey passes through to the Windows guest but an external USB3
+drive does not, and what it would take to fix it.
+
+Branch: `explore/usb-container-hotplug`. Builds on the `security_opt:
+label=disable` fix already on `main` (PR #411).
+
+## TL;DR
+
+Live USB hot-plug is **not achievable** in winpodx's architecture. dockur
+runs QEMU inside a **rootless Podman container**, and QEMU's libusb device
+list is **frozen at container/QEMU start** — the container's separate
+network namespace (plus no `udevd` / `/run/udev`) means libusb's udev
+netlink hotplug monitor never receives kernel uevents. So `device_add
+usb-host` can only attach a device that was present **and at the same bus
+address** when QEMU started.
+
+VirtualBox / virt-manager succeed because they are **host processes**
+(host netns, live libusb hotplug). The containerization is the difference.
+
+The realistic fix is **boot-time passthrough (recreate-to-attach, like
+PCI)**: pass assigned USB devices on QEMU's start-up command line so the
+fresh boot enumeration grabs them. This is **not yet implemented** —
+it needs a real-hardware smoke test before merge (no blind compose
+changes; that has broken pod boot three times historically).
+
+## The layered walls (each independently necessary)
+
+| # | Wall | Status |
+|---|------|--------|
+| 1 | **SELinux** — `container_t` can't open `usb_device_t` nodes | **Fixed** (#411, `security_opt: label=disable`, scoped to this container) |
+| 2 | **Node write permission** — QEMU usb-host needs `O_RDWR`; udev tags only some classes `uaccess` | Needs a per-device udev rule (sudo, once) |
+| 3 | **Frozen libusb list** — QEMU's device list never updates after start | The real blocker for "live"; requires recreate to refresh |
+
+### Wall 2 — write permission
+
+`udev` grants the active-seat user an `uaccess` ACL only to certain device
+classes (security keys, input, sound, cameras). USB **mass storage**,
+**Bluetooth**, etc. get **no** `uaccess` tag, so their `/dev/bus/usb/BBB/DDD`
+node stays `root:root rw-rw-r--`. The rootless container's user (mapped
+from container-root via the userns) is neither owner nor group, so it gets
+only `other::r--` = **read-only**. QEMU usb-host needs to open the node
+`O_RDWR` to claim interfaces, so it can't.
+
+- YubiKey works because udev tags it `TAGS=...uaccess...` → `user:<you>:rw`.
+- Fix: a per-device udev rule, installed once with sudo, persistent across
+  replug/reboot:
+  ```
+  SUBSYSTEM=="usb", ATTR{idVendor}=="2109", ATTR{idProduct}=="0715", MODE="0660", TAG+="uaccess"
+  ```
+  (`setfacl -m u:<you>:rw <node>` works too but is wiped on every replug —
+  and USB3 devices re-enumerate their address frequently.)
+
+### Wall 3 — the frozen libusb device list (the deep one)
+
+QEMU's `usb-host` backend uses libusb. libusb on Linux keeps its device
+list live via a udev/netlink hotplug monitor thread
+(`udev_monitor_new_from_netlink`). Inside the rootless container that
+monitor receives **no events** — the container is in a separate network
+namespace (kernel uevents are netns-scoped) and there is no `udevd` /
+`/run/udev`. So `libusb_get_device_list` returns the **boot-time
+snapshot**, forever.
+
+**Evidence (independent of any timing/replug coordination):**
+
+HMP probe against the running guest, `device_add usb-host,hostbus=2,hostaddr=N`:
+
+| Device | Host state | QEMU response |
+|--------|-----------|---------------|
+| WD `1058:2626` @ addr 20 (stable since QEMU boot) | present | `failed to **open** 2:20` — **found**, perm-only |
+| SSD `2109:0715` @ addr 30 (re-enumerated after boot) | present (sysfs + fresh `lsusb` both confirm) | `failed to **find** 2:30` — **not in QEMU's list** |
+
+Corroboration: 6+ long-lived libusb monitors (a `ctypes` poller of
+`libusb_get_device_list`) — in the default netns, in `--network=host`, and
+in `--network=host` **with `/run/udev` bind-mounted** — every one stayed
+**frozen within its lifetime**, while the SSD's address churned
+`30→33→34→36→39` *across* runs (proving replugs happened, just never
+visible to a single long-lived context). A **fresh** context (each new
+`lsusb` / monitor) always sees the current state. So it is specifically
+the long-lived (QEMU) context that goes stale.
+
+Notes:
+- USB3 is not special per se — `qemu-xhci` has `p3=7` SuperSpeed ports, and
+  the (stable) USB3 WD **is** in QEMU's list. The killer is post-boot
+  address churn + the frozen list. USB3 just churns more (link re-training).
+- `--network=host` + `/run/udev` mount did **not** restore hotplug in
+  testing. (It may be theoretically possible with a running udevd in the
+  right netns, but it would break winpodx's `127.0.0.1:port` mapping model
+  and was not made to work.)
+
+## Consequence
+
+`device_add usb-host` for a device not in QEMU's frozen list produces an
+empty **1.5 Mb/s "USB Host Device"** stub — it never opens the real device.
+The YubiKey "works live" only because it was present + stable at QEMU start.
+
+So the current `usb_live` live-attach design (monitor `device_add` at
+runtime) cannot work for the general case.
+
+## Proposed fix — boot-time passthrough (recreate-to-attach)
+
+Treat USB like PCI: pass assigned USB devices on QEMU's **start-up** args so
+the fresh boot enumeration grabs them.
+
+- `compose._qemu_arguments_for_host` already has the builder
+  (`devices.qemu_device_args` emits `-device usb-host,vendorid=0x..,productid=0x..`)
+  but only calls it for PCI. Extend it to USB.
+- Match by **vendorid/productid** (not hostbus/hostaddr) so an absent device
+  yields a pending device rather than aborting boot.
+- Target dockur's controller: `bus=xhci.0` — **verify ordering**: our
+  `ARGUMENTS` must be appended after dockur emits `-device qemu-xhci,id=xhci`,
+  or `bus=xhci.0` won't resolve.
+- Requires the node writable at boot → the Wall-2 udev rule.
+- UX change: USB attach becomes **recreate-on-attach** (like PCI), not live.
+  Update `cli/device.py` + the GUI Devices tab messaging; revisit the
+  `usb_live` flag semantics.
+
+### Open questions to settle on real hardware (before merge)
+
+1. Does `-device usb-host,vendorid=,productid=` abort QEMU boot when the
+   device is absent, or create a pending device? (Determines whether we can
+   always emit it or must gate on presence.)
+2. Does `bus=xhci.0` resolve from `ARGUMENTS`, or do we need our own
+   controller?
+3. Does a boot-added device actually appear in Windows end-to-end (not just
+   a stub)?
+4. Address-churning devices (some USB3 bridges/docks re-enumerate
+   repeatedly) may still miss the boot enumeration window — acceptable?
+
+## What works today (shipped on main)
+
+- `uaccess` USB2 devices (security keys) attach **live**.
+- The `security_opt: label=disable` SELinux lift (#411).
+- For files on an external drive, FreeRDP drive redirection
+  (`\\tsclient\media`, already wired) is the right tool and works for any
+  filesystem — raw passthrough of a LUKS/ext4 disk is useless to Windows
+  anyway.

--- a/docs/design/USB-PASSTHROUGH-INVESTIGATION.md
+++ b/docs/design/USB-PASSTHROUGH-INVESTIGATION.md
@@ -9,22 +9,23 @@ label=disable` fix already on `main` (PR #411).
 
 ## TL;DR
 
-Live USB hot-plug is **not achievable** in winpodx's architecture. dockur
-runs QEMU inside a **rootless Podman container**, and QEMU's libusb device
-list is **frozen at container/QEMU start** — the container's separate
+Live USB hot-plug via **QEMU's own `usb-host`** is not achievable here:
+dockur runs QEMU inside a **rootless Podman container**, and QEMU's libusb
+device list is **frozen at container/QEMU start** — the container's separate
 network namespace (plus no `udevd` / `/run/udev`) means libusb's udev
 netlink hotplug monitor never receives kernel uevents. So `device_add
-usb-host` can only attach a device that was present **and at the same bus
-address** when QEMU started.
+usb-host` can only attach a device present **and at the same bus address**
+as at QEMU start. VirtualBox / virt-manager succeed because they are **host
+processes** (host netns, live libusb hotplug) — the containerization is the
+difference.
 
-VirtualBox / virt-manager succeed because they are **host processes**
-(host netns, live libusb hotplug). The containerization is the difference.
-
-The realistic fix is **boot-time passthrough (recreate-to-attach, like
-PCI)**: pass assigned USB devices on QEMU's start-up command line so the
-fresh boot enumeration grabs them. This is **not yet implemented** —
-it needs a real-hardware smoke test before merge (no blind compose
-changes; that has broken pod boot three times historically).
+**But live IS achievable by bypassing the container:** redirect USB from a
+**host** process (`usbredirect`) into a QEMU `usb-redir` socket channel —
+the host process has live libusb hotplug, so attach/detach is truly live.
+Write access needs no persistent udev rule — run just `usbredirect` under
+`pkexec`/`sudo` at attach time (transient root, nothing persistent touched).
+See "Live fix that bypasses the container" below. Feasible at every layer
+tested; end-to-end (device-in-Windows) not yet smoke-verified.
 
 ## The layered walls (each independently necessary)
 
@@ -128,6 +129,63 @@ the fresh boot enumeration grabs them.
    a stub)?
 4. Address-churning devices (some USB3 bridges/docks re-enumerate
    repeatedly) may still miss the boot enumeration window — acceptable?
+
+## Live fix that bypasses the container — usbredir + transient root
+
+The frozen-libusb wall only applies to QEMU **inside** the container. A
+**host** process has live libusb hotplug (that's why VirtualBox /
+virt-manager work). So redirect USB from the host:
+
+```
+[host] usbredirect --device VID:PID  <--socket-->  [qemu] usb-redir chardev  -->  Windows (native driver)
+       ^ host process => live libusb hotplug => true live attach/detach
+```
+
+- QEMU side: `-chardev socket,id=urN,... -device usb-redir,chardev=urN`.
+  Confirmed: dockur's QEMU has the `usb-redir` device; the channel can even
+  be added to a running guest via HMP `chardev-add` + `device_add usb-redir`
+  (no recreate). USB-over-socket is the same mechanism SPICE uses.
+- Host side: `usbredirect` (openSUSE `usbredir` package) grabs the device
+  with the **host's** libusb and pipes it to QEMU. Live: spawn = attach,
+  kill = detach.
+- **Write permission, without a persistent system change** (the user does
+  not want to touch udev rules): run **just `usbredirect`** under
+  `pkexec`/`sudo` at attach time. Root opens the root-owned device node
+  directly — no udev rule, no group, nothing persistent. The privileged
+  process is one small short-lived USB forwarder, not winpodx. (Contrast:
+  VirtualBox ships a broad install-time udev rule + `vboxusers` group; we
+  can avoid that entirely with transient root.)
+- Windows guest sees the **real device with its native driver** (URB-level
+  redirection), not a translated/class share.
+
+### Transport snag (the one open item)
+
+The usbredir socket must be reachable host<->container. On this host the
+podman bridge firewall blocks **both** directions for arbitrary ports
+(host->10.89.0.2:port refused; container->10.89.0.1:port refused). So the
+socket has to ride winpodx's existing **compose `ports:` mapping**
+(`127.0.0.1:<port>:<port>`, same as RDP/VNC/agent) — which means a
+**one-time recreate** to add the `usb-redir` channel + port-map. After
+that, attach/detach is fully live via `usbredirect`. (The HMP live-add of
+the channel works but is moot until the socket is reachable.)
+
+### Status
+
+Feasible at every layer tested (QEMU `usb-redir` ✓, HMP channel-add ✓, host
+`usbredirect` ✓, `pkexec` ✓, transient-root model ✓). **End-to-end not yet
+verified** — device-appears-in-Windows needs the port-mapped socket wired
+(one recreate) + a real smoke. No blind compose change before that smoke.
+
+### Proposed winpodx integration
+
+1. compose: add a `usb-redir` chardev (socket server) + `127.0.0.1:<port>:<port>`
+   map per concurrent USB slot (e.g. 4 slots). One-time recreate when the
+   feature is enabled.
+2. `device attach <usb>`: spawn `pkexec usbredirect --device <vid:pid> --to
+   tcp:127.0.0.1:<port>` (transient root, no persistent change). `detach`:
+   kill that process. Replaces the broken qemu-libusb `live_attach`.
+3. GUI Devices tab drives the same; surface the pkexec prompt / failures.
+4. Security keys etc. (uaccess) can still use the existing path without root.
 
 ## What works today (shipped on main)
 

--- a/src/winpodx/cli/device.py
+++ b/src/winpodx/cli/device.py
@@ -213,31 +213,33 @@ def _detach(args: argparse.Namespace) -> None:
 
 
 def _live_unavailable_reason(cfg: Config) -> str | None:
-    """Return why live USB isn't available (for diagnostics), or None if it is."""
-    if not getattr(cfg.pod, "usb_live", True):
-        return (
-            "usb_live is disabled in config — set `usb_live = true` and "
-            "`winpodx pod recreate` to expose the host USB bus to the guest"
-        )
+    """Return why live USB isn't available (for diagnostics), or None if it is.
+
+    Live USB now rides usbredir (host ``usbredirect`` -> QEMU ``usb-redir``
+    socket), which needs neither the ``/dev/bus/usb`` bind nor ``usb_live`` —
+    the host side opens the device, not the container. So the only gate is the
+    guest being up.
+    """
     if not _guest_running(cfg):
         return "the guest isn't running"
     return None
 
 
 def _apply_usb_attach(cfg: Config, dc: D.DeviceConfig) -> None:
-    """Hot-plug a USB device into the running guest via dockur's QEMU monitor
-    (no restart). Prints exactly what happened so a failure is visible."""
+    """Live-attach a USB device into the running guest via usbredir (no
+    restart). A host ``usbredirect`` runs under pkexec/sudo to open the device,
+    so a password prompt may appear. Prints exactly what happened."""
     reason = _live_unavailable_reason(cfg)
     if reason is not None:
         print(f"  Persisted; live attach skipped because {reason}.")
         return
-    print("  Hot-plugging via the QEMU monitor …")
+    print("  Live-attaching via usbredir (you may be prompted for your password) …")
     try:
         D.live_attach(cfg.pod.backend, cfg.pod.container_name, dc)
-        print("  Hot-plugged into the running guest (live, no restart).")
+        print("  Redirected into the running guest (live, no restart).")
     except D.HmpError as e:
         print(f"  Live attach FAILED: {e}")
-        print("  (Persisted. Check `podman logs` / that the device is plugged in.)")
+        print("  (Persisted. Check that the device is plugged in + usbredir is installed.)")
 
 
 def _apply_usb_detach(cfg: Config, dc: D.DeviceConfig) -> None:
@@ -245,7 +247,7 @@ def _apply_usb_detach(cfg: Config, dc: D.DeviceConfig) -> None:
     if reason is not None:
         print(f"  Un-persisted; live detach skipped because {reason}.")
         return
-    print("  Unplugging via the QEMU monitor …")
+    print("  Unplugging (tearing down the usbredir session) …")
     try:
         D.live_detach(cfg.pod.backend, cfg.pod.container_name, dc)
         print("  Unplugged from the running guest (live).")

--- a/src/winpodx/core/devices.py
+++ b/src/winpodx/core/devices.py
@@ -380,27 +380,31 @@ def _hmp_raise_on_error(reply: str, action: str, dev: DeviceConfig) -> None:
 
 
 def live_attach(backend: str, container: str, dev: DeviceConfig) -> None:
-    """Hot-plug a USB device into the running guest via the QEMU monitor
-    (``device_add usb-host``). Raises :class:`HmpError` on failure. PCI is not
-    supported live — pass it via a recreate."""
+    """Live-attach a USB device to the running guest.
+
+    Delegates to the **usbredir** path (``core.usbredir``): a host
+    ``usbredirect`` feeds a QEMU ``usb-redir`` socket channel. We do NOT use
+    ``device_add usb-host`` — QEMU's in-container libusb is frozen at boot (the
+    container's netns/userns block USB hotplug), so a runtime ``usb-host`` only
+    yields an empty stub. The usbredir grab runs host-side where libusb hotplug
+    works, so this is truly live. Raises :class:`HmpError` on failure. PCI is
+    not supported live — pass it via a recreate.
+    """
     if dev.dtype != "usb":
         raise HmpError(f"live attach only supports USB devices, not {dev.dtype!r}")
-    vid, pid = dev.did.split(":")
-    cmd = (
-        f"device_add usb-host,vendorid=0x{vid},productid=0x{pid},"
-        f"id={usb_qom_id(dev)},bus={DOCKUR_USB_BUS}"
-    )
-    log.info("HMP live-attach usb %s", dev.did)
-    _hmp_raise_on_error(hmp_command(backend, container, cmd), "attach", dev)
-    log.info("HMP live-attach usb %s ok", dev.did)
+    from winpodx.core import usbredir
+
+    log.info("usbredir live-attach usb %s", dev.did)
+    usbredir.attach(backend, container, dev)
+    log.info("usbredir live-attach usb %s ok", dev.did)
 
 
 def live_detach(backend: str, container: str, dev: DeviceConfig) -> None:
-    """Unplug a previously hot-plugged USB device via ``device_del``."""
+    """Tear down the live usbredir session for a USB device (idempotent)."""
     if dev.dtype != "usb":
         raise HmpError(f"live detach only supports USB devices, not {dev.dtype!r}")
-    log.info("HMP live-detach usb %s", dev.did)
-    _hmp_raise_on_error(
-        hmp_command(backend, container, f"device_del {usb_qom_id(dev)}"), "detach", dev
-    )
-    log.info("HMP live-detach usb %s ok", dev.did)
+    from winpodx.core import usbredir
+
+    log.info("usbredir live-detach usb %s", dev.did)
+    usbredir.detach(backend, container, dev)
+    log.info("usbredir live-detach usb %s ok", dev.did)

--- a/src/winpodx/core/usbredir.py
+++ b/src/winpodx/core/usbredir.py
@@ -1,0 +1,460 @@
+# SPDX-License-Identifier: MIT
+"""Live USB passthrough via usbredir — bypasses the container's frozen libusb.
+
+Why not ``device_add usb-host``: dockur runs QEMU inside a rootless Podman
+container whose netns/userns block kernel USB uevents, so QEMU's in-process
+libusb never sees hotplug — its device list is frozen at boot and a runtime
+``device_add usb-host`` for anything not present-at-boot yields an empty stub.
+See ``docs/design/USB-PASSTHROUGH-INVESTIGATION.md``.
+
+What works (verified live on a USB3 SuperSpeed device): redirect from the
+**host**, which has live libusb hotplug.
+
+    [host] usbredirect --device VID:PID  <->  relay  <->  [qemu] usb-redir chardev  ->  Windows
+
+* QEMU side: a ``usb-redir`` device backed by a socket ``chardev``, added to
+  the *running* guest via HMP ``chardev-add`` + ``device_add`` — no recreate.
+* The socket lives on the container's loopback; the host reaches it through the
+  same ``<backend> exec ... /dev/tcp`` transport winpodx already uses for the
+  monitor (so no compose ``ports:`` map, no recreate). A small **relay**
+  process bridges a host-loopback port to it.
+* Host ``usbredirect`` grabs the device with the host's libusb and speaks the
+  usbredir protocol over that socket. Spawn = attach, exit = detach → live.
+* Opening a root-owned device node needs privilege for **just usbredirect** —
+  run it under ``pkexec``/``sudo`` at attach time. No persistent udev rule, no
+  group, nothing installed; the only privileged process is one short-lived USB
+  forwarder. (uaccess devices like security keys don't even need that.)
+
+State for each attached device is tracked in ``<data>/usbredir/<id>.json`` so a
+later ``detach`` (a separate process) can tear it down.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+from winpodx.core.devices import (
+    DeviceConfig,
+    HmpError,
+    hmp_command,
+)
+
+log = logging.getLogger(__name__)
+
+# Port ranges. The qemu port is on the *container* loopback (only has to avoid
+# dockur's own: 3389 RDP, 8006 VNC, 8765 agent, 7100 monitor). The host port is
+# on the host loopback. They live in different namespaces so the two ranges may
+# overlap numerically without conflict; we keep them distinct for clarity.
+_QEMU_PORT_BASE = 7310
+_HOST_PORT_BASE = 7410
+_MAX_SLOTS = 16  # generous cap on concurrent redirected USB devices
+
+
+def _state_dir() -> Path:
+    from winpodx.utils.paths import data_dir
+
+    d = data_dir() / "usbredir"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _qom_id(dev: DeviceConfig) -> str:
+    """Stable QOM/chardev id for a redirected device (add + del use it)."""
+    return "wpxur-" + dev.did.replace(":", "")
+
+
+def _state_path(dev: DeviceConfig) -> Path:
+    return _state_dir() / f"{_qom_id(dev)}.json"
+
+
+def _proc_alive(pid: int | None) -> bool:
+    if not pid:
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Dependency + slot helpers
+# ---------------------------------------------------------------------------
+
+
+def usbredirect_path() -> str | None:
+    """Return the host ``usbredirect`` binary, or None if not installed."""
+    return shutil.which("usbredirect")
+
+
+def _privilege_wrapper() -> list[str] | None:
+    """Return the command prefix that runs ``usbredirect`` as root.
+
+    Prefers ``pkexec`` (graphical polkit prompt, right for the GUI) when a
+    display is present, else ``sudo`` (terminal prompt). Returns ``None`` if
+    neither is available.
+    """
+    has_display = bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+    pkexec = shutil.which("pkexec")
+    sudo = shutil.which("sudo")
+    if has_display and pkexec:
+        return [pkexec]
+    if sudo:
+        return [sudo]
+    if pkexec:
+        return [pkexec]
+    return None
+
+
+def _active_slots() -> set[int]:
+    used: set[int] = set()
+    for f in _state_dir().glob("*.json"):
+        try:
+            used.add(int(json.loads(f.read_text()).get("slot", -1)))
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+    used.discard(-1)
+    return used
+
+
+def _alloc_slot() -> int:
+    used = _active_slots()
+    for slot in range(_MAX_SLOTS):
+        if slot not in used:
+            return slot
+    raise HmpError(f"too many USB devices redirected at once (max {_MAX_SLOTS})")
+
+
+# ---------------------------------------------------------------------------
+# The relay (run as a detached child: `python -m winpodx.core.usbredir relay …`)
+# ---------------------------------------------------------------------------
+
+
+def _run_relay(backend: str, container: str, qemu_port: int, host_port: int) -> int:
+    """Bridge a host-loopback TCP port to the container's QEMU usb-redir socket.
+
+    Listens on ``127.0.0.1:host_port``; on the first connection (from
+    ``usbredirect``) it opens the container's ``127.0.0.1:qemu_port`` via
+    ``<backend> exec ... /dev/tcp`` and shuttles bytes both ways until either
+    side closes. One-shot: exits when that single session ends (usbredirect
+    does not reconnect; winpodx tears the relay down on detach).
+    """
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", host_port))
+    srv.listen(1)
+    print(f"relay up 127.0.0.1:{host_port} <-> {container}:{qemu_port}", flush=True)
+    try:
+        conn, _addr = srv.accept()
+    except OSError:
+        return 0
+    bridge = subprocess.Popen(
+        [
+            backend,
+            "exec",
+            "-i",
+            container,
+            "bash",
+            "-c",
+            f"exec 3<>/dev/tcp/127.0.0.1/{qemu_port}; cat <&3 & cat >&3",
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        bufsize=0,
+    )
+
+    def _sock_to_bridge() -> None:
+        try:
+            while True:
+                data = conn.recv(65536)
+                if not data:
+                    break
+                assert bridge.stdin is not None
+                bridge.stdin.write(data)
+        except OSError:
+            pass
+        finally:
+            try:
+                assert bridge.stdin is not None
+                bridge.stdin.close()
+            except OSError:
+                pass
+
+    def _bridge_to_sock() -> None:
+        try:
+            assert bridge.stdout is not None
+            fd = bridge.stdout.fileno()
+            while True:
+                data = os.read(fd, 65536)
+                if not data:
+                    break
+                conn.sendall(data)
+        except OSError:
+            pass
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
+
+    t1 = threading.Thread(target=_sock_to_bridge, daemon=True)
+    t2 = threading.Thread(target=_bridge_to_sock, daemon=True)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+    try:
+        bridge.terminate()
+    except OSError:
+        pass
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Attach / detach
+# ---------------------------------------------------------------------------
+
+
+def is_attached(dev: DeviceConfig) -> bool:
+    """True if a live redirection session for *dev* is recorded and running."""
+    path = _state_path(dev)
+    if not path.exists():
+        return False
+    try:
+        state = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    return _proc_alive(state.get("relay_pid"))
+
+
+def attach(backend: str, container: str, dev: DeviceConfig) -> None:
+    """Start a live usbredir session redirecting *dev* into the running guest.
+
+    Raises :class:`HmpError` on any failure (after cleaning up partial state).
+    """
+    if dev.dtype != "usb":
+        raise HmpError(f"usbredir attach only supports USB devices, not {dev.dtype!r}")
+    if is_attached(dev):
+        log.info("usbredir: %s already attached", dev.did)
+        return
+
+    ured = usbredirect_path()
+    if not ured:
+        raise HmpError(
+            "usbredirect not found. Install the host 'usbredir' package "
+            "(openSUSE: sudo zypper install usbredir; Fedora: usbredir; "
+            "Debian/Ubuntu: usbredir)."
+        )
+    priv = _privilege_wrapper()
+    if priv is None:
+        raise HmpError("neither pkexec nor sudo found — cannot open the USB device as root")
+
+    vid, pid = dev.did.split(":")
+    qom = _qom_id(dev)
+    slot = _alloc_slot()
+    qemu_port = _QEMU_PORT_BASE + slot
+    host_port = _HOST_PORT_BASE + slot
+
+    # 1) Add the usb-redir channel to the running guest (live, no recreate).
+    #    chardev = socket SERVER on the container's loopback; the relay dials in.
+    chardev_cmd = f"chardev-add socket,id={qom},host=127.0.0.1,port={qemu_port},server=on,wait=off"
+    reply = hmp_command(backend, container, chardev_cmd)
+    if _looks_like_error(reply):
+        raise HmpError(f"chardev-add for {dev.did} failed: {_tail(reply)}")
+    dev_cmd = f"device_add usb-redir,chardev={qom},id={qom}"
+    reply = hmp_command(backend, container, dev_cmd)
+    if _looks_like_error(reply):
+        _hmp_cleanup(backend, container, qom, drop_device=False)
+        raise HmpError(f"device_add usb-redir for {dev.did} failed: {_tail(reply)}")
+
+    relay_log = _state_dir() / f"{qom}.relay.log"
+    ured_log = _state_dir() / f"{qom}.usbredirect.log"
+    relay_proc = None
+    ured_proc = None
+    try:
+        # 2) Relay: host:host_port <-> container:qemu_port (detached).
+        relay_proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "winpodx.core.usbredir",
+                "relay",
+                backend,
+                container,
+                str(qemu_port),
+                str(host_port),
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=open(relay_log, "wb"),
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        _wait_port(host_port, timeout=5.0)
+
+        # 3) usbredirect (root, transient) grabs the device + connects to relay.
+        ured_proc = subprocess.Popen(
+            [*priv, ured, "--device", dev.did, "--to", f"127.0.0.1:{host_port}"],
+            stdin=subprocess.DEVNULL,
+            stdout=open(ured_log, "wb"),
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+
+        # 4) Confirm the channel actually connected (usbredirect reached qemu).
+        #    Generous timeout: a pkexec/polkit password dialog can take a while
+        #    to authenticate before usbredirect even starts grabbing the device.
+        if not _wait_chardev_connected(backend, container, qom, timeout=45.0):
+            raise HmpError(
+                f"usbredir channel for {dev.did} never connected — "
+                f"see {ured_log} (auth declined? device busy? not present?)"
+            )
+
+        _state_path(dev).write_text(
+            json.dumps(
+                {
+                    "did": dev.did,
+                    "qom": qom,
+                    "slot": slot,
+                    "qemu_port": qemu_port,
+                    "host_port": host_port,
+                    "relay_pid": relay_proc.pid,
+                    "usbredirect_pid": ured_proc.pid,
+                }
+            )
+        )
+        log.info("usbredir attach %s ok (slot %d)", dev.did, slot)
+    except Exception:
+        # Roll everything back so a failed attach leaves no orphans.
+        _kill(relay_proc)
+        _kill(ured_proc)
+        _hmp_cleanup(backend, container, qom, drop_device=True)
+        raise
+
+
+def detach(backend: str, container: str, dev: DeviceConfig) -> None:
+    """Tear down the live usbredir session for *dev* (idempotent)."""
+    if dev.dtype != "usb":
+        raise HmpError(f"usbredir detach only supports USB devices, not {dev.dtype!r}")
+    path = _state_path(dev)
+    qom = _qom_id(dev)
+    state: dict = {}
+    if path.exists():
+        try:
+            state = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            state = {}
+
+    # Killing the (user-owned) relay closes the socket; usbredirect exits on
+    # its own when its connection drops, so we don't need root to detach.
+    _kill_pid(state.get("relay_pid"))
+    time.sleep(0.3)
+    if _proc_alive(state.get("usbredirect_pid")):
+        # usbredirect didn't exit on socket close — it's root, so escalate.
+        _kill_pid(state.get("usbredirect_pid"), privileged=True)
+
+    _hmp_cleanup(backend, container, qom, drop_device=True)
+    path.unlink(missing_ok=True)
+    log.info("usbredir detach %s ok", dev.did)
+
+
+# ---------------------------------------------------------------------------
+# small helpers
+# ---------------------------------------------------------------------------
+
+_ERR_TOKENS = ("error", "could not", "failed", "no such", "unable", "cannot")
+
+
+def _looks_like_error(reply: str) -> bool:
+    low = " ".join(reply.split()).lower()
+    return any(tok in low for tok in _ERR_TOKENS)
+
+
+def _tail(reply: str) -> str:
+    return " ".join(reply.split())[-200:]
+
+
+def _wait_port(port: int, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.2)
+    raise HmpError(f"relay never came up on 127.0.0.1:{port}")
+
+
+def _wait_chardev_connected(backend: str, container: str, qom: str, timeout: float) -> bool:
+    """Poll ``info chardev`` until the usb-redir socket shows a peer (``<->``)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            reply = hmp_command(backend, container, "info chardev")
+        except HmpError:
+            reply = ""
+        for line in reply.replace("\r", "").splitlines():
+            if qom in line and "<->" in line and "disconnected" not in line:
+                return True
+        time.sleep(0.6)
+    return False
+
+
+def _hmp_cleanup(backend: str, container: str, qom: str, *, drop_device: bool) -> None:
+    """Best-effort removal of the usb-redir device + chardev from the guest."""
+    try:
+        if drop_device:
+            hmp_command(backend, container, f"device_del {qom}")
+            time.sleep(0.3)
+        hmp_command(backend, container, f"chardev-remove {qom}")
+    except HmpError as e:
+        log.warning("usbredir cleanup of %s incomplete: %s", qom, e)
+
+
+def _kill(proc: subprocess.Popen | None) -> None:
+    if proc is None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+    except OSError:
+        try:
+            proc.terminate()
+        except OSError:
+            pass
+
+
+def _kill_pid(pid: int | None, *, privileged: bool = False) -> None:
+    if not pid:
+        return
+    if privileged:
+        priv = _privilege_wrapper()
+        if priv:
+            subprocess.run([*priv, "kill", str(pid)], check=False)
+        return
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError:
+        pass
+
+
+def _main(argv: list[str]) -> int:
+    if len(argv) >= 5 and argv[0] == "relay":
+        return _run_relay(argv[1], argv[2], int(argv[3]), int(argv[4]))
+    print(
+        "usage: python -m winpodx.core.usbredir relay <backend> <container> <qport> <hport>",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv[1:]))

--- a/src/winpodx/gui/_main_window_devices.py
+++ b/src/winpodx/gui/_main_window_devices.py
@@ -211,9 +211,7 @@ class DevicesMixin:
 
         msg = tr("Assigned ") + f"{dc.dtype} {dc.did}. "
         if dc.dtype == "usb":
-            if not getattr(cfg.pod, "usb_live", True):
-                msg += tr("Enable usb_live + recreate to hot-plug USB.")
-            elif _guest_running(cfg):
+            if _guest_running(cfg):
                 try:
                     D.live_attach(cfg.pod.backend, cfg.pod.container_name, dc)
                     msg += tr("Hot-plugged live.")
@@ -245,7 +243,7 @@ class DevicesMixin:
 
         msg = tr("Released ") + f"{dc.dtype} {dc.did}. "
         if dc.dtype == "usb":
-            if getattr(cfg.pod, "usb_live", True) and _guest_running(cfg):
+            if _guest_running(cfg):
                 try:
                     D.live_detach(cfg.pod.backend, cfg.pod.container_name, dc)
                     msg += tr("Unplugged live.")

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -128,34 +128,35 @@ def _fake_run(reply: str = "", *, rc: int = 0, stderr: str = "", captured: list 
     return run
 
 
-def test_live_attach_builds_device_add(monkeypatch):
-    cap: list = []
-    # Monitor echoes the command; device_add prints nothing on success.
-    monkeypatch.setattr(
-        D.subprocess, "run", _fake_run("(qemu) device_add ...\n(qemu) ", captured=cap)
-    )
+def test_live_attach_delegates_to_usbredir(monkeypatch):
+    # live_attach no longer uses `device_add usb-host` (QEMU's in-container
+    # libusb is frozen — see core/usbredir). It delegates to the usbredir path.
+    from winpodx.core import usbredir
+
+    calls: list = []
+    monkeypatch.setattr(usbredir, "attach", lambda be, c, dev: calls.append((be, c, dev.did)))
     D.live_attach("podman", "winpodx-windows", D.DeviceConfig("usb", "1234:5678", "Dongle"))
-    script = cap[0][-1]  # the bash -c script
-    assert cap[0][:3] == ["podman", "exec", "winpodx-windows"]
-    assert f"/dev/tcp/127.0.0.1/{D.DOCKUR_MONITOR_PORT}" in script
-    assert "device_add usb-host,vendorid=0x1234,productid=0x5678" in script
-    assert f"id={D.usb_qom_id(D.DeviceConfig('usb', '1234:5678'))}" in script
-    assert f"bus={D.DOCKUR_USB_BUS}" in script
+    assert calls == [("podman", "winpodx-windows", "1234:5678")]
 
 
-def test_live_attach_raises_on_error_reply(monkeypatch):
-    monkeypatch.setattr(
-        D.subprocess, "run", _fake_run("(qemu) device_add ...\nError: no device found\n(qemu) ")
-    )
-    with pytest.raises(D.HmpError, match="attach"):
+def test_live_attach_propagates_usbredir_error(monkeypatch):
+    from winpodx.core import usbredir
+
+    def boom(be, c, dev):
+        raise D.HmpError("usbredirect not found")
+
+    monkeypatch.setattr(usbredir, "attach", boom)
+    with pytest.raises(D.HmpError, match="usbredirect"):
         D.live_attach("podman", "winpodx-windows", D.DeviceConfig("usb", "1234:5678"))
 
 
-def test_live_detach_builds_device_del(monkeypatch):
-    cap: list = []
-    monkeypatch.setattr(D.subprocess, "run", _fake_run("(qemu) ", captured=cap))
+def test_live_detach_delegates_to_usbredir(monkeypatch):
+    from winpodx.core import usbredir
+
+    calls: list = []
+    monkeypatch.setattr(usbredir, "detach", lambda be, c, dev: calls.append((be, c, dev.did)))
     D.live_detach("podman", "winpodx-windows", D.DeviceConfig("usb", "1234:5678"))
-    assert f"device_del {D.usb_qom_id(D.DeviceConfig('usb', '1234:5678'))}" in cap[0][-1]
+    assert calls == [("podman", "winpodx-windows", "1234:5678")]
 
 
 def test_live_attach_rejects_pci():

--- a/tests/test_usbredir.py
+++ b/tests/test_usbredir.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the usbredir live-USB passthrough path (core/usbredir.py)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from winpodx.core import usbredir as U
+from winpodx.core.devices import DeviceConfig, HmpError
+
+
+@pytest.fixture()
+def statedir(tmp_path, monkeypatch):
+    """Point usbredir's state dir at a throwaway tmp path."""
+    from winpodx.utils import paths
+
+    monkeypatch.setattr(paths, "data_dir", lambda: tmp_path)
+    return tmp_path / "usbredir"
+
+
+def test_qom_id_stable():
+    assert U._qom_id(DeviceConfig("usb", "1058:2626")) == "wpxur-10582626"
+
+
+def test_alloc_slot_empty(statedir):
+    assert U._alloc_slot() == 0
+
+
+def test_alloc_slot_skips_used(statedir):
+    statedir.mkdir(parents=True, exist_ok=True)
+    (statedir / "a.json").write_text(json.dumps({"slot": 0}))
+    (statedir / "b.json").write_text(json.dumps({"slot": 1}))
+    assert U._alloc_slot() == 2
+
+
+def test_attach_rejects_pci(statedir):
+    with pytest.raises(HmpError, match="only supports USB"):
+        U.attach("podman", "c", DeviceConfig("pci", "01:00.0"))
+
+
+def test_attach_requires_usbredirect(statedir, monkeypatch):
+    monkeypatch.setattr(U, "usbredirect_path", lambda: None)
+    with pytest.raises(HmpError, match="usbredirect not found"):
+        U.attach("podman", "c", DeviceConfig("usb", "1058:2626"))
+
+
+def test_attach_requires_privilege(statedir, monkeypatch):
+    monkeypatch.setattr(U, "usbredirect_path", lambda: "/usr/bin/usbredirect")
+    monkeypatch.setattr(U, "_privilege_wrapper", lambda: None)
+    with pytest.raises(HmpError, match="pkexec nor sudo"):
+        U.attach("podman", "c", DeviceConfig("usb", "1058:2626"))
+
+
+def test_is_attached_false_without_state(statedir):
+    assert U.is_attached(DeviceConfig("usb", "1058:2626")) is False
+
+
+def test_detach_idempotent_without_state(statedir, monkeypatch):
+    cleaned: list = []
+    monkeypatch.setattr(U, "_hmp_cleanup", lambda be, c, qom, drop_device: cleaned.append(qom))
+    # No state file -> must not crash, and still attempt HMP cleanup.
+    U.detach("podman", "c", DeviceConfig("usb", "1058:2626"))
+    assert cleaned == ["wpxur-10582626"]
+
+
+def test_looks_like_error():
+    assert U._looks_like_error("Error: no such device")
+    assert U._looks_like_error("(qemu) could not open")
+    assert not U._looks_like_error("(qemu) ")
+
+
+def test_attach_rolls_back_when_channel_never_connects(statedir, monkeypatch):
+    # chardev-add/device_add "succeed" (empty reply), processes are stubbed,
+    # but the channel never connects -> attach raises and leaves no state +
+    # runs HMP cleanup (no orphan device/chardev).
+    dev = DeviceConfig("usb", "1058:2626")
+    monkeypatch.setattr(U, "usbredirect_path", lambda: "/usr/bin/usbredirect")
+    monkeypatch.setattr(U, "_privilege_wrapper", lambda: ["sudo"])
+    monkeypatch.setattr(U, "hmp_command", lambda be, c, cmd, **kw: "(qemu) ")
+    monkeypatch.setattr(U, "_wait_port", lambda port, timeout: None)
+    monkeypatch.setattr(U, "_wait_chardev_connected", lambda be, c, qom, timeout: False)
+    monkeypatch.setattr(U, "_kill", lambda p: None)
+
+    class _FakeProc:
+        pid = 1234567
+
+    monkeypatch.setattr(U.subprocess, "Popen", lambda *a, **k: _FakeProc())
+    cleaned: list = []
+    monkeypatch.setattr(
+        U, "_hmp_cleanup", lambda be, c, qom, drop_device: cleaned.append((qom, drop_device))
+    )
+    with pytest.raises(HmpError, match="never connected"):
+        U.attach("podman", "c", dev)
+    assert not U._state_path(dev).exists()
+    assert cleaned and cleaned[0][0] == "wpxur-10582626"
+
+
+def test_attach_writes_state_on_success(statedir, monkeypatch):
+    dev = DeviceConfig("usb", "1058:2626")
+    monkeypatch.setattr(U, "usbredirect_path", lambda: "/usr/bin/usbredirect")
+    monkeypatch.setattr(U, "_privilege_wrapper", lambda: ["sudo"])
+    monkeypatch.setattr(U, "hmp_command", lambda be, c, cmd, **kw: "(qemu) ")
+    monkeypatch.setattr(U, "_wait_port", lambda port, timeout: None)
+    monkeypatch.setattr(U, "_wait_chardev_connected", lambda be, c, qom, timeout: True)
+
+    class _FakeProc:
+        pid = 4242
+
+    monkeypatch.setattr(U.subprocess, "Popen", lambda *a, **k: _FakeProc())
+    U.attach("podman", "c", dev)
+    state = json.loads(U._state_path(dev).read_text())
+    assert state["did"] == "1058:2626"
+    assert state["qom"] == "wpxur-10582626"
+    assert state["relay_pid"] == 4242 and state["usbredirect_pid"] == 4242
+    assert state["qemu_port"] == U._QEMU_PORT_BASE and state["host_port"] == U._HOST_PORT_BASE


### PR DESCRIPTION
QEMU's in-container libusb is frozen at boot (the rootless container's netns/userns block USB hotplug uevents), so `device_add usb-host` only ever yielded an empty stub for runtime hot-plugs. Replace that broken path with **usbredir**: a host `usbredirect` process (host libusb = live hotplug) feeds a QEMU `usb-redir` socket channel.

## How
- `core/usbredir.py` `attach()`: live-add a `usb-redir` chardev+device via HMP (no recreate), spawn a host relay bridging a loopback port to the container's QEMU socket over the same `<backend> exec ... /dev/tcp` transport winpodx uses for the monitor (no compose port-map — the podman bridge firewall blocks ad-hoc ports), then run `usbredirect` under `pkexec`/`sudo` to open the device (transient root; **no persistent udev rule / group**). Confirms the channel connected, else rolls everything back. Per-device state under `<data>/usbredir/`.
- `detach()`: kill the user-owned relay (usbredirect exits on socket close), escalate-kill if needed, HMP cleanup. Idempotent.
- `devices.live_attach/live_detach` delegate to usbredir (no more `device_add usb-host`). CLI/GUI messaging updated; the obsolete `usb_live` gate dropped (usbredir needs neither the `/dev/bus/usb` bind nor `usb_live`).

## Verification
Verified end-to-end by hand: a USB3 SuperSpeed SSD that was always a 1.5 Mb/s stub via `usb-host` appears in Windows **live at 5000 Mb/s** via usbredir. Unit tests for the orchestration (`tests/test_usbredir.py`, 11) + full suite **1720 passed, 1 skipped**, ruff clean.

**No compose change** — all runtime HMP + host processes, so zero pod-boot risk. Adds host deps: `usbredir` (usbredirect) + `pkexec`/`sudo`. Security keys (uaccess) still attach without root.

Investigation + design recorded in `docs/design/USB-PASSTHROUGH-INVESTIGATION.md`.

Refs #286. Live attach/detach smoke on real hardware pending (release-gated, not merge-gated).