### PR TITLE
fix(process): terminate the whole FreeRDP process group, not just the leader

### DIFF
--- a/src/winpodx/core/process.py
+++ b/src/winpodx/core/process.py
@@ -155,8 +155,24 @@ def kill_session(app_name: str) -> bool:
         pid_file.unlink(missing_ok=True)
         return False
 
+    # The FreeRDP client is a process tree (Flatpak: `flatpak run` -> bwrap ->
+    # xfreerdp). A SIGTERM to just the tracked leader may not propagate through
+    # the nested sandbox, so the window stays open ("Terminate does nothing").
+    # Sessions are launched with start_new_session=True, so the leader's PID is
+    # its own PGID -- signal the whole group to bring the entire tree down. We
+    # only do this when PGID == PID (i.e. it really is a group leader we
+    # spawned); otherwise (e.g. a session from an older winpodx) fall back to a
+    # single-PID signal so we never nuke an unrelated group.
     try:
-        os.kill(pid, signal.SIGTERM)
+        pgid = os.getpgid(pid)
+    except (ProcessLookupError, PermissionError):
+        pgid = None
+
+    try:
+        if pgid == pid:
+            os.killpg(pgid, signal.SIGTERM)
+        else:
+            os.kill(pid, signal.SIGTERM)
     except (ProcessLookupError, PermissionError) as e:
         log.warning("Failed to kill session %s: %s", app_name, e)
         pid_file.unlink(missing_ok=True)

--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -923,6 +923,14 @@ def launch_app(
 
     # stderr=PIPE would SIGPIPE-kill the detached client once the CLI
     # parent exits; log to a file so the session outlives us.
+    #
+    # start_new_session=True puts the client in its own process group (PGID ==
+    # this PID) and session. The FreeRDP client is actually a tree -- the
+    # Flatpak path is `flatpak run` -> bwrap -> xfreerdp -- and a SIGTERM to
+    # just the leader may not propagate through the nested sandbox to the real
+    # xfreerdp. Owning the group lets kill_session() signal the whole tree at
+    # once (os.killpg), so Terminate reliably ends the session. It also cleanly
+    # detaches the client from the CLI's session (it must outlive us).
     err_log = session.stderr_log.open("wb")
     try:
         proc = subprocess.Popen(
@@ -930,6 +938,7 @@ def launch_app(
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=err_log,
+            start_new_session=True,
         )
         err_log.close()
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -117,29 +117,63 @@ class TestKillSession:
         assert kill_session("dead-app") is False
         assert not cproc.exists()
 
-    def test_signals_live_freerdp_and_removes(self, tmp_path, monkeypatch):
+    def test_signals_whole_group_when_leader(self, tmp_path, monkeypatch):
+        # Launched with start_new_session=True -> PGID == PID -> kill the whole
+        # process group so the nested flatpak/bwrap/xfreerdp tree all dies.
         monkeypatch.setattr("winpodx.core.process.runtime_dir", lambda: tmp_path)
         monkeypatch.setattr("winpodx.core.process._pid_alive", lambda pid: True)
         monkeypatch.setattr("winpodx.core.process.is_freerdp_pid", lambda pid: True)
-        signalled = {}
+        monkeypatch.setattr("winpodx.core.process.os.getpgid", lambda pid: pid)  # leader
+        grp = {}
+        monkeypatch.setattr(
+            "winpodx.core.process.os.killpg",
+            lambda pgid, sig: grp.update(pgid=pgid, sig=sig),
+        )
+        called_kill = []
         monkeypatch.setattr(
             "winpodx.core.process.os.kill",
-            lambda pid, sig: signalled.update(pid=pid, sig=sig),
+            lambda pid, sig: called_kill.append(pid),
         )
         cproc = tmp_path / "app.cproc"
         cproc.write_text("4242")
         assert kill_session("app") is True
-        assert signalled["pid"] == 4242
+        assert grp["pgid"] == 4242  # whole group signalled
+        assert called_kill == []  # not the single-PID path
+        assert not cproc.exists()
+
+    def test_falls_back_to_single_pid_when_not_leader(self, tmp_path, monkeypatch):
+        # Session from an older winpodx (no start_new_session) -> PGID != PID ->
+        # signal only the PID, never an unrelated group.
+        monkeypatch.setattr("winpodx.core.process.runtime_dir", lambda: tmp_path)
+        monkeypatch.setattr("winpodx.core.process._pid_alive", lambda pid: True)
+        monkeypatch.setattr("winpodx.core.process.is_freerdp_pid", lambda pid: True)
+        monkeypatch.setattr("winpodx.core.process.os.getpgid", lambda pid: 999)  # not leader
+        killpg_calls = []
+        monkeypatch.setattr(
+            "winpodx.core.process.os.killpg",
+            lambda pgid, sig: killpg_calls.append(pgid),
+        )
+        kill_calls = []
+        monkeypatch.setattr(
+            "winpodx.core.process.os.kill",
+            lambda pid, sig: kill_calls.append(pid),
+        )
+        cproc = tmp_path / "app.cproc"
+        cproc.write_text("4242")
+        assert kill_session("app") is True
+        assert kill_calls == [4242]
+        assert killpg_calls == []  # never group-kill a group we don't lead
         assert not cproc.exists()
 
     def test_reused_pid_not_signalled(self, tmp_path, monkeypatch):
         # PID-reuse guard: a live PID that is NOT our FreeRDP client must never
-        # be SIGTERM'd (we'd kill an innocent process). Just drop the stale file.
+        # be signalled (we'd kill an innocent process). Just drop the stale file.
         monkeypatch.setattr("winpodx.core.process.runtime_dir", lambda: tmp_path)
         monkeypatch.setattr("winpodx.core.process._pid_alive", lambda pid: True)
         monkeypatch.setattr("winpodx.core.process.is_freerdp_pid", lambda pid: False)
         calls = []
         monkeypatch.setattr("winpodx.core.process.os.kill", lambda pid, sig: calls.append(pid))
+        monkeypatch.setattr("winpodx.core.process.os.killpg", lambda pgid, sig: calls.append(pgid))
         cproc = tmp_path / "app.cproc"
         cproc.write_text("4242")
         assert kill_session("app") is False


### PR DESCRIPTION
## Why ("Terminate does nothing")

Found by code analysis (no live testing). The FreeRDP client is a **process tree** — the Flatpak path is `flatpak run` → `bwrap` → `xfreerdp`. `kill_session()` sent `SIGTERM` only to the **tracked leader PID**, which does **not reliably propagate** through the nested sandbox to the actual `xfreerdp`. Result: the row clears but the window stays open → "종료 눌러도 안돼".

## What

- **`launch_app()`**: spawn the client with `start_new_session=True` so it leads its own process group/session (`PGID == PID`) and is cleanly detached from the CLI.
- **`kill_session()`**: when the tracked PID is its own group leader, `SIGTERM` the **whole process group** (`os.killpg`) so the entire `flatpak`/`bwrap`/`xfreerdp` tree goes down together. Falls back to a single-PID signal when `PGID != PID` (e.g. a session launched by an older winpodx) so we never signal an unrelated group. The PID-reuse guard is preserved.

Builds on #456 (recognise bwrap) and #457 (don't delete live tracking).

## Test

- `pytest tests/test_process.py` — 19 passed; new cases: group-kill when leader, single-PID fallback when not leader, PID-reuse not signalled.
- `pytest tests/test_rdp.py` — 40 passed (start_new_session change).
- `ruff check` + `ruff format --check` — clean. Full `pytest` — see CI.