### PR TITLE
fix(web): align Pages CNAME + canonical/og to www.winpodx.org

### DIFF
--- a/web/CNAME
+++ b/web/CNAME
@@ -1,1 +1,1 @@
-winpodx.org
+www.winpodx.org

--- a/web/faq.html
+++ b/web/faq.html
@@ -7,7 +7,7 @@
   <title>FAQ — WinPodX</title>
   <meta name="description" content="WinPodX FAQ: how it works, Windows licensing, performance, security & telemetry, which apps work, and how it compares to a VM, RDP, or Wine.">
   <link rel="icon" type="image/svg+xml" href="assets/winpodx-icon.svg">
-  <link rel="canonical" href="https://winpodx.org/faq.html">
+  <link rel="canonical" href="https://www.winpodx.org/faq.html">
   <meta name="theme-color" content="#0d1117">
   <link rel="stylesheet" href="style.css">
 </head>

--- a/web/features.html
+++ b/web/features.html
@@ -7,7 +7,7 @@
   <title>Features — WinPodX</title>
   <meta name="description" content="WinPodX features: seamless RemoteApp windows, reverse-open, zero-config discovery, peripherals, multi-session RDP, automation & resilience.">
   <link rel="icon" type="image/svg+xml" href="assets/winpodx-icon.svg">
-  <link rel="canonical" href="https://winpodx.org/features.html">
+  <link rel="canonical" href="https://www.winpodx.org/features.html">
   <meta name="theme-color" content="#0d1117">
   <link rel="stylesheet" href="style.css">
 </head>

--- a/web/get-started.html
+++ b/web/get-started.html
@@ -7,7 +7,7 @@
   <title>Get started — WinPodX</title>
   <meta name="description" content="Install WinPodX: one-line curl, or native packages for openSUSE, Fedora, Debian/Ubuntu, RHEL, Arch, NixOS, and AppImage. Requirements + first-time setup.">
   <link rel="icon" type="image/svg+xml" href="assets/winpodx-icon.svg">
-  <link rel="canonical" href="https://winpodx.org/get-started.html">
+  <link rel="canonical" href="https://www.winpodx.org/get-started.html">
   <meta name="theme-color" content="#0d1117">
   <link rel="stylesheet" href="style.css">
 </head>

--- a/web/index.html
+++ b/web/index.html
@@ -7,12 +7,12 @@
   <title>WinPodX — Windows apps as native Linux windows</title>
   <meta name="description" content="Run Windows apps on Linux as first-class native windows — real icons, taskbar, file associations. FreeRDP RemoteApp + dockur/windows. One-command setup.">
   <link rel="icon" type="image/svg+xml" href="assets/winpodx-icon.svg">
-  <link rel="canonical" href="https://winpodx.org/">
+  <link rel="canonical" href="https://www.winpodx.org/">
   <meta property="og:title" content="WinPodX — Windows apps as native Linux windows">
   <meta property="og:description" content="Click an app. Word opens. That's it. FreeRDP RemoteApp + dockur/windows, zero config.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://winpodx.org/">
-  <meta property="og:image" content="https://winpodx.org/assets/winpodx-demo.png">
+  <meta property="og:url" content="https://www.winpodx.org/">
+  <meta property="og:image" content="https://www.winpodx.org/assets/winpodx-demo.png">
   <meta name="theme-color" content="#0d1117">
   <link rel="stylesheet" href="style.css">
 </head>


### PR DESCRIPTION
DNS (per Cloudflare): `winpodx.org` CNAME→ `www.winpodx.org` CNAME→ `kernalix7.github.io`. So **www.winpodx.org** is the domain bound to GitHub Pages.

Align the site to match:
- GitHub Pages `CNAME` file: `winpodx.org` → **`www.winpodx.org`** (the domain actually pointed at Pages; lets Pages 301 the apex → www consistently with Cloudflare).
- Every page `rel=canonical` + `og:url` / `og:image`: apex → **https://www.winpodx.org/…** (was apex, mismatching the served/redirect-target host).

Static-only, no content change.