### PR TITLE
feat(web): richer landing + Features / Get-started / FAQ pages

### DIFF
--- a/web/faq.html
+++ b/web/faq.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<!-- SPDX-License-Identifier: MIT — winpodx.org/faq. No trackers. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>FAQ — winpodx</title>
+  <meta name="description" content="winpodx FAQ: how it works, Windows licensing, performance, security & telemetry, which apps work, and how it compares to a VM, RDP, or Wine.">
+  <link rel="icon" type="image/svg+xml" href="assets/winpodx-icon.svg">
+  <link rel="canonical" href="https://winpodx.org/faq.html">
+  <meta name="theme-color" content="#0d1117">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<header class="nav">
+  <div class="wrap">
+    <a class="brand" href="/" style="color:var(--text)"><img src="assets/winpodx-icon.svg" alt="">winpodx</a>
+    <nav class="links">
+      <a href="features.html">Features</a>
+      <a href="get-started.html">Get started</a>
+      <a href="faq.html" class="active">FAQ</a>
+      <a class="gh" href="https://github.com/kernalix7/winpodx">GitHub</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <section class="page-hero wrap">
+    <span class="eyebrow">FAQ</span>
+    <h1>Common questions</h1>
+    <p>Still stuck? Open an issue on <a href="https://github.com/kernalix7/winpodx/issues">GitHub</a>.</p>
+  </section>
+
+  <section class="wrap">
+    <div class="faq">
+      <details open>
+        <summary>Is this a VM, Wine, or something else?</summary>
+        <div class="a">It's a real Windows VM presented as native windows. winpodx runs Windows in a KVM-backed container (via <a href="https://github.com/dockur/windows">dockur/windows</a>) and surfaces each app as its own Linux window over FreeRDP RemoteApp (RAIL). So you get full Windows compatibility — unlike Wine — without staring at a full-screen Windows desktop.</div>
+      </details>
+      <details>
+        <summary>Do I need a Windows license?</summary>
+        <div class="a">Same as any Windows VM: you need a valid Windows license to activate it for normal use. winpodx automates the install but doesn't provide Windows or a license — those come from Microsoft.</div>
+      </details>
+      <details>
+        <summary>How fast is it? Is it just remote desktop?</summary>
+        <div class="a">It's local RDP to a VM on your own machine over loopback — not a network connection to a remote server — so latency is minimal. Windows runs natively on KVM, and a host-adaptive tuning profile (<code>+invtsc</code>, <code>platform_tick</code>, etc.) is applied based on your CPU. The first launch takes ~5–10 min (Windows ISO download + Sysprep); subsequent launches are near-instant.</div>
+      </details>
+      <details>
+        <summary>Does it phone home or collect telemetry?</summary>
+        <div class="a">No. winpodx has <b>no telemetry of any kind</b> — no analytics, no usage tracking, no phone-home. It even disables Windows' own telemetry/ads/Cortana by default (debloat). It's MIT-licensed and the source is fully public.</div>
+      </details>
+      <details>
+        <summary>Which apps work?</summary>
+        <div class="a">Anything that runs on Windows — Office, Adobe, niche enterprise tools, games' launchers, etc. First boot auto-discovers installed apps from Registry App Paths, the Start Menu, UWP/MSIX, Chocolatey, and Scoop, then registers each with its real icon. You can add custom app profiles in the GUI or with <code>winpodx app</code>.</div>
+      </details>
+      <details>
+        <summary>Can Linux apps open from inside Windows too?</summary>
+        <div class="a">Yes — that's "reverse-open". Your Linux apps appear in the Windows guest's "Open with…" menu with their real icons; picking one round-trips the file open back to the host's <code>xdg-open</code>. It's on by default.</div>
+      </details>
+      <details>
+        <summary>What about clipboard, sound, printers, and USB?</summary>
+        <div class="a">Clipboard (text + images), sound, printers, and your home directory (<code>\\tsclient\home</code>) are shared by default. USB drives auto-map to drive letters, and there's live USB device passthrough (a host ↔ guest switcher) for things like security dongles.</div>
+      </details>
+      <details>
+        <summary>What are the requirements?</summary>
+        <div class="a">A CPU with virtualization extensions + <code>/dev/kvm</code>, 8 GB+ RAM (12 GB+ recommended), ~30 GB free disk, a container runtime (<code>podman</code> ≥ 4 recommended; <code>docker</code> / <code>libvirt</code> also work), and FreeRDP 3+. See <a href="get-started.html">Get started</a> for the full list and per-distro install.</div>
+      </details>
+      <details>
+        <summary>Which Linux distros are supported?</summary>
+        <div class="a">openSUSE, Fedora (incl. Atomic/Silverblue/Kinoite), Debian, Ubuntu, RHEL / AlmaLinux / Rocky, Arch, and NixOS — plus a distro-agnostic AppImage. Install is one line on all of them.</div>
+      </details>
+      <details>
+        <summary>Does the container keep running and eating resources?</summary>
+        <div class="a">No — it auto-suspends when idle and resumes on the next launch. You can also enable pod auto-start on login, or stop it entirely. A stalled RDP guest is detected and self-healed without a manual restart.</div>
+      </details>
+      <details>
+        <summary>How do I uninstall? Will it wipe my Windows data?</summary>
+        <div class="a">One line: <code>curl -fsSL …/uninstall.sh | bash -s -- --confirm</code>. It keeps the Windows VM data by default; pass <code>--purge</code> to wipe everything.</div>
+      </details>
+      <details>
+        <summary>Is it stable? What's the project status?</summary>
+        <div class="a">It's in active <b>beta</b> (v0.6.0) — usable day-to-day, with ongoing polish. Bug reports and PRs are welcome on <a href="https://github.com/kernalix7/winpodx/issues">GitHub</a>.</div>
+      </details>
+    </div>
+  </section>
+</main>
+
+<footer>
+  <div class="wrap">
+    <div class="cols">
+      <div><span class="brand" style="font-size:16px;font-weight:700;color:var(--text)">winpodx</span>
+        <div style="margin-top:6px">Windows apps, as native Linux citizens.</div></div>
+      <div class="links">
+        <a href="features.html">Features</a><a href="get-started.html">Get started</a><a href="faq.html">FAQ</a>
+        <a href="https://github.com/kernalix7/winpodx">GitHub</a>
+        <a href="https://github.com/kernalix7/winpodx/releases">Releases</a>
+        <a href="https://github.com/sponsors/kernalix7">Sponsor</a>
+      </div>
+    </div>
+    <div class="legal">MIT licensed — Kim DaeHyun · Powered by
+      <a href="https://github.com/dockur/windows">dockur/windows</a> + <a href="https://www.freerdp.com/">FreeRDP</a>.
+      Not affiliated with Microsoft.</div>
+  </div>
+</footer>
+</body>
+</html>

