### PR TITLE
chore(brand): WinPodX across CLI output, installers, OEM console, docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Report a bug to help us improve winpodx
+about: Report a bug to help us improve WinPodX
 title: "[Bug] "
 labels: bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Suggest a new feature or improvement for winpodx
+about: Suggest a new feature or improvement for WinPodX
 title: "[Feature] "
 labels: enhancement
 assignees: ''

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing to winpodx
+# Contributing to WinPodX
 
 **English** | [한국어](docs/CONTRIBUTING.ko.md)
 
-Thank you for your interest in contributing to winpodx! This guide will help you get started.
+Thank you for your interest in contributing to WinPodX! This guide will help you get started.
 
 ## Prerequisites
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,13 +69,13 @@ This project follows these security practices:
 
 ## Host <-> Guest Trust Model
 
-winpodx treats the Windows guest as a **semi-trusted** component, not a trusted
+WinPodX treats the Windows guest as a **semi-trusted** component, not a trusted
 extension of the host. This section documents how that trust boundary is drawn
 and enforced, specifically for the app-discovery channel introduced in v0.1.7.
 
 ### Provisioning scope and threat assumptions
 
-winpodx provisions the Windows guest itself inside a rootless Podman container
+WinPodX provisions the Windows guest itself inside a rootless Podman container
 (or, optionally, Docker / libvirt). Because the host controls the image, the
 unattended-install answer file, and the OEM post-install scripts, a freshly
 provisioned guest starts in a known-good state.
@@ -121,7 +121,7 @@ interpolated into a subprocess argument list:
   decoder before it is written under `~/.local/share/icons/hicolor/`.
 - **`_safe_rmtree`** — refuses to delete any path outside
   `~/.local/share/winpodx/apps/`.
-- **`_is_within`** — refuses to write any path outside the winpodx user data
+- **`_is_within`** — refuses to write any path outside the WinPodX user data
   directory.
 - **List-args subprocess only** — all subprocess invocations pass an argv
   list; `shell=True` is never used on guest-derived strings.

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,6 +1,6 @@
 # Third-Party Licenses
 
-winpodx is MIT-licensed (see [LICENSE](LICENSE)). This document lists the
+WinPodX is MIT-licensed (see [LICENSE](LICENSE)). This document lists the
 third-party components redistributed inside the source tree or pulled in as
 runtime/optional dependencies, together with their upstream licenses.
 
@@ -13,7 +13,7 @@ runtime/optional dependencies, together with their upstream licenses.
 - License: MIT
 - Bundled as: `config/oem/rdprrap-0.1.3-windows-x64.zip`
 - Role: enables multi-session RDP on the Windows guest during first-boot OEM
-  install. Same copyright holder as winpodx.
+  install. Same copyright holder as WinPodX.
 
 rdprrap's own source tree ports code from three upstream projects whose
 licenses require attribution / license-text redistribution. The bundled ZIP
@@ -27,16 +27,16 @@ therefore ships:
 - `THIRD_PARTY_LICENSES.txt` — compiled Rust-dependency attributions,
   auto-generated from the crate graph.
 
