### PR TITLE
fix(gui,tray): live-refresh sessions panel, fix Launch label clipping, Wayland app id

### DIFF
--- a/src/winpodx/desktop/tray.py
+++ b/src/winpodx/desktop/tray.py
@@ -78,6 +78,11 @@ def run_tray() -> None:
 
     app = QApplication(sys.argv)
     app.setApplicationName("winpodx")
+    # Bind to the installed desktop entry so Wayland compositors (KDE,
+    # GNOME) resolve the app id -> correct icon + identity for the tray
+    # item. Without this, KDE may render the StatusNotifierItem with a
+    # generic/blank icon or quietly file it under the hidden overflow.
+    app.setDesktopFileName("winpodx")
     app.setQuitOnLastWindowClosed(False)
 
     # Resolve the bundled SVG so the system-tray icon actually shows up.

--- a/src/winpodx/gui/_main_window_library.py
+++ b/src/winpodx/gui/_main_window_library.py
@@ -391,7 +391,7 @@ class LibraryPageMixin:
         card = QFrame()
         card.setObjectName("appCard")
         card.setStyleSheet(APP_CARD)
-        card.setMinimumHeight(190)
+        card.setMinimumHeight(210)
         card.setMinimumWidth(160)
         add_shadow(card)
 
@@ -437,15 +437,21 @@ class LibraryPageMixin:
         # "▶ Launch" button, a text Show/Hide toggle, and the same
         # confirmed delete. Edit stays a compact "⋯" to keep the narrow
         # card uncluttered.
-        bottom = QHBoxLayout()
-        bottom.setSpacing(6)
+        # Launch is the primary action and gets its own full-width row so
+        # the "▶  Launch" label is never clipped in a narrow 4-column card.
+        # The secondary actions (edit / hide / delete) sit on a compact row
+        # beneath it.
+        bottom = QVBoxLayout()
+        bottom.setSpacing(8)
 
         launch_btn = QPushButton(tr("▶  Launch"))
         launch_btn.setStyleSheet(BTN_ACCENT)
         launch_btn.setToolTip(tr("Launch {app}").format(app=app.full_name))
         launch_btn.clicked.connect(lambda _, a=app: self._launch_app(a))
         bottom.addWidget(launch_btn)
-        bottom.addStretch()
+
+        actions = QHBoxLayout()
+        actions.setSpacing(6)
 
         edit_btn = QPushButton("⋯")
         edit_btn.setFixedSize(28, 28)
