### PR TITLE
docs: add GitHub Sponsors badge to README Support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,10 +281,11 @@ For security issues, follow the process in [SECURITY.md](SECURITY.md).
 
 If winpodx makes your Linux desktop a little nicer:
 
+[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-GitHub-EA4AAA?logo=githubsponsors&logoColor=white&style=for-the-badge)](https://github.com/sponsors/kernalix7)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-F16061?logo=ko-fi&logoColor=white&style=for-the-badge)](https://ko-fi.com/kernalix7)
 [![Fairy](https://img.shields.io/badge/🧚_Fairy-EE6E73?style=for-the-badge&logoColor=white)](https://fairy.hada.io/@kernalix7)
 
-Ko-fi handles international cards and PayPal; fairy.hada.io is a Korean tipping platform. Bug reports, PRs, and stars on the repo are equally appreciated and free.
+GitHub Sponsors supports recurring or one-time sponsorship; Ko-fi handles international cards and PayPal; fairy.hada.io is a Korean tipping platform. Bug reports, PRs, and stars on the repo are equally appreciated and free.
 
 ## License
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -281,10 +281,11 @@ ruff format --check src/ tests/
 
 winpodx 가 Linux 데스크톱을 조금이라도 더 좋게 만들었다면:
 
+[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-GitHub-EA4AAA?logo=githubsponsors&logoColor=white&style=for-the-badge)](https://github.com/sponsors/kernalix7)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-F16061?logo=ko-fi&logoColor=white&style=for-the-badge)](https://ko-fi.com/kernalix7)
 [![Fairy](https://img.shields.io/badge/🧚_Fairy-EE6E73?style=for-the-badge&logoColor=white)](https://fairy.hada.io/@kernalix7)
 
-Ko-fi 는 해외 카드 / PayPal 결제; fairy.hada.io 는 국내 결제용.
+GitHub Sponsors 는 정기 / 일시 후원; Ko-fi 는 해외 카드 / PayPal 결제; fairy.hada.io 는 국내 결제용.
 버그 리포트, PR, 별점도 환영합니다 —
 Bug reports, PRs, and stars on the repo are equally appreciated and free.
 


### PR DESCRIPTION
Follow-up to the FUNDING.yml change (#432). Adds the **GitHub Sponsors** badge (linking to https://github.com/sponsors/kernalix7) ahead of Ko-fi/Fairy in the Support section of `README.md` and its Korean mirror `docs/README.ko.md`, with a one-line note that GitHub Sponsors covers recurring/one-time sponsorship.