### PR TITLE
feat(app): hide/show apps from the Linux menu (#319)

### DIFF
--- a/src/winpodx/cli/app.py
+++ b/src/winpodx/cli/app.py
@@ -37,13 +37,37 @@ def handle_app(args: argparse.Namespace) -> None:
         _install_all()
     elif cmd == "remove":
         _remove_app(args.name)
+    elif cmd == "hide":
+        _set_hidden(args.name, True)
+    elif cmd == "show":
+        _set_hidden(args.name, False)
     elif cmd == "sessions":
         _show_sessions()
     elif cmd == "kill":
         _kill_session(args.name)
     else:
-        print(tr("Usage: winpodx app {list|refresh|run|install|install-all|remove|sessions|kill}"))
+        print(
+            tr(
+                "Usage: winpodx app "
+                "{list|refresh|run|install|install-all|remove|hide|show|sessions|kill}"
+            )
+        )
         sys.exit(1)
+
+
+def _set_hidden(name: str, hidden: bool) -> None:
+    """Hide/show an app in the Linux menu (persists across rescans)."""
+    _validate_app_name(name)
+    from winpodx.core.app import set_app_hidden
+
+    app = set_app_hidden(name, hidden)
+    if app is None:
+        print(tr("App '{name}' not found.").format(name=name), file=sys.stderr)
+        sys.exit(1)
+    if hidden:
+        print(tr("Hid '{name}' — removed from the Linux app menu.").format(name=name))
+    else:
+        print(tr("Showing '{name}' — added to the Linux app menu.").format(name=name))
 
 
 def _list_apps() -> None:

--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -88,6 +88,14 @@ def cli(argv: list[str] | None = None) -> None:
     rm_p = app_sub.add_parser("remove", help="Remove app from desktop")
     rm_p.add_argument("name", help="App name to remove")
 
+    hide_p = app_sub.add_parser(
+        "hide", help="Hide an app from the Linux app menu (persists across rescans)"
+    )
+    hide_p.add_argument("name", help="App name to hide")
+
+    show_p = app_sub.add_parser("show", help="Show a previously hidden app in the Linux app menu")
+    show_p.add_argument("name", help="App name to show")
+
     app_sub.add_parser("sessions", help="Show active sessions")
 
     kill_p = app_sub.add_parser("kill", help="Kill an active session")

--- a/src/winpodx/core/app.py
+++ b/src/winpodx/core/app.py
@@ -185,3 +185,55 @@ def find_app(name: str) -> AppInfo | None:
         if app.name == name:
             return app
     return None
+
+
+def _find_app_dir(name: str) -> Path | None:
+    """Return the directory holding ``<name>/app.toml`` (user dir wins over
+    discovered), or None. Name is validated to block path traversal."""
+    if not name or len(name) > 255 or not _SAFE_NAME_RE.match(name):
+        return None
+    for base in (user_apps_dir(), discovered_apps_dir()):
+        cand = base / name
+        if _is_within(cand, base) and (cand / "app.toml").is_file():
+            return cand
+    return None
+
+
+def set_app_hidden(name: str, hidden: bool) -> AppInfo | None:
+    """Set an app's ``hidden`` flag in its app.toml and sync its Linux menu entry.
+
+    Hidden apps are dropped from the app menu (``.desktop`` removed); shown apps
+    get it (re)installed. The flag is persisted to app.toml so the choice
+    survives the next discovery sweep (discovery honours an explicit override).
+    Returns the updated :class:`AppInfo`, or ``None`` if the app isn't found.
+    """
+    from winpodx.utils.toml_writer import dumps as toml_dumps
+
+    app_dir = _find_app_dir(name)
+    if app_dir is None:
+        return None
+    toml_path = app_dir / "app.toml"
+    try:
+        data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError, OSError):
+        return None
+    data["hidden"] = bool(hidden)
+    toml_path.write_text(toml_dumps(data), encoding="utf-8")
+
+    app = load_app(app_dir)
+    if app is None:
+        return None
+
+    # Sync the Linux app-menu entry: drop it when hidden, (re)install when shown.
+    try:
+        from winpodx.desktop.entry import install_desktop_entry, remove_desktop_entry
+        from winpodx.desktop.icons import update_icon_cache
+
+        if hidden:
+            remove_desktop_entry(name)
+        else:
+            install_desktop_entry(app)
+        update_icon_cache()
+    except Exception as e:  # noqa: BLE001 — menu sync is best-effort
+        log.warning("desktop entry sync for %s failed: %s", name, e)
+    return app

