### PR TITLE
feat(web): inline SVG icons + motion polish

### DIFF
--- a/web/faq.html
+++ b/web/faq.html
@@ -13,6 +13,20 @@
 </head>
 <body>
 
+<svg class="sprite" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+  <symbol id="i-window" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18"/></symbol>
+  <symbol id="i-swap" viewBox="0 0 24 24"><path d="M17 1l4 4-4 4"/><path d="M3 11V9a4 4 0 0 1 4-4h14"/><path d="M7 23l-4-4 4-4"/><path d="M21 13v2a4 4 0 0 1-4 4H3"/></symbol>
+  <symbol id="i-bolt" viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9z"/></symbol>
+  <symbol id="i-hdd" viewBox="0 0 24 24"><line x1="22" y1="12" x2="2" y2="12"/><path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/><line x1="6" y1="16" x2="6.01" y2="16"/><line x1="10" y1="16" x2="10.01" y2="16"/></symbol>
+  <symbol id="i-activity" viewBox="0 0 24 24"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></symbol>
+  <symbol id="i-lock" viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></symbol>
+  <symbol id="i-download" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M7 10l5 5 5-5"/><path d="M12 15V3"/></symbol>
+  <symbol id="i-grid" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></symbol>
+  <symbol id="i-cursor" viewBox="0 0 24 24"><path d="M3 3l7.5 18 2.5-7.5L21 11z"/></symbol>
+  <symbol id="i-github" viewBox="0 0 24 24"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></symbol>
+</svg>
+
+
 <header class="nav">
   <div class="wrap">
     <a class="brand" href="/" style="color:var(--text)"><img src="assets/winpodx-icon.svg" alt="">winpodx</a>
@@ -20,7 +34,7 @@
       <a href="features.html">Features</a>
       <a href="get-started.html">Get started</a>
       <a href="faq.html" class="active">FAQ</a>
-      <a class="gh" href="https://github.com/kernalix7/winpodx">GitHub</a>
+      <a class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg"><use href="#i-github"/></svg> GitHub</a>
     </nav>
   </div>
 </header>

--- a/web/features.html
+++ b/web/features.html
@@ -13,6 +13,20 @@
 </head>
 <body>
 
+<svg class="sprite" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+  <symbol id="i-window" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18"/></symbol>
+  <symbol id="i-swap" viewBox="0 0 24 24"><path d="M17 1l4 4-4 4"/><path d="M3 11V9a4 4 0 0 1 4-4h14"/><path d="M7 23l-4-4 4-4"/><path d="M21 13v2a4 4 0 0 1-4 4H3"/></symbol>
+  <symbol id="i-bolt" viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9z"/></symbol>
+  <symbol id="i-hdd" viewBox="0 0 24 24"><line x1="22" y1="12" x2="2" y2="12"/><path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/><line x1="6" y1="16" x2="6.01" y2="16"/><line x1="10" y1="16" x2="10.01" y2="16"/></symbol>
+  <symbol id="i-activity" viewBox="0 0 24 24"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></symbol>
+  <symbol id="i-lock" viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></symbol>
+  <symbol id="i-download" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M7 10l5 5 5-5"/><path d="M12 15V3"/></symbol>
+  <symbol id="i-grid" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></symbol>
+  <symbol id="i-cursor" viewBox="0 0 24 24"><path d="M3 3l7.5 18 2.5-7.5L21 11z"/></symbol>
+  <symbol id="i-github" viewBox="0 0 24 24"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></symbol>
+</svg>
+
+
 <header class="nav">
   <div class="wrap">
     <a class="brand" href="/" style="color:var(--text)"><img src="assets/winpodx-icon.svg" alt="">winpodx</a>
@@ -20,7 +34,7 @@
       <a href="features.html" class="active">Features</a>
       <a href="get-started.html">Get started</a>
       <a href="faq.html">FAQ</a>
-      <a class="gh" href="https://github.com/kernalix7/winpodx">GitHub</a>
+      <a class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg"><use href="#i-github"/></svg> GitHub</a>
     </nav>
   </div>
 </header>