--- a/web/features.html
+++ b/web/features.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<!-- SPDX-License-Identifier: MIT — winpodx.org/features. No trackers. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Features — winpodx</title>
+  <meta name="description" content="winpodx features: seamless RemoteApp windows, reverse-open, zero-config discovery, peripherals, multi-session RDP, automation & resilience.">
+  <link rel="icon" type="image/svg+xml" href="assets/winpodx-icon.svg">
+  <link rel="canonical" href="https://winpodx.org/features.html">
+  <meta name="theme-color" content="#0d1117">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<header class="nav">
+  <div class="wrap">
+    <a class="brand" href="/" style="color:var(--text)"><img src="assets/winpodx-icon.svg" alt="">winpodx</a>
+    <nav class="links">
+      <a href="features.html" class="active">Features</a>
+      <a href="get-started.html">Get started</a>
+      <a href="faq.html">FAQ</a>
+      <a class="gh" href="https://github.com/kernalix7/winpodx">GitHub</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <section class="page-hero wrap">
+    <span class="eyebrow">Features</span>
+    <h1>Windows apps, as native Linux citizens</h1>
+    <p>The full picture — from per-app RemoteApp windows to the bidirectional "Open with…" bridge, peripherals, multi-session RDP, and self-healing operations.</p>
+  </section>
+
+  <section class="wrap">
+    <h2>Seamless app windows</h2>
+    <div class="feat">
+      <div class="block">
+        <h3>RemoteApp (RAIL), not a desktop</h3>
+        <p>Each Windows app renders as its own native Linux window — no full-screen Windows desktop. Drop into a full desktop only when you actually want one (<code>winpodx app run desktop</code>).</p>
+      </div>
+      <div class="block">
+        <h3>Real taskbar identity</h3>
+        <p>Per-app taskbar icons via <code>WM_CLASS</code> matching (<code>/wm-class:&lt;stem&gt;</code> + <code>StartupWMClass</code>), so each window pins and alt-tabs like a first-class Linux app.</p>
+      </div>
+      <div class="block">
+        <h3>Bidirectional file associations</h3>
+        <p>Double-click a <code>.docx</code> in your file manager and Word opens. The reverse works too — see below.</p>
+      </div>
+      <div class="block">
+        <h3>Multi-session RDP</h3>
+        <p>The bundled <a href="https://github.com/kernalix7/rdprrap">rdprrap</a> auto-enables up to 10 independent RDP sessions, so multiple apps run truly in parallel. RAIL prerequisites are set automatically during the unattended install.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="alt"><div class="wrap">
+    <h2>Reverse-open — Linux apps inside Windows</h2>
+    <div class="feat">
+      <div class="block">
+        <h3>In the Windows "Open with…" menu</h3>
+        <p>Your Linux apps appear in the Windows guest's right-click "Open with…" menu by default, with correct per-app icons in both the short menu and the long "Choose another app" dialog.</p>
+      </div>
+      <div class="block">
+        <h3>Round-trips to the host</h3>
+        <p>Pick a Linux app inside Windows and the file open round-trips back to the host's <code>xdg-open</code>. winpodx auto-discovers host-side Linux apps and their MIME associations from freedesktop standards.</p>
+      </div>
+      <div class="block">
+        <h3>Manageable</h3>
+        <p>Tune the allow/deny lists via <code>winpodx host-open</code> or the GUI Settings panel.</p>
+      </div>
+    </div>
+  </div></section>
+
+  <section class="wrap">
+    <h2>Zero-config launch &amp; discovery</h2>
+    <div class="feat">
+      <div class="block">
+        <h3>First click provisions everything</h3>
+        <p>Config, container, and desktop entries are created on the first app launch — no manual VM setup.</p>
+      </div>
+      <div class="block">
+        <h3>Auto-discovery</h3>
+        <p>First boot scans the running Windows guest and registers every installed app with its real icon — Registry App Paths, Start Menu, UWP/MSIX, Chocolatey, Scoop. Rescan any time with <code>winpodx app refresh</code> or the GUI Refresh button.</p>
+      </div>
+      <div class="block">
+        <h3>Multi-backend</h3>
+        <p>Podman (default), Docker, libvirt/KVM, or a manual RDP endpoint — pick at setup.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="alt"><div class="wrap">
+    <h2>Peripherals &amp; sharing</h2>
+    <div class="grid">
+      <div class="card"><h3><span class="dot">●</span>On by default</h3><ul>
+        <li>Clipboard — bidirectional text + images</li>
+        <li>Sound — RDP audio streaming</li>
+        <li>Printers — Linux printers shared to Windows</li>
+        <li>Home directory — shared as <code>\\tsclient\home</code></li>
+      </ul></div>
+      <div class="card"><h3><span class="dot">●</span>Storage &amp; devices</h3><ul>
+        <li>USB drives auto-mapped to drive letters (E:, F:, …)</li>
+        <li>Drives plugged in mid-session resolve, subfolders work</li>
+        <li>Live USB device passthrough (host ↔ guest switcher)</li>
+        <li>Smart DPI scaling from GNOME / KDE / Sway / Hyprland / Cinnamon</li>
+      </ul></div>
+    </div>
+  </div></section>
+
+  <section class="wrap">
+    <h2>Automation, resilience &amp; security</h2>
+    <div class="grid">
+      <div class="card"><h3><span class="dot">●</span>Keeps itself healthy</h3><ul>
+        <li>Auto suspend / resume — pauses when idle, resumes on launch</li>
+        <li>Optional pod auto-start on login</li>
+        <li>UNRESPONSIVE → recover: self-heals a stalled RDP guest</li>
+        <li>Windows disk auto-grows when C: fills, bounded by host space</li>
+      </ul></div>
+      <div class="card"><h3><span class="dot">●</span>Secure &amp; private</h3><ul>
+        <li>Password auto-rotation — 20-char, 7-day cycle, atomic rollback</li>
+        <li>Windows debloat: telemetry, ads, Cortana off by default</li>
+        <li>FreeRDP <code>extra_flags</code> allowlist (regex-validated)</li>
+        <li>No winpodx telemetry — ever</li>
+      </ul></div>
+      <div class="card"><h3><span class="dot">●</span>Operations</h3><ul>
+        <li><code>winpodx doctor</code> — deps / pod / RDP / agent / disk health</li>
+        <li><code>--json</code>, <code>--quick</code>, and <code>--fix</code> auto-remediation</li>
+        <li>Guest sync after a host upgrade; offline / air-gapped install</li>
+        <li>One-line uninstall (keeps VM data unless <code>--purge</code>)</li>
+      </ul></div>
+      <div class="card"><h3><span class="dot">●</span>Polish</h3><ul>
+        <li>Host-adaptive Windows-on-KVM tuning profile</li>
+        <li>Time sync after host sleep/wake</li>
+        <li>Multilingual UI (en / ko / zh / ja / de / fr / it)</li>
+        <li>Qt6 GUI: Apps / Settings / Tools / Terminal / Info + tray</li>
+      </ul></div>
+    </div>
+    <p class="lead" style="margin-top:26px"><a href="https://github.com/kernalix7/winpodx/blob/main/docs/FEATURES.md">Deep dives in the docs →</a></p>
+  </section>
+</main>
+
+<footer>
+  <div class="wrap">
+    <div class="cols">
+      <div><span class="brand" style="font-size:16px;font-weight:700;color:var(--text)">winpodx</span>
+        <div style="margin-top:6px">Windows apps, as native Linux citizens.</div></div>
+      <div class="links">
+        <a href="features.html">Features</a><a href="get-started.html">Get started</a><a href="faq.html">FAQ</a>
+        <a href="https://github.com/kernalix7/winpodx">GitHub</a>
+        <a href="https://github.com/kernalix7/winpodx/releases">Releases</a>
+        <a href="https://github.com/sponsors/kernalix7">Sponsor</a>
+      </div>
+    </div>
+    <div class="legal">MIT licensed — Kim DaeHyun · Powered by
+      <a href="https://github.com/dockur/windows">dockur/windows</a> + <a href="https://www.freerdp.com/">FreeRDP</a>.
+      Not affiliated with Microsoft.</div>
+  </div>
+</footer>
+</body>
+</html>

