### PR TITLE
fix(web): GitHub icon rendered huge + filled (missing viewBox)

### DIFF
--- a/web/faq.html
+++ b/web/faq.html
@@ -34,7 +34,7 @@
       <a href="features.html">Features</a>
       <a href="get-started.html">Get started</a>
       <a href="faq.html" class="active">FAQ</a>
-      <a class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg"><use href="#i-github"/></svg> GitHub</a>
+      <a class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg" viewBox="0 0 24 24"><use href="#i-github"/></svg> GitHub</a>
     </nav>
   </div>
 </header>

--- a/web/features.html
+++ b/web/features.html
@@ -34,7 +34,7 @@
       <a href="features.html" class="active">Features</a>
       <a href="get-started.html">Get started</a>
       <a href="faq.html">FAQ</a>
-      <a class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg"><use href="#i-github"/></svg> GitHub</a>
+      <a class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg" viewBox="0 0 24 24"><use href="#i-github"/></svg> GitHub</a>
     </nav>
   </div>
 </header>

--- a/web/get-started.html
+++ b/web/get-started.html
@@ -34,7 +34,7 @@
       <a href="features.html">Features</a>
       <a href="get-started.html" class="active">Get started</a>
       <a href="faq.html">FAQ</a>
-      <a class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg"><use href="#i-github"/></svg> GitHub</a>
+      <a class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg" viewBox="0 0 24 24"><use href="#i-github"/></svg> GitHub</a>
     </nav>
   </div>
 </header>

--- a/web/index.html
+++ b/web/index.html
@@ -38,7 +38,7 @@
       <a href="features.html">Features</a>
       <a href="get-started.html">Get started</a>
       <a href="faq.html">FAQ</a>
-      <a class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg"><use href="#i-github"/></svg> GitHub</a>
+      <a class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg" viewBox="0 0 24 24"><use href="#i-github"/></svg> GitHub</a>
     </nav>
   </div>
 </header>
@@ -65,7 +65,7 @@
 
     <div class="cta">
       <a class="btn primary" href="get-started.html">Get started →</a>
-      <a class="btn ghost" href="https://github.com/kernalix7/winpodx"><svg class="isvg"><use href="#i-github"/></svg> Star on GitHub</a>
+      <a class="btn ghost" href="https://github.com/kernalix7/winpodx"><svg class="isvg" viewBox="0 0 24 24"><use href="#i-github"/></svg> Star on GitHub</a>
     </div>
   </section>
 


### PR DESCRIPTION
The `.isvg` GitHub `<use>` svgs in the nav and hero had no `viewBox`, so browsers ignored the 16px CSS size + `fill:none` and drew the octocat at intrinsic size, filled black — a giant cat over the hero (reported via screenshot). Adds `viewBox="0 0 24 24"` to all five `.isvg` elements so the sizing/stroke styling applies. Card + step icons already had viewBox and rendered fine.