@@ -93,13 +107,13 @@
   <section class="alt"><div class="wrap">
     <h2>Peripherals &amp; sharing</h2>
     <div class="grid">
-      <div class="card"><h3><span class="dot">●</span>On by default</h3><ul>
+      <div class="card"><h3><span class="ico"><svg viewBox="0 0 24 24"><use href="#i-bolt"/></svg></span>On by default</h3><ul>
         <li>Clipboard — bidirectional text + images</li>
         <li>Sound — RDP audio streaming</li>
         <li>Printers — Linux printers shared to Windows</li>
         <li>Home directory — shared as <code>\\tsclient\home</code></li>
       </ul></div>
-      <div class="card"><h3><span class="dot">●</span>Storage &amp; devices</h3><ul>
+      <div class="card"><h3><span class="ico"><svg viewBox="0 0 24 24"><use href="#i-hdd"/></svg></span>Storage &amp; devices</h3><ul>
         <li>USB drives auto-mapped to drive letters (E:, F:, …)</li>
         <li>Drives plugged in mid-session resolve, subfolders work</li>
         <li>Live USB device passthrough (host ↔ guest switcher)</li>
@@ -111,25 +125,25 @@
   <section class="wrap">
     <h2>Automation, resilience &amp; security</h2>
     <div class="grid">
-      <div class="card"><h3><span class="dot">●</span>Keeps itself healthy</h3><ul>
+      <div class="card"><h3><span class="ico"><svg viewBox="0 0 24 24"><use href="#i-activity"/></svg></span>Keeps itself healthy</h3><ul>
         <li>Auto suspend / resume — pauses when idle, resumes on launch</li>
         <li>Optional pod auto-start on login</li>
         <li>UNRESPONSIVE → recover: self-heals a stalled RDP guest</li>
         <li>Windows disk auto-grows when C: fills, bounded by host space</li>
       </ul></div>
-      <div class="card"><h3><span class="dot">●</span>Secure &amp; private</h3><ul>
+      <div class="card"><h3><span class="ico"><svg viewBox="0 0 24 24"><use href="#i-lock"/></svg></span>Secure &amp; private</h3><ul>
         <li>Password auto-rotation — 20-char, 7-day cycle, atomic rollback</li>
         <li>Windows debloat: telemetry, ads, Cortana off by default</li>
         <li>FreeRDP <code>extra_flags</code> allowlist (regex-validated)</li>
         <li>No winpodx telemetry — ever</li>
       </ul></div>
-      <div class="card"><h3><span class="dot">●</span>Operations</h3><ul>
+      <div class="card"><h3><span class="ico"><svg viewBox="0 0 24 24"><use href="#i-grid"/></svg></span>Operations</h3><ul>
         <li><code>winpodx doctor</code> — deps / pod / RDP / agent / disk health</li>
         <li><code>--json</code>, <code>--quick</code>, and <code>--fix</code> auto-remediation</li>
         <li>Guest sync after a host upgrade; offline / air-gapped install</li>
         <li>One-line uninstall (keeps VM data unless <code>--purge</code>)</li>
       </ul></div>
-      <div class="card"><h3><span class="dot">●</span>Polish</h3><ul>
+      <div class="card"><h3><span class="ico"><svg viewBox="0 0 24 24"><use href="#i-window"/></svg></span>Polish</h3><ul>
         <li>Host-adaptive Windows-on-KVM tuning profile</li>
         <li>Time sync after host sleep/wake</li>
         <li>Multilingual UI (en / ko / zh / ja / de / fr / it)</li>

--- a/web/get-started.html
+++ b/web/get-started.html
@@ -13,6 +13,20 @@
 </head>
 <body>
 