--- a/web/get-started.html
+++ b/web/get-started.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<!-- SPDX-License-Identifier: MIT — winpodx.org/get-started. No trackers. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Get started — winpodx</title>
+  <meta name="description" content="Install winpodx: one-line curl, or native packages for openSUSE, Fedora, Debian/Ubuntu, RHEL, Arch, NixOS, and AppImage. Requirements + first-time setup.">
+  <link rel="icon" type="image/svg+xml" href="assets/winpodx-icon.svg">
+  <link rel="canonical" href="https://winpodx.org/get-started.html">
+  <meta name="theme-color" content="#0d1117">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<header class="nav">
+  <div class="wrap">
+    <a class="brand" href="/" style="color:var(--text)"><img src="assets/winpodx-icon.svg" alt="">winpodx</a>
+    <nav class="links">
+      <a href="features.html">Features</a>
+      <a href="get-started.html" class="active">Get started</a>
+      <a href="faq.html">FAQ</a>
+      <a class="gh" href="https://github.com/kernalix7/winpodx">GitHub</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <section class="page-hero wrap">
+    <span class="eyebrow">Get started</span>
+    <h1>Up and running in one line</h1>
+    <p>The curl installer works on every supported distro and runs setup for you. Or use your native package manager and run <code>winpodx setup</code> once.</p>
+  </section>
+
+  <section class="wrap">
+    <h2>1 · Install</h2>
+    <p class="lead">The one-liner installs winpodx, runs setup, and waits for the first Windows boot (~5–10 min).</p>
+    <div class="install" style="margin-top:24px">
+      <div class="label">Any supported distro</div>
+      <div class="code"><button class="copy" data-copy="curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash">Copy</button><span class="prompt">$ </span>curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash</div>
+    </div>
+
+    <h2 style="margin-top:48px;font-size:22px">Or via a package manager</h2>
+    <div class="dist">
+      <div class="item"><h3>openSUSE (Tumbleweed / Leap / Slowroll)</h3>
+        <div class="code"><button class="copy" data-copy="sudo zypper addrepo https://download.opensuse.org/repositories/home:/Kernalix7/openSUSE_Tumbleweed/home:Kernalix7.repo
+sudo zypper install winpodx">Copy</button>sudo zypper addrepo …home:Kernalix7.repo
+sudo zypper install winpodx</div></div>
+      <div class="item"><h3>Fedora 42 / 43 / 44</h3>
+        <div class="code"><button class="copy" data-copy="sudo dnf config-manager addrepo --from-repofile=https://download.opensuse.org/repositories/home:/Kernalix7/Fedora_43/home:Kernalix7.repo
+sudo dnf install winpodx">Copy</button>sudo dnf config-manager addrepo --from-repofile=…
+sudo dnf install winpodx</div></div>
+      <div class="item"><h3>Arch / Manjaro</h3>
+        <div class="code"><button class="copy" data-copy="yay -S winpodx">Copy</button><span class="prompt">$ </span>yay -S winpodx</div></div>
+      <div class="item"><h3>NixOS</h3>
+        <div class="code"><button class="copy" data-copy="nix run github:kernalix7/winpodx">Copy</button><span class="prompt">$ </span>nix run github:kernalix7/winpodx</div></div>
+      <div class="item"><h3>Debian / Ubuntu (.deb)</h3>
+        <div class="code"><button class="copy" data-copy="sudo apt install ./winpodx_<version>_all_debian13.deb">Copy</button><span class="prompt">$ </span>sudo apt install ./winpodx_&lt;version&gt;_all_debian13.deb</div></div>
+      <div class="item"><h3>AlmaLinux / Rocky / RHEL (.rpm)</h3>
+        <div class="code"><button class="copy" data-copy="sudo dnf install ./winpodx-<version>-0.noarch.el10.rpm">Copy</button><span class="prompt">$ </span>sudo dnf install ./winpodx-&lt;version&gt;-0.noarch.el10.rpm</div></div>
+      <div class="item"><h3>AppImage (any distro)</h3>
+        <div class="code"><button class="copy" data-copy="chmod +x winpodx-*-x86_64.AppImage
+./winpodx-*-x86_64.AppImage setup">Copy</button>chmod +x winpodx-*-x86_64.AppImage
+./winpodx-*-x86_64.AppImage setup</div></div>
+      <div class="item"><h3>Uninstall</h3>
+        <div class="code"><button class="copy" data-copy="curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh | bash -s -- --confirm">Copy</button>curl -fsSL …/uninstall.sh | bash -s -- --confirm</div></div>
+    </div>
+    <div class="note" style="border-left-color:var(--blue)">
+      <b>After a package / AppImage install</b>, run <code>winpodx setup</code> once to generate the
+      config + compose and confirm host deps — package installs ship the binary only, so they don't
+      kick off a 10-minute Windows download out of the blue. The curl one-liner does this for you.
+    </div>
+  </section>
+
+  <section class="alt"><div class="wrap">
+    <h2>2 · First-time setup</h2>
+    <p class="lead">Already used the curl one-liner? It ran setup — skip to launch.</p>
+    <div class="dist">
+      <div class="item"><h3>Auto (host-detected defaults)</h3>
+        <div class="code"><button class="copy" data-copy="winpodx setup">Copy</button><span class="prompt">$ </span>winpodx setup</div></div>
+      <div class="item"><h3>Interactive wizard</h3>
+        <div class="code"><button class="copy" data-copy="winpodx setup --customize">Copy</button><span class="prompt">$ </span>winpodx setup --customize</div></div>
+    </div>
+    <p class="lead" style="margin-top:18px;text-align:left;max-width:none">
+      Setup writes <code>~/.config/winpodx/winpodx.toml</code> + <code>compose.yaml</code>, registers the GUI launcher,
+      and confirms FreeRDP + Podman/Docker + KVM. The first app launch then provisions the pod and reaches a usable
+      RDP session in ~5–10 min.</p>
+    <div class="install" style="margin-top:8px">
+      <div class="label">Launch (first run ~5–10 min, then near-instant)</div>
+      <div class="code"><button class="copy" data-copy="winpodx app run desktop
+winpodx pod wait-ready --logs">Copy</button>winpodx app run desktop          <span style="color:var(--overlay0)"># first launch</span>
+winpodx pod wait-ready --logs    <span style="color:var(--overlay0)"># watch progress</span></div>
+    </div>
+  </div></section>
+
+  <section class="wrap">
+    <h2>3 · Requirements</h2>
+    <div class="feat" style="margin-top:24px">
+      <div class="block">
+        <h3>Hardware virtualization</h3>
+        <p>An x86_64 or aarch64 CPU with virtualization extensions (VT-x / AMD-V / EL2), and access to <code>/dev/kvm</code>. winpodx runs Windows in a KVM-backed container — without KVM the install completes but Windows never boots.</p>
+      </div>
+      <div class="block">
+        <h3>Memory &amp; disk</h3>
+        <p>8 GB+ RAM (12 GB+ recommended) and ~30 GB free disk for the Windows image.</p>
+      </div>
+      <div class="block">
+        <h3>Container runtime + FreeRDP</h3>
+        <p>A host container runtime (<code>podman</code> ≥ 4 recommended; <code>docker</code> / <code>libvirt</code> also supported) and FreeRDP 3+. <code>winpodx setup-host</code> fixes kvm-group + <code>/etc/subuid</code> / <code>subgid</code> via one <code>pkexec</code> prompt; <code>winpodx doctor</code> surfaces anything still missing.</p>
+      </div>
+    </div>
+    <p class="lead" style="margin-top:26px">
+      <a class="btn primary" href="https://github.com/kernalix7/winpodx/blob/main/docs/INSTALL.md">Full install docs →</a>
+    </p>
+  </section>
+</main>
+
+<footer>
+  <div class="wrap">
+    <div class="cols">
+      <div><span class="brand" style="font-size:16px;font-weight:700;color:var(--text)">winpodx</span>
+        <div style="margin-top:6px">Windows apps, as native Linux citizens.</div></div>
+      <div class="links">
+        <a href="features.html">Features</a><a href="get-started.html">Get started</a><a href="faq.html">FAQ</a>
+        <a href="https://github.com/kernalix7/winpodx">GitHub</a>
+        <a href="https://github.com/kernalix7/winpodx/releases">Releases</a>
+        <a href="https://github.com/sponsors/kernalix7">Sponsor</a>
+      </div>
+    </div>
+    <div class="legal">MIT licensed — Kim DaeHyun · Powered by
+      <a href="https://github.com/dockur/windows">dockur/windows</a> + <a href="https://www.freerdp.com/">FreeRDP</a>.
+      Not affiliated with Microsoft.</div>
+  </div>
+</footer>
+
+<script>
+  document.querySelectorAll("button.copy").forEach(function (b) {
+    b.addEventListener("click", function () {
+      navigator.clipboard.writeText(b.dataset.copy).then(function () {
+        var t = b.textContent; b.textContent = "Copied"; setTimeout(function () { b.textContent = t; }, 1500);
+      });
+    });
+  });
+</script>
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- SPDX-License-Identifier: MIT — winpodx.org landing page. No trackers. -->
+<!-- SPDX-License-Identifier: MIT — winpodx.org. No trackers, no telemetry. -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -8,7 +8,6 @@
   <meta name="description" content="Run Windows apps on Linux as first-class native windows — real icons, taskbar, file associations. FreeRDP RemoteApp + dockur/windows. One-command setup.">
   <link rel="icon" type="image/svg+xml" href="assets/winpodx-icon.svg">
   <link rel="canonical" href="https://winpodx.org/">
