### PR TITLE
fix(rdp): drop stale FreeRDP-2 flags from the extra-flags allowlist (#380)

### DIFF
--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -587,19 +587,22 @@ _BARE_FLAGS: frozenset[str] = frozenset(
         # which already passes through the existing `/gfx` value-regex
         # in _SIMPLE_VALUE_FLAGS. Only the genuine BOOL toggles stay
         # in the bare allowlist.
-        "+gfx-progressive",
-        "-gfx-progressive",
-        "+gfx-thin-client",
-        "-gfx-thin-client",
-        "+gfx-small-cache",
-        "-gfx-small-cache",
+        #
+        # #380 (notnotno, FreeRDP 3.26): `progressive`, `thin-client`, and
+        # `small-cache` are the SAME case as `gfx-h264` — they are `/gfx:`
+        # sub-options, NOT bare `+/-` toggles. The earlier fix removed
+        # `gfx-h264` but missed these siblings, so `+gfx-progressive` etc.
+        # passed our allowlist only to be rejected by xfreerdp's own parser.
+        # Removed; use `/gfx:progressive:on|off`, `/gfx:thin-client:on|off`,
+        # `/gfx:small-cache:on|off` instead (the `/gfx` value-regex accepts
+        # all three).
         # Visual / desktop toggles (already in default cmd; expose for override).
         "+wallpaper",
         "-wallpaper",
         "+themes",
         "-themes",
-        "+window-position",
-        "-window-position",
+        # #380: `window-position` takes coordinates (`/window-position:<x>x<y>`),
+        # it is not a bare toggle — moved to _SIMPLE_VALUE_FLAGS below.
         "+decorations",
         "-decorations",
         # Input grab / mouse-keyboard policy.
@@ -661,6 +664,7 @@ _SIMPLE_VALUE_FLAGS: dict[str, re.Pattern[str]] = {
     "/gdi": re.compile(r"(sw|hw)"),  # software vs hardware GDI repaint
     "/monitors": re.compile(r"[0-9]{1,2}(,[0-9]{1,2}){0,7}"),  # /monitors:0,1
     "/smart-sizing": re.compile(r"[1-9][0-9]{1,4}x[1-9][0-9]{1,4}"),  # /smart-sizing:WxH
+    "/window-position": re.compile(r"[0-9]{1,5}x[0-9]{1,5}"),  # /window-position:<x>x<y> (#380)
 }
 
 # Device-redirection allowlist; empty set rejects all :value forms.

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -487,28 +487,18 @@ class TestBuildRdpCommand:
             assert bad not in cmd, f"OPTIONAL-typed flag leaked through: {bad!r}"
 
     def test_codec_toggles_pass_filter(self, cfg, monkeypatch):
-        """Genuine BOOL toggles still pass — gfx-progressive,
-        gfx-thin-client, gfx-small-cache, wallpaper, themes, decorations,
+        """Genuine BOOL toggles still pass — wallpaper, themes, decorations,
         grab-*, async-*, auto-reconnect, *-cache. Without these in
-        _BARE_FLAGS they were silently dropped before reaching
-        xfreerdp3."""
+        _BARE_FLAGS they were silently dropped before reaching xfreerdp3.
+
+        (gfx-progressive / gfx-thin-client / gfx-small-cache were removed in
+        #380 — they are `/gfx:` sub-options, not bare toggles; see
+        ``test_gfx_suboptions_and_window_position``.)"""
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
             lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
         )
-        # FreeRDP 3.x cmdline split:
-        #   - BOOL flags (`+/-name`): the genuine bare toggles below.
-        #   - OPTIONAL/REQUIRED (`/name:value` only): rfx, gfx-h264, nsc,
-        #     jpeg, avc444 — these were attempted as bare in the original
-        #     v0.4.3 patch and FreeRDP itself rejected them with
-        #     "Unexpected keyword" (xiyeming's 2026-05-06/07 test in
-        #     #126). Stripped from the allowlist to surface the parse
-        #     failure at the filter layer instead of producing a confusing
-        #     stderr from xfreerdp3.
         toggles = (
-            "-gfx-progressive +gfx-progressive "
-            "-gfx-thin-client +gfx-thin-client "
-            "-gfx-small-cache +gfx-small-cache "
             "-wallpaper +wallpaper -themes +themes "
             "-decorations +decorations "
             "-grab-keyboard +grab-keyboard -grab-mouse +grab-mouse "
@@ -524,6 +514,37 @@ class TestBuildRdpCommand:
         for toggle in toggles.split():
             assert toggle in cmd, f"toggle dropped by filter: {toggle!r}"
 
+    def test_gfx_suboptions_and_window_position(self, cfg, monkeypatch):
+        """#380 (notnotno, FreeRDP 3.26): the gfx sub-options and
+        window-position use `/name:value` syntax, not bare `+/-` toggles.
+
+        - `+gfx-progressive` etc. + `+/-window-position` must be REJECTED
+          (they passed the old allowlist only for xfreerdp to reject them).
+        - `/gfx:progressive:on|off`, `/gfx:thin-client:on`,
+          `/gfx:small-cache:off`, and `/window-position:<x>x<y>` must PASS."""
+        monkeypatch.setattr(
+            "winpodx.core.rdp.find_freerdp",
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
+        )
+        bad = (
+            "+gfx-progressive -gfx-progressive "
+            "+gfx-thin-client -gfx-thin-client "
+            "+gfx-small-cache -gfx-small-cache "
+            "+window-position -window-position"
+        )
+        cfg.rdp.extra_flags = bad
+        cmd, _ = build_rdp_command(cfg)
+        for flag in bad.split():
+            assert flag not in cmd, f"stale FreeRDP-2 flag leaked: {flag!r}"
+
+        good = (
+            "/gfx:progressive:on /gfx:thin-client:on /gfx:small-cache:off /window-position:100x200"
+        )
+        cfg.rdp.extra_flags = good
+        cmd, _ = build_rdp_command(cfg)
+        for flag in good.split():
+            assert flag in cmd, f"correct FreeRDP-3 flag dropped: {flag!r}"
+
     def test_extra_args_kwarg_appended_after_global_extra_flags(self, cfg, monkeypatch):
         """Per-launch `extra_args` (CLI --extra-args / GUI per-launch)
         is appended AFTER `cfg.rdp.extra_flags` so per-launch overrides
@@ -534,15 +555,17 @@ class TestBuildRdpCommand:
             "winpodx.core.rdp.find_freerdp",
             lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
         )
-        cfg.rdp.extra_flags = "+gfx-progressive"  # global says: enable
-        cmd, _ = build_rdp_command(cfg, extra_args="-gfx-progressive /not-a-real-flag:bad")
+        # `aero` is not in the default command, so the only occurrences come
+        # from global (+) then per-launch (-) — clean ordering check.
+        cfg.rdp.extra_flags = "+aero"  # global says: enable
+        cmd, _ = build_rdp_command(cfg, extra_args="-aero /not-a-real-flag:bad")
 
         # Both global and per-launch survived the filter.
-        assert "+gfx-progressive" in cmd
-        assert "-gfx-progressive" in cmd
+        assert "+aero" in cmd
+        assert "-aero" in cmd
         # Per-launch lands AFTER global; this is the override semantics
         # callers rely on.
-        assert cmd.index("-gfx-progressive") > cmd.index("+gfx-progressive")
+        assert cmd.index("-aero") > cmd.index("+aero")
         # Unsafe flag in extra_args is dropped, same as via cfg.rdp.extra_flags.
         assert "/not-a-real-flag:bad" not in cmd
 


### PR DESCRIPTION
Reported by @notnotno (FreeRDP 3.26): several flags in the `--extra-args` allowlist use FreeRDP-2 syntax that 3.x rejects — they passed winpodx's filter only for xfreerdp to error with "Unexpected keyword".

`gfx-progressive` / `gfx-thin-client` / `gfx-small-cache` are `/gfx:` sub-options, not bare `+/-` toggles — the same case as `gfx-h264` (a prior fix removed that one but missed these siblings). `window-position` takes coordinates.

- Removed `+/-gfx-{progressive,thin-client,small-cache}` and `+/-window-position` from `_BARE_FLAGS`.
- Added `/window-position:<x>x<y>` to `_SIMPLE_VALUE_FLAGS`.
- `/gfx:progressive:on|off` etc. already pass via the existing `/gfx` value-regex — unchanged.

Tests: correct `/gfx:*:on|off` + `/window-position:<x>x<y>` accepted, stale bare forms rejected. Full suite 1729 passed, 1 skipped; ruff clean. Refs #380.