+<svg class="sprite" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+  <symbol id="i-window" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18"/></symbol>
+  <symbol id="i-swap" viewBox="0 0 24 24"><path d="M17 1l4 4-4 4"/><path d="M3 11V9a4 4 0 0 1 4-4h14"/><path d="M7 23l-4-4 4-4"/><path d="M21 13v2a4 4 0 0 1-4 4H3"/></symbol>
+  <symbol id="i-bolt" viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9z"/></symbol>
+  <symbol id="i-hdd" viewBox="0 0 24 24"><line x1="22" y1="12" x2="2" y2="12"/><path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/><line x1="6" y1="16" x2="6.01" y2="16"/><line x1="10" y1="16" x2="10.01" y2="16"/></symbol>
+  <symbol id="i-activity" viewBox="0 0 24 24"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></symbol>
+  <symbol id="i-lock" viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></symbol>
+  <symbol id="i-download" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M7 10l5 5 5-5"/><path d="M12 15V3"/></symbol>
+  <symbol id="i-grid" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></symbol>
+  <symbol id="i-cursor" viewBox="0 0 24 24"><path d="M3 3l7.5 18 2.5-7.5L21 11z"/></symbol>
+  <symbol id="i-github" viewBox="0 0 24 24"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></symbol>
+</svg>
+
+
 <header class="nav">
   <div class="wrap">
     <a class="brand" href="/" style="color:var(--text)"><img src="assets/winpodx-icon.svg" alt="">winpodx</a>
@@ -20,7 +34,7 @@
       <a href="features.html">Features</a>
       <a href="get-started.html" class="active">Get started</a>
       <a href="faq.html">FAQ</a>
-      <a class="gh" href="https://github.com/kernalix7/winpodx">GitHub</a>
+      <a class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg"><use href="#i-github"/></svg> GitHub</a>
     </nav>
   </div>
 </header>

--- a/web/index.html
+++ b/web/index.html
@@ -18,6 +18,19 @@
 </head>
 <body>
 
+<svg class="sprite" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+  <symbol id="i-window" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18"/></symbol>
+  <symbol id="i-swap" viewBox="0 0 24 24"><path d="M17 1l4 4-4 4"/><path d="M3 11V9a4 4 0 0 1 4-4h14"/><path d="M7 23l-4-4 4-4"/><path d="M21 13v2a4 4 0 0 1-4 4H3"/></symbol>
+  <symbol id="i-bolt" viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9z"/></symbol>
+  <symbol id="i-hdd" viewBox="0 0 24 24"><line x1="22" y1="12" x2="2" y2="12"/><path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/><line x1="6" y1="16" x2="6.01" y2="16"/><line x1="10" y1="16" x2="10.01" y2="16"/></symbol>
+  <symbol id="i-activity" viewBox="0 0 24 24"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></symbol>
+  <symbol id="i-lock" viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></symbol>
+  <symbol id="i-download" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M7 10l5 5 5-5"/><path d="M12 15V3"/></symbol>
+  <symbol id="i-grid" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></symbol>
+  <symbol id="i-cursor" viewBox="0 0 24 24"><path d="M3 3l7.5 18 2.5-7.5L21 11z"/></symbol>
+  <symbol id="i-github" viewBox="0 0 24 24"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></symbol>
+</svg>
+
 <header class="nav">
   <div class="wrap">
     <a class="brand" href="/" style="color:var(--text)"><img src="assets/winpodx-icon.svg" alt="">winpodx</a>
@@ -25,7 +38,7 @@
       <a href="features.html">Features</a>
       <a href="get-started.html">Get started</a>
       <a href="faq.html">FAQ</a>
-      <a class="gh" href="https://github.com/kernalix7/winpodx">GitHub</a>
+      <a class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg"><use href="#i-github"/></svg> GitHub</a>
     </nav>
   </div>
 </header>
@@ -52,7 +65,7 @@
 
     <div class="cta">
       <a class="btn primary" href="get-started.html">Get started →</a>
-      <a class="btn ghost" href="https://github.com/kernalix7/winpodx">★ Star on GitHub</a>
+      <a class="btn ghost" href="https://github.com/kernalix7/winpodx"><svg class="isvg"><use href="#i-github"/></svg> Star on GitHub</a>
     </div>
   </section>
 
@@ -67,17 +80,17 @@
       <p class="lead">No manual VM wrangling. winpodx provisions everything on the first app click.</p>
       <div class="steps">
         <div class="step">