-winpodx redistributes the ZIP unmodified. All four attribution files are
+WinPodX redistributes the ZIP unmodified. All four attribution files are
 extracted into the Windows guest at first-boot install time
 (`C:\Program Files\RDP Wrapper\` and `C:\winpodx\rdprrap\`), which is where
 the binaries live and is the redistribution surface that the upstream
 licenses govern.
 
-> **Historical note.** winpodx 0.1.6 bundled rdprrap 0.1.0, which upstream
+> **Historical note.** WinPodX 0.1.6 bundled rdprrap 0.1.0, which upstream
 > later withdrew because the 0.1.0 / 0.1.1 ZIPs were missing `NOTICE` and
 > `vendor/licenses/`. 0.1.7 onward bundles 0.1.3 and is the first
-> license-compliant winpodx release for this component.
+> license-compliant WinPodX release for this component.
 
 ### rcedit
 
@@ -50,7 +50,7 @@ licenses govern.
 ### winpodx-reverse-open-shim
 
 - Own code (`config/oem/reverse-open/shim/`, `Cargo.toml` declares MIT).
-- License: MIT (same as winpodx).
+- License: MIT (same as WinPodX).
 - Bundled as: `config/oem/reverse-open/shim/bin/winpodx-reverse-open-shim.exe`
 - Role: stub Windows Explorer invokes from "Open with" to relay a
   file-open request back to the host's reverse-open listener.
@@ -65,11 +65,11 @@ licenses govern.
 
 | Package | License | Extra | Linkage |
 |---------|---------|-------|---------|
-| [PySide6](https://pypi.org/project/PySide6/) | LGPL-3.0-or-later (with [Qt for Python FAQ exceptions](https://www.qt.io/qt-for-python)) | `winpodx[gui]` | Dynamic — imported at runtime. Not redistributed by winpodx. |
+| [PySide6](https://pypi.org/project/PySide6/) | LGPL-3.0-or-later (with [Qt for Python FAQ exceptions](https://www.qt.io/qt-for-python)) | `winpodx[gui]` | Dynamic — imported at runtime. Not redistributed by WinPodX. |
 | [docker](https://pypi.org/project/docker/) (docker-py) | Apache-2.0 | `winpodx[docker]` | Dynamic — imported at runtime. |
-| [pyxdg](https://pypi.org/project/pyxdg/) | LGPL-2.0-or-later | (none — soft optional) | Dynamic — try-imported at runtime by `core/reverse_open/mime.py` for the long-tail MIME→extension fallback when a type isn't in the curated 86-entry table. winpodx works without it (fallback simply returns the curated entry only). Not vendored. |
+| [pyxdg](https://pypi.org/project/pyxdg/) | LGPL-2.0-or-later | (none — soft optional) | Dynamic — try-imported at runtime by `core/reverse_open/mime.py` for the long-tail MIME→extension fallback when a type isn't in the curated 86-entry table. WinPodX works without it (fallback simply returns the curated entry only). Not vendored. |
 
-LGPL compliance: winpodx does not statically link, vendor, or redistribute
+LGPL compliance: WinPodX does not statically link, vendor, or redistribute
 the PySide6 binaries. Users install them from PyPI (or their distro) at their
 own discretion; the LGPL reverse-engineering / replacement rights are preserved
 because the libraries remain swappable at the Python import level.
@@ -100,12 +100,12 @@ immutable distros:
 - **FreeRDP** (xfreerdp / wlfreerdp / sdl-freerdp) — Apache-2.0
 - **Podman**, **conmon**, **crun**, **netavark**, **slirp4netns**, **passt** —
   Apache-2.0
-- **podman-compose** — GPL-2.0, invoked by winpodx as a **separate executable
-  via subprocess** (mere aggregation under GPLv2 §2 — winpodx itself stays
+- **podman-compose** — GPL-2.0, invoked by WinPodX as a **separate executable
+  via subprocess** (mere aggregation under GPLv2 §2 — WinPodX itself stays
   MIT; the GPL does not reach across the exec boundary)
 
 Each bundled component's license + NOTICE text is shipped inside the AppImage
-at `usr/share/doc/winpodx/third-party/`, alongside winpodx's own `LICENSE` and
+at `usr/share/doc/winpodx/third-party/`, alongside WinPodX's own `LICENSE` and
 this file at `usr/share/doc/winpodx/`. A GPL-2.0 source offer for
 podman-compose is included there too. The CI build step that collects these is
 in `.github/workflows/appimage-publish.yml`.
@@ -119,17 +119,17 @@ the fat AppImage above bundles them):
 - **FreeRDP 3+** — Apache-2.0
 - **Podman** / Docker — Apache-2.0 / Apache-2.0
 - **Microsoft Windows** — EULA-governed; the user supplies their own license
-  via the dockur/windows image, which winpodx pulls at setup time.
+  via the dockur/windows image, which WinPodX pulls at setup time.
 - **dockur/windows container image** — MIT
-  (https://github.com/dockur/windows). winpodx orchestrates but does not
+  (https://github.com/dockur/windows). WinPodX orchestrates but does not
   redistribute this image.
 
 ## Reference projects (inspiration only, no code redistributed)
 
 - **winapps** (https://github.com/winapps-org/winapps) — independent
-  predecessor that also wraps FreeRDP RemoteApp. winpodx's CLI shape and
+  predecessor that also wraps FreeRDP RemoteApp. WinPodX's CLI shape and
   `.cproc` tracking concepts are compatible with winapps configuration
-  conventions for migration, but winpodx does not copy winapps source code.
+  conventions for migration, but WinPodX does not copy winapps source code.
 - **LinOffice** — concept reference only; no source derivation.
 
 If you find any attribution gap, please open an issue.

--- a/config/oem/README.md
+++ b/config/oem/README.md
@@ -1,4 +1,4 @@
-# winpodx OEM post-install
+# WinPodX OEM post-install
 
 Files in this directory are mounted read-only into the guest at `/oem` by
 `config/oem:/oem:Z` in the generated compose.yaml. The dockur/windows image

--- a/config/oem/install.bat
+++ b/config/oem/install.bat
@@ -3,7 +3,7 @@ REM First-boot OEM setup for winpodx Windows guest. Runs once during dockur's un
 
 set WINPODX_OEM_VERSION=26
 
-echo [winpodx] Starting post-install configuration (version %WINPODX_OEM_VERSION%)...
+echo [WinPodX] Starting post-install configuration (version %WINPODX_OEM_VERSION%)...
 
 REM ---------------------------------------------------------------------------
 REM Windows Defender exclusions - ABSOLUTE FIRST STEP.
@@ -47,14 +47,14 @@ REM quarantined and reverse-open silently breaks. Exclude the path (and
 REM the shim process) here, first-step, so the exclusion is in place
 REM before per-user logon stages the files. Add-MpPreference accepts a
 REM not-yet-existent path, so registering it early is fine.
-echo [winpodx] Adding Windows Defender exclusions for C:\OEM, C:\winpodx, C:\Users\Public\winpodx, and the winpodx helper processes...
+echo [WinPodX] Adding Windows Defender exclusions for C:\OEM, C:\winpodx, C:\Users\Public\winpodx, and the winpodx helper processes...
 powershell -NoProfile -Command "try { Add-MpPreference -ExclusionPath 'C:\OEM','C:\winpodx','C:\Users\Public\winpodx' -ErrorAction Stop; Add-MpPreference -ExclusionProcess 'rdprrap-installer.exe','winpodx-reverse-open-shim.exe' -ErrorAction Stop } catch { Write-Output ('defender-exclusion: ' + $_.Exception.Message) }" >nul 2>&1
 
-echo [winpodx] Setting DNS...
+echo [WinPodX] Setting DNS...
 netsh interface ip set dns "Ethernet" static 1.1.1.1
 netsh interface ip add dns "Ethernet" 1.0.0.1 index=2
 
-echo [winpodx] Enabling Remote Desktop...
+echo [WinPodX] Enabling Remote Desktop...
 reg add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server" /v fDenyTSConnections /t REG_DWORD /d 0 /f
 reg add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server" /v fSingleSessionPerUser /t REG_DWORD /d 0 /f
 
@@ -62,7 +62,7 @@ REM NLA off for automated FreeRDP; SecurityLayer=2 keeps TLS on the RDP channel.
 reg add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v UserAuthentication /t REG_DWORD /d 0 /f
 reg add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v SecurityLayer /t REG_DWORD /d 2 /f
 
-echo [winpodx] Enabling RemoteApp...
+echo [WinPodX] Enabling RemoteApp...
 reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Terminal Server\TSAppAllowList" /v fDisabledAllowList /t REG_DWORD /d 1 /f
 
 REM Without fInheritInitialProgram, Windows ignores /shell: and /app: from the RDP client.
@@ -76,10 +76,10 @@ REM Bug B (v0.1.9 / OEM v7): host suspend / long idle commonly leaves Windows
 REM with TermService stalled or the virtual NIC in power-save, breaking RDP
 REM while VNC keeps working. Two preventive measures so the host-side
 REM recover_rdp_if_needed() helper has less to do.
-echo [winpodx] Disabling NIC power-save...
+echo [WinPodX] Disabling NIC power-save...
 powershell -NoProfile -Command "Get-NetAdapter -ErrorAction SilentlyContinue | Where-Object {$_.Status -ne 'Disabled'} | Set-NetAdapterPowerManagement -AllowComputerToTurnOffDevice $false -ErrorAction SilentlyContinue" >nul 2>&1
 
-echo [winpodx] Configuring TermService recovery actions...
+echo [WinPodX] Configuring TermService recovery actions...
 REM 3 attempts at 5s spacing, 24h reset window - Windows itself recovers
 REM TermService crashes without needing host intervention.
 sc.exe failure TermService reset= 86400 actions= restart/5000/restart/5000/restart/5000 >nul 2>&1
@@ -98,7 +98,7 @@ REM     concurrent sessions but doesn't suppress that prompt - only
 REM     auto-logoff does.
 REM Both the machine policy and the RDP-Tcp WinStation keys are set;
 REM whichever Windows consults first finds the saner default.
-echo [winpodx] Disabling RDP session timeouts + enabling keep-alive...
+echo [WinPodX] Disabling RDP session timeouts + enabling keep-alive...
 reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" /v MaxIdleTime /t REG_DWORD /d 0 /f >nul 2>&1
 reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" /v MaxDisconnectionTime /t REG_DWORD /d 30000 /f >nul 2>&1
 reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" /v MaxConnectionTime /t REG_DWORD /d 0 /f >nul 2>&1
@@ -109,7 +109,7 @@ reg add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-T
 reg add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v MaxConnectionTime /t REG_DWORD /d 0 /f >nul 2>&1
 reg add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v KeepAliveTimeout /t REG_DWORD /d 1 /f >nul 2>&1
 
-echo [winpodx] Configuring firewall...
+echo [WinPodX] Configuring firewall...
 REM Delete-then-add keeps the rule idempotent; plain add creates duplicates on re-run.
 netsh advfirewall firewall set rule group="Remote Desktop" new enable=yes 2>nul
 netsh advfirewall firewall delete rule name="RDP TCP" >nul 2>&1
@@ -126,7 +126,7 @@ REM "Remote Desktop" group rule above; 8765 needs an explicit rule.
 netsh advfirewall firewall delete rule name="winpodx-agent" >nul 2>&1
 netsh advfirewall firewall add rule name="winpodx-agent" dir=in action=allow protocol=tcp localport=8765 2>nul
 
-echo [winpodx] Optimizing for RDP...
+echo [WinPodX] Optimizing for RDP...
 reg add "HKCU\Control Panel\Desktop" /v DragFullWindows /t REG_SZ /d 0 /f
 reg add "HKCU\Control Panel\Desktop" /v MenuShowDelay /t REG_SZ /d 0 /f
 reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects" /v VisualFXSetting /t REG_DWORD /d 2 /f
@@ -195,13 +195,13 @@ reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Serialize" /v S
 
 reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" /v GlobalUserDisabled /t REG_DWORD /d 1 /f
 
-echo [winpodx] Home folder is available at \\tsclient\home via RDP drive redirection
+echo [WinPodX] Home folder is available at \\tsclient\home via RDP drive redirection
 
 REM dockur's base image ships a "Shared" desktop item pointing to \\host.lan\Data (SMB) that we don't use; replace with Home/USB shortcuts to the RDP redirections.
-echo [winpodx] Creating desktop shortcuts to tsclient shares...
+echo [WinPodX] Creating desktop shortcuts to tsclient shares...
 powershell -NoProfile -ExecutionPolicy Bypass -Command "$d=[Environment]::GetFolderPath('Desktop'); foreach($n in 'Shared','Shared.lnk'){ $p=Join-Path $d $n; if(Test-Path -LiteralPath $p){ Remove-Item -Force -Recurse -LiteralPath $p -ErrorAction SilentlyContinue } }; $s=New-Object -ComObject WScript.Shell; foreach($x in @(@('Home','\\tsclient\home'), @('USB','\\tsclient\media'))){ $l=$s.CreateShortcut((Join-Path $d ($x[0]+'.lnk'))); $l.TargetPath=$x[1]; $l.Save() }"
 
-echo [winpodx] Setting up USB media auto-mapping...
+echo [WinPodX] Setting up USB media auto-mapping...
 mkdir C:\winpodx 2>nul
 
 REM Prefer compose-mounted C:\winpodx-scripts; fall back to well-known install locations over \\tsclient\home. See config/oem/README.md.
@@ -224,9 +224,9 @@ if not defined WINPODX_SRC_OK (
     )
 )
 if not defined WINPODX_SRC_OK (
-    echo [winpodx] WARNING: media_monitor.ps1 not found in any known location.
-    echo [winpodx] Mount the scripts dir at C:\winpodx-scripts via compose, or
-    echo [winpodx] place media_monitor.ps1 under ~/.local/share/winpodx/scripts/windows/.
+    echo [WinPodX] WARNING: media_monitor.ps1 not found in any known location.
+    echo [WinPodX] Mount the scripts dir at C:\winpodx-scripts via compose, or
+    echo [WinPodX] place media_monitor.ps1 under ~/.local/share/winpodx/scripts/windows/.
 )
 REM WinpodxMedia HKCU\Run registration moved later in install.bat -- the
 REM same PowerShell block that registers WinpodxAgent now writes both
@@ -240,7 +240,7 @@ if exist C:\winpodx\oem_updater.ps1 del /F /Q C:\winpodx\oem_updater.ps1 >nul 2>
 REM Parenthesized echo strips the trailing space that `echo X > file` leaves behind.
 (echo %WINPODX_OEM_VERSION%)>C:\winpodx\oem_version.txt
 
-echo [winpodx] Installing multi-session RDP (rdprrap) - offline bundle...
+echo [WinPodX] Installing multi-session RDP (rdprrap) - offline bundle...
 REM Bundle ships under config/oem/ and is staged into C:\OEM\ by dockur's unattended install.
 REM The pin file (version / filename / sha256) lives next to the zip. No network
 REM access is required - everything is copied straight from the staged folder.
@@ -270,7 +270,7 @@ if exist "%RDPRRAP_INSTALLED%" (
 )
 REM Check sits on its own line so %RDPRRAP_CUR% expands AFTER the for-loop above (no delayed expansion needed).
 if defined RDPRRAP_CUR if /I "%RDPRRAP_CUR%"=="%RDPRRAP_VERSION%" (
-    echo [winpodx] rdprrap %RDPRRAP_VERSION% already installed, skipping.
+    echo [WinPodX] rdprrap %RDPRRAP_VERSION% already installed, skipping.
     goto :rdprrap_done
 )
 
@@ -278,7 +278,7 @@ REM Locate the bundled zip inside the OEM staging folder.
 set "RDPRRAP_ZIP_SRC="
 if exist "C:\OEM\%RDPRRAP_FILENAME%" set "RDPRRAP_ZIP_SRC=C:\OEM\%RDPRRAP_FILENAME%"
 if not defined RDPRRAP_ZIP_SRC (
-    echo [winpodx] WARNING: bundled %RDPRRAP_FILENAME% not found at C:\winpodx or C:\OEM; staying single-session.
+    echo [WinPodX] WARNING: bundled %RDPRRAP_FILENAME% not found at C:\winpodx or C:\OEM; staying single-session.
     goto :rdprrap_done
 )
 
@@ -289,9 +289,9 @@ for /f "usebackq skip=1 delims=" %%H in (`certutil -hashfile "%RDPRRAP_ZIP_SRC%"
 )
 set "RDPRRAP_GOT=%RDPRRAP_GOT: =%"
 if /I not "%RDPRRAP_GOT%"=="%RDPRRAP_SHA256%" (
-    echo [winpodx] WARNING: rdprrap sha256 mismatch on bundle; staying single-session.
-    echo [winpodx]   expected %RDPRRAP_SHA256%
-    echo [winpodx]   got      %RDPRRAP_GOT%
+    echo [WinPodX] WARNING: rdprrap sha256 mismatch on bundle; staying single-session.
+    echo [WinPodX]   expected %RDPRRAP_SHA256%
+    echo [WinPodX]   got      %RDPRRAP_GOT%
     goto :rdprrap_done
 )
 