--- a/src/winpodx/gui/_main_window_apps.py
+++ b/src/winpodx/gui/_main_window_apps.py
@@ -80,6 +80,25 @@ class AppCrudMixin:
         self._reload_apps()
         self.info_label.setText(tr("Removed: {name}").format(name=app.full_name))
 
+    def _on_toggle_app_hidden(self, app: AppInfo) -> None:
+        """Hide a visible app (or show a hidden one) from the Linux app menu.
+
+        Persists the choice into app.toml (sticky across rescans) and syncs the
+        ``.desktop`` entry. After hiding, the app drops out of the default grid
+        but is still reachable via the "Hidden" toggle for un-hiding.
+        """
+        from winpodx.core.app import set_app_hidden
+
+        updated = set_app_hidden(app.name, not app.hidden)
+        if updated is None:
+            self.info_label.setText(tr("Could not update: {name}").format(name=app.full_name))
+            return
+        self._reload_apps()
+        if updated.hidden:
+            self.info_label.setText(tr("Hidden: {name}").format(name=app.full_name))
+        else:
+            self.info_label.setText(tr("Shown: {name}").format(name=app.full_name))
+
     def _reload_apps(self) -> None:
         self.apps = list_available_apps()
         self._refresh_hidden_button()

--- a/src/winpodx/gui/_main_window_library.py
+++ b/src/winpodx/gui/_main_window_library.py
@@ -357,6 +357,27 @@ class LibraryPageMixin:
         edit_btn.clicked.connect(lambda _, a=app: self._on_edit_app(a))
         bottom.addWidget(edit_btn)
 
+        hide_btn = QPushButton("🙈" if not app.hidden else "👁")
+        hide_btn.setFixedSize(28, 28)
+        hide_btn.setToolTip(tr("Show in menu") if app.hidden else tr("Hide from menu"))
+        hide_btn.setStyleSheet(
+            f"""
+            QPushButton {{
+                background: transparent;
+                color: {C.OVERLAY0};
+                border: none;
+                border-radius: 14px;
+                font-size: 14px;
+            }}
+            QPushButton:hover {{
+                color: {C.TEXT};
+                background: {C.SURFACE1};
+            }}
+            """
+        )
+        hide_btn.clicked.connect(lambda _, a=app: self._on_toggle_app_hidden(a))
+        bottom.addWidget(hide_btn)
+
         del_btn = QPushButton("✕")
         del_btn.setFixedSize(28, 28)
         del_btn.setToolTip(tr("Delete"))
@@ -435,6 +456,18 @@ class LibraryPageMixin:
         )
         edit_btn.clicked.connect(lambda: self._on_edit_app(app))
         layout.addWidget(edit_btn)
+        layout.addSpacing(6)
+
+        hide_btn = QPushButton(tr("Show") if app.hidden else tr("Hide"))
+        hide_btn.setStyleSheet(
+            f"QPushButton {{ background: {C.SURFACE1}; color: {C.SUBTEXT0};"
+            f" font-size: 12px; border-radius: 6px; padding: 6px 14px;"
+            f" border: none; }}"
+            f"QPushButton:hover {{ background: {C.SURFACE2};"
+            f" color: {C.TEXT}; }}"
+        )
+        hide_btn.clicked.connect(lambda: self._on_toggle_app_hidden(app))
+        layout.addWidget(hide_btn)
         layout.addSpacing(6)
 
         del_btn = QPushButton("✕")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -89,3 +89,74 @@ def test_list_available_apps_user_overrides_discovered(monkeypatch, tmp_path):
     assert len(apps) == 1
     assert apps[0].full_name == "User Word"
     assert apps[0].source == "user"