-          <div class="n">1</div>
+          <div class="head"><span class="n">1</span><span class="ico"><svg viewBox="0 0 24 24"><use href="#i-download"/></svg></span></div>
           <h3>Install &amp; setup</h3>
           <p>One command pulls a Windows container (<a href="https://github.com/dockur/windows">dockur/windows</a>) in rootless Podman, runs an unattended Windows install, and applies the RemoteApp + agent setup.</p>
         </div>
         <div class="step">
-          <div class="n">2</div>
+          <div class="head"><span class="n">2</span><span class="ico green"><svg viewBox="0 0 24 24"><use href="#i-grid"/></svg></span></div>
           <h3>Apps auto-discovered</h3>
           <p>First boot scans the guest — Registry App Paths, Start Menu, UWP/MSIX, Chocolatey, Scoop — and registers every app with its real icon as a Linux <code>.desktop</code> entry.</p>
         </div>
         <div class="step">
-          <div class="n">3</div>
+          <div class="head"><span class="n">3</span><span class="ico"><svg viewBox="0 0 24 24"><use href="#i-cursor"/></svg></span></div>
           <h3>Click &amp; launch</h3>
           <p>Click the app like any native one. It opens in its own Linux window via FreeRDP RemoteApp — pinnable, alt-tabbable, file-associated. No full desktop.</p>
         </div>
@@ -111,37 +124,37 @@
       <h2>What it does</h2>
       <p class="lead">Each Windows app becomes its own Linux window — pinnable, alt-tabbable, file-associated, both directions.</p>
       <div class="grid">
-        <div class="card"><h3><span class="dot">●</span>Seamless app windows</h3><ul>
+        <div class="card"><h3><span class="ico"><svg viewBox="0 0 24 24"><use href="#i-window"/></svg></span>Seamless app windows</h3><ul>
           <li>RemoteApp (RAIL) renders each app as a native window — no desktop</li>
           <li>Per-app taskbar icons via <code>WM_CLASS</code> matching</li>
           <li>Double-click <code>.docx</code> → Word opens</li>
           <li>Multi-session RDP: up to 10 independent sessions</li>
         </ul></div>
-        <div class="card"><h3><span class="dot">●</span>Reverse-open</h3><ul>
+        <div class="card"><h3><span class="ico"><svg viewBox="0 0 24 24"><use href="#i-swap"/></svg></span>Reverse-open</h3><ul>
           <li>Linux apps appear in the Windows "Open with…" menu, by default</li>
           <li>Correct per-app icons in both Windows chooser dialogs</li>
           <li>Round-trips the file open back to host <code>xdg-open</code></li>
           <li>Auto-discovers host apps + MIME from freedesktop standards</li>
         </ul></div>
-        <div class="card"><h3><span class="dot">●</span>Zero-config launch</h3><ul>
+        <div class="card"><h3><span class="ico"><svg viewBox="0 0 24 24"><use href="#i-bolt"/></svg></span>Zero-config launch</h3><ul>
           <li>First click auto-provisions config, container, desktop entries</li>
           <li>First-boot discovery registers every app with its real icon</li>
           <li>Registry App Paths, Start Menu, UWP/MSIX, Chocolatey, Scoop</li>
           <li>Backends: Podman (default), Docker, libvirt/KVM, manual RDP</li>
         </ul></div>
-        <div class="card"><h3><span class="dot">●</span>Peripherals &amp; sharing</h3><ul>
+        <div class="card"><h3><span class="ico"><svg viewBox="0 0 24 24"><use href="#i-hdd"/></svg></span>Peripherals &amp; sharing</h3><ul>
           <li>Clipboard (text + images), sound, printers — on by default</li>
           <li>Home directory shared as <code>\\tsclient\home</code></li>
           <li>USB drives auto-mapped; live USB device passthrough</li>
           <li>Smart DPI scaling auto-detected from your desktop</li>
         </ul></div>
-        <div class="card"><h3><span class="dot">●</span>Automation &amp; resilience</h3><ul>
+        <div class="card"><h3><span class="ico"><svg viewBox="0 0 24 24"><use href="#i-activity"/></svg></span>Automation &amp; resilience</h3><ul>
           <li>Auto suspend / resume; optional pod auto-start on login</li>
           <li>Self-heals a stalled RDP guest (UNRESPONSIVE → recover)</li>
           <li>Password auto-rotation; Windows disk auto-grow</li>
           <li>Health checks + auto-fix via <code>winpodx doctor --fix</code></li>
         </ul></div>
