### PR TITLE
i18n: translate session-terminate UI strings into all 6 catalogs

### DIFF
--- a/src/winpodx/locale/de.json
+++ b/src/winpodx/locale/de.json
@@ -812,5 +812,15 @@
   "▨  Hardware": "▨  Hardware",
   "▶  Launch": "▶  Starten",
   "◨  Performance Tuning": "◨  Leistungstuning",
-  "🌐  Localization": "🌐  Lokalisierung"
+  "🌐  Localization": "🌐  Lokalisierung",
+  "RDP Sessions": "RDP-Sitzungen",
+  "No active RDP sessions.": "Keine aktiven RDP-Sitzungen.",
+  "PID {pid}": "PID {pid}",
+  "Terminate": "Beenden",
+  "Terminated session: {name}": "Sitzung beendet: {name}",
+  "Could not terminate {name} (already closed?)": "{name} konnte nicht beendet werden (bereits geschlossen?)",
+  "Failed to terminate {name}": "{name} konnte nicht beendet werden",
+  "Terminate Session": "Sitzung beenden",
+  "(no active sessions)": "(keine aktiven Sitzungen)",
+  "Terminate: {name}": "Beenden: {name}"
 }

--- a/src/winpodx/locale/fr.json
+++ b/src/winpodx/locale/fr.json
@@ -812,5 +812,15 @@
   "▨  Hardware": "▨  Matériel",
   "▶  Launch": "▶  Lancer",
   "◨  Performance Tuning": "◨  Réglage des performances",
-  "🌐  Localization": "🌐  Localisation"
+  "🌐  Localization": "🌐  Localisation",
+  "RDP Sessions": "Sessions RDP",
+  "No active RDP sessions.": "Aucune session RDP active.",
+  "PID {pid}": "PID {pid}",
+  "Terminate": "Arrêter",
+  "Terminated session: {name}": "Session arrêtée : {name}",
+  "Could not terminate {name} (already closed?)": "Impossible d'arrêter {name} (déjà fermée ?)",
+  "Failed to terminate {name}": "Échec de l'arrêt de {name}",
+  "Terminate Session": "Arrêter la session",
+  "(no active sessions)": "(aucune session active)",
+  "Terminate: {name}": "Arrêter : {name}"
 }

--- a/src/winpodx/locale/it.json
+++ b/src/winpodx/locale/it.json
@@ -812,5 +812,15 @@
   "▨  Hardware": "▨  Hardware",
   "▶  Launch": "▶  Avvia",
   "◨  Performance Tuning": "◨  Ottimizzazione delle prestazioni",
-  "🌐  Localization": "🌐  Localizzazione"
+  "🌐  Localization": "🌐  Localizzazione",
+  "RDP Sessions": "Sessioni RDP",
+  "No active RDP sessions.": "Nessuna sessione RDP attiva.",
+  "PID {pid}": "PID {pid}",
+  "Terminate": "Termina",
+  "Terminated session: {name}": "Sessione terminata: {name}",
+  "Could not terminate {name} (already closed?)": "Impossibile terminare {name} (già chiusa?)",
+  "Failed to terminate {name}": "Terminazione di {name} non riuscita",
+  "Terminate Session": "Termina sessione",
+  "(no active sessions)": "(nessuna sessione attiva)",
+  "Terminate: {name}": "Termina: {name}"
 }

--- a/src/winpodx/locale/ja.json
+++ b/src/winpodx/locale/ja.json
@@ -812,5 +812,15 @@
   "▨  Hardware": "▨  ハードウェア",
   "▶  Launch": "▶  起動",
   "◨  Performance Tuning": "◨  パフォーマンスチューニング",
-  "🌐  Localization": "🌐  ローカライズ"
+  "🌐  Localization": "🌐  ローカライズ",
+  "RDP Sessions": "RDPセッション",
+  "No active RDP sessions.": "アクティブなRDPセッションはありません。",
+  "PID {pid}": "PID {pid}",
+  "Terminate": "終了",
+  "Terminated session: {name}": "セッションを終了: {name}",
+  "Could not terminate {name} (already closed?)": "{name} を終了できませんでした（すでに閉じていますか？）",
+  "Failed to terminate {name}": "{name} の終了に失敗しました",
+  "Terminate Session": "セッションを終了",
+  "(no active sessions)": "（アクティブなセッションなし）",
+  "Terminate: {name}": "終了: {name}"
 }

--- a/src/winpodx/locale/ko.json
+++ b/src/winpodx/locale/ko.json
@@ -812,5 +812,15 @@
   "▨  Hardware": "▨  하드웨어",
   "▶  Launch": "▶  실행",
   "◨  Performance Tuning": "◨  성능 튜닝",
-  "🌐  Localization": "🌐  지역화"
+  "🌐  Localization": "🌐  지역화",
+  "RDP Sessions": "RDP 세션",
+  "No active RDP sessions.": "활성 RDP 세션이 없습니다.",
+  "PID {pid}": "PID {pid}",
+  "Terminate": "종료",
+  "Terminated session: {name}": "세션 종료됨: {name}",
+  "Could not terminate {name} (already closed?)": "{name}을(를) 종료할 수 없음(이미 닫힘?)",
+  "Failed to terminate {name}": "{name} 종료 실패",
+  "Terminate Session": "세션 종료",
+  "(no active sessions)": "(활성 세션 없음)",
+  "Terminate: {name}": "종료: {name}"
 }

--- a/src/winpodx/locale/zh.json
+++ b/src/winpodx/locale/zh.json
@@ -812,5 +812,15 @@
   "▨  Hardware": "▨  硬件",
   "▶  Launch": "▶  启动",
   "◨  Performance Tuning": "◨  性能调优",
-  "🌐  Localization": "🌐  本地化"
+  "🌐  Localization": "🌐  本地化",
+  "RDP Sessions": "RDP 会话",
+  "No active RDP sessions.": "没有活动的 RDP 会话。",
+  "PID {pid}": "PID {pid}",
+  "Terminate": "终止",
+  "Terminated session: {name}": "已终止会话：{name}",
+  "Could not terminate {name} (already closed?)": "无法终止 {name}（已关闭？）",
+  "Failed to terminate {name}": "终止 {name} 失败",
+  "Terminate Session": "终止会话",
+  "(no active sessions)": "（无活动会话）",
+  "Terminate: {name}": "终止：{name}"
 }


### PR DESCRIPTION
## Why

Follow-up to #450 / #453. The tray **Terminate Session** menu (#452) and the new Tools-page **RDP Sessions** panel (#453) introduced 10 new `tr()` strings with no catalog entries, so `de/fr/it/ja/ko/zh` fell back to English.

## What

Add native translations for all 10 strings to every catalog:

`RDP Sessions`, `No active RDP sessions.`, `PID {pid}`, `Terminate`, `Terminated session: {name}`, `Could not terminate {name} (already closed?)`, `Failed to terminate {name}`, `Terminate Session`, `(no active sessions)`, `Terminate: {name}`.

- Placeholders `{name}` / `{pid}` and the literals `RDP` / `PID` are preserved verbatim so `.format()` keeps working in every language.
- Purely additive — no existing translation was modified (verified: only a trailing comma + the 10 new keys per file).

## Test

- `pytest tests/test_i18n.py` — 6 passed
- Live lookup: `tr("Terminate")` → `종료` (ko) / `終了` (ja) / `Beenden` (de); placeholder strings still `.format()` correctly; English identity intact.