### PR TITLE
feat(tray): Terminate Session submenu (#450)

### DIFF
--- a/src/winpodx/desktop/tray.py
+++ b/src/winpodx/desktop/tray.py
@@ -365,6 +365,50 @@ def run_tray() -> None:
 
     menu.addMenu(apps_menu)
 
+    # Terminate-session submenu (#450): lists the tracked .cproc RDP sessions;
+    # each entry SIGTERMs that session via core.process.kill_session — the same
+    # path as `winpodx app kill`. Rebuilt on open so it reflects live sessions.
+    sessions_menu = QMenu(tr("Terminate Session"))
+
+    def _make_session_kill(app_name: str):
+        def handler() -> None:
+            from winpodx.core.process import kill_session
+
+            def op() -> None:
+                if not kill_session(app_name):
+                    raise RuntimeError("session not found or already closed")
+
+            _run_in_thread(
+                op,
+                tr("Terminated session: {name}").format(name=app_name),
+                tr("Failed to terminate {name}").format(name=app_name),
+            )
+
+        return handler
+
+    def _rebuild_sessions_menu() -> None:
+        sessions_menu.clear()
+        try:
+            from winpodx.core.process import list_active_sessions
+
+            active = list_active_sessions()
+        except Exception as e:  # noqa: BLE001 — never crash the tray on enumeration
+            log.warning("sessions menu: enumeration failed: %s", e)
+            active = []
+        if not active:
+            empty = QAction(tr("(no active sessions)"))
+            empty.setEnabled(False)
+            sessions_menu.addAction(empty)
+            return
+        for s in active:
+            act = QAction(tr("Terminate: {name}").format(name=s.app_name))
+            act.triggered.connect(_make_session_kill(s.app_name))
+            sessions_menu.addAction(act)
+
+    sessions_menu.aboutToShow.connect(_rebuild_sessions_menu)
+    _rebuild_sessions_menu()
+    menu.addMenu(sessions_menu)
+
     menu.addSeparator()
 
     # USB device switcher (#300). A checkable entry per host USB device:


### PR DESCRIPTION
Implements the tray-side session termination requested in #450.

The core already shipped `winpodx app sessions` + `winpodx app kill <name>` (`core.process.list_active_sessions` / `kill_session`). This adds the **tray UI** the issue asked for:

- New **"Terminate Session"** submenu in the system tray.
- Rebuilt on open (`aboutToShow`) → lists the live `.cproc`-tracked FreeRDP sessions; "(no active sessions)" when empty.
- Each entry SIGTERMs that session off the UI thread, shows a result notification, and refreshes the tray status/count.
- Reuses the existing tested backbone — no new kill logic.

So users no longer need `ps -ef | grep xfreerdp` + `kill`.

Targeted tests green (process/desktop/cli sessions+kill: 76+13). ruff + format clean. New tr() labels fall back to English in non-English UIs until added to locale catalogs (follow-up).