### PR TITLE
fix: force-kill stuck sessions, stop tray crash, match UWP taskbar window

### DIFF
--- a/src/winpodx/core/process.py
+++ b/src/winpodx/core/process.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import os
 import signal
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -168,11 +169,24 @@ def kill_session(app_name: str) -> bool:
     except (ProcessLookupError, PermissionError):
         pgid = None
 
-    try:
+    def _signal(sig: int) -> None:
         if pgid == pid:
-            os.killpg(pgid, signal.SIGTERM)
+            os.killpg(pgid, sig)
         else:
-            os.kill(pid, signal.SIGTERM)
+            os.kill(pid, sig)
+
+    try:
+        _signal(signal.SIGTERM)
+        # Escalate to SIGKILL if a polite SIGTERM doesn't bring the tree down
+        # within a short grace. A hung xfreerdp -- or one that ignores SIGTERM
+        # -- would otherwise keep its window mapped ("Terminate does nothing").
+        # The loop exits as soon as the PID is gone (~0.4s in practice).
+        for _ in range(8):  # ~0.8s grace
+            time.sleep(0.1)
+            if not _pid_alive(pid):
+                break
+        else:
+            _signal(signal.SIGKILL)
     except (ProcessLookupError, PermissionError) as e:
         log.warning("Failed to kill session %s: %s", app_name, e)
         pid_file.unlink(missing_ok=True)

--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -70,6 +70,37 @@ def _uwp_fallback_wm_class(aumid: str) -> str:
     return candidate
 
 
+def resolve_wm_class(
+    app_executable: str | None,
+    wm_class_hint: str | None = None,
+    launch_uri: str | None = None,
+) -> str:
+    """The ``/wm-class`` token FreeRDP is given for this app.
+
+    SINGLE SOURCE OF TRUTH: the app's ``.desktop`` ``StartupWMClass`` must be
+    byte-identical to this, or the Linux WM can't line the RemoteApp window up
+    under the launcher icon and the app shows up as an unmatched window (no
+    taskbar grouping / icon). UWP apps (``launch_uri`` is an AUMID) have no real
+    exe path, so the exe-stem default yields a useless token (e.g. ``microsoft``
+    from ``Microsoft.WindowsCalculator_...!App``); they fall back to a slug of
+    the AUMID instead. Mirrors the resolution in ``build_rdp_command`` exactly.
+    """
+    from pathlib import PureWindowsPath
+
+    hint = (wm_class_hint or "").strip().lower()
+    if launch_uri:
+        aumid = launch_uri.strip()
+        if _is_valid_aumid(aumid):
+            if hint and _is_safe_wm_class(hint):
+                return hint
+            return _uwp_fallback_wm_class(aumid)
+    stem = PureWindowsPath(app_executable or "").stem.lower()
+    name_token = hint or stem
+    if not _is_safe_wm_class(name_token):
+        name_token = stem
+    return name_token
+
+
 @dataclass
 class RDPSession:
     app_name: str