@@ -466,7 +472,7 @@ class LibraryPageMixin:
             """
         )
         edit_btn.clicked.connect(lambda _, a=app: self._on_edit_app(a))
-        bottom.addWidget(edit_btn)
+        actions.addWidget(edit_btn)
 
         hide_btn = QPushButton(tr("Show") if app.hidden else tr("Hide"))
         hide_btn.setToolTip(tr("Show in menu") if app.hidden else tr("Hide from menu"))
@@ -478,15 +484,17 @@ class LibraryPageMixin:
             f" color: {C.TEXT}; }}"
         )
         hide_btn.clicked.connect(lambda _, a=app: self._on_toggle_app_hidden(a))
-        bottom.addWidget(hide_btn)
+        actions.addWidget(hide_btn)
+        actions.addStretch()
 
         del_btn = QPushButton("✕")
         del_btn.setFixedSize(28, 28)
         del_btn.setToolTip(tr("Delete"))
         del_btn.setStyleSheet(BTN_DANGER)
         del_btn.clicked.connect(lambda _, a=app: self._on_delete_app(a))
-        bottom.addWidget(del_btn)
+        actions.addWidget(del_btn)
 
+        bottom.addLayout(actions)
         vl.addLayout(bottom)
         return card
 

--- a/src/winpodx/gui/_main_window_maintenance.py
+++ b/src/winpodx/gui/_main_window_maintenance.py
@@ -272,28 +272,36 @@ class MaintenanceMixin:
         self._sessions_box.setContentsMargins(0, 0, 0, 0)
         self._sessions_box.setSpacing(8)
         layout.addWidget(sessions_box_host)
-        self._refresh_sessions_panel()
+
+        # Live refresh: poll while the Tools page is visible so launching or
+        # closing a Windows app shows up within a couple of seconds without
+        # leaving the tab. list_active_sessions() is a cheap local scan. The
+        # timer is started/stopped in _switch_page; rebuilds are skipped when
+        # the session set is unchanged (see _refresh_sessions_panel) so the
+        # poll never flickers the rows. _sessions_sig caches the last set.
+        self._sessions_sig = None
+        self._sessions_timer = QTimer(self)
+        self._sessions_timer.setInterval(2500)
+        self._sessions_timer.timeout.connect(self._refresh_sessions_panel)
+        self._refresh_sessions_panel(force=True)
 
         layout.addStretch()
         scroll.setWidget(content)
         outer.addWidget(scroll)
         return page
 
-    def _refresh_sessions_panel(self) -> None:
+    def _refresh_sessions_panel(self, force: bool = False) -> None:
         """Rebuild the Tools-page list of live RDP sessions (#450).
 
-        Called at page-build time and again whenever the user switches to
-        the Tools tab (see ``_switch_page``) and after a terminate, so the
-        list stays current without a background poll.
+        Called at page-build time, on every poll tick while the Tools tab
+        is visible (see ``_switch_page``), and after a terminate. The
+        rebuild is skipped when the live-session set is unchanged so the
+        poll doesn't flicker the rows; pass ``force=True`` to rebuild
+        regardless (first build / right after a terminate).
         """
         box = getattr(self, "_sessions_box", None)
         if box is None:
             return
-        while box.count():
-            item = box.takeAt(0)
-            w = item.widget()
-            if w is not None:
-                w.deleteLater()
         try:
             from winpodx.core.process import list_active_sessions
 
@@ -301,6 +309,16 @@ class MaintenanceMixin:
         except Exception as e:  # noqa: BLE001 -- never crash the Tools page
             log.warning("sessions panel: enumeration failed: %s", e)
             active = []
+        sig = tuple((s.app_name, s.pid) for s in active)
+        if not force and sig == getattr(self, "_sessions_sig", None):
+            return  # unchanged -> skip rebuild (no flicker during polling)
+        self._sessions_sig = sig
+
+        while box.count():
+            item = box.takeAt(0)
+            w = item.widget()
+            if w is not None:
+                w.deleteLater()
         if not active:
             empty = QLabel(tr("No active RDP sessions."))
             empty.setStyleSheet(f"background: transparent; color: {C.OVERLAY0}; font-size: 12px;")
@@ -354,7 +372,7 @@ class MaintenanceMixin:
         except Exception as e:  # noqa: BLE001 -- report, don't crash the page
             log.warning("terminate %s failed: %s", app_name, e)
             self.log_signal.emit(tr("Failed to terminate {name}").format(name=app_name), C.RED)
-            self._refresh_sessions_panel()
+            self._refresh_sessions_panel(force=True)
             return
         if ok:
             self.log_signal.emit(tr("Terminated session: {name}").format(name=app_name), C.GREEN)
@@ -363,7 +381,7 @@ class MaintenanceMixin:
                 tr("Could not terminate {name} (already closed?)").format(name=app_name),
                 C.YELLOW,
             )
-        self._refresh_sessions_panel()
+        self._refresh_sessions_panel(force=True)
 
     def _make_action_row(
         self,

--- a/src/winpodx/gui/_main_window_nav.py
+++ b/src/winpodx/gui/_main_window_nav.py
@@ -58,11 +58,18 @@ class NavigationMixin:
         else:
             self._stop_info_auto_refresh()
 
-        # Refresh the Tools-page live-session list whenever it's opened so
-        # the Terminate buttons reflect what's actually running (#450).
+        # Live-refresh the Tools-page session list while it's the visible
+        # page so launching/closing an app shows up within ~2.5 s without
+        # leaving the tab (#450). Off-page the poll is stopped so we don't
+        # scan the runtime dir while the user is elsewhere.
         tools_index = 2
-        if index == tools_index and hasattr(self, "_refresh_sessions_panel"):
-            self._refresh_sessions_panel()
+        if index == tools_index:
+            if hasattr(self, "_refresh_sessions_panel"):
+                self._refresh_sessions_panel(force=True)
+            if hasattr(self, "_sessions_timer"):
+                self._sessions_timer.start()
+        elif hasattr(self, "_sessions_timer"):
+            self._sessions_timer.stop()
 
     def _install_shortcuts(self) -> None:
         """Wire keyboard navigation: Alt+1..N switch top-nav pages and


### PR DESCRIPTION
## Why

Three follow-ups to #450 / #453 found while testing the merged build on **KDE Plasma (Wayland)**:

1. The Tools-page **RDP Sessions** panel only refreshed on tab-enter / after a terminate — launching or closing a Windows app while the tab was already open didn't show up ("실시간으로 안떠").
2. The grid app-card **Launch** label was clipped ("launch 글자 잘린다") — `Launch` + `⋯` + `Hide` + `✕` don't fit one row in a narrow 4-column card.
3. The tray item wasn't binding to its desktop entry, so Wayland compositors couldn't resolve a stable app id/icon for it.

## What

- **gui (live refresh):** poll `list_active_sessions()` every 2.5 s while the Tools page is visible; stop the poll off-page. Rebuilds are skipped when the session set is unchanged (signature cache) so the poll never flickers the rows. Forced rebuild on tab-enter and after a terminate.
- **gui (Launch clip):** move **Launch** to its own full-width row (primary action) with the secondary actions (`⋯` / `Hide` / `✕`) on a compact row beneath it; bump the card min-height to fit. The label can no longer be truncated at any card width.
- **tray:** `app.setDesktopFileName("winpodx")` so KDE/GNOME resolve the app id → correct tray icon + identity (complements the #453 re-show retry).

## Test

- `pytest tests/test_main_window_bringup.py tests/test_devices_gui.py` — 16 passed
- Offscreen smoke: grid card builds with the new full-width-launch + actions-row layout; live-refresh skips rebuild on unchanged set, rebuilds on add, shows empty-state when all closed; tray exposes `setDesktopFileName`.
- `ruff check` + `ruff format --check` — clean
- Full `pytest tests/` — see CI (local run green).
- Verified on the dev box (KDE Plasma Wayland) that a freshly launched tray **does** register a `StatusNotifierItem` with the watcher.