-  <!-- Open Graph -->
   <meta property="og:title" content="winpodx — Windows apps as native Linux windows">
   <meta property="og:description" content="Click an app. Word opens. That's it. FreeRDP RemoteApp + dockur/windows, zero config.">
   <meta property="og:type" content="website">
@@ -21,11 +20,11 @@
 
 <header class="nav">
   <div class="wrap">
-    <span class="brand"><img src="assets/winpodx-icon.svg" alt="">winpodx</span>
+    <a class="brand" href="/" style="color:var(--text)"><img src="assets/winpodx-icon.svg" alt="">winpodx</a>
     <nav class="links">
-      <a href="#features">Features</a>
-      <a href="#install">Install</a>
-      <a href="https://github.com/kernalix7/winpodx/blob/main/docs/USAGE.md">Docs</a>
+      <a href="features.html">Features</a>
+      <a href="get-started.html">Get started</a>
+      <a href="faq.html">FAQ</a>
       <a class="gh" href="https://github.com/kernalix7/winpodx">GitHub</a>
     </nav>
   </div>
@@ -34,7 +33,7 @@
 <main>
   <section class="hero wrap">
     <img class="logo" src="assets/winpodx-icon.svg" alt="winpodx logo">
-    <h1>Click an app. Word opens.<br>That's it.</h1>
+    <h1>Click an app.<br><span class="grad">Word opens. That's it.</span></h1>
     <p class="sub">Native Linux windows for every Windows app — real icons, real
       <code>WM_CLASS</code>, pin-to-taskbar. FreeRDP RemoteApp + dockur/windows.
       Zero config.</p>