+
+
+# -- hide / show (set_app_hidden) -----------------------------------------
+
+
+def _write_app(d, name="myapp"):
+    (d / name).mkdir(parents=True)
+    (d / name / "app.toml").write_text(
+        f'name = "{name}"\nfull_name = "My App"\nexecutable = "C:\\\\a.exe"\n'
+    )
+
+
+def test_set_app_hidden_toggles_toml_and_desktop(monkeypatch, tmp_path):
+    import winpodx.core.app as app_mod
+    import winpodx.desktop.entry as entry_mod
+    import winpodx.desktop.icons as icons_mod
+
+    user = tmp_path / "user"
+    _write_app(user)
+    monkeypatch.setattr(app_mod, "user_apps_dir", lambda: user)
+    monkeypatch.setattr(app_mod, "discovered_apps_dir", lambda: tmp_path / "discovered")
+    calls: list = []
+    monkeypatch.setattr(entry_mod, "remove_desktop_entry", lambda n: calls.append(("rm", n)))
+    monkeypatch.setattr(entry_mod, "install_desktop_entry", lambda a: calls.append(("add", a.name)))
+    monkeypatch.setattr(icons_mod, "update_icon_cache", lambda: None)
+
+    app = app_mod.set_app_hidden("myapp", True)
+    assert app is not None and app.hidden is True
+    assert "hidden = true" in (user / "myapp" / "app.toml").read_text()
+    assert ("rm", "myapp") in calls  # dropped from the Linux menu
+
+    app = app_mod.set_app_hidden("myapp", False)
+    assert app is not None and app.hidden is False
+    assert "hidden = false" in (user / "myapp" / "app.toml").read_text()
+    assert ("add", "myapp") in calls  # re-added to the Linux menu
+
+
+def test_set_app_hidden_not_found(monkeypatch, tmp_path):
+    import winpodx.core.app as app_mod
+
+    monkeypatch.setattr(app_mod, "user_apps_dir", lambda: tmp_path / "u")
+    monkeypatch.setattr(app_mod, "discovered_apps_dir", lambda: tmp_path / "d")
+    assert app_mod.set_app_hidden("ghost", True) is None
+
+
+def test_set_app_hidden_rejects_bad_name(monkeypatch, tmp_path):
+    import winpodx.core.app as app_mod
+
+    monkeypatch.setattr(app_mod, "user_apps_dir", lambda: tmp_path / "u")
+    monkeypatch.setattr(app_mod, "discovered_apps_dir", lambda: tmp_path / "d")
+    assert app_mod.set_app_hidden("../etc", True) is None
+    assert app_mod.set_app_hidden("a/b", True) is None
+    assert app_mod._find_app_dir("..") is None
+
+
+def test_cli_app_hide_dispatch(monkeypatch):
+    import argparse
+
+    from winpodx.cli import app as app_cli
+
+    calls: list = []
+    monkeypatch.setattr(
+        "winpodx.core.app.set_app_hidden",
+        lambda name, hidden: (
+            calls.append((name, hidden))
+            or type("A", (), {"hidden": hidden, "full_name": name, "name": name})()
+        ),
+    )
+    app_cli.handle_app(argparse.Namespace(app_command="hide", name="myapp"))
+    app_cli.handle_app(argparse.Namespace(app_command="show", name="myapp"))
+    assert calls == [("myapp", True), ("myapp", False)]


### PR DESCRIPTION
Discovery already auto-hides system-shim noise and honours a sticky `hidden` override in app.toml, but there was no easy way to mark a *specific* app hidden — you had to hand-edit app.toml (Delete only removed the profile, which reappeared on the next rescan). This adds the user-driven hide/show action the `AppInfo.hidden` docstring already promised.

## What
- `core.app.set_app_hidden(name, hidden)` — writes the flag into app.toml (lossless dict rewrite, so it survives the next discovery sweep) and syncs the `.desktop` entry: removed when hidden, (re)installed when shown. Path-traversal-safe app-dir lookup.
- CLI: `winpodx app hide <name>` / `winpodx app show <name>`.
- GUI Library: a per-card Hide/Show button (grid + list views). Hidden apps drop out of the default grid but stay reachable via the existing "Hidden" toggle for un-hiding.

## Why
Closes the gap in #319: junk is auto-hidden, but the reporter wanted to hide specific apps (e.g. the utility exes Office drags in) without it being undone on every rescan. The sticky override existed; this gives it a one-click / one-command UI.

Tests: core toggle (toml persistence + desktop sync + not-found + traversal rejection) + CLI dispatch. Full suite 1725 passed, 1 skipped; ruff clean. Refs #319.