-        <div class="card"><h3><span class="dot">●</span>Lean &amp; private</h3><ul>
+        <div class="card"><h3><span class="ico"><svg viewBox="0 0 24 24"><use href="#i-lock"/></svg></span>Lean &amp; private</h3><ul>
           <li>Near-zero Python deps — stdlib only on 3.11+</li>
           <li>No telemetry, ever</li>
           <li>Multilingual UI (en / ko / zh / ja / de / fr / it)</li>

--- a/web/style.css
+++ b/web/style.css
@@ -257,3 +257,46 @@ table.cmp tbody tr:last-child td, table.cmp tbody tr:last-child th { border-bott
   .steps, .dist { grid-template-columns: 1fr; }
   .page-hero h1 { font-size: 28px; }
 }
+
+/* ===== v3: inline SVG icons + motion polish ===== */
+svg.sprite { position: absolute; width: 0; height: 0; overflow: hidden; }
+
+/* accent icon chip (cards, sections) */
+.ico {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 40px; height: 40px; border-radius: 10px; flex: none;
+  background: rgba(56, 139, 253, 0.12); color: var(--blue);
+  border: 1px solid rgba(56, 139, 253, 0.25);
+}
+.ico svg { width: 22px; height: 22px; stroke: currentColor; fill: none;
+  stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+.ico.green { background: rgba(63, 185, 80, 0.12); color: var(--green); border-color: rgba(63,185,80,0.28); }
+.ico.peach { background: rgba(255, 166, 87, 0.12); color: var(--peach); border-color: rgba(255,166,87,0.28); }
+
+/* card header with icon */
+.card h3, .step h3, .feat .block h3, .secttl { display: flex; align-items: center; gap: 12px; }
+.card h3 .ico, .feat .block h3 .ico { width: 34px; height: 34px; border-radius: 9px; }
+.card h3 .ico svg, .feat .block h3 .ico svg { width: 19px; height: 19px; }
+
+/* section title with icon (centered) */
+.secttl { justify-content: center; }
+
+/* inline svg sizing for nav/footer/buttons */
+.isvg { width: 16px; height: 16px; vertical-align: -3px; stroke: currentColor; fill: none;
+  stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+
+/* motion: cards/steps lift on hover */
+.card, .step, .feat .block, .dist .item, .pill { transition: transform .15s ease, border-color .15s ease, background .15s ease; }
+.card:hover, .step:hover, .feat .block:hover, .dist .item:hover { transform: translateY(-3px); border-color: var(--surface2); }
+.pill:hover { transform: translateY(-2px); border-color: var(--blue); color: var(--text); }
+.btn { transition: transform .12s ease, background .15s ease, border-color .15s ease; }
+.btn:hover { transform: translateY(-1px); }
+@media (prefers-reduced-motion: reduce) {
+  .card, .step, .feat .block, .dist .item, .pill, .btn { transition: none; }
+  .card:hover, .step:hover, .feat .block:hover, .dist .item:hover, .pill:hover, .btn:hover { transform: none; }
+  html { scroll-behavior: auto; }
+}
+
+/* step: number + icon row */
+.step .head { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; }
+.step .head .n { margin-bottom: 0; }


### PR DESCRIPTION
Adds a small **inline SVG icon sprite** (12 Feather-style symbols, `currentColor` stroke — no icon library, no network, no trackers, no telemetry) and wires it through the site:

- Feature cards (index + features) get accent **icon chips** instead of a bullet.
- The *How it works* steps pair the number with a step icon (download / grid / cursor).
- Nav + hero "Star on GitHub" get the GitHub mark.
- New **motion**: cards / steps / pills lift on hover, buttons nudge — all gated behind `prefers-reduced-motion`.

CSS adds `.ico` accent chips (blue/green/peach), `.isvg` inline glyphs, hover-lift transitions, and the step head row. Validated: every `<use>` resolves to an in-page `<symbol>`, and all asset/page refs resolve. Redeploys to https://winpodx.org on merge.