### PR TITLE
fix(process): never delete a live session's tracking file

### DIFF
--- a/src/winpodx/core/process.py
+++ b/src/winpodx/core/process.py
@@ -77,6 +77,27 @@ def is_freerdp_pid(pid: int) -> bool:
     return _cmdline_is_freerdp(cmdline)
 
 
+def _pid_alive(pid: int) -> bool:
+    """True if a process with this PID currently exists (any identity).
+
+    Unlike :func:`is_freerdp_pid` this does NOT inspect the cmdline -- it is
+    the test for "is the tracked PID gone?". Keeping the two separate is
+    deliberate: a live PID we merely fail to *recognise* as FreeRDP (a new
+    sandbox wrapper, or version skew where an old reader meets a newly-wrapped
+    client) must never cause a live session's ``.cproc`` to be deleted. Only a
+    genuinely dead PID may be cleaned up.
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, owned by another uid (defensive; shouldn't happen)
+    except OSError:
+        return False
+    return True
+
+
 @dataclass
 class TrackedProcess:
     app_name: str
@@ -97,34 +118,49 @@ def list_active_sessions() -> list[TrackedProcess]:
     for f in rd.glob("*.cproc"):
         try:
             pid = int(f.read_text().strip())
-            proc = TrackedProcess(app_name=f.stem, pid=pid)
-            if proc.is_alive:
-                sessions.append(proc)
-            else:
-                f.unlink(missing_ok=True)
         except (ValueError, OSError):
-            f.unlink(missing_ok=True)
+            f.unlink(missing_ok=True)  # corrupt / unreadable -> drop
+            continue
+        proc = TrackedProcess(app_name=f.stem, pid=pid)
+        if proc.is_alive:
+            sessions.append(proc)  # live FreeRDP -> list it
+        elif not _pid_alive(pid):
+            f.unlink(missing_ok=True)  # genuinely dead -> clean up
+        # else: PID alive but not recognised as FreeRDP (PID reuse, or a
+        # wrapper this version doesn't know yet) -> keep the file, don't list.
+        # A reader must NEVER destroy a live session's tracking state; only a
+        # dead PID is cleaned up here.
     return sessions
 
 
 def kill_session(app_name: str) -> bool:
-    """Kill an active RDP session by app name."""
+    """Terminate an active RDP session by app name (SIGTERM the tracked PID)."""
     pid_file = runtime_dir() / f"{app_name}.cproc"
     if not pid_file.exists():
         return False
 
     try:
         pid = int(pid_file.read_text().strip())
-
-        # Verify it's actually a FreeRDP process before killing (PID reuse)
-        if not is_freerdp_pid(pid):
-            pid_file.unlink(missing_ok=True)
-            return False
-
-        os.kill(pid, signal.SIGTERM)
+    except (ValueError, OSError):
         pid_file.unlink(missing_ok=True)
-        return True
-    except (ValueError, ProcessLookupError, PermissionError) as e:
+        return False
+
+    if not _pid_alive(pid):
+        pid_file.unlink(missing_ok=True)  # already gone -> clean up
+        return False
+
+    # PID-reuse guard: if the live PID was recycled into something that is not
+    # our FreeRDP client, don't SIGTERM a stranger -- the real session is gone.
+    if not is_freerdp_pid(pid):
+        pid_file.unlink(missing_ok=True)
+        return False
+
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError) as e:
         log.warning("Failed to kill session %s: %s", app_name, e)
         pid_file.unlink(missing_ok=True)
         return False
+
+    pid_file.unlink(missing_ok=True)
+    return True

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -79,6 +79,31 @@ class TestListActiveSessions:
         assert len(sessions) == 0
         assert not cproc.exists()
 
+    def test_lists_live_freerdp(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("winpodx.core.process.runtime_dir", lambda: tmp_path)
+        monkeypatch.setattr("winpodx.core.process._pid_alive", lambda pid: True)
+        monkeypatch.setattr("winpodx.core.process.is_freerdp_pid", lambda pid: True)
+        cproc = tmp_path / "Notepad.cproc"
+        cproc.write_text("4242")
+        sessions = list_active_sessions()
+        assert [(s.app_name, s.pid) for s in sessions] == [("Notepad", 4242)]
+        assert cproc.exists()
+
+    def test_keeps_live_but_unrecognized_cproc(self, tmp_path, monkeypatch):
+        # Regression: a live PID we fail to recognise as FreeRDP (a new sandbox
+        # wrapper, or an old reader meeting a newly-wrapped client) must NOT be
+        # listed -- but its .cproc must NOT be deleted either. A reader deleting
+        # a live session's tracking file was the root cause of sessions
+        # vanishing / Terminate finding nothing.
+        monkeypatch.setattr("winpodx.core.process.runtime_dir", lambda: tmp_path)
+        monkeypatch.setattr("winpodx.core.process._pid_alive", lambda pid: True)
+        monkeypatch.setattr("winpodx.core.process.is_freerdp_pid", lambda pid: False)
+        cproc = tmp_path / "app.cproc"
+        cproc.write_text("4242")
+        sessions = list_active_sessions()
+        assert sessions == []
+        assert cproc.exists()  # NOT deleted -- live PID, just unrecognised
+
 
 class TestKillSession:
     def test_returns_false_no_pidfile(self, tmp_path, monkeypatch):
@@ -90,4 +115,33 @@ class TestKillSession:
         cproc = tmp_path / "dead-app.cproc"
         cproc.write_text("99999999")
         assert kill_session("dead-app") is False
+        assert not cproc.exists()
+
+    def test_signals_live_freerdp_and_removes(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("winpodx.core.process.runtime_dir", lambda: tmp_path)
+        monkeypatch.setattr("winpodx.core.process._pid_alive", lambda pid: True)
+        monkeypatch.setattr("winpodx.core.process.is_freerdp_pid", lambda pid: True)
+        signalled = {}
+        monkeypatch.setattr(
+            "winpodx.core.process.os.kill",
+            lambda pid, sig: signalled.update(pid=pid, sig=sig),
+        )
+        cproc = tmp_path / "app.cproc"
+        cproc.write_text("4242")
+        assert kill_session("app") is True
+        assert signalled["pid"] == 4242
+        assert not cproc.exists()
+
+    def test_reused_pid_not_signalled(self, tmp_path, monkeypatch):
+        # PID-reuse guard: a live PID that is NOT our FreeRDP client must never
+        # be SIGTERM'd (we'd kill an innocent process). Just drop the stale file.
+        monkeypatch.setattr("winpodx.core.process.runtime_dir", lambda: tmp_path)
+        monkeypatch.setattr("winpodx.core.process._pid_alive", lambda pid: True)
+        monkeypatch.setattr("winpodx.core.process.is_freerdp_pid", lambda pid: False)
+        calls = []
+        monkeypatch.setattr("winpodx.core.process.os.kill", lambda pid, sig: calls.append(pid))
+        cproc = tmp_path / "app.cproc"
+        cproc.write_text("4242")
+        assert kill_session("app") is False
+        assert calls == []
         assert not cproc.exists()


### PR DESCRIPTION
## Why

User report: RDP sessions **show up then vanish** in the tray/GUI, and **Terminate does nothing** ("떠있는데 금방 사라진다", "지우기 해도 안지워지고").

Root cause: `list_active_sessions()` deleted a `.cproc` file whenever `is_freerdp_pid()` returned `False`. That conflates two very different situations:

1. the PID is **dead** → cleanup is correct;
2. the PID is **alive but its cmdline isn't recognised** as FreeRDP — e.g. Flatpak's `flatpak run` re-execs into `bwrap`, or an **old reader still running after an upgrade** meets a newly-wrapped client.

In case (2) a *reader* was destroying a **live** session's tracking state, so the session disappeared and `kill_session()` then had no `.cproc` to act on. This recurs on every upgrade that changes the launch wrapper.

## What

Separate **liveness** from **identity**:

- `_pid_alive(pid)` = `os.kill(pid, 0)` — does the PID exist at all.
- `list_active_sessions()` removes a `.cproc` **only when the PID is genuinely dead**. A live-but-unrecognised PID keeps its file (just isn't listed) — a reader never destroys live state.
- `kill_session()` SIGTERMs the tracked PID when it's alive, keeping the cmdline check only as a **PID-reuse guard** (never signal an unrelated recycled PID).

Simpler, and robust to any FreeRDP launch wrapper and to version skew during upgrades. This generalises #456 (which only taught the recogniser about `bwrap`).

## Test

- `pytest tests/test_process.py` — 18 passed (added: lists live FreeRDP; **keeps live-but-unrecognised .cproc** (regression); signals live FreeRDP + removes; reused-PID not signalled).
- Verified live on KDE + Flatpak FreeRDP earlier: launch keeps tracking; `kill_session()` kills the bwrap session in ~0.4 s and removes the `.cproc`.
- `ruff check` + `ruff format --check` — clean. Full `pytest` — see CI.