@@ -43,16 +42,16 @@
       <span class="badge beta">beta · v0.6.0</span>
       <span class="badge">MIT</span>
       <span class="badge">Python 3.9+</span>
-      <span class="badge">stdlib-only on 3.11+</span>
+      <span class="badge">no telemetry</span>
     </div>
 
     <div class="install" id="install">
-      <div class="label">Install (latest stable)</div>
+      <div class="label">Install (latest stable · any supported distro)</div>
       <div class="code"><button class="copy" data-copy="curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash">Copy</button><span class="prompt">$ </span>curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/install.sh | bash</div>
     </div>
 
     <div class="cta">
-      <a class="btn primary" href="https://github.com/kernalix7/winpodx#quick-install">Get started</a>
+      <a class="btn primary" href="get-started.html">Get started →</a>
       <a class="btn ghost" href="https://github.com/kernalix7/winpodx">★ Star on GitHub</a>
     </div>
   </section>
@@ -62,63 +61,92 @@
     <div class="cap">Windows About / Performance Monitor / PowerShell each in their own Linux window, alongside the winpodx Apps grid.</div>
   </div>
 
-  <section id="features" class="wrap">
-    <h2>What it does</h2>
-    <p class="lead">No full-screen RDP. Each Windows app becomes its own Linux window — pinnable, alt-tabbable, file-associated, both directions.</p>
-    <div class="grid">
-      <div class="card">
-        <h3><span class="dot">●</span>Seamless app windows</h3>
-        <ul>
+  <section class="alt">
+    <div class="wrap">
+      <h2>How it works</h2>
+      <p class="lead">No manual VM wrangling. winpodx provisions everything on the first app click.</p>
+      <div class="steps">
+        <div class="step">
+          <div class="n">1</div>
+          <h3>Install &amp; setup</h3>
+          <p>One command pulls a Windows container (<a href="https://github.com/dockur/windows">dockur/windows</a>) in rootless Podman, runs an unattended Windows install, and applies the RemoteApp + agent setup.</p>
+        </div>
+        <div class="step">
+          <div class="n">2</div>
+          <h3>Apps auto-discovered</h3>
+          <p>First boot scans the guest — Registry App Paths, Start Menu, UWP/MSIX, Chocolatey, Scoop — and registers every app with its real icon as a Linux <code>.desktop</code> entry.</p>
+        </div>
+        <div class="step">
+          <div class="n">3</div>
+          <h3>Click &amp; launch</h3>
+          <p>Click the app like any native one. It opens in its own Linux window via FreeRDP RemoteApp — pinnable, alt-tabbable, file-associated. No full desktop.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="wrap">
+    <h2>Why not just RDP, a VM, or Wine?</h2>
+    <p class="lead">winpodx keeps real Windows compatibility while feeling native.</p>
+    <div class="table-wrap">
+      <table class="cmp">
+        <colgroup><col><col class="win"><col><col><col></colgroup>
+        <thead>
+          <tr><th></th><th>winpodx</th><th>Full-screen RDP</th><th>Bare VM</th><th>Wine</th></tr>
+        </thead>
+        <tbody>
+          <tr><th>Per-app native windows</th><td class="yes">✓</td><td class="no">desktop only</td><td class="no">desktop only</td><td class="yes">✓</td></tr>
+          <tr><th>Real Windows compatibility</th><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td><td class="no">partial</td></tr>
+          <tr><th>Taskbar icons + file assoc.</th><td class="yes">✓</td><td class="no">✕</td><td class="no">✕</td><td class="no">limited</td></tr>
+          <tr><th>One-command setup</th><td class="yes">✓</td><td class="no">manual</td><td class="no">manual</td><td class="no">per-app</td></tr>
+          <tr><th>Linux apps in Windows menu</th><td class="yes">✓</td><td class="no">✕</td><td class="no">✕</td><td class="no">✕</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="lead" style="margin-top:18px"><a href="features.html">See all features →</a></p>
+  </section>
+
+  <section id="features" class="alt">
+    <div class="wrap">
+      <h2>What it does</h2>
+      <p class="lead">Each Windows app becomes its own Linux window — pinnable, alt-tabbable, file-associated, both directions.</p>
+      <div class="grid">
+        <div class="card"><h3><span class="dot">●</span>Seamless app windows</h3><ul>
           <li>RemoteApp (RAIL) renders each app as a native window — no desktop</li>
           <li>Per-app taskbar icons via <code>WM_CLASS</code> matching</li>
