### PR TITLE
fix(setup): verify backend daemon is reachable, not just the CLI (#395)

### DIFF
--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -627,11 +627,19 @@ def handle_setup(args: argparse.Namespace) -> None:
     print(tr("=== winpodx setup ===\n"))
 
     print(tr("Checking dependencies..."))
-    deps = check_all()
+    # probe_daemons: verify the container backends actually answer, not just
+    # that their CLI is on PATH (#395 — docker CLI present but DOCKER_HOST
+    # pointed at a dead podman socket).
+    deps = check_all(probe_daemons=True)
     # `kvm` is now part of check_all() (0.6.0 item D), so the inline probe
     # this block used to carry is gone -- the iteration below covers it.
     for name, dep in deps.items():
-        status = "OK" if dep.found else "MISSING"
+        if not dep.found:
+            status = "MISSING"
+        elif dep.daemon_reachable is False:
+            status = "DAEMON DOWN"
+        else:
+            status = "OK"
         print(f"  {name:<15} [{status}] {dep.note}")
 
     if not deps["freerdp"].found:
@@ -840,6 +848,26 @@ def handle_setup(args: argparse.Namespace) -> None:
         #      create the directory, and `chattr +C` on btrfs so the
         #      Windows raw disk image inherits NoCoW from day one.
         _decide_storage_mode(cfg, non_interactive=non_interactive)
+
+        # #395: bail out with an actionable message if the selected backend's
+        # daemon isn't reachable, rather than letting compose fail with a
+        # confusing "Cannot connect to the Docker daemon" traceback. `deps`
+        # was probed with probe_daemons=True above.
+        sel = deps.get(cfg.pod.backend)
+        if sel is not None and sel.found and sel.daemon_reachable is False:
+            print()
+            print(
+                tr("Cannot use the {backend} backend: {hint}").format(
+                    backend=cfg.pod.backend, hint=sel.note
+                )
+            )
+            print(
+                tr(
+                    "Fix the daemon (above) and re-run `winpodx setup`, or switch "
+                    "backend with `winpodx config set pod.backend <podman|docker>`."
+                )
+            )
+            raise SystemExit(1)
 
         _generate_compose(cfg)
         _recreate_container(cfg)

--- a/src/winpodx/utils/deps.py
+++ b/src/winpodx/utils/deps.py
@@ -26,6 +26,12 @@ class DepCheck:
     found: bool
     path: str = ""
     note: str = ""
+    # For container backends only: True/False once the daemon/socket has been
+    # probed (via check_all(probe_daemons=True)), None when not probed. `found`
+    # means the CLI is on PATH; daemon_reachable means a command actually talks
+    # to its daemon (#395 — a docker CLI with DOCKER_HOST set to a dead podman
+    # socket is `found` but not `daemon_reachable`).
+    daemon_reachable: bool | None = None
 
 
 # Optional dependencies probed by name on PATH. Order matches what we want
@@ -78,19 +84,73 @@ def check_kvm() -> DepCheck:
     )
 
 