@@ -340,7 +340,7 @@ REM default for our zip layout, so the inner rdprrap-<version>/ folder
 REM that Expand-Archive used to leave behind isn't present after tar
 REM extraction. We still defensively check + flatten via cmd's MOVE /Y
 REM in case the archive layout changes.
-echo [winpodx] Extracting rdprrap %RDPRRAP_VERSION%...
+echo [WinPodX] Extracting rdprrap %RDPRRAP_VERSION%...
 set "RDPRRAP_EXTRACTED="
 for %%T in (1 2 3) do (
     if not defined RDPRRAP_EXTRACTED (
@@ -349,7 +349,7 @@ for %%T in (1 2 3) do (
         if not errorlevel 1 set "RDPRRAP_EXTRACTED=1"
         if not defined RDPRRAP_EXTRACTED (
             (echo extract attempt %%T failed; sleeping 2s)>>"%RDPRRAP_LOG%"
-            echo [winpodx]   extract attempt %%T failed, retrying after 2s...
+            echo [WinPodX]   extract attempt %%T failed, retrying after 2s...
             REM Plain timeout instead of `powershell Start-Sleep` - PS
             REM call here would re-introduce the very engine load that
             REM tar is bypassing.
@@ -359,8 +359,8 @@ for %%T in (1 2 3) do (
 )
 if not defined RDPRRAP_EXTRACTED (
     (echo FINAL: extract-failed)>>"%RDPRRAP_LOG%"
-    echo [winpodx] WARNING: rdprrap extraction failed after 3 attempts; staying single-session.
-    echo [winpodx]   diagnostic log: %RDPRRAP_LOG%
+    echo [WinPodX] WARNING: rdprrap extraction failed after 3 attempts; staying single-session.
+    echo [WinPodX]   diagnostic log: %RDPRRAP_LOG%
     (echo extract-failed)>"%RDPRRAP_STATUS%"
     goto :rdprrap_done
 )
@@ -379,8 +379,8 @@ for /d %%D in ("%RDPRRAP_DIR%\rdprrap-*") do (
 set "RDPRRAP_EXE=%RDPRRAP_DIR%\rdprrap-installer.exe"
 if not exist "%RDPRRAP_EXE%" (
     (echo FINAL: extract-failed - rdprrap-installer.exe missing after extract)>>"%RDPRRAP_LOG%"
-    echo [winpodx] WARNING: rdprrap-installer.exe missing after extract; staying single-session.
-    echo [winpodx]   diagnostic log: %RDPRRAP_LOG%
+    echo [WinPodX] WARNING: rdprrap-installer.exe missing after extract; staying single-session.
+    echo [WinPodX]   diagnostic log: %RDPRRAP_LOG%
     (echo extract-failed)>"%RDPRRAP_STATUS%"
     goto :rdprrap_done
 )
@@ -400,28 +400,28 @@ REM The script writes the same .activation_status / install.log markers
 REM install.bat used to write directly. Idempotency marker
 REM (.installed_version) stays install.bat's responsibility - only OEM
 REM time has the SHA-pinned bundle context to safely stamp it.
-echo [winpodx] Activating rdprrap (delegating to rdprrap-activate.ps1)...
+echo [WinPodX] Activating rdprrap (delegating to rdprrap-activate.ps1)...
 powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0rdprrap-activate.ps1" >>"%RDPRRAP_LOG%" 2>&1
 set "RDPRRAP_RC=%ERRORLEVEL%"
 (echo rdprrap-activate.ps1 exit=%RDPRRAP_RC%)>>"%RDPRRAP_LOG%"
 if not "%RDPRRAP_RC%"=="0" (
-    echo [winpodx] WARNING: rdprrap-activate.ps1 exited with code %RDPRRAP_RC%; staying single-session.
-    echo [winpodx]   diagnostic log: %RDPRRAP_LOG%
+    echo [WinPodX] WARNING: rdprrap-activate.ps1 exited with code %RDPRRAP_RC%; staying single-session.
+    echo [WinPodX]   diagnostic log: %RDPRRAP_LOG%
     goto :rdprrap_done
 )
 
 (echo %RDPRRAP_VERSION%)>"%RDPRRAP_INSTALLED%"
-echo [winpodx] rdprrap %RDPRRAP_VERSION% installed and activated.
+echo [WinPodX] rdprrap %RDPRRAP_VERSION% installed and activated.
 goto :rdprrap_done
 
 :rdprrap_skip
-echo [winpodx] rdprrap_version.txt not found or incomplete; staying single-session.
+echo [WinPodX] rdprrap_version.txt not found or incomplete; staying single-session.
 :rdprrap_done
 
 REM ---------------------------------------------------------------------
 REM v0.2.2-rev1: winpodx guest HTTP agent
 REM ---------------------------------------------------------------------
-echo [winpodx] Installing winpodx guest agent...
+echo [WinPodX] Installing WinPodX guest agent...
 copy /Y "%~dp0agent\agent.ps1" "C:\OEM\agent.ps1" 2>nul
 mkdir C:\OEM\agent-runs 2>nul
 
@@ -534,7 +534,7 @@ REM      install 2026-05-02 18:48).
 REM   3. Single PS round-trip writes both WinpodxAgent and WinpodxMedia,
 REM      replacing the two separate reg-add lines + the WinpodxMedia
 REM      special case below.
-echo [winpodx] Registering HKCU\Run entries...
+echo [WinPodX] Registering HKCU\Run entries...
 echo [agent-install] step=hkcu-run-register status=enter>>"%SETUP_LOG%"
 powershell -NoProfile -ExecutionPolicy Bypass -Command ^
   "$wrap = 'C:\Users\Public\winpodx\launchers\hidden-launcher.vbs';" ^
@@ -575,7 +575,7 @@ REM Same wscript+hidden-launcher.vbs wrapper / direct-PS fallback
 REM split as the HKCU\Run registration above. Spawned via
 REM Start-Process detached so install.bat doesn't block on the agent's
 REM event loop.
-echo [winpodx] Starting guest agent...
+echo [WinPodX] Starting guest agent...
 echo [agent-install] step=spawn status=enter>>"%SETUP_LOG%"
 powershell -NoProfile -ExecutionPolicy Bypass -Command ^
   "$wrap = 'C:\Users\Public\winpodx\launchers\hidden-launcher.vbs';" ^
@@ -641,7 +641,7 @@ REM wscript hidden-launcher wrapper so the 1-min wakeups never flash a
 REM console. Registered via the ScheduledTasks cmdlets so we can attach
 REM BOTH an AtLogOn trigger AND a 1-minute repetition (schtasks.exe can
 REM only set one schedule per task).
-echo [winpodx] Registering agent keep-alive scheduled task...
+echo [WinPodX] Registering agent keep-alive scheduled task...
 echo [agent-install] step=keepalive-task status=enter>>"%SETUP_LOG%"
 if exist "C:\Users\Public\winpodx\launchers\agent-keepalive.ps1" (
     if not exist C:\winpodx mkdir C:\winpodx
@@ -675,7 +675,7 @@ echo [agent-install] step=keepalive-task status=exit rc=%ERRORLEVEL%>>"%SETUP_LO
 REM Token is delivered via the OEM bind mount - no \\tsclient\home copy
 REM needed. Setup stages it to {oem_dir}/agent_token.txt before container
 REM creation; dockur lays the OEM directory contents into C:\OEM\.
-echo [winpodx] Guest agent installed.
+echo [WinPodX] Guest agent installed.
 
 REM Stage power-monitor.ps1 under C:\winpodx (C:\OEM is wiped after
 REM first boot, so anything we want to keep needs a copy outside it).
@@ -695,14 +695,14 @@ if exist C:\OEM\power-monitor.ps1 (
     REM this session too -- otherwise the very first host suspend
     REM after install (before the next guest reboot) goes unhandled.
     schtasks /run /tn "winpodx-power-monitor" >nul 2>&1
-    echo [winpodx] Guest power monitor scheduled.
+    echo [WinPodX] Guest power monitor scheduled.
 )
 
 REM Sentinel lives under C:\winpodx so it survives past the one-shot C:\OEM stage.
 (echo done)>C:\winpodx\setup_done.txt
 
-echo [winpodx] Post-install configuration complete (version %WINPODX_OEM_VERSION%)!
-echo [winpodx] RDP is now enabled. You can connect with FreeRDP.
+echo [WinPodX] Post-install configuration complete (version %WINPODX_OEM_VERSION%)!
+echo [WinPodX] RDP is now enabled. You can connect with FreeRDP.
 
 REM ---------------------------------------------------------------------------
 REM TermService cycle -- ABSOLUTELY LAST STEP.
@@ -736,7 +736,7 @@ REM cmd.exe dies before reaching that, the marker stays at
 REM `patched-pending-cycle` and the host's `_apply_multi_session`
 REM ServiceDll cross-check (PR #85) will reconcile it to `enabled` on
 REM next apply-fixes.
-echo [winpodx] Cycling TermService to load termwrap.dll (final step)...
+echo [WinPodX] Cycling TermService to load termwrap.dll (final step)...
 net stop TermService /y >nul 2>&1
 net start TermService >nul 2>&1
 
@@ -771,9 +771,9 @@ REM
 REM If shutdown fails for any reason, the marker is left behind --
 REM apply-fixes treats this as "still need second-pass reboot" and
 REM offers to retry. Failure mode is detectable, not silent.
-echo [winpodx] Scheduling reboot to apply registry / power settings...
+echo [WinPodX] Scheduling reboot to apply registry / power settings...
 (echo pending)>C:\winpodx\oem_reboot_pending.txt 2>nul
 reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce" ^
     /v WinpodxClearOemRebootMarker /t REG_SZ ^
     /d "cmd.exe /c del /q C:\winpodx\oem_reboot_pending.txt" /f >nul
-shutdown /r /t 15 /c "winpodx: applying registry / power settings"
+shutdown /r /t 15 /c "WinPodX: applying registry / power settings"

--- a/install.sh
+++ b/install.sh
@@ -104,13 +104,13 @@ WINPODX_ALLOW_OLD_PODMAN="${WINPODX_ALLOW_OLD_PODMAN:-}"
 WINPODX_VERBOSE="${WINPODX_VERBOSE:-}"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
-log()  { echo -e "${GREEN}[winpodx]${NC} $*"; }
+log()  { echo -e "${GREEN}[WinPodX]${NC} $*"; }
 warn() { echo -e "${YELLOW}[warn]${NC} $*"; }
 err()  { echo -e "${RED}[error]${NC} $*" >&2; }
 
 usage() {
     sed -n '4,93p' "${BASH_SOURCE[0]:-/dev/null}" 2>/dev/null || cat <<'USAGE_EOF'
-winpodx installer — see install.sh header for full usage.
+WinPodX installer — see install.sh header for full usage.
 
 Flags:
   --mode r|a|c|n      Install mode (Recommended / Automatic / Custom / No)
@@ -622,7 +622,7 @@ print_system_check() {
         osname="${PRETTY_NAME:-$DISTRO}"
     fi
     echo ""
-    echo "================ winpodx system check ================"
+    echo "================ WinPodX system check ================"
     echo "  Distro:        $osname"
     echo "  Architecture:  $ARCH_LABEL"
     echo "  python3:       $(yesno "$PYTHON3_PRESENT")  $(tool_version python3)"
@@ -642,7 +642,7 @@ print_system_check() {
     echo "======================================================"
     if [ "$PODMAN_TOO_OLD" = true ]; then
         echo ""
-        warn "podman $PODMAN_MAJOR.x is too old for winpodx (need >= 4 for rootless"
+        warn "podman $PODMAN_MAJOR.x is too old for WinPodX (need >= 4 for rootless"
         warn "'group_add: keep-groups' + modern compose; Ubuntu 22.04 ships 3.4 — #271)."
         warn "Either:"
         warn "  - upgrade podman (Kubic / devel:kubic:libcontainers repo:"
@@ -686,11 +686,11 @@ if [ -z "$INSTALL_MODE" ]; then
         # Automatic (reuse what's present, install only what's strictly
         # missing) without prompting.
         INSTALL_MODE="a"
-        log "Existing winpodx install detected — upgrading; reusing current config (skipping install-mode prompt)."
+        log "Existing WinPodX install detected — upgrading; reusing current config (skipping install-mode prompt)."
     elif [ "$INTERACTIVE" = true ]; then
         cat <<'MODE_EOF'
 Install mode?
-  [R]ecommended  winpodx's recommended stack (Podman backend + deps); installs missing system packages via the distro package manager (sudo).
+  [R]ecommended  WinPodX's recommended stack (Podman backend + deps); installs missing system packages via the distro package manager (sudo).
   [A]utomatic    Reuse what's already installed; only install what's strictly missing; pick the backend from what's present (prefer an already-working docker/podman). Minimal sudo.
   [C]ustom       Choose backend (podman/docker) and whether to include the GUI, then install accordingly.
   [N]o           Cancel without changing anything.
@@ -816,7 +816,7 @@ fi
 # WINPODX_ALLOW_OLD_PODMAN=1 / --allow-old-podman overrides (e.g. podman was
 # upgraded out-of-band since the probe).
 if [ "$WINPODX_BACKEND" = "podman" ] && [ "$PODMAN_TOO_OLD" = true ] && [ "$WINPODX_ALLOW_OLD_PODMAN" != "1" ]; then
-    warn "podman $PODMAN_MAJOR.x is too old for winpodx (need >= 4; Ubuntu 22.04 ships 3.4 -- #271)."
+    warn "podman $PODMAN_MAJOR.x is too old for WinPodX (need >= 4; Ubuntu 22.04 ships 3.4 -- #271)."
     if [ "$INTERACTIVE" = true ]; then
         if [ "$DOCKER_PRESENT" = true ]; then
             echo "docker is installed and usable."
@@ -1388,7 +1388,7 @@ fi
 gtk-update-icon-cache -f -t "$ICON_BASE" 2>/dev/null || true
 # Rebuild KDE Plasma sycoca cache
 kbuildsycoca6 --noincremental 2>/dev/null || kbuildsycoca5 --noincremental 2>/dev/null || true
-log "Installed winpodx GUI launcher and icon"
+log "Installed WinPodX GUI launcher and icon"
 
 # v0.1.9: bundled app profiles were dropped. The app menu now populates
 # automatically the first time the Windows pod boots — `winpodx app run
@@ -1543,7 +1543,7 @@ GUI_LABEL="yes"
 [ -n "$WINPODX_NO_GUI" ] && GUI_LABEL="no (--no-gui)"
 
 echo ""
-echo -e "${GREEN}  ┌─ winpodx installed ──────────────────────────────────────${NC}"
+echo -e "${GREEN}  ┌─ WinPodX installed ──────────────────────────────────────${NC}"
 printf "  │  version   %s\n" "$INSTALLED_VER"
 printf "  │  backend   %s\n" "${WINPODX_BACKEND:-podman}"
 printf "  │  GUI       %s\n" "$GUI_LABEL"
@@ -1560,6 +1560,6 @@ echo "    winpodx doctor             # health check if something looks off"
 echo "    winpodx --help             # every command"
 echo ""
 echo "  Your Windows apps are already in the application menu — click any one"
-echo "  and winpodx handles the pod, the RDP session, and the window for you."
+echo "  and WinPodX handles the pod, the RDP session, and the window for you."
 echo ""
 log "Installation complete!"

--- a/packaging/appimage/README.md
+++ b/packaging/appimage/README.md
@@ -1,6 +1,6 @@
-# winpodx AppImage build
+# WinPodX AppImage build
 
-Builds a distro-agnostic **Thin** AppImage of winpodx (0.6.0 item A).
+Builds a distro-agnostic **Thin** AppImage of WinPodX (0.6.0 item A).
 
 There are **two build paths**, both producing a Thin AppImage:
 
@@ -19,7 +19,7 @@ Same model as `install.sh`:
 
 - **`podman` (recommended)** or `docker` — installed via the
   host distro package manager. Rootless podman fundamentally needs host
-  systemd / subuid integration that an AppImage can't carry, so winpodx
+  systemd / subuid integration that an AppImage can't carry, so WinPodX
   cannot ship one that works.
 - KVM kernel module + `/dev/kvm` access + `kvm` group membership.
 - `/etc/subuid` + `/etc/subgid` for rootless Podman.
@@ -94,11 +94,11 @@ exactly like the wheel / `.deb` / `.rpm`.
 
 ## Licensing
 
-winpodx itself is **MIT** and stays MIT. The Thin AppImage redistributes
+WinPodX itself is **MIT** and stays MIT. The Thin AppImage redistributes
 only the FreeRDP 3 client stack from Fedora 41, so its license + NOTICE
 texts travel inside it:
 
-- winpodx `LICENSE` (MIT) + `THIRD_PARTY_LICENSES.md` at
+- WinPodX `LICENSE` (MIT) + `THIRD_PARTY_LICENSES.md` at
   `${APPDIR}/usr/share/doc/winpodx/`
 - bundled FreeRDP package licenses (Apache-2.0: `freerdp-libs`,
   `libwinpr`) under `${APPDIR}/usr/share/doc/winpodx/third-party/<pkg>/`

--- a/packaging/appimage/recipe/winpodx.desktop
+++ b/packaging/appimage/recipe/winpodx.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Name=winpodx
+Name=WinPodX
 GenericName=Windows app integration for Linux
 Comment=Run Windows apps natively on Linux via FreeRDP + Podman
 Exec=winpodx app run desktop

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -95,6 +95,6 @@ paru -S winpodx
 - The PKGBUILD builds from the GitHub release tarball, not from the wheel
   uploaded to the GitHub Release. This keeps Arch users building from the
   same source OBS and the debs-publish/rhel-publish workflows build from.
-- No `winpodx-bin` companion package: winpodx is pure-Python `noarch`/`any`,
+- No `winpodx-bin` companion package: WinPodX is pure-Python `noarch`/`any`,
   so building from source takes ~1 second on any Arch install — a -bin
   package would add maintenance burden without any install-speed payoff.

--- a/packaging/obs/README.md
+++ b/packaging/obs/README.md
@@ -1,6 +1,6 @@
-# OBS 배포 가이드 (winpodx)
+# OBS 배포 가이드 (WinPodX)
 
-openSUSE Build Service에 winpodx를 올려서 Tumbleweed, Fedora, Leap용 RPM을
+openSUSE Build Service에 WinPodX를 올려서 Tumbleweed, Fedora, Leap용 RPM을
 자동 빌드하고, GitHub Release에 첨부하는 절차입니다.
 
 - 프로젝트: https://build.opensuse.org/package/show/home:Kernalix7/winpodx

--- a/src/winpodx/cli/debloat_menu.py
+++ b/src/winpodx/cli/debloat_menu.py
@@ -81,7 +81,7 @@ def run_menu(
     current_preset: str | None = initial_preset
 
     print_fn("")
-    print_fn(tr("=== winpodx debloat (menu) ==="))
+    print_fn(tr("=== WinPodX debloat (menu) ==="))
     print_fn(tr("h / ? for help. Press <a> to apply, <q> to quit."))
     print_fn("")
 

--- a/src/winpodx/cli/doctor.py
+++ b/src/winpodx/cli/doctor.py
@@ -105,7 +105,7 @@ def handle_doctor(args: argparse.Namespace) -> None:
         return
 
     print()
-    print("=== winpodx doctor ===")
+    print("=== WinPodX doctor ===")
     if quick and not do_fix:
         print(tr("(--quick: container-health probe skipped)"))
     print()
@@ -137,7 +137,7 @@ def handle_doctor(args: argparse.Namespace) -> None:
         sys.exit(1)
     elif warn_count:
         print(
-            tr("Summary: {warn_count} WARN, no FAIL — winpodx is mostly OK.").format(
+            tr("Summary: {warn_count} WARN, no FAIL — WinPodX is mostly OK.").format(
                 warn_count=warn_count
             )
         )

--- a/src/winpodx/cli/first_run.py
+++ b/src/winpodx/cli/first_run.py
@@ -103,7 +103,7 @@ def maybe_run_first_run_prompt(
         return False
 
     print_fn("")
-    print_fn(tr("winpodx has not been set up yet on this account."))
+    print_fn(tr("WinPodX has not been set up yet on this account."))
     print_fn("")
     print_fn(tr("Run setup now?"))
     print_fn(tr("  [Y]es     -- auto setup (host-detected defaults, no prompts)"))

--- a/src/winpodx/cli/migrate.py
+++ b/src/winpodx/cli/migrate.py
@@ -189,7 +189,7 @@ def run_migrate(args: argparse.Namespace) -> int:
     if installed is None:
         _write_installed_version(current)
         print(
-            tr("winpodx {version}: fresh install recorded. No migration needed.").format(
+            tr("WinPodX {version}: fresh install recorded. No migration needed.").format(
                 version=current
             )
         )
@@ -200,7 +200,7 @@ def run_migrate(args: argparse.Namespace) -> int:
 
     if inst_cmp >= cur_cmp:
         _write_installed_version(current)
-        print(tr("winpodx {version}: already current.").format(version=current))
+        print(tr("WinPodX {version}: already current.").format(version=current))
         # v0.1.9.3: even on "already current" still run the idempotent
         # Windows-side apply. Patch versions (0.1.9.x) collapse to the
         # same (0,1,9) tuple under [:3] truncation, so without this an
@@ -220,7 +220,7 @@ def run_migrate(args: argparse.Namespace) -> int:
         return 0
 
     print(
-        tr("winpodx: {installed} -> {current} detected\n").format(
+        tr("WinPodX: {installed} -> {current} detected\n").format(
             installed=installed, current=current
         )
     )
@@ -287,7 +287,7 @@ def _maybe_cleanup_legacy_bundled(non_interactive: bool) -> None:
 
     print(
         tr(
-            "\nFound {count} legacy bundled-app entries from a previous winpodx version"
+            "\nFound {count} legacy bundled-app entries from a previous WinPodX version"
             " (these were removed in 0.1.9):"
         ).format(count=len(stale_desktop))
     )
@@ -611,7 +611,7 @@ def _probe_password_sync(non_interactive: bool) -> None:
                 "  WARNING: cfg.password does not match Windows guest's account "
                 "password (FreeRDP authentication failed).\n"
                 "  This usually means password rotation has been silently failing "
-                "for prior winpodx versions (the runtime apply path was broken).\n"
+                "for prior WinPodX versions (the runtime apply path was broken).\n"
                 "\n"
                 "  To fix: run `winpodx pod sync-password` and provide the "
                 "password Windows currently accepts (typically the original "
@@ -662,7 +662,7 @@ def _ensure_canonical_image_pin(non_interactive: bool) -> None:
 
     pin_changed = cfg.pod.image != DOCKUR_IMAGE_PIN
     if pin_changed:
-        print("\nAligning container image with this winpodx version...")
+        print("\nAligning container image with this WinPodX version...")
         print(f"  was: {cfg.pod.image}")
         print(f"  now: {DOCKUR_IMAGE_PIN}")
         cfg.pod.image = DOCKUR_IMAGE_PIN

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -391,7 +391,7 @@ def _sync_password(non_interactive: bool) -> None:
     else:
         print(
             tr(
-                "winpodx will authenticate once with a recovery password (the password "
+                "WinPodX will authenticate once with a recovery password (the password "
                 "Windows currently accepts), then reset the Windows account to the "
                 "value in your winpodx config."
             )
@@ -399,7 +399,7 @@ def _sync_password(non_interactive: bool) -> None:
         print()
         print(tr("Common recovery passwords to try:"))
         print(tr("  - The password from your original setup (compose.yml PASSWORD env)"))
-        print(tr("  - The first password you set when winpodx was installed"))
+        print(tr("  - The first password you set when WinPodX was installed"))
         print()
         recovery_pw = getpass.getpass(tr("Recovery password (input hidden): "))
         if not recovery_pw:
@@ -1205,7 +1205,7 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
             eta_min = max(1, eta_remaining_secs // 60)
             print(
                 tr(
-                    "[winpodx] Slow Windows ISO download detected "
+                    "[WinPodX] Slow Windows ISO download detected "
                     "(~{eta_min}m remaining). "
                     "Extending wait to {total_min}m total."
                 ).format(eta_min=eta_min, total_min=total_min)
@@ -1526,7 +1526,7 @@ def _recover_oem() -> None:
         sys.exit(1)
 
     print(
-        tr("[winpodx] Checking container '{container}' is running...").format(container=container)
+        tr("[WinPodX] Checking container '{container}' is running...").format(container=container)
     )
     try:
         result = subprocess.run(
@@ -1556,7 +1556,7 @@ def _recover_oem() -> None:
         )
         sys.exit(1)
 
-    print(tr("[winpodx] Verifying /oem/install.bat exists inside container..."))
+    print(tr("[WinPodX] Verifying /oem/install.bat exists inside container..."))
     try:
         check = subprocess.run(
             [cmd, "exec", container, "sh", "-c", "test -f /oem/install.bat"],
@@ -1584,7 +1584,7 @@ def _recover_oem() -> None:
     # new trust boundary, but serving the whole /storage would.
     serve_dir = "/tmp/winpodx-recover"
     print(
-        tr("[winpodx] Tarring /oem into {serve_dir}/oem.tar.gz inside container...").format(
+        tr("[WinPodX] Tarring /oem into {serve_dir}/oem.tar.gz inside container...").format(
             serve_dir=serve_dir
         )
     )
@@ -1614,7 +1614,7 @@ def _recover_oem() -> None:
     # not forwarded to the host. Reachable from the Windows guest via
     # QEMU's NAT gateway 10.0.2.2:8766. Serves only the dedicated
     # recover dir (one file), not /storage.
-    print(tr("[winpodx] Starting HTTP server on container port 8766..."))
+    print(tr("[WinPodX] Starting HTTP server on container port 8766..."))
     # Best-effort cleanup of any prior server on 8766.
     subprocess.run(
         [
@@ -1816,7 +1816,7 @@ def _sync_guest(*, force: bool) -> None:
     hv = host_version()
     gv = read_guest_version(cfg)
     print(
-        tr("host:  winpodx {version}, OEM bundle {oem}").format(
+        tr("host:  WinPodX {version}, OEM bundle {oem}").format(
             version=hv.winpodx, oem=hv.oem_bundle
         )
     )
@@ -1824,7 +1824,7 @@ def _sync_guest(*, force: bool) -> None:
         print(tr("guest: version stamp not found (will sync)"))
     else:
         print(
-            tr("guest: winpodx {version}, OEM bundle {oem}").format(
+            tr("guest: WinPodX {version}, OEM bundle {oem}").format(
                 version=gv.winpodx, oem=gv.oem_bundle
             )
         )

--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -624,7 +624,7 @@ def handle_setup(args: argparse.Namespace) -> None:
         non_interactive = True
         customize = False
 
-    print(tr("=== winpodx setup ===\n"))
+    print(tr("=== WinPodX setup ===\n"))
 
     print(tr("Checking dependencies..."))
     # probe_daemons: verify the container backends actually answer, not just
@@ -965,7 +965,7 @@ def handle_setup(args: argparse.Namespace) -> None:
     skip_provision = os.environ.get("WINPODX_NO_PROVISION") == "1"
     if cfg.pod.backend not in ("podman", "docker") or skip_provision:
         print(tr("Apps are now in your application menu."))
-        print(tr("Just click any app. winpodx handles the rest automatically."))
+        print(tr("Just click any app. WinPodX handles the rest automatically."))
         if cfg.pod.backend in ("podman", "docker") and skip_provision:
             print(
                 tr(

--- a/src/winpodx/cli/uninstall.py
+++ b/src/winpodx/cli/uninstall.py
@@ -60,7 +60,7 @@ def handle_uninstall(args: argparse.Namespace) -> None:
     sys.exit(
         "uninstall.sh not found. Looked in:\n  - "
         + "\n  - ".join(str(p) for p in _candidate_paths())
-        + "\n\nReinstall winpodx, or fetch the script directly:\n"
+        + "\n\nReinstall WinPodX, or fetch the script directly:\n"
         "  curl -fsSL https://raw.githubusercontent.com/kernalix7/winpodx/main/uninstall.sh "
         "| bash -s -- --yes"
     )

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -43,7 +43,7 @@ export WINPODX_NO_TRAY_SPAWN=1
 ###############################################################################
 
 GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
-log()  { echo -e "${GREEN}[winpodx]${NC} $*"; }
+log()  { echo -e "${GREEN}[WinPodX]${NC} $*"; }
 warn() { echo -e "${YELLOW}[warn]${NC} $*"; }
 
 AUTO=false
@@ -168,12 +168,12 @@ detect_install_source() {
 
 echo ""
 echo "=========================================="
-echo " winpodx uninstaller"
+echo " WinPodX uninstaller"
 echo "=========================================="
 if [[ "$PURGE" == true ]]; then
     echo " Mode: FULL PURGE (container + volumes + storage + config + files)"
 else
-    echo " Mode: winpodx files only (container + volumes + config kept)"
+    echo " Mode: WinPodX files only (container + volumes + config kept)"
 fi
 [[ "$FROM_POSTRM" == true ]] && echo " (re-entered from package post-remove hook)"
 echo ""
@@ -354,7 +354,7 @@ DESKTOP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
 # Remove winpodx GUI launcher
 if [[ -f "$DESKTOP_DIR/winpodx.desktop" ]]; then
     rm -f "$DESKTOP_DIR/winpodx.desktop"
-    log "Removed winpodx GUI launcher"
+    log "Removed WinPodX GUI launcher"
     REMOVED=$((REMOVED + 1))
 fi
 # Remove app desktop entries


### PR DESCRIPTION
Second brand sweep covering the surfaces the first pass (#443) didn't touch. Audited **file-by-file, read directly (no blanket scripts)**, 5 disjoint groups in parallel, verified both directions.

**Changed — human-visible brand → WinPodX:**
- **CLI** (`cli/*.py`): the `[winpodx]` progress prefix → `[WinPodX]`, section banners (`=== WinPodX setup/doctor ===`), brand prose in printed messages (migrate / pod / first_run / uninstall) + host/guest version labels.
- **Installers**: `install.sh` `log()` prefix → `[WinPodX]` + brand prose; `uninstall.sh` prose.
- **OEM**: `config/oem/install.bat` `echo [WinPodX] …` prefixes (paths in the messages stay lowercase).
- **Docs / metadata**: CONTRIBUTING, SECURITY, THIRD_PARTY_LICENSES, both issue templates, packaging READMEs, `config/oem/README`, and `packaging/appimage/recipe/winpodx.desktop` `Name=`.

**Kept lowercase (identifiers):** every `winpodx <subcommand>`, prog/flag names, paths (`C:\winpodx`, `~/.config/winpodx`, `winpodx.toml`, `winpodx-windows`, `winpodx-*.desktop`), URLs, `WINPODX_*`, `Icon=`/`Exec=`, registry keys, scheduled-task / `HKCU\Run` names (`WinpodxAgent`…), logger names, the `GuestVersion.winpodx` field, code in command snippets. **`core/*.py` made zero changes** — all occurrences there are technical.

**Verification:** word-boundary `git grep` → no command/path/URL wrongly capitalized; all markdown fences balanced; `install.sh`/`uninstall.sh` pass `bash -n`; ruff clean; full suite **1747 passed**.