-          <li>Double-click <code>.docx</code> in your file manager → Word opens</li>
+          <li>Double-click <code>.docx</code> → Word opens</li>
           <li>Multi-session RDP: up to 10 independent sessions</li>
-        </ul>
-      </div>
-      <div class="card">
-        <h3><span class="dot">●</span>Reverse-open</h3>
-        <ul>
+        </ul></div>
+        <div class="card"><h3><span class="dot">●</span>Reverse-open</h3><ul>
           <li>Linux apps appear in the Windows "Open with…" menu, by default</li>
           <li>Correct per-app icons in both Windows chooser dialogs</li>
-          <li>Selecting one round-trips the file open back to host <code>xdg-open</code></li>
+          <li>Round-trips the file open back to host <code>xdg-open</code></li>
           <li>Auto-discovers host apps + MIME from freedesktop standards</li>
-        </ul>
-      </div>
-      <div class="card">
-        <h3><span class="dot">●</span>Zero-config launch</h3>
-        <ul>
-          <li>First app click auto-provisions config, container, desktop entries</li>
-          <li>First-boot discovery registers every installed Windows app with its real icon</li>
+        </ul></div>
+        <div class="card"><h3><span class="dot">●</span>Zero-config launch</h3><ul>
+          <li>First click auto-provisions config, container, desktop entries</li>
+          <li>First-boot discovery registers every app with its real icon</li>
           <li>Registry App Paths, Start Menu, UWP/MSIX, Chocolatey, Scoop</li>
           <li>Backends: Podman (default), Docker, libvirt/KVM, manual RDP</li>
-        </ul>
-      </div>
-      <div class="card">
-        <h3><span class="dot">●</span>Peripherals &amp; sharing</h3>
-        <ul>
-          <li>Clipboard (text + images), sound, and printers — on by default</li>
+        </ul></div>
+        <div class="card"><h3><span class="dot">●</span>Peripherals &amp; sharing</h3><ul>
+          <li>Clipboard (text + images), sound, printers — on by default</li>
           <li>Home directory shared as <code>\\tsclient\home</code></li>