-def check_all() -> dict[str, DepCheck]:
+def check_backend_daemon(cmd: str, *, timeout: float = 8.0) -> tuple[bool, str]:
+    """Probe whether ``<cmd> info`` can actually reach its daemon / socket.
+
+    ``shutil.which`` only proves the CLI is installed — not that the daemon is
+    running or that ``DOCKER_HOST`` points somewhere valid. #395: a ``docker``
+    CLI with ``DOCKER_HOST`` set to a non-running podman socket looks present,
+    but every compose call fails with "Cannot connect to the Docker daemon".
+
+    Returns ``(reachable, hint)``; ``hint`` is an actionable message when
+    unreachable, else ``""``.
+    """
+    import subprocess
+
+    exe = shutil.which(cmd)
+    if not exe:
+        return (False, "")
+    try:
+        result = subprocess.run(
+            [exe, "info"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return (False, f"{cmd} found but its daemon did not respond in {int(timeout)}s")
+    if result.returncode == 0:
+        return (True, "")
+    low = (result.stderr or result.stdout or "").lower()
+    hint = f"{cmd} CLI found but its daemon is unreachable"
+    if "podman.sock" in low or "/podman/" in low:
+        hint += (
+            " — DOCKER_HOST points at a podman socket; start it with "
+            "`systemctl --user start podman.socket`, unset DOCKER_HOST, or use "
+            "the podman backend (`winpodx config set pod.backend podman`)"
+        )
+    elif "cannot connect" in low or "daemon" in low or "refused" in low:
+        hint += " — is the daemon running? (check DOCKER_HOST)"
+    return (False, hint)
+
+
+def check_all(probe_daemons: bool = False) -> dict[str, DepCheck]:
     """Run every host dep check.
 
     Returns a dict keyed by canonical short name (``freerdp``, ``podman``,
     ``docker``, ``flatpak``, ``kvm``). Every dependency has an entry; the
     caller decides what's required vs optional. Missing entries indicate a bug
     in this function, never a missing dependency.
+
+    ``probe_daemons`` (default False) additionally verifies, for any container
+    backend that's on PATH, that its daemon actually answers (``<cmd> info``)
+    and records the result in ``DepCheck.daemon_reachable`` + an actionable
+    ``note`` when it doesn't. Off by default because the probe spawns a
+    subprocess per backend; the setup wizard opts in, the fast callers (backend
+    selector, GUI quick-check) don't.
     """
     checks: dict[str, DepCheck] = {}
     checks["freerdp"] = check_freerdp()
     for cmd, desc in OPTIONAL_DEPS.items():
         path = shutil.which(cmd)
-        checks[cmd] = DepCheck(name=cmd, found=bool(path), path=path or "", note=desc)
+        dep = DepCheck(name=cmd, found=bool(path), path=path or "", note=desc)
+        if probe_daemons and path and cmd in ("docker", "podman"):
+            reachable, hint = check_backend_daemon(cmd)
+            dep.daemon_reachable = reachable
+            if not reachable and hint:
+                dep.note = hint
+        checks[cmd] = dep
     checks["kvm"] = check_kvm()
     return checks
 

--- a/tests/test_agent_token.py
+++ b/tests/test_agent_token.py
@@ -122,7 +122,7 @@ class TestSetupStagesOemToken:
 
         monkeypatch.setattr(
             "winpodx.cli.setup_cmd.check_all",
-            lambda: {"freerdp": DepCheck(name="freerdp", found=True, note="stub")},
+            lambda **_: {"freerdp": DepCheck(name="freerdp", found=True, note="stub")},
         )
 
         args = argparse.Namespace(backend=None, non_interactive=True)

--- a/tests/test_deps_unified.py
+++ b/tests/test_deps_unified.py
@@ -163,3 +163,76 @@ def test_doctor_does_not_shutil_which_freerdp() -> None:
         f"cli/doctor.py calls shutil.which on freerdp binary names {overlap}; "
         "delegate to winpodx.utils.deps.check_freerdp instead"
     )
+
+
+# -- daemon reachability (#395) -------------------------------------------
+
+
+def test_check_backend_daemon_reachable(monkeypatch):
+    import subprocess
+    import types
+
+    import winpodx.utils.deps as D
+
+    monkeypatch.setattr(D.shutil, "which", lambda c: "/usr/bin/" + c)
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="", stderr="")
+    )
+    assert D.check_backend_daemon("docker") == (True, "")
+
+
+def test_check_backend_daemon_podman_socket_hint(monkeypatch):
+    import subprocess
+    import types
+
+    import winpodx.utils.deps as D
+
+    monkeypatch.setattr(D.shutil, "which", lambda c: "/usr/bin/" + c)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: types.SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr="Cannot connect to the Docker daemon at unix:///run/user/1000/podman/podman.sock",
+        ),
+    )
+    ok, hint = D.check_backend_daemon("docker")
+    assert ok is False
+    assert "podman socket" in hint.lower()
+
+
+def test_check_backend_daemon_not_on_path(monkeypatch):
+    import winpodx.utils.deps as D
+
+    monkeypatch.setattr(D.shutil, "which", lambda c: None)
+    assert D.check_backend_daemon("docker") == (False, "")
+
+
+def test_check_all_probe_daemons_annotates(monkeypatch):
+    import winpodx.utils.deps as D
+
+    monkeypatch.setattr(
+        D.shutil,
+        "which",
+        lambda c: ("/usr/bin/" + c) if c in ("docker", "podman", "flatpak") else None,
+    )
+    monkeypatch.setattr(D, "check_freerdp", lambda: D.DepCheck(name="x", found=True))
+    monkeypatch.setattr(D, "check_backend_daemon", lambda cmd, **k: (False, f"{cmd} daemon down"))
+
+    deps = D.check_all(probe_daemons=True)
+    assert deps["docker"].daemon_reachable is False
+    assert "daemon down" in deps["docker"].note
+    assert deps["podman"].daemon_reachable is False
+    # flatpak isn't a container backend -> not probed
+    assert deps["flatpak"].daemon_reachable is None
+
+
+def test_check_all_default_does_not_probe(monkeypatch):
+    import winpodx.utils.deps as D
+
+    monkeypatch.setattr(D.shutil, "which", lambda c: "/usr/bin/" + c)
+    monkeypatch.setattr(D, "check_freerdp", lambda: D.DepCheck(name="x", found=True))
+    deps = D.check_all()
+    assert deps["docker"].daemon_reachable is None
+    assert deps["podman"].daemon_reachable is None

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -404,7 +404,7 @@ class TestAgentTokenStaging:
         monkeypatch.setattr("winpodx.cli.setup_cmd._find_oem_dir", lambda: str(oem_dir))
         monkeypatch.setattr(
             "winpodx.cli.setup_cmd.check_all",
-            lambda: {"freerdp": DepCheck(name="freerdp", found=True, note="stub")},
+            lambda **_: {"freerdp": DepCheck(name="freerdp", found=True, note="stub")},
         )
 
         args = argparse.Namespace(backend=None, non_interactive=True)


### PR DESCRIPTION
Reported by @urbantigerau: `winpodx setup` showed `docker [OK]` but failed with "Cannot connect to the Docker daemon at unix:///run/user/1000/podman/podman.sock" — the `docker` CLI was on PATH but `DOCKER_HOST` pointed at a non-running podman socket, so every compose call failed with a confusing traceback.

The dependency check only ran `shutil.which` (CLI presence), never verifying the daemon answers.

- `deps.check_backend_daemon(cmd)` probes `<cmd> info`; on failure returns an actionable hint, specifically flagging the `DOCKER_HOST`→podman-socket case (suggesting `systemctl --user start podman.socket`, unset `DOCKER_HOST`, or switch to the podman backend).
- `check_all(probe_daemons=True)` records `DepCheck.daemon_reachable` + the hint (opt-in, so the backend selector / GUI quick-check stay subprocess-free; the setup wizard opts in).
- Setup now shows `[DAEMON DOWN]` instead of a misleading `[OK]`, and bails out before recreating the container with the hint rather than the raw compose traceback.

Tests: probe reachable / podman-socket hint / not-on-PATH + the opt-in annotation. Full suite 1734 passed, 1 skipped; ruff clean. Refs #395.