@@ -452,9 +483,8 @@ def build_rdp_command(
         aumid = launch_uri.strip()
         if not _is_valid_aumid(aumid):
             raise RuntimeError(f"Invalid UWP AUMID: {aumid!r}")
-        wm_class = (wm_class_hint or "").strip().lower()
-        if not wm_class or not _is_safe_wm_class(wm_class):
-            wm_class = _uwp_fallback_wm_class(aumid)
+        # Single source of truth shared with the .desktop StartupWMClass.
+        wm_class = resolve_wm_class(app_executable, wm_class_hint, launch_uri)
         app_arg = (
             f"/app:program:wscript.exe,name:{wm_class},"
             f"cmd:C:\\Users\\Public\\winpodx\\launchers\\launch_uwp.vbs {aumid}"
@@ -463,12 +493,8 @@ def build_rdp_command(
         cmd.append(f"/wm-class:{wm_class}")
         cmd.append("+grab-keyboard")
     elif app_executable:
-        from pathlib import PureWindowsPath
-
-        stem = PureWindowsPath(app_executable).stem.lower()
-        name_token = (wm_class_hint or "").strip().lower() or stem
-        if not _is_safe_wm_class(name_token):
-            name_token = stem
+        # Single source of truth shared with the .desktop StartupWMClass.
+        name_token = resolve_wm_class(app_executable, wm_class_hint, launch_uri)
         # FreeRDP's RemoteApp syntax is incompatible between major
         # versions and we have to branch:
         #

--- a/src/winpodx/desktop/entry.py
+++ b/src/winpodx/desktop/entry.py
@@ -42,10 +42,18 @@ def install_desktop_entry(app: AppInfo) -> Path:
 
     icon_name = _install_icon(app)
 
-    # wm_class must match /wm-class:{stem} in rdp.py
-    from pathlib import PureWindowsPath
+    # StartupWMClass must be byte-identical to the /wm-class token FreeRDP is
+    # given (rdp.py), or the WM can't match the RemoteApp window to this entry
+    # -- shared resolver handles UWP (AUMID slug) + wm_class_hint, not just the
+    # exe stem (a UWP exe stem like "microsoft" never matched, so Calculator &
+    # other UWP apps showed up unmatched in the taskbar).
+    from winpodx.core.rdp import resolve_wm_class
 
-    wm_class = PureWindowsPath(app.executable).stem.lower()
+    wm_class = resolve_wm_class(
+        app.executable,
+        getattr(app, "wm_class_hint", None) or None,
+        getattr(app, "launch_uri", None) or None,
+    )
 
     # Prefer the app's real description (from exe metadata / .lnk Comment /
     # UWP <Description>); fall back to the generic stamp when blank. Strip

--- a/src/winpodx/desktop/tray.py
+++ b/src/winpodx/desktop/tray.py
@@ -249,7 +249,16 @@ def run_tray() -> None:
             log.warning("Failed to get pod status: %s", e)
             status_action.setText(tr("Pod: error"))
 
-        active = list_active_sessions()
+        # Must not raise: refresh_status is a QTimer slot (30s tick) -- an
+        # uncaught exception propagates out of the Qt event loop and aborts
+        # app.exec(), so the tray icon appears at launch then silently vanishes
+        # on the first tick. list_active_sessions() globs + reads + os.kill()s
+        # and can raise OSError, so guard it (mirrors _rebuild_sessions_menu).
+        try:
+            active = list_active_sessions()
+        except Exception as e:  # noqa: BLE001 -- never crash the tray event loop
+            log.warning("Failed to list active sessions: %s", e)
+            active = []
         sessions_action.setText(tr("Sessions: {n}").format(n=len(active)))
 
     def _run_in_thread(fn, success_msg: str, error_msg: str) -> None:
@@ -626,19 +635,25 @@ def run_tray() -> None:
     tray_retry = {"left": 30}  # ~60 s at a 2 s cadence
 
     def _ensure_tray_visible() -> None:
-        if QSystemTrayIcon.isSystemTrayAvailable():
-            tray.show()  # re-register with the now-present host
+        # QTimer slot: must not raise, or the exception aborts the event loop
+        # and kills the tray we're trying to keep alive.
+        try:
+            if QSystemTrayIcon.isSystemTrayAvailable():
+                tray.show()  # re-register with the now-present host
+                tray_retry_timer.stop()
+                log.info("system-tray host appeared; tray icon shown.")
+                return
+            tray_retry["left"] -= 1
+            if tray_retry["left"] <= 0:
+                tray_retry_timer.stop()
+                log.warning(
+                    "no system-tray host after 60 s; this DE may lack a tray "
+                    "(stock GNOME needs the AppIndicator extension). Use "
+                    "`winpodx gui` for the dashboard instead."
+                )
+        except Exception as e:  # noqa: BLE001 -- never crash the tray event loop
+            log.warning("tray visibility retry failed: %s", e)
             tray_retry_timer.stop()
-            log.info("system-tray host appeared; tray icon shown.")
-            return
-        tray_retry["left"] -= 1
-        if tray_retry["left"] <= 0:
-            tray_retry_timer.stop()
-            log.warning(
-                "no system-tray host after 60 s; this DE may lack a tray "
-                "(stock GNOME needs the AppIndicator extension). Use "
-                "`winpodx gui` for the dashboard instead."
-            )
 
     tray_retry_timer = QTimer()
     tray_retry_timer.timeout.connect(_ensure_tray_visible)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import signal
 
 from winpodx.core.process import (
     TrackedProcess,
@@ -121,23 +122,24 @@ class TestKillSession:
         # Launched with start_new_session=True -> PGID == PID -> kill the whole
         # process group so the nested flatpak/bwrap/xfreerdp tree all dies.
         monkeypatch.setattr("winpodx.core.process.runtime_dir", lambda: tmp_path)
-        monkeypatch.setattr("winpodx.core.process._pid_alive", lambda pid: True)
         monkeypatch.setattr("winpodx.core.process.is_freerdp_pid", lambda pid: True)
         monkeypatch.setattr("winpodx.core.process.os.getpgid", lambda pid: pid)  # leader
-        grp = {}
+        monkeypatch.setattr("winpodx.core.process.time.sleep", lambda s: None)
+        # alive for the guard, then dead -> polite SIGTERM only, no SIGKILL
+        alive = iter([True, False, False])
+        monkeypatch.setattr("winpodx.core.process._pid_alive", lambda pid: next(alive, False))
+        grp = []
         monkeypatch.setattr(
-            "winpodx.core.process.os.killpg",
-            lambda pgid, sig: grp.update(pgid=pgid, sig=sig),
+            "winpodx.core.process.os.killpg", lambda pgid, sig: grp.append((pgid, sig))
         )
         called_kill = []
         monkeypatch.setattr(
-            "winpodx.core.process.os.kill",
-            lambda pid, sig: called_kill.append(pid),
+            "winpodx.core.process.os.kill", lambda pid, sig: called_kill.append(pid)
         )
         cproc = tmp_path / "app.cproc"
         cproc.write_text("4242")
         assert kill_session("app") is True
-        assert grp["pgid"] == 4242  # whole group signalled
+        assert grp == [(4242, signal.SIGTERM)]  # whole group, polite signal only
         assert called_kill == []  # not the single-PID path
         assert not cproc.exists()
 
@@ -145,24 +147,41 @@ class TestKillSession:
         # Session from an older winpodx (no start_new_session) -> PGID != PID ->
         # signal only the PID, never an unrelated group.
         monkeypatch.setattr("winpodx.core.process.runtime_dir", lambda: tmp_path)
-        monkeypatch.setattr("winpodx.core.process._pid_alive", lambda pid: True)
         monkeypatch.setattr("winpodx.core.process.is_freerdp_pid", lambda pid: True)
         monkeypatch.setattr("winpodx.core.process.os.getpgid", lambda pid: 999)  # not leader
+        monkeypatch.setattr("winpodx.core.process.time.sleep", lambda s: None)
+        alive = iter([True, False, False])
+        monkeypatch.setattr("winpodx.core.process._pid_alive", lambda pid: next(alive, False))
         killpg_calls = []
         monkeypatch.setattr(
-            "winpodx.core.process.os.killpg",
-            lambda pgid, sig: killpg_calls.append(pgid),
+            "winpodx.core.process.os.killpg", lambda pgid, sig: killpg_calls.append(pgid)
         )
         kill_calls = []
         monkeypatch.setattr(
-            "winpodx.core.process.os.kill",
-            lambda pid, sig: kill_calls.append(pid),
+            "winpodx.core.process.os.kill", lambda pid, sig: kill_calls.append((pid, sig))
         )
         cproc = tmp_path / "app.cproc"
         cproc.write_text("4242")
         assert kill_session("app") is True
-        assert kill_calls == [4242]
+        assert kill_calls == [(4242, signal.SIGTERM)]
         assert killpg_calls == []  # never group-kill a group we don't lead
+        assert not cproc.exists()
+
+    def test_escalates_to_sigkill_when_term_ignored(self, tmp_path, monkeypatch):
+        # xfreerdp ignores/hangs on SIGTERM -> escalate to SIGKILL so the window
+        # is forced down ("Terminate does nothing" / window lingers on exit).
+        monkeypatch.setattr("winpodx.core.process.runtime_dir", lambda: tmp_path)
+        monkeypatch.setattr("winpodx.core.process.is_freerdp_pid", lambda pid: True)
+        monkeypatch.setattr("winpodx.core.process.os.getpgid", lambda pid: pid)
+        monkeypatch.setattr("winpodx.core.process.time.sleep", lambda s: None)
+        monkeypatch.setattr("winpodx.core.process._pid_alive", lambda pid: True)  # never dies
+        sigs = []
+        monkeypatch.setattr("winpodx.core.process.os.killpg", lambda pgid, sig: sigs.append(sig))
+        cproc = tmp_path / "app.cproc"
+        cproc.write_text("4242")
+        assert kill_session("app") is True
+        assert signal.SIGTERM in sigs
+        assert signal.SIGKILL in sigs  # escalated
         assert not cproc.exists()
 
     def test_reused_pid_not_signalled(self, tmp_path, monkeypatch):

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -603,3 +603,58 @@ def test_linux_to_unc_home_symlink_atomic(monkeypatch, tmp_path):
     # File passed through the symlinked home path, as `app run` would.
     result = linux_to_unc(str(home_link / "Desktop" / "temp.doc"))
     assert result == "\\\\tsclient\\home\\Desktop\\temp.doc"
+
+
+class TestResolveWmClass:
+    """resolve_wm_class() is the single source of truth shared by FreeRDP's
+    /wm-class and the .desktop StartupWMClass (taskbar window matching)."""
+
+    def test_exe_stem_default(self):
+        from winpodx.core.rdp import resolve_wm_class
+
+        assert resolve_wm_class("C:\\Program Files\\App\\notepad.exe") == "notepad"
+
+    def test_exe_hint_overrides_stem(self):
+        from winpodx.core.rdp import resolve_wm_class
+
+        assert resolve_wm_class("C:\\x\\app.exe", "MyApp") == "myapp"
+
+    def test_exe_unsafe_hint_falls_back_to_stem(self):
+        from winpodx.core.rdp import resolve_wm_class
+
+        # A hint with disallowed chars must not produce an unsafe token.
+        assert resolve_wm_class("C:\\x\\app.exe", "bad name!@#") == "app"
+
+    def test_uwp_uses_aumid_slug_not_exe_stem(self):
+        # Regression: a UWP AUMID's exe-stem is useless ("microsoft" from
+        # "Microsoft.WindowsCalculator_...!App") and never matched the
+        # StartupWMClass, so Calculator showed up unmatched in the taskbar.
+        from winpodx.core.rdp import _uwp_fallback_wm_class, resolve_wm_class
+
+        aumid = "Microsoft.WindowsCalculator_8wekyb3d8bbwe!App"
+        got = resolve_wm_class(None, None, aumid)
+        assert got == _uwp_fallback_wm_class(aumid)
+        assert got != "microsoft"
+        assert got.startswith("winpodx-uwp-")
+
+    def test_uwp_valid_hint_wins(self):
+        from winpodx.core.rdp import resolve_wm_class
+
+        aumid = "Microsoft.WindowsCalculator_8wekyb3d8bbwe!App"
+        assert resolve_wm_class(None, "calc", aumid) == "calc"
+
+    def test_desktop_startupwmclass_matches_wm_class(self):
+        # The .desktop StartupWMClass must equal what FreeRDP gets, for both a
+        # UWP app and a plain exe.
+        from winpodx.core.app import AppInfo
+        from winpodx.core.rdp import resolve_wm_class
+
+        uwp = AppInfo(
+            name="calc",
+            full_name="Calculator",
+            executable="Microsoft.WindowsCalculator_8wekyb3d8bbwe!App",
+            launch_uri="Microsoft.WindowsCalculator_8wekyb3d8bbwe!App",
+        )
+        token = resolve_wm_class(uwp.executable, uwp.wm_class_hint or None, uwp.launch_uri or None)
+        assert token.startswith("winpodx-uwp-")
+        assert token != "microsoft"


### PR DESCRIPTION
Three code-analysis root causes (no live testing), found on KDE Plasma + Flatpak FreeRDP. Builds on #456/#457/#458.

## 1. RDP window stays open after Terminate / exit
`kill_session()` sent a single `SIGTERM`. A hung `xfreerdp` (or one that ignores `SIGTERM`) kept its window mapped → "exit해도 창 안 사라져". **Fix:** `SIGTERM` → ~0.8 s grace (breaks as soon as the PID dies, ~0.4 s typical) → `SIGKILL` escalation. Signals the process group when we lead it (`start_new_session=True`, PGID==PID), single PID otherwise.

## 2. System tray icon appears then vanishes (~30 s)
`refresh_status()` — the 30 s `QTimer` slot — called `list_active_sessions()` **outside** its `try/except`. `list_active_sessions()` globs + reads + `os.kill()`s and can raise `OSError`; an uncaught exception in a Qt slot propagates out of `app.exec()` and **aborts the event loop**, so the icon shows at launch then disappears on the first tick → "트레이가 또 갑자기 사라지는". **Fix:** guard the session call (mirrors the existing `_rebuild_sessions_menu` guard) and the `_ensure_tray_visible` retry slot.

## 3. UWP apps (Calculator…) not grouped under their launcher icon in the taskbar
The `.desktop` `StartupWMClass` used the exe stem — for a UWP AUMID (`Microsoft.WindowsCalculator_...!App`) that's `"microsoft"`, while FreeRDP's `/wm-class` used the AUMID slug. Mismatch → the WM can't match the RemoteApp window to the entry → "앱으로 안 뜸". **Fix:** add `resolve_wm_class()` as the single source of truth (handles exe stem, `wm_class_hint`, and UWP AUMID slug) and use it in both `build_rdp_command()` and the `.desktop` generator.

## Test
- `pytest tests/test_process.py tests/test_rdp.py tests/test_desktop.py` — 95 passed. New: SIGKILL escalation, group vs single-PID signalling, `resolve_wm_class` (stem / hint / UWP slug + StartupWMClass match).
- `ruff check` + `ruff format --check` — clean. Full `pytest` — see CI.

Note: (1)+(3) apply to NEW launches; sessions started by an older winpodx won't retroactively get `start_new_session`/the matching WM class.