-          <li>USB drives auto-mapped to drive letters; live USB device passthrough</li>
+          <li>USB drives auto-mapped; live USB device passthrough</li>
           <li>Smart DPI scaling auto-detected from your desktop</li>
-        </ul>
-      </div>
-      <div class="card">
-        <h3><span class="dot">●</span>Automation &amp; resilience</h3>
-        <ul>
+        </ul></div>
+        <div class="card"><h3><span class="dot">●</span>Automation &amp; resilience</h3><ul>
           <li>Auto suspend / resume; optional pod auto-start on login</li>
           <li>Self-heals a stalled RDP guest (UNRESPONSIVE → recover)</li>
           <li>Password auto-rotation; Windows disk auto-grow</li>
-          <li>Health checks + auto-remediation via <code>winpodx doctor --fix</code></li>
-        </ul>
-      </div>
-      <div class="card">
-        <h3><span class="dot">●</span>Lean &amp; private</h3>
-        <ul>
+          <li>Health checks + auto-fix via <code>winpodx doctor --fix</code></li>
+        </ul></div>
+        <div class="card"><h3><span class="dot">●</span>Lean &amp; private</h3><ul>
           <li>Near-zero Python deps — stdlib only on 3.11+</li>
           <li>No telemetry, ever</li>
           <li>Multilingual UI (en / ko / zh / ja / de / fr / it)</li>
           <li>Qt6 GUI + a lightweight system tray</li>
-        </ul>
+        </ul></div>
       </div>
     </div>
   </section>
@@ -127,21 +155,15 @@
     <h2>Works on</h2>
     <p class="lead">One-line install across the major Linux families.</p>
     <div class="pills">
-      <span class="pill">openSUSE</span>
-      <span class="pill">Fedora</span>
-      <span class="pill">Fedora Atomic</span>
-      <span class="pill">Debian</span>
-      <span class="pill">Ubuntu</span>
-      <span class="pill">RHEL / Alma / Rocky</span>
-      <span class="pill">Arch</span>
-      <span class="pill">NixOS</span>
-      <span class="pill">AppImage (any distro)</span>
+      <span class="pill">openSUSE</span><span class="pill">Fedora</span><span class="pill">Fedora Atomic</span>
+      <span class="pill">Debian</span><span class="pill">Ubuntu</span><span class="pill">RHEL / Alma / Rocky</span>
+      <span class="pill">Arch</span><span class="pill">NixOS</span><span class="pill">AppImage (any distro)</span>
     </div>
     <div class="note">
       <b>Needs hardware virtualization.</b> winpodx runs Windows in a KVM-backed
       container — an x86_64 / aarch64 CPU with virtualization extensions, 8 GB+ RAM
       (12 GB+ recommended), and ~30 GB free disk. First install takes ~5–10 minutes
-      (Windows ISO download + Sysprep + OEM apply).
+      (Windows ISO download + Sysprep + OEM apply). <a href="get-started.html">Full requirements →</a>
     </div>
   </section>
 </main>
@@ -154,10 +176,11 @@
         <div style="margin-top:6px">Windows apps, as native Linux citizens.</div>
       </div>
       <div class="links">
+        <a href="features.html">Features</a>
+        <a href="get-started.html">Get started</a>
+        <a href="faq.html">FAQ</a>
         <a href="https://github.com/kernalix7/winpodx">GitHub</a>
         <a href="https://github.com/kernalix7/winpodx/releases">Releases</a>
-        <a href="https://github.com/kernalix7/winpodx/blob/main/docs/INSTALL.md">Install</a>
-        <a href="https://github.com/kernalix7/winpodx/blob/main/docs/USAGE.md">Usage</a>
         <a href="https://github.com/kernalix7/winpodx/issues">Issues</a>
         <a href="https://github.com/sponsors/kernalix7">Sponsor</a>
       </div>
@@ -172,7 +195,6 @@
 </footer>
 
 <script>
