### PR TITLE
fix(devices): usbredir relay readiness race (connection refused) (#286)

### DIFF
--- a/src/winpodx/core/usbredir.py
+++ b/src/winpodx/core/usbredir.py
@@ -299,7 +299,13 @@ def attach(backend: str, container: str, dev: DeviceConfig) -> None:
             stderr=subprocess.STDOUT,
             start_new_session=True,
         )
-        _wait_port(host_port, timeout=5.0)
+        # Wait for the relay to be *listening* — by polling its log for the
+        # "relay up" marker, NOT by connecting. The relay accepts exactly one
+        # connection, so a probe connect would be consumed in usbredirect's
+        # place (the relay would then bridge an empty socket and exit, leaving
+        # usbredirect with "connection refused"). Once listen() has run the OS
+        # queues incoming connections, so usbredirect can connect with no race.
+        _wait_relay_ready(relay_log, timeout=5.0)
 
         # 3) usbredirect (root, transient) grabs the device + connects to relay.
         ured_proc = subprocess.Popen(
@@ -383,15 +389,23 @@ def _tail(reply: str) -> str:
     return " ".join(reply.split())[-200:]
 
 
-def _wait_port(port: int, timeout: float) -> None:
+def _wait_relay_ready(log_path: Path, timeout: float) -> None:
+    """Wait until the relay has called ``listen()`` (it logs ``relay up``).
+
+    We poll the relay's log rather than opening a probe connection: the relay
+    accepts a single connection, so a probe would be consumed in usbredirect's
+    place. After ``listen()`` the kernel queues connects, so usbredirect won't
+    get "connection refused".
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         try:
-            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+            if "relay up" in log_path.read_text(errors="replace"):
                 return
         except OSError:
-            time.sleep(0.2)
-    raise HmpError(f"relay never came up on 127.0.0.1:{port}")
+            pass
+        time.sleep(0.1)
+    raise HmpError("relay did not start listening in time")
 
 
 def _wait_chardev_connected(backend: str, container: str, qom: str, timeout: float) -> bool:

--- a/tests/test_usbredir.py
+++ b/tests/test_usbredir.py
@@ -79,7 +79,7 @@ def test_attach_rolls_back_when_channel_never_connects(statedir, monkeypatch):
     monkeypatch.setattr(U, "usbredirect_path", lambda: "/usr/bin/usbredirect")
     monkeypatch.setattr(U, "_privilege_wrapper", lambda: ["sudo"])
     monkeypatch.setattr(U, "hmp_command", lambda be, c, cmd, **kw: "(qemu) ")
-    monkeypatch.setattr(U, "_wait_port", lambda port, timeout: None)
+    monkeypatch.setattr(U, "_wait_relay_ready", lambda log, timeout: None)
     monkeypatch.setattr(U, "_wait_chardev_connected", lambda be, c, qom, timeout: False)
     monkeypatch.setattr(U, "_kill", lambda p: None)
 
@@ -102,7 +102,7 @@ def test_attach_writes_state_on_success(statedir, monkeypatch):
     monkeypatch.setattr(U, "usbredirect_path", lambda: "/usr/bin/usbredirect")
     monkeypatch.setattr(U, "_privilege_wrapper", lambda: ["sudo"])
     monkeypatch.setattr(U, "hmp_command", lambda be, c, cmd, **kw: "(qemu) ")
-    monkeypatch.setattr(U, "_wait_port", lambda port, timeout: None)
+    monkeypatch.setattr(U, "_wait_relay_ready", lambda log, timeout: None)
     monkeypatch.setattr(U, "_wait_chardev_connected", lambda be, c, qom, timeout: True)
 
     class _FakeProc:


### PR DESCRIPTION
Follow-up to #412. GUI/CLI attach added the usb-redir channel and the relay, but `usbredirect` failed with `Could not connect to 127.0.0.1: connection refused`, leaving an empty 1.5 Mb/s usb-redir stub instead of the real device.

Cause: `attach()` waited for the relay by opening a **probe TCP connection**. The relay accepts exactly one connection (one-shot bridge), so the probe was consumed in usbredirect's place — the relay bridged the empty probe, saw it close, and exited, so the real usbredirect was refused.

Fix: wait for the relay's `listen()` by polling its log for the `relay up` marker instead of connecting. After `listen()` the kernel queues connects, so usbredirect connects with no race.

Tested: usbredir unit tests updated (mock `_wait_relay_ready`), 50 passed in the device+usbredir subset, ruff clean. Refs #286.