### PR TITLE
fix(process): track Flatpak FreeRDP sessions wrapped by bwrap

### DIFF
--- a/src/winpodx/core/process.py
+++ b/src/winpodx/core/process.py
@@ -44,6 +44,18 @@ def _cmdline_is_freerdp(cmdline: bytes) -> bool:
     if prog == b"flatpak":
         tail = [a.lower() for a in argv[1:] if a]
         return b"com.freerdp.freerdp" in tail
+    if prog in (b"bwrap", b"bubblewrap"):
+        # `flatpak run com.freerdp.FreeRDP` re-execs (same PID) into
+        # `bwrap ... -- xfreerdp ...`, so the tracked PID's argv[0] becomes
+        # bwrap. Recognise a freerdp client basename (or the Flatpak app id)
+        # among bwrap's args so session tracking survives the sandbox --
+        # otherwise list_active_sessions() unlinks a live session's .cproc
+        # and the tray / GUI report no active sessions while apps are running.
+        for a in argv[1:]:
+            base = a.rsplit(b"/", 1)[-1].lower()
+            if base in _FREERDP_ARGV0 or base == b"com.freerdp.freerdp":
+                return True
+        return False
     return False
 
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -20,6 +20,21 @@ class TestCmdlineIsFreerdp:
     def test_argv0_flatpak_freerdp(self):
         assert _cmdline_is_freerdp(b"flatpak\0run\0com.freerdp.FreeRDP\0/v:host\0")
 
+    def test_argv0_bwrap_wrapped_xfreerdp(self):
+        # `flatpak run com.freerdp.FreeRDP` re-execs (same PID) into
+        # `bwrap ... -- xfreerdp ...`; the wrapped client must still count or
+        # list_active_sessions() unlinks a live session's .cproc.
+        assert _cmdline_is_freerdp(
+            b"/usr/bin/bwrap\0--args\0072\0--\0xfreerdp\0/v:127.0.0.1:3390\0"
+        )
+
+    def test_argv0_bwrap_wrapped_flatpak_appid(self):
+        assert _cmdline_is_freerdp(b"bwrap\0--\0com.freerdp.FreeRDP\0/v:host\0")
+
+    def test_bwrap_without_freerdp_rejected(self):
+        # A bwrap sandbox around something else must not be adopted.
+        assert not _cmdline_is_freerdp(b"/usr/bin/bwrap\0--\0sleep\0900\0")
+
     def test_freerdp_only_in_later_argv_rejected(self):
         # Regression: "freerdp" in a later arg must not match.
         assert not _cmdline_is_freerdp(


### PR DESCRIPTION
## Why

The tray and the new GUI **Tools → RDP Sessions** panel reported **no active sessions while Windows apps were actually running** ("활성 rdp 세션이 안뜨는데").

Root cause (reproduced on KDE Plasma with the **Flatpak FreeRDP**): winpodx prefers `com.freerdp.FreeRDP`, and `flatpak run` re-execs **in the same PID** into `bwrap ... -- xfreerdp ...`. So the PID winpodx tracks in its `.cproc` file ends up with `argv[0] = bwrap`. `_cmdline_is_freerdp()` only recognised `xfreerdp*` / `flatpak` as `argv[0]`, so `is_freerdp_pid()` returned `False` for the live session → `list_active_sessions()` treated it as dead and **unlinked the `.cproc`** → the session disappeared from tracking even though `xfreerdp` was alive.

Observed: 3 live `xfreerdp` processes (under `bwrap`), **zero `.cproc` files** left in `/run/user/1000/winpodx`.

## What

`_cmdline_is_freerdp()` now also accepts a `bwrap` / `bubblewrap` `argv[0]` when a freerdp client basename (or the `com.freerdp.FreeRDP` app id) appears among its args — mirroring the existing `flatpak` handling. A bwrap sandbox wrapping anything else is still rejected (no false adoption / PID-reuse risk).

Note: this is forward-looking — sessions whose `.cproc` was already unlinked won't reappear; relaunching the app writes a fresh `.cproc` that now survives.

## Test

- `pytest tests/test_process.py` — 14 passed (added 3 cases: bwrap-wrapped xfreerdp ✓, bwrap-wrapped app id ✓, bwrap-without-freerdp rejected ✓)
- Verified on the live box: `is_freerdp_pid(<bwrap pid>)` flips `False → True`; the raw `xfreerdp` PID still `True`; a bwrap around `sleep` stays `False`.
- `ruff check` + `ruff format --check` — clean
- Full `pytest tests/` — see CI.