-  // Minimal copy-to-clipboard for the install command. No external libs, no tracking.
   document.querySelectorAll("button.copy").forEach(function (b) {
     b.addEventListener("click", function () {
       navigator.clipboard.writeText(b.dataset.copy).then(function () {

--- a/web/style.css
+++ b/web/style.css
@@ -159,3 +159,101 @@ footer .legal { margin-top: 22px; font-size: 13px; color: var(--overlay0); }
   .grid { grid-template-columns: 1fr; }
   .nav .links a:not(.gh) { display: none; }
 }
+
+/* ===== v2: multi-page + richer landing ===== */
+
+/* gradient accent behind the hero */
+.hero { position: relative; overflow: hidden; }
+.hero::before {
+  content: ""; position: absolute; inset: -40% 0 auto 0; height: 520px; z-index: -1;
+  background: radial-gradient(60% 60% at 50% 0%, rgba(56, 139, 253, 0.18), transparent 70%);
+  pointer-events: none;
+}
+.hero h1 .grad {
+  background: linear-gradient(90deg, var(--blue), var(--sapphire) 60%, var(--green));
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+}
+
+/* active nav link */
+.nav .links a.active { color: var(--text); }
+.nav .links a.active::after {
+  content: ""; display: block; height: 2px; background: var(--blue);
+  border-radius: 2px; margin-top: 3px;
+}
+
+/* sub-page hero (smaller) */
+.page-hero { text-align: center; padding: 56px 0 8px; position: relative; }
+.page-hero h1 { font-size: 36px; letter-spacing: -0.4px; }
+.page-hero p { color: var(--subtext1); font-size: 17px; max-width: 640px; margin: 14px auto 0; }
+.page-hero .eyebrow {
+  display: inline-block; font-size: 12px; font-weight: 700; letter-spacing: 1.5px;
+  text-transform: uppercase; color: var(--blue); margin-bottom: 12px;
+}
+
+/* alternating section background */
+section.alt { background: var(--base); border-block: 1px solid var(--surface1); }
+
+/* how-it-works steps */
+.steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; margin-top: 36px; }
+.step { background: var(--base); border: 1px solid var(--surface1); border-radius: var(--radius); padding: 24px; }
+section.alt .step { background: var(--mantle); }
+.step .n {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 34px; height: 34px; border-radius: 50%; font-weight: 700;
+  background: var(--surface0); color: var(--blue); border: 1px solid var(--blue); margin-bottom: 14px;
+}
+.step h3 { font-size: 16px; margin-bottom: 8px; }
+.step p { color: var(--subtext1); font-size: 14px; }
+.step code { background: var(--surface0); border-radius: 5px; padding: 1px 6px; font-size: 12.5px; }
+
+/* comparison table */
+.table-wrap { margin-top: 32px; overflow-x: auto; border: 1px solid var(--surface1); border-radius: var(--radius); }
+table.cmp { width: 100%; border-collapse: collapse; font-size: 14px; min-width: 560px; }
+table.cmp th, table.cmp td { padding: 13px 16px; text-align: left; border-bottom: 1px solid var(--surface1); }
+table.cmp thead th { background: var(--surface0); color: var(--text); font-size: 13px; }
+table.cmp tbody th { color: var(--subtext1); font-weight: 600; }
+table.cmp td { color: var(--subtext1); }
+table.cmp .yes { color: var(--green); font-weight: 700; }
+table.cmp .no { color: var(--overlay0); }
+table.cmp col.win { background: rgba(56, 139, 253, 0.06); }
+table.cmp tbody tr:last-child td, table.cmp tbody tr:last-child th { border-bottom: none; }
+
+/* feature deep-dive blocks */
+.feat { display: grid; grid-template-columns: 1fr; gap: 16px; margin-top: 30px; }
+.feat .block {
+  background: var(--base); border: 1px solid var(--surface1); border-radius: var(--radius);
+  border-left: 3px solid var(--blue); padding: 22px 24px;
+}
+.feat .block h3 { font-size: 18px; margin-bottom: 8px; }
+.feat .block p { color: var(--subtext1); font-size: 14.5px; }
+.feat .block p + p { margin-top: 8px; }
+.feat .block code { background: var(--surface0); border-radius: 5px; padding: 1px 6px; font-size: 13px; }
+
+/* install / get-started blocks */
+.dist { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; margin-top: 28px; }
+.dist .item { background: var(--base); border: 1px solid var(--surface1); border-radius: var(--radius); padding: 18px 20px; }
+.dist .item h3 { font-size: 15px; margin-bottom: 10px; color: var(--text); }
+.dist .item .code { font-size: 13px; padding: 12px 14px; }
+
+/* FAQ */
+.faq { max-width: 800px; margin: 32px auto 0; }
+.faq details {
+  background: var(--base); border: 1px solid var(--surface1); border-radius: var(--radius);
+  padding: 4px 20px; margin-bottom: 12px;
+}
+.faq details[open] { border-color: var(--surface2); }
+.faq summary {
+  cursor: pointer; font-weight: 600; font-size: 16px; padding: 14px 0; list-style: none;
+  display: flex; justify-content: space-between; align-items: center; color: var(--text);
+}
+.faq summary::-webkit-details-marker { display: none; }
+.faq summary::after { content: "+"; color: var(--blue); font-size: 22px; font-weight: 400; }
+.faq details[open] summary::after { content: "−"; }
+.faq .a { color: var(--subtext1); font-size: 14.5px; padding: 0 0 16px; }
+.faq .a code { background: var(--surface0); border-radius: 5px; padding: 1px 6px; font-size: 13px; }
+.faq .a a { color: var(--blue); }
+
+@media (max-width: 720px) {
+  .steps, .dist { grid-template-columns: 1fr; }
+  .page-hero h1 { font-size: 28px; }
+}


### PR DESCRIPTION
Expands winpodx.org into a small multi-page site (still hand-written static HTML/CSS, **no framework, no trackers, no telemetry**):

- **index.html** — gradient hero, a *How it works* 3-step section, a winpodx-vs-RDP/VM/Wine **comparison table**, and cross-page nav/footer.
- **features.html** — deep-dive feature blocks across seamless windows / reverse-open / discovery / peripherals / automation·resilience·security.
- **get-started.html** — the one-liner + per-distro package commands (openSUSE / Fedora / Arch / Nix / .deb / .rpm / AppImage), first-time setup, and hardware/runtime requirements.
- **faq.html** — 12 Q&A (real VM vs Wine, Windows licensing, performance, no-telemetry, which apps, reverse-open, peripherals, uninstall, status) as native `<details>` accordions.
- **style.css** — new components (gradient accent, steps, comparison table, sub-page hero, dist grid, FAQ accordion, active-nav indicator).

All pages validated: structure + every local asset/page ref resolves. On merge, `pages.yml` redeploys to https://winpodx.org.