### PR TITLE
fix(rdp): resolve $HOME symlink in linux_to_unc for Fedora Atomic (#418)

### DIFF
--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -972,7 +972,13 @@ def linux_to_unc(path: str) -> str:
     if _INVALID_WIN_CHARS & set(posix_str):
         raise ValueError(f"Path contains characters invalid for Windows: {posix_str}")
 
-    home = Path.home()
+    # Resolve $HOME (and the media base) too, not just the file (#418). On
+    # Fedora Atomic / Silverblue / Kinoite, /home is a symlink to /var/home, so
+    # `Path(path).resolve()` yields /var/home/me/... while a bare `Path.home()`
+    # stays /home/me — the prefix check then wrongly reports the file as
+    # "outside shared locations". Resolving both sides makes the comparison
+    # symlink-agnostic (and is a no-op on normal layouts).
+    home = Path.home().resolve()
     sep = "\\"
     try:
         relative = p.relative_to(home)
@@ -984,6 +990,7 @@ def linux_to_unc(path: str) -> str:
     # Media share mounted as \\tsclient\media.
     media_base = _find_media_base()
     if media_base is not None:
+        media_base = media_base.resolve()
         try:
             relative = p.relative_to(media_base)
             win_path = str(relative).replace("/", sep)

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -581,3 +581,25 @@ class TestBuildRdpCommand:
         cmd_empty, _ = build_rdp_command(cfg, extra_args="")
         assert cmd_no_extra == cmd_empty
         assert "" not in cmd_empty
+
+
+def test_linux_to_unc_home_symlink_atomic(monkeypatch, tmp_path):
+    # Fedora Atomic / Silverblue / Kinoite: /home is a symlink to /var/home.
+    # Path.home() stays the symlink path; the file resolves to the target.
+    # Both sides must resolve so the prefix check matches (#418).
+    real_home = tmp_path / "var_home" / "me"
+    real_home.mkdir(parents=True)
+    home_link = tmp_path / "home" / "me"
+    home_link.parent.mkdir(parents=True)
+    home_link.symlink_to(real_home)  # /home/me -> /var/home/me
+
+    doc = real_home / "Desktop" / "temp.doc"
+    doc.parent.mkdir()
+    doc.touch()
+
+    monkeypatch.setattr("winpodx.core.rdp.Path.home", staticmethod(lambda: home_link))
+    monkeypatch.setattr("winpodx.core.rdp._find_media_base", lambda: None)
+
+    # File passed through the symlinked home path, as `app run` would.
+    result = linux_to_unc(str(home_link / "Desktop" / "temp.doc"))
+    assert result == "\\\\tsclient\\home\\Desktop\\temp.doc"


### PR DESCRIPTION
## Problem

On Fedora Atomic variants (Silverblue / Kinoite) `/home` is a symlink to `/var/home`. `linux_to_unc()` resolved the input file (`Path(path).resolve()` → `/var/home/me/...`) but compared it against an **unresolved** `Path.home()` (`/home/me`), so the `relative_to()` prefix check failed and every in-home file was reported as *"outside shared locations"* — breaking `winpodx app run <app> <file>` (#418).

## Fix

Resolve `$HOME` and the media base to their realpaths before the comparison, so the prefix check is symlink-agnostic. No-op on conventional layouts where `resolve()` returns the same path.

## Test

Added `test_linux_to_unc_home_symlink_atomic` — builds a `/home/me → /var/home/me` symlink, places a file under the target, and asserts the path maps to `\\tsclient\home\Desktop\temp.doc`. Full suite: 1735 passed.