### PR TITLE
feat(gui): UI/UX overhaul — unified design system across all pages

### DIFF
--- a/src/winpodx/gui/_main_window_bringup.py
+++ b/src/winpodx/gui/_main_window_bringup.py
@@ -85,7 +85,17 @@ from PySide6.QtWidgets import (
 
 from winpodx.core.i18n import tr
 from winpodx.gui._widget_helpers import BusyDialog
-from winpodx.gui.theme import FONT_CAPTION, FONT_SUBHEAD, C
+from winpodx.gui.theme import (
+    BTN_PRIMARY,
+    BTN_SECONDARY,
+    DIALOG,
+    FONT_CAPTION,
+    FONT_SUBHEAD,
+    PLAIN_TEXT,
+    SPACE_M,
+    SPACE_S,
+    C,
+)
 
 log = logging.getLogger(__name__)
 
@@ -175,6 +185,7 @@ class BringUpProgressDialog(QDialog):
         self.setWindowTitle(tr("Setting up Windows"))
         self.setWindowModality(Qt.WindowModality.WindowModal)
         self.setMinimumWidth(560)
+        self.setStyleSheet(DIALOG + PLAIN_TEXT)
         self._on_cancel = on_cancel
         self._cfg = cfg
 
@@ -200,7 +211,7 @@ class BringUpProgressDialog(QDialog):
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(20, 18, 20, 18)
-        layout.setSpacing(10)
+        layout.setSpacing(SPACE_M)
 
         # ----- header row (phase progress + label) -----------------------
         self.header = QLabel(tr("Starting..."))
@@ -228,7 +239,7 @@ class BringUpProgressDialog(QDialog):
             row = QWidget()
             row_layout = QHBoxLayout(row)
             row_layout.setContentsMargins(0, 0, 0, 0)
-            row_layout.setSpacing(8)
+            row_layout.setSpacing(SPACE_S)
 
             glyph = QLabel("   ")
             glyph.setFont(self._mono_font)
@@ -269,7 +280,10 @@ class BringUpProgressDialog(QDialog):
         self.pod_log_toggle.setChecked(False)
         self.pod_log_toggle.setArrowType(Qt.ArrowType.RightArrow)
         self.pod_log_toggle.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
-        self.pod_log_toggle.setStyleSheet("QToolButton { border: none; padding: 4px 0; }")
+        self.pod_log_toggle.setStyleSheet(
+            f"QToolButton {{ color: {C.SUBTEXT1}; border: none; padding: 6px 0; }}"
+            f"QToolButton:hover {{ color: {C.TEXT}; }}"
+        )
         self.pod_log_toggle.toggled.connect(self._on_pod_log_toggled)
         layout.addWidget(self.pod_log_toggle)
 
@@ -297,6 +311,7 @@ class BringUpProgressDialog(QDialog):
         footer_layout.addWidget(self.elapsed_label, stretch=1)
 
         self.cancel_btn = QPushButton(tr("Cancel"))
+        self.cancel_btn.setStyleSheet(BTN_SECONDARY)
         self.cancel_btn.clicked.connect(self._handle_cancel)
         footer_layout.addWidget(self.cancel_btn)
 
@@ -336,6 +351,7 @@ class BringUpProgressDialog(QDialog):
         # its label so the user knows the request registered.
         self.cancel_btn.setEnabled(False)
         self.cancel_btn.setText(tr("Cancelling..."))
+        self.cancel_btn.setStyleSheet(BTN_SECONDARY)
         try:
             self._on_cancel()
         except Exception:  # noqa: BLE001
@@ -429,6 +445,7 @@ class BringUpProgressDialog(QDialog):
             )
             self.sub_detail.setText(error_msg or tr("(no error message)"))
         self.cancel_btn.setText(tr("Close"))
+        self.cancel_btn.setStyleSheet(BTN_PRIMARY)
         self.cancel_btn.setEnabled(True)
         self.cancel_btn.setToolTip("")
         try:

--- a/src/winpodx/gui/_main_window_devices.py
+++ b/src/winpodx/gui/_main_window_devices.py
@@ -36,8 +36,27 @@ from PySide6.QtWidgets import (
 from winpodx.core import devices as D
 from winpodx.core.config import Config
 from winpodx.core.i18n import tr
-from winpodx.gui._widget_helpers import make_warning_callout, show_toast
-from winpodx.gui.theme import C
+from winpodx.gui._widget_helpers import (
+    add_shadow,
+    make_empty_panel,
+    make_page_heading,
+    make_warning_callout,
+    show_toast,
+)
+from winpodx.gui.theme import (
+    ACTION_ROW,
+    BTN_GHOST,
+    BTN_PRIMARY,
+    BTN_SECONDARY,
+    SCROLL_AREA,
+    SETTINGS_SECTION,
+    SPACE_L,
+    SPACE_M,
+    SPACE_S,
+    SPACE_XL,
+    SPACE_XXL,
+    C,
+)
 
 
 class _LiveOpSignals(QObject):
@@ -69,34 +88,36 @@ class DevicesMixin:
     def _build_devices_page(self) -> QWidget:
         page = QWidget()
         outer = QVBoxLayout(page)
-        outer.setContentsMargins(24, 20, 24, 20)
-        outer.setSpacing(12)
+        outer.setContentsMargins(SPACE_XXL, SPACE_XL, SPACE_XXL, SPACE_XL)
+        outer.setSpacing(SPACE_M)
 
-        title = QLabel(tr("Devices"))
-        title.setStyleSheet(f"font-size: 18px; font-weight: 600; color: {C.TEXT};")
-        outer.addWidget(title)
-
-        subtitle = QLabel(
-            tr(
-                "Pass host USB / PCI devices through to the Windows guest. "
-                "USB hot-plugs live; PCI needs a guest restart and confirmation."
+        outer.addWidget(
+            make_page_heading(
+                tr("Devices"),
+                tr(
+                    "Pass host USB / PCI devices through to the Windows guest. "
+                    "USB hot-plugs live; PCI needs a guest restart and confirmation."
+                ),
             )
         )
-        subtitle.setWordWrap(True)
-        subtitle.setStyleSheet(f"color: {C.SUBTEXT0}; font-size: 12px;")
-        outer.addWidget(subtitle)
 
         bar = QHBoxLayout()
+        bar.setSpacing(SPACE_M)
         refresh = QPushButton(tr("Refresh"))
+        refresh.setStyleSheet(BTN_SECONDARY)
         refresh.clicked.connect(self._render_devices)
         bar.addWidget(refresh)
         self._devices_status = QLabel("")
-        self._devices_status.setStyleSheet(f"color: {C.SUBTEXT1}; font-size: 12px;")
+        self._devices_status.setStyleSheet(
+            f"color: {C.SUBTEXT1}; font-size: 12px; "
+            f"background: {C.SURFACE0}; border: 1px solid {C.SURFACE1}; "
+            "border-radius: 8px; padding: 7px 10px;"
+        )
         bar.addWidget(self._devices_status, 1)
         outer.addLayout(bar)
 
         columns = QHBoxLayout()
-        columns.setSpacing(16)
+        columns.setSpacing(SPACE_L)
         self._dev_host_col, host_card = self._device_column(tr("Host devices"))
         self._dev_guest_col, guest_card = self._device_column(tr("Assigned to guest"))
         columns.addWidget(host_card, 1)
@@ -108,20 +129,24 @@ class DevicesMixin:
 
     def _device_column(self, heading: str) -> tuple[QVBoxLayout, QWidget]:
         card = QFrame()
-        card.setStyleSheet(f"QFrame {{ background: {C.SURFACE0}; border-radius: 12px; }}")
+        card.setObjectName("settingsSection")
+        card.setStyleSheet(SETTINGS_SECTION)
+        add_shadow(card, blur=14, y=2, alpha=35)
         lay = QVBoxLayout(card)
-        lay.setContentsMargins(14, 12, 14, 12)
+        lay.setContentsMargins(SPACE_L, SPACE_L, SPACE_L, SPACE_L)
+        lay.setSpacing(SPACE_M)
         head = QLabel(heading)
-        head.setStyleSheet(f"font-weight: 600; color: {C.TEXT}; font-size: 14px;")
+        head.setStyleSheet(f"font-weight: 700; color: {C.BLUE}; font-size: 14px;")
         lay.addWidget(head)
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QFrame.NoFrame)
+        scroll.setStyleSheet(SCROLL_AREA)
         inner = QWidget()
         col = QVBoxLayout(inner)
         col.setContentsMargins(0, 0, 0, 0)
-        col.setSpacing(8)
+        col.setSpacing(SPACE_S)
         col.addStretch(1)
         scroll.setWidget(inner)
         lay.addWidget(scroll, 1)
@@ -170,23 +195,22 @@ class DevicesMixin:
 
         self._devices_status.setText(tr("Guest running: ") + (tr("yes") if running else tr("no")))
 
-    def _empty_label(self, text: str) -> QLabel:
-        lbl = QLabel(text)
-        lbl.setStyleSheet(f"color: {C.SUBTEXT0}; font-size: 12px; padding: 6px;")
-        return lbl
+    def _empty_label(self, text: str) -> QWidget:
+        return make_empty_panel(text)
 
     def _device_row(self, host: D.HostDevice, *, assigned: bool) -> QWidget:
         safety = D.classify_safety(host)
         row = QFrame()
-        row.setStyleSheet(f"QFrame {{ background: {C.SURFACE1}; border-radius: 8px; }}")
+        row.setObjectName("actionRow")
+        row.setStyleSheet(ACTION_ROW)
         h = QHBoxLayout(row)
-        h.setContentsMargins(10, 8, 10, 8)
-        h.setSpacing(8)
+        h.setContentsMargins(SPACE_M, SPACE_S, SPACE_M, SPACE_S)
+        h.setSpacing(SPACE_M)
 
         badge = QLabel(host.dtype.upper())
         badge_color = C.GREEN if safety.safe else C.RED
         badge.setStyleSheet(
-            f"background: {badge_color}; color: #0d1117; border-radius: 4px;"
+            f"background: {badge_color}; color: #0d1117; border-radius: 6px;"
             " padding: 1px 6px; font-size: 11px; font-weight: 700;"
         )
         badge.setAlignment(Qt.AlignCenter)
@@ -205,9 +229,11 @@ class DevicesMixin:
 
         if assigned:
             btn = QPushButton(tr("← Detach"))
+            btn.setStyleSheet(BTN_GHOST)
             btn.clicked.connect(lambda _=False, dev=host: self._on_detach(dev))
         else:
             btn = QPushButton(tr("Attach →"))
+            btn.setStyleSheet(BTN_PRIMARY)
             btn.clicked.connect(lambda _=False, dev=host: self._on_attach(dev))
         h.addWidget(btn)
         return row

--- a/src/winpodx/gui/_main_window_header.py
+++ b/src/winpodx/gui/_main_window_header.py
@@ -35,6 +35,7 @@ from PySide6.QtWidgets import (
 
 from winpodx.core.i18n import tr
 from winpodx.gui.theme import (
+    BTN_PRIMARY,
     INFO_BAR,
     POD_CHIP,
     POD_CTRL,
@@ -54,7 +55,7 @@ class HeaderMixin:
         bar.setStyleSheet(TOP_BAR)
 
         layout = QHBoxLayout(bar)
-        layout.setContentsMargins(20, 0, 20, 0)
+        layout.setContentsMargins(24, 0, 24, 0)
         layout.setSpacing(0)
 
         from winpodx.desktop.icons import bundled_data_path
@@ -77,10 +78,10 @@ class HeaderMixin:
         logo_text.setStyleSheet(
             f"background: transparent; color: {C.TEXT};"
             " font-size: 16px; font-weight: bold;"
-            " letter-spacing: 1px;"
+            " letter-spacing: 0px;"
         )
         layout.addWidget(logo_text)
-        layout.addSpacing(32)
+        layout.addSpacing(28)
 
         tab_container = QWidget()
         tab_container.setStyleSheet(TAB_BTN)
@@ -114,8 +115,8 @@ class HeaderMixin:
         chip.setObjectName("podChip")
         chip.setStyleSheet(POD_CHIP)
         chip_l = QHBoxLayout(chip)
-        chip_l.setContentsMargins(12, 4, 6, 4)
-        chip_l.setSpacing(6)
+        chip_l.setContentsMargins(12, 4, 8, 4)
+        chip_l.setSpacing(8)
 
         self.pod_dot = QLabel("●")
         self.pod_dot.setStyleSheet(
@@ -176,7 +177,7 @@ class HeaderMixin:
         banner.setStyleSheet(STATUS_BANNER_WARN)
 
         layout = QHBoxLayout(banner)
-        layout.setContentsMargins(20, 0, 20, 0)
+        layout.setContentsMargins(24, 0, 24, 0)
         layout.setSpacing(12)
 
         self.banner_icon = QLabel("⚠")
@@ -196,12 +197,7 @@ class HeaderMixin:
         # relabel it "Restart" (recovery) vs the default "Start Now". The
         # action is the same ensure_ready() path either way.
         self.banner_btn = QPushButton(tr("Start Now"))
-        self.banner_btn.setStyleSheet(
-            f"QPushButton {{ background: {C.BLUE}; color: {C.CRUST};"
-            f" border: none; border-radius: 6px;"
-            f" padding: 4px 14px; font-size: 12px; font-weight: bold; }}"
-            f"QPushButton:hover {{ background: {C.LAVENDER}; }}"
-        )
+        self.banner_btn.setStyleSheet(BTN_PRIMARY)
         self.banner_btn.clicked.connect(self._on_start_pod)
         layout.addWidget(self.banner_btn)
 
@@ -214,8 +210,8 @@ class HeaderMixin:
         bar.setStyleSheet(INFO_BAR)
 
         layout = QHBoxLayout(bar)
-        layout.setContentsMargins(20, 0, 20, 0)
-        layout.setSpacing(16)
+        layout.setContentsMargins(24, 0, 24, 0)
+        layout.setSpacing(14)
 
         self.info_label = QLabel(tr("{n} apps available").format(n=len(self.apps)))
         self.info_label.setStyleSheet(
@@ -278,7 +274,7 @@ class HeaderMixin:
         bar.setFixedHeight(38)
 
         layout = QVBoxLayout(bar)
-        layout.setContentsMargins(20, 4, 20, 4)
+        layout.setContentsMargins(24, 4, 24, 4)
         layout.setSpacing(0)
 
         # Two lines stacked: most-recent on top, previous below it

--- a/src/winpodx/gui/_main_window_info.py
+++ b/src/winpodx/gui/_main_window_info.py
@@ -28,8 +28,19 @@ from PySide6.QtWidgets import (
 )
 
 from winpodx.core.i18n import tr
-from winpodx.gui._widget_helpers import add_shadow
-from winpodx.gui.theme import BTN_GHOST, SCROLL_AREA, SETTINGS_SECTION, C
+from winpodx.gui._widget_helpers import add_shadow, make_empty_panel, make_page_heading
+from winpodx.gui.theme import (
+    BTN_GHOST,
+    SCROLL_AREA,
+    SETTINGS_SECTION,
+    SPACE_L,
+    SPACE_M,
+    SPACE_S,
+    SPACE_XL,
+    SPACE_XXL,
+    C,
+    rgba,
+)
 from winpodx.gui.workers import InfoWorker
 
 
@@ -75,15 +86,11 @@ class InfoPageMixin:
 
         content = QWidget()
         layout = QVBoxLayout(content)
-        layout.setContentsMargins(32, 28, 32, 32)
-        layout.setSpacing(16)
+        layout.setContentsMargins(SPACE_XXL, SPACE_XL, SPACE_XXL, SPACE_XXL)
+        layout.setSpacing(SPACE_L)
 
         header = QHBoxLayout()
-        title = QLabel(tr("Info"))
-        title.setStyleSheet(
-            f"background: transparent; color: {C.TEXT}; font-size: 22px; font-weight: bold;"
-        )
-        header.addWidget(title)
+        header.addWidget(make_page_heading(tr("Info")))
         header.addStretch()
 
         refresh_btn = QPushButton(tr("Refresh Info"))
@@ -136,8 +143,8 @@ class InfoPageMixin:
         add_shadow(card)
 
         layout = QVBoxLayout(card)
-        layout.setContentsMargins(24, 22, 24, 22)
-        layout.setSpacing(6)
+        layout.setContentsMargins(SPACE_XL, SPACE_XL, SPACE_XL, SPACE_XL)
+        layout.setSpacing(SPACE_S)
 
         header = QLabel(tr(title))
         header.setStyleSheet(
@@ -149,19 +156,17 @@ class InfoPageMixin:
         accent.setFixedHeight(1)
         accent.setStyleSheet(f"background: {C.SURFACE1};")
         layout.addWidget(accent)
-        layout.addSpacing(8)
+        layout.addSpacing(SPACE_S)
 
         body = QVBoxLayout()
-        body.setSpacing(4)
+        body.setSpacing(SPACE_S)
         layout.addLayout(body)
 
         # Stash the body layout on the frame for later population.
         card.setProperty("info_body", body)
         self._info_card_bodies[title.lower()] = body
         # Initial placeholder
-        loading = QLabel(tr("Loading..."))
-        loading.setStyleSheet(f"color: {C.OVERLAY0};")
-        body.addWidget(loading)
+        body.addWidget(make_empty_panel(tr("Loading...")))
         return card
 
     def _render_health_card(self, probes: list[dict], overall: str) -> None:
@@ -182,9 +187,7 @@ class InfoPageMixin:
                 w.deleteLater()
 
         if not probes:
-            empty = QLabel(tr("No probes ran (health module unavailable)."))
-            empty.setStyleSheet(f"color: {C.OVERLAY0};")
-            body.addWidget(empty)
+            body.addWidget(make_empty_panel(tr("No probes ran (health module unavailable).")))
             return
 
         overall_color = self._HEALTH_BADGE_COLORS.get(overall, C.SUBTEXT0)
@@ -200,7 +203,9 @@ class InfoPageMixin:
             badge = QLabel(status.upper())
             badge.setFixedWidth(48)
             badge.setStyleSheet(
-                f"color: {color}; font-size: 11px; font-weight: bold; background: transparent;"
+                f"color: {color}; font-size: 11px; font-weight: bold; "
+                f"background: {rgba(color, 0.12)}; border: 1px solid {rgba(color, 0.35)}; "
+                "border-radius: 6px; padding: 2px 6px;"
             )
             name = QLabel(p.get("name", ""))
             name.setStyleSheet(f"color: {C.TEXT}; font-size: 12px;")
@@ -216,6 +221,9 @@ class InfoPageMixin:
             row.addWidget(duration, 0)
             holder = QWidget()
             holder.setLayout(row)
+            holder.setStyleSheet(
+                f"background: {rgba(C.MANTLE, 0.55)}; border-radius: 8px; padding: 2px;"
+            )
             body.addWidget(holder)
 
     def _set_info_card_rows(self, key: str, rows: list[tuple[str, str]]) -> None:
@@ -231,8 +239,10 @@ class InfoPageMixin:
                 w.deleteLater()
         for label, value in rows:
             row = QHBoxLayout()
+            row.setSpacing(SPACE_M)
             lbl = QLabel(label)
             lbl.setStyleSheet(f"color: {C.SUBTEXT0}; font-size: 12px;")
+            lbl.setMinimumWidth(140)
             val = QLabel(value)
             val.setStyleSheet(f"color: {C.TEXT}; font-size: 12px;")
             val.setWordWrap(True)

--- a/src/winpodx/gui/_main_window_library.py
+++ b/src/winpodx/gui/_main_window_library.py
@@ -46,6 +46,7 @@ from winpodx.core.i18n import tr
 from winpodx.gui._widget_helpers import (
     add_shadow,
     make_app_avatar,
+    make_empty_panel,
     make_source_badge,
 )
 from winpodx.gui.theme import (
@@ -55,10 +56,14 @@ from winpodx.gui.theme import (
     BTN_DANGER,
     BTN_GHOST,
     BTN_PRIMARY,
+    BTN_SECONDARY,
     FILTER_CHIP,
     FONT_CAPTION,
     SCROLL_AREA,
     SEARCH_BAR,
+    SPACE_L,
+    SPACE_M,
+    SPACE_S,
     VIEW_TOGGLE,
     C,
     avatar_color,
@@ -80,7 +85,7 @@ class LibraryPageMixin:
         layout.setSpacing(0)
 
         toolbar = QHBoxLayout()
-        toolbar.setSpacing(12)
+        toolbar.setSpacing(SPACE_M)
 
         # Leading magnifier glyph so the box reads as a search field rather
         # than a bare input (Task 3). Kept as a sibling label — the shared
@@ -129,7 +134,7 @@ class LibraryPageMixin:
         self.btn_list.clicked.connect(lambda: self._set_view("list"))
         tgl.addWidget(self.btn_list)
         toolbar.addWidget(toggle_wrap)
-        toolbar.addSpacing(8)
+        toolbar.addSpacing(SPACE_S)
 
         self.refresh_btn = QPushButton(tr("Refresh Apps"))
         self.refresh_btn.setIcon(QIcon.fromTheme("view-refresh"))
@@ -137,7 +142,7 @@ class LibraryPageMixin:
         self.refresh_btn.setToolTip(tr("Scan the running pod for installed Windows apps"))
         self.refresh_btn.clicked.connect(self._on_refresh_apps)
         toolbar.addWidget(self.refresh_btn)
-        toolbar.addSpacing(6)
+        toolbar.addSpacing(SPACE_S)
 
         # Hybrid filter UX — hidden apps (system shims auto-filtered by the
         # noise denylist, plus anything the user manually hid) collapse by
@@ -152,7 +157,7 @@ class LibraryPageMixin:
         )
         self.btn_show_hidden.clicked.connect(self._on_toggle_hidden)
         toolbar.addWidget(self.btn_show_hidden)
-        toolbar.addSpacing(6)
+        toolbar.addSpacing(SPACE_S)
 
         add_btn = QPushButton(tr("+  Add App"))
         add_btn.setStyleSheet(BTN_PRIMARY)
@@ -160,7 +165,7 @@ class LibraryPageMixin:
         toolbar.addWidget(add_btn)
 
         layout.addLayout(toolbar)
-        layout.addSpacing(12)
+        layout.addSpacing(SPACE_M)
 
         self.refresh_progress = QProgressBar()
         self.refresh_progress.setRange(0, 0)  # indeterminate
@@ -178,7 +183,7 @@ class LibraryPageMixin:
         self._category_btns: list[QPushButton] = []
         self._build_category_chips()
         layout.addLayout(self._category_row)
-        layout.addSpacing(16)
+        layout.addSpacing(SPACE_L)
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
@@ -327,41 +332,24 @@ class LibraryPageMixin:
             title = tr("No apps yet")
             body = tr("Add a Windows app profile to get started.")
 
-        panel = QWidget()
-        panel.setStyleSheet("background: transparent;")
-        col = QVBoxLayout(panel)
-        col.setContentsMargins(0, 60, 0, 60)
-        col.setSpacing(8)
-        col.setAlignment(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignHCenter)
-
-        title_lbl = QLabel(title)
-        title_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        title_lbl.setStyleSheet(
-            f"background: transparent; color: {C.SUBTEXT0}; font-size: 15px; font-weight: bold;"
+        panel = make_empty_panel(
+            title,
+            body,
+            action_label=action_label,
+            action_cb=action_cb if callable(action_cb) else None,
         )
-        col.addWidget(title_lbl)
-
-        body_lbl = QLabel(body)
-        body_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        body_lbl.setWordWrap(True)
-        body_lbl.setStyleSheet(f"background: transparent; color: {C.OVERLAY0}; font-size: 13px;")
-        col.addWidget(body_lbl)
-
-        if action_label and callable(action_cb):
-            col.addSpacing(8)
-            btn = QPushButton(action_label)
-            btn.setStyleSheet(BTN_PRIMARY)
-            btn.clicked.connect(action_cb)
-            col.addWidget(btn, alignment=Qt.AlignmentFlag.AlignCenter)
-
+        panel.setMinimumHeight(220)
         return panel
 
     def _populate_grid(self, apps: list[AppInfo]) -> None:
         """Grid view - cards."""
         cols = 4
         grid = QGridLayout()
-        grid.setSpacing(14)
+        grid.setHorizontalSpacing(SPACE_L)
+        grid.setVerticalSpacing(SPACE_L)
         grid.setContentsMargins(0, 0, 0, 0)
+        for col in range(cols):
+            grid.setColumnStretch(col, 1)
 
         for i, app in enumerate(apps):
             card = self._make_app_card(app)
@@ -391,12 +379,12 @@ class LibraryPageMixin:
         card = QFrame()
         card.setObjectName("appCard")
         card.setStyleSheet(APP_CARD)
-        card.setMinimumHeight(210)
-        card.setMinimumWidth(160)
+        card.setMinimumHeight(220)
+        card.setMinimumWidth(180)
         add_shadow(card)
 
         vl = QVBoxLayout(card)
-        vl.setContentsMargins(16, 18, 16, 14)
+        vl.setContentsMargins(SPACE_L, SPACE_L, SPACE_L, SPACE_L)
         vl.setSpacing(0)
 
         top_row = QHBoxLayout()
@@ -412,7 +400,7 @@ class LibraryPageMixin:
             top_row.addWidget(badge, alignment=Qt.AlignmentFlag.AlignTop)
 
         vl.addLayout(top_row)
-        vl.addSpacing(12)
+        vl.addSpacing(SPACE_M)
 
         name_lbl = QLabel(app.full_name)
         name_lbl.setStyleSheet(
@@ -442,7 +430,7 @@ class LibraryPageMixin:
         # The secondary actions (edit / hide / delete) sit on a compact row
         # beneath it.
         bottom = QVBoxLayout()
-        bottom.setSpacing(8)
+        bottom.setSpacing(SPACE_S)
 
         launch_btn = QPushButton(tr("▶  Launch"))
         launch_btn.setStyleSheet(BTN_ACCENT)
@@ -451,7 +439,7 @@ class LibraryPageMixin:
         bottom.addWidget(launch_btn)
 
         actions = QHBoxLayout()
-        actions.setSpacing(6)
+        actions.setSpacing(SPACE_S)
 
         edit_btn = QPushButton("⋯")
         edit_btn.setFixedSize(28, 28)
@@ -476,13 +464,7 @@ class LibraryPageMixin:
 
         hide_btn = QPushButton(tr("Show") if app.hidden else tr("Hide"))
         hide_btn.setToolTip(tr("Show in menu") if app.hidden else tr("Hide from menu"))
-        hide_btn.setStyleSheet(
-            f"QPushButton {{ background: {C.SURFACE1}; color: {C.SUBTEXT0};"
-            f" font-size: 12px; border-radius: 6px; padding: 6px 14px;"
-            f" border: none; }}"
-            f"QPushButton:hover {{ background: {C.SURFACE2};"
-            f" color: {C.TEXT}; }}"
-        )
+        hide_btn.setStyleSheet(BTN_SECONDARY)
         hide_btn.clicked.connect(lambda _, a=app: self._on_toggle_app_hidden(a))
         actions.addWidget(hide_btn)
         actions.addStretch()
@@ -509,18 +491,18 @@ class LibraryPageMixin:
         add_shadow(tile, blur=12, y=2, alpha=35)
 
         layout = QHBoxLayout(tile)
-        layout.setContentsMargins(0, 0, 16, 0)
+        layout.setContentsMargins(0, 0, SPACE_L, 0)
         layout.setSpacing(0)
 
         stripe = QFrame()
         stripe.setFixedWidth(4)
         stripe.setStyleSheet(f"background: {color}; border-radius: 2px; margin: 8px 0 8px 8px;")
         layout.addWidget(stripe)
-        layout.addSpacing(14)
+        layout.addSpacing(SPACE_M)
 
         avatar = make_app_avatar(app, size=40, radius=10, font_size=16)
         layout.addWidget(avatar)
-        layout.addSpacing(14)
+        layout.addSpacing(SPACE_M)
 
         info = QVBoxLayout()
         info.setSpacing(2)
@@ -557,25 +539,13 @@ class LibraryPageMixin:
         layout.addSpacing(8)
 
         edit_btn = QPushButton(tr("Edit"))
-        edit_btn.setStyleSheet(
-            f"QPushButton {{ background: {C.SURFACE1}; color: {C.SUBTEXT0};"
-            f" font-size: 12px; border-radius: 6px; padding: 6px 14px;"
-            f" border: none; }}"
-            f"QPushButton:hover {{ background: {C.SURFACE2};"
-            f" color: {C.TEXT}; }}"
-        )
+        edit_btn.setStyleSheet(BTN_SECONDARY)
         edit_btn.clicked.connect(lambda: self._on_edit_app(app))
         layout.addWidget(edit_btn)
         layout.addSpacing(6)
 
         hide_btn = QPushButton(tr("Show") if app.hidden else tr("Hide"))
-        hide_btn.setStyleSheet(
-            f"QPushButton {{ background: {C.SURFACE1}; color: {C.SUBTEXT0};"
-            f" font-size: 12px; border-radius: 6px; padding: 6px 14px;"
-            f" border: none; }}"
-            f"QPushButton:hover {{ background: {C.SURFACE2};"
-            f" color: {C.TEXT}; }}"
-        )
+        hide_btn.setStyleSheet(BTN_SECONDARY)
         hide_btn.clicked.connect(lambda: self._on_toggle_app_hidden(app))
         layout.addWidget(hide_btn)
         layout.addSpacing(6)

--- a/src/winpodx/gui/_main_window_license.py
+++ b/src/winpodx/gui/_main_window_license.py
@@ -29,7 +29,18 @@ from PySide6.QtWidgets import (
 )
 
 from winpodx.core.i18n import tr
-from winpodx.gui.theme import SCROLL_AREA, TERMINAL, C
+from winpodx.gui._widget_helpers import add_shadow, make_page_heading
+from winpodx.gui.theme import (
+    SCROLL_AREA,
+    SETTINGS_SECTION,
+    SPACE_L,
+    SPACE_M,
+    SPACE_S,
+    SPACE_XL,
+    SPACE_XXL,
+    TERMINAL,
+    C,
+)
 from winpodx.utils.paths import bundle_dir
 
 log = logging.getLogger(__name__)
@@ -165,25 +176,20 @@ class LicensePageMixin:
 
         content = QWidget()
         layout = QVBoxLayout(content)
-        layout.setContentsMargins(32, 28, 32, 32)
-        layout.setSpacing(14)
+        layout.setContentsMargins(SPACE_XXL, SPACE_XL, SPACE_XXL, SPACE_XXL)
+        layout.setSpacing(SPACE_M)
 
         # --- License title -------------------------------------------------
-        title = QLabel(tr("License"))
-        title.setStyleSheet(
-            f"background: transparent; color: {C.TEXT}; font-size: 22px; font-weight: bold;"
-        )
-        layout.addWidget(title)
-
-        subtitle = QLabel(
-            tr(
-                "WinPodX is MIT-licensed open source. See LICENSE in the source "
-                "tree for the canonical text."
+        layout.addWidget(
+            make_page_heading(
+                tr("License"),
+                tr(
+                    "WinPodX is MIT-licensed open source. See LICENSE in the source "
+                    "tree for the canonical text."
+                ),
             )
         )
-        subtitle.setStyleSheet(f"background: transparent; color: {C.OVERLAY0}; font-size: 12px;")
-        subtitle.setWordWrap(True)
-        layout.addWidget(subtitle)
+        layout.addSpacing(SPACE_S)
 
         # --- MIT license text ----------------------------------------------
         license_text = self._read_license_text()
@@ -197,8 +203,7 @@ class LicensePageMixin:
         # --- Third-party acknowledgments -----------------------------------
         ack_header = QLabel(tr("Third-party components"))
         ack_header.setStyleSheet(
-            f"background: transparent; color: {C.BLUE};"
-            " font-size: 15px; font-weight: bold; padding-top: 8px;"
+            f"background: transparent; color: {C.BLUE}; font-size: 15px; font-weight: bold;"
         )
         layout.addWidget(ack_header)
 
@@ -217,10 +222,12 @@ class LicensePageMixin:
 
         for name, license_, purpose, url in _THIRD_PARTY_ACK:
             row = QFrame()
-            row.setStyleSheet(f"background: {C.SURFACE0}; border-radius: 6px; padding: 8px;")
+            row.setObjectName("settingsSection")
+            row.setStyleSheet(SETTINGS_SECTION)
+            add_shadow(row, blur=10, y=1, alpha=28)
             row_layout = QVBoxLayout(row)
-            row_layout.setContentsMargins(12, 8, 12, 8)
-            row_layout.setSpacing(2)
+            row_layout.setContentsMargins(SPACE_L, SPACE_M, SPACE_L, SPACE_M)
+            row_layout.setSpacing(SPACE_S)
 
             heading = QLabel(f"{name}  ·  {license_}")
             heading.setStyleSheet(

--- a/src/winpodx/gui/_main_window_logs.py
+++ b/src/winpodx/gui/_main_window_logs.py
@@ -35,7 +35,19 @@ from PySide6.QtWidgets import (
 
 from winpodx.core.config import Config
 from winpodx.core.i18n import tr
-from winpodx.gui.theme import BTN_GHOST, BTN_PRIMARY, COMBO, TERMINAL, C
+from winpodx.gui._widget_helpers import make_page_heading
+from winpodx.gui.theme import (
+    BTN_GHOST,
+    BTN_PRIMARY,
+    COMBO,
+    INPUT,
+    SPACE_M,
+    SPACE_S,
+    SPACE_XL,
+    SPACE_XXL,
+    TERMINAL,
+    C,
+)
 
 log = logging.getLogger(__name__)
 
@@ -244,15 +256,13 @@ class LogsMixin:
     def _build_logs_page(self) -> QWidget:
         page = QWidget()
         layout = QVBoxLayout(page)
-        layout.setContentsMargins(32, 28, 32, 20)
+        layout.setContentsMargins(SPACE_XXL, SPACE_XL, SPACE_XXL, SPACE_XL)
+        layout.setSpacing(SPACE_M)
 
         header = QHBoxLayout()
-        title = QLabel(tr("Terminal"))
-        title.setStyleSheet(
-            f"background: transparent; color: {C.TEXT}; font-size: 22px; font-weight: bold;"
-        )
-        header.addWidget(title)
-        header.addSpacing(16)
+        header.setSpacing(SPACE_S)
+        header.addWidget(make_page_heading(tr("Terminal")))
+        header.addSpacing(SPACE_M)
 
         # Log level dropdown — changes both what gets written to
         # ``~/.config/winpodx/winpodx.log`` (which the "Live (app)"
@@ -342,7 +352,7 @@ class LogsMixin:
             header.addWidget(btn)
 
         layout.addLayout(header)
-        layout.addSpacing(10)
+        layout.addSpacing(SPACE_S)
 
         self.log_output = QTextEdit()
         self.log_output.setReadOnly(True)
@@ -350,7 +360,7 @@ class LogsMixin:
         layout.addWidget(self.log_output)
 
         cmd_row = QHBoxLayout()
-        cmd_row.setSpacing(8)
+        cmd_row.setSpacing(SPACE_S)
 
         prompt = QLabel("❯")
         prompt.setStyleSheet(
@@ -364,7 +374,9 @@ class LogsMixin:
                 container=self.cfg.pod.container_name
             )
         )
-        self.cmd_input.setStyleSheet(f"""
+        self.cmd_input.setStyleSheet(
+            INPUT
+            + f"""
             QLineEdit {{
                 background: {C.CRUST}; color: {C.TEXT};
                 border: 1px solid {C.SURFACE0}; border-radius: 8px;
@@ -373,7 +385,8 @@ class LogsMixin:
                 font-size: 13px;
             }}
             QLineEdit:focus {{ border-color: {C.BLUE}; }}
-        """)
+        """
+        )
         self.cmd_input.returnPressed.connect(self._on_cmd_enter)
         cmd_row.addWidget(self.cmd_input)
 

--- a/src/winpodx/gui/_main_window_maintenance.py
+++ b/src/winpodx/gui/_main_window_maintenance.py
@@ -38,12 +38,24 @@ from PySide6.QtWidgets import (
 
 from winpodx.core.config import Config
 from winpodx.core.i18n import tr
-from winpodx.gui._widget_helpers import BusyDialog, add_shadow, make_warning_callout
+from winpodx.gui._widget_helpers import (
+    BusyDialog,
+    add_shadow,
+    make_empty_panel,
+    make_page_heading,
+    make_section_label,
+    make_warning_callout,
+)
 from winpodx.gui.theme import (
     ACTION_ROW,
     BTN_DANGER,
     BTN_PRIMARY,
+    BTN_SECONDARY,
     SCROLL_AREA,
+    SPACE_L,
+    SPACE_S,
+    SPACE_XL,
+    SPACE_XXL,
     C,
     accent_color,
 )
@@ -83,6 +95,7 @@ def _confirm_with_callout(
     btn_row = QHBoxLayout()
     btn_row.addStretch(1)
     cancel = QPushButton(tr("Cancel"))
+    cancel.setStyleSheet(BTN_SECONDARY)
     cancel.clicked.connect(dlg.reject)
     btn_row.addWidget(cancel)
     proceed = QPushButton(tr("Proceed"))
@@ -108,29 +121,16 @@ class MaintenanceMixin:
 
         content = QWidget()
         layout = QVBoxLayout(content)
-        layout.setContentsMargins(32, 24, 32, 20)
+        layout.setContentsMargins(SPACE_XXL, SPACE_XL, SPACE_XXL, SPACE_XL)
+        layout.setSpacing(0)
 
-        title = QLabel(tr("Tools"))
-        title.setStyleSheet(
-            f"background: transparent; color: {C.TEXT}; font-size: 22px; font-weight: bold;"
+        layout.addWidget(
+            make_page_heading(tr("Tools"), tr("System maintenance and pod management"))
         )
-        layout.addWidget(title)
+        layout.addSpacing(SPACE_XL)
 
-        sub = QLabel(tr("System maintenance and pod management"))
-        sub.setStyleSheet(f"background: transparent; color: {C.OVERLAY0}; font-size: 13px;")
-        layout.addWidget(sub)
-        layout.addSpacing(20)
-
-        grp1 = QLabel(tr("Pod Management"))
-        grp1.setStyleSheet(
-            "background: transparent;"
-            f" color: {C.SUBTEXT0};"
-            " font-size: 11px;"
-            " font-weight: bold;"
-            " text-transform: uppercase;"
-        )
-        layout.addWidget(grp1)
-        layout.addSpacing(8)
+        layout.addWidget(make_section_label(tr("Pod Management")))
+        layout.addSpacing(SPACE_S)
 
         pod_tools = [
             ("⏸", tr("Suspend Pod"), tr("Pause container (keeps memory)"), self._on_suspend),
@@ -140,18 +140,10 @@ class MaintenanceMixin:
         for i, (icon, label, desc, handler) in enumerate(pod_tools):
             layout.addWidget(self._make_action_row(icon, label, desc, handler, i))
 
-        layout.addSpacing(20)
+        layout.addSpacing(SPACE_XL)
 
-        grp2 = QLabel(tr("System"))
-        grp2.setStyleSheet(
-            "background: transparent;"
-            f" color: {C.SUBTEXT0};"
-            " font-size: 11px;"
-            " font-weight: bold;"
-            " text-transform: uppercase;"
-        )
-        layout.addWidget(grp2)
-        layout.addSpacing(8)
+        layout.addWidget(make_section_label(tr("System")))
+        layout.addSpacing(SPACE_S)
 
         sys_tools = [
             ("✧", tr("Clean Locks"), tr("Remove Office lock files"), self._on_cleanup),
@@ -182,25 +174,18 @@ class MaintenanceMixin:
         for i, (icon, label, desc, handler) in enumerate(sys_tools):
             layout.addWidget(self._make_action_row(icon, label, desc, handler, i + 3))
 
-        layout.addSpacing(20)
+        layout.addSpacing(SPACE_XL)
 
-        grp3 = QLabel(tr("Windows Update"))
-        grp3.setStyleSheet(
-            "background: transparent;"
-            f" color: {C.SUBTEXT0};"
-            " font-size: 11px;"
-            " font-weight: bold;"
-            " text-transform: uppercase;"
-        )
-        layout.addWidget(grp3)
-        layout.addSpacing(8)
+        layout.addWidget(make_section_label(tr("Windows Update")))
+        layout.addSpacing(SPACE_S)
 
         update_row = QFrame()
         update_row.setObjectName("actionRow")
         update_row.setStyleSheet(ACTION_ROW)
         update_row.setMinimumHeight(64)
         rl = QHBoxLayout(update_row)
-        rl.setContentsMargins(16, 8, 16, 8)
+        rl.setContentsMargins(SPACE_L, SPACE_S, SPACE_L, SPACE_S)
+        rl.setSpacing(SPACE_L)
 
         update_icon = QLabel("⇅")
         update_icon.setFixedSize(36, 36)
@@ -250,18 +235,10 @@ class MaintenanceMixin:
 
         self._refresh_update_status()
 
-        layout.addSpacing(20)
+        layout.addSpacing(SPACE_XL)
 
-        grp4 = QLabel(tr("RDP Sessions"))
-        grp4.setStyleSheet(
-            "background: transparent;"
-            f" color: {C.SUBTEXT0};"
-            " font-size: 11px;"
-            " font-weight: bold;"
-            " text-transform: uppercase;"
-        )
-        layout.addWidget(grp4)
-        layout.addSpacing(8)
+        layout.addWidget(make_section_label(tr("RDP Sessions")))
+        layout.addSpacing(SPACE_S)
 
         # The tray's "Terminate Session" menu isn't always reachable --
         # on some DEs (stock GNOME, occasional Wayland startup races) the
@@ -320,9 +297,7 @@ class MaintenanceMixin:
             if w is not None:
                 w.deleteLater()
         if not active:
-            empty = QLabel(tr("No active RDP sessions."))
-            empty.setStyleSheet(f"background: transparent; color: {C.OVERLAY0}; font-size: 12px;")
-            box.addWidget(empty)
+            box.addWidget(make_empty_panel(tr("No active RDP sessions.")))
             return
         for s in active:
             box.addWidget(self._make_session_row(s.app_name, s.pid))
@@ -334,7 +309,8 @@ class MaintenanceMixin:
         row.setStyleSheet(ACTION_ROW)
         row.setMinimumHeight(56)
         rl = QHBoxLayout(row)
-        rl.setContentsMargins(16, 8, 16, 8)
+        rl.setContentsMargins(SPACE_L, SPACE_S, SPACE_L, SPACE_S)
+        rl.setSpacing(SPACE_L)
 
         icon = QLabel("▢")
         icon.setFixedSize(36, 36)
@@ -400,8 +376,8 @@ class MaintenanceMixin:
         add_shadow(row, blur=12, y=2, alpha=35)
 
         rl = QHBoxLayout(row)
-        rl.setContentsMargins(16, 0, 20, 0)
-        rl.setSpacing(16)
+        rl.setContentsMargins(SPACE_L, 0, SPACE_XL, 0)
+        rl.setSpacing(SPACE_L)
 
         color = accent_color(color_idx)
         icon_circle = QLabel(icon)

--- a/src/winpodx/gui/_main_window_settings.py
+++ b/src/winpodx/gui/_main_window_settings.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import logging
 import threading
 
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QApplication,
     QComboBox,
@@ -38,14 +39,14 @@ from PySide6.QtWidgets import (
 
 from winpodx.core.config import Config
 from winpodx.core.i18n import tr
-from winpodx.gui._widget_helpers import add_shadow, make_warning_callout
+from winpodx.gui._widget_helpers import add_shadow, make_page_heading, make_warning_callout
 from winpodx.gui.theme import (
     BTN_PRIMARY,
+    CHECKBOX,
     COMBO,
     FONT_BODY,
     FONT_CAPTION,
     FONT_HEADER,
-    FONT_HERO,
     INPUT,
     RADIUS_S,
     SCROLL_AREA,
@@ -201,20 +202,11 @@ class SettingsPageMixin:
         content = QWidget()
         layout = QVBoxLayout(content)
         layout.setContentsMargins(SPACE_XXL, SPACE_XL, SPACE_XXL, SPACE_XL)
+        layout.setSpacing(SPACE_M)
 
-        title = QLabel(tr("Settings"))
-        title.setStyleSheet(
-            f"background: transparent; color: {C.TEXT}; "
-            f"font-size: {FONT_HERO}px; font-weight: bold;"
+        layout.addWidget(
+            make_page_heading(tr("Settings"), tr("Configure RDP and container settings"))
         )
-        layout.addWidget(title)
-
-        sub = QLabel(tr("Configure RDP and container settings"))
-        sub.setStyleSheet(
-            f"background: transparent; color: {C.OVERLAY0}; font-size: {FONT_BODY}px;"
-        )
-        layout.addWidget(sub)
-        layout.addSpacing(SPACE_S)
 
         cols = QHBoxLayout()
         cols.setSpacing(SPACE_L)
@@ -637,6 +629,7 @@ class SettingsPageMixin:
             tr("Start the Windows pod at login (launches the tray + boots the pod)")
         )
         self.checkbox_autostart_tray.setChecked(is_autostart_enabled())
+        self.checkbox_autostart_tray.setStyleSheet(CHECKBOX)
 
         def _on_autostart_toggled(checked: bool) -> None:
             # Apply immediately — no Save Settings click needed. Unified
@@ -670,6 +663,7 @@ class SettingsPageMixin:
         lang_row = QHBoxLayout()
         lang_row.addWidget(QLabel(tr("WinPodX UI language")))
         self.input_ui_language = QComboBox()
+        self.input_ui_language.setStyleSheet(COMBO)
         for code in _UI_LANGUAGES:
             self.input_ui_language.addItem(_LANG_LABELS.get(code, code), code)
         cur = self.cfg.ui.language if self.cfg.ui.language in _UI_LANGUAGES else "auto"
@@ -777,11 +771,12 @@ class SettingsPageMixin:
         form = QGridLayout()
         form.setVerticalSpacing(SPACE_S + 2)
         form.setHorizontalSpacing(SPACE_M)
+        form.setColumnMinimumWidth(0, 150)
         lbl = QLabel(tr("Profile"))
         lbl.setStyleSheet(
             f"background: transparent; color: {C.SUBTEXT0}; font-size: {FONT_BODY}px;"
         )
-        form.addWidget(lbl, 0, 0)
+        form.addWidget(lbl, 0, 0, alignment=Qt.AlignmentFlag.AlignRight)
         form.addWidget(profile_combo, 0, 1)
         layout.addLayout(form)
 
@@ -860,13 +855,14 @@ class SettingsPageMixin:
         form = QGridLayout()
         form.setVerticalSpacing(SPACE_S + 2)
         form.setHorizontalSpacing(SPACE_M)
+        form.setColumnMinimumWidth(0, 150)
 
         for row, (label, widget) in enumerate(fields):
             lbl = QLabel(label)
             lbl.setStyleSheet(
                 f"background: transparent; color: {C.SUBTEXT0}; font-size: {FONT_BODY}px;"
             )
-            form.addWidget(lbl, row, 0)
+            form.addWidget(lbl, row, 0, alignment=Qt.AlignmentFlag.AlignRight)
             form.addWidget(widget, row, 1)
 
         layout.addLayout(form)

--- a/src/winpodx/gui/_widget_helpers.py
+++ b/src/winpodx/gui/_widget_helpers.py
@@ -32,7 +32,24 @@ from PySide6.QtWidgets import (
 
 from winpodx.core.app import AppInfo
 from winpodx.core.i18n import tr
-from winpodx.gui.theme import FONT_BODY, FONT_CAPTION, RADIUS_M, C, avatar_color
+from winpodx.gui.theme import (
+    BTN_PRIMARY,
+    BTN_SECONDARY,
+    DIALOG,
+    EMPTY_STATE,
+    FONT_BODY,
+    FONT_CAPTION,
+    PAGE_SUBTITLE,
+    PAGE_TITLE,
+    RADIUS_M,
+    SECTION_LABEL,
+    SPACE_L,
+    SPACE_M,
+    SPACE_S,
+    SPACE_XL,
+    C,
+    avatar_color,
+)
 
 # Toast colors keyed by kind. Background is the accent at low alpha (set via
 # the stylesheet rgba), text is the accent itself for contrast on MANTLE.
@@ -82,7 +99,7 @@ def make_source_badge(app: AppInfo) -> QLabel | None:
         " border-radius: 7px;"
         " font-size: 9px; font-weight: bold;"
         " padding: 2px 7px;"
-        " letter-spacing: 0.3px;"
+        " letter-spacing: 0px;"
     )
     return badge
 
@@ -217,6 +234,7 @@ class BusyDialog(QDialog):
         self.setWindowTitle(title)
         self.setModal(True)
         self.setMinimumWidth(380)
+        self.setStyleSheet(DIALOG)
         self._cancel_cbs: list[Callable[[], None]] = []
 
         layout = QVBoxLayout(self)
@@ -243,6 +261,7 @@ class BusyDialog(QDialog):
             row = QHBoxLayout()
             row.addStretch(1)
             self._cancel_btn = QPushButton(tr("Cancel"))
+            self._cancel_btn.setStyleSheet(BTN_SECONDARY)
             self._cancel_btn.clicked.connect(self._on_cancel_clicked)
             row.addWidget(self._cancel_btn)
             layout.addLayout(row)
@@ -294,6 +313,80 @@ def make_warning_callout(text: str, *, level: str = "warn") -> QFrame:
     label.setWordWrap(True)
     label.setStyleSheet(f"color: {C.SUBTEXT1}; font-size: {FONT_CAPTION}px;")
     row.addWidget(label, 1)
+    return frame
+
+
+def make_page_heading(title: str, subtitle: str = "") -> QWidget:
+    """Build a consistent page title/subtitle block."""
+    holder = QWidget()
+    layout = QVBoxLayout(holder)
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.setSpacing(SPACE_S)
+
+    title_lbl = QLabel(title)
+    title_lbl.setStyleSheet(PAGE_TITLE)
+    layout.addWidget(title_lbl)
+
+    if subtitle:
+        subtitle_lbl = QLabel(subtitle)
+        subtitle_lbl.setWordWrap(True)
+        subtitle_lbl.setStyleSheet(PAGE_SUBTITLE)
+        layout.addWidget(subtitle_lbl)
+
+    return holder
+
+
+def make_section_label(text: str) -> QLabel:
+    """Build the compact uppercase section label used on dense pages."""
+    label = QLabel(text)
+    label.setStyleSheet(SECTION_LABEL)
+    return label
+
+
+def make_empty_panel(
+    title: str,
+    body: str = "",
+    *,
+    action_label: str = "",
+    action_cb: Callable[[], None] | None = None,
+) -> QFrame:
+    """Build a deliberate empty/loading/error state panel."""
+    frame = QFrame()
+    frame.setObjectName("emptyState")
+    frame.setStyleSheet(EMPTY_STATE)
+
+    layout = QVBoxLayout(frame)
+    layout.setContentsMargins(SPACE_XL, SPACE_XL, SPACE_XL, SPACE_XL)
+    layout.setSpacing(SPACE_S)
+    layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+    title_lbl = QLabel(title)
+    title_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    title_lbl.setWordWrap(True)
+    title_lbl.setStyleSheet(
+        f"background: transparent; color: {C.SUBTEXT1}; "
+        f"font-size: {FONT_BODY}px; font-weight: bold;"
+    )
+    layout.addWidget(title_lbl)
+
+    if body:
+        body_lbl = QLabel(body)
+        body_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        body_lbl.setWordWrap(True)
+        body_lbl.setStyleSheet(
+            f"background: transparent; color: {C.OVERLAY0}; font-size: {FONT_CAPTION}px;"
+        )
+        layout.addWidget(body_lbl)
+
+    if action_label and action_cb is not None:
+        layout.addSpacing(SPACE_M)
+        btn = QPushButton(action_label)
+        btn.setStyleSheet(BTN_PRIMARY)
+        btn.clicked.connect(action_cb)
+        layout.addWidget(btn, alignment=Qt.AlignmentFlag.AlignCenter)
+
+    frame.setMinimumHeight(148)
+    layout.setContentsMargins(SPACE_XL, SPACE_L, SPACE_XL, SPACE_L)
     return frame
 
 

--- a/src/winpodx/gui/app_dialog.py
+++ b/src/winpodx/gui/app_dialog.py
@@ -21,10 +21,14 @@ from PySide6.QtWidgets import (
 
 from winpodx.core.i18n import tr
 from winpodx.gui.theme import (
-    BTN_GHOST,
     BTN_PRIMARY,
+    BTN_SECONDARY,
+    DIALOG,
     FONT_CAPTION,
     INPUT,
+    SPACE_L,
+    SPACE_M,
+    SPACE_S,
     C,
     avatar_color,
 )
@@ -49,14 +53,17 @@ class AppProfileDialog(QDialog):
         super().__init__(parent)
         self.edit_mode = edit_mode
         self.setWindowTitle(tr("Edit App") if edit_mode else tr("Add App"))
-        # Taller than before to fit the per-field helper text + the inline
-        # validation message added in the GUI UX overhaul.
-        self.setFixedSize(580, 540)
-        self.setStyleSheet(f"""
-            QDialog {{ background: {C.MANTLE}; }}
+        # Minimum size keeps the default compact, while allowing translations
+        # and long helper text to breathe instead of clipping.
+        self.setMinimumSize(580, 540)
+        self.resize(600, 560)
+        self.setStyleSheet(
+            DIALOG
+            + f"""
             QLabel {{ color: {C.TEXT}; font-size: 13px; }}
             {INPUT}
-        """)
+        """
+        )
 
         layout = QVBoxLayout(self)
         layout.setSpacing(0)
@@ -67,7 +74,7 @@ class AppProfileDialog(QDialog):
         header.setStyleSheet(f"background: {C.CRUST}; border-bottom: 3px solid {color};")
         header_l = QHBoxLayout(header)
         header_l.setContentsMargins(28, 20, 28, 20)
-        header_l.setSpacing(16)
+        header_l.setSpacing(SPACE_L)
 
         letter = (full_name or name or "?")[0].upper()
         self._avatar = QLabel(letter)
@@ -95,11 +102,11 @@ class AppProfileDialog(QDialog):
         body = QWidget()
         body_l = QVBoxLayout(body)
         body_l.setContentsMargins(28, 24, 28, 24)
-        body_l.setSpacing(8)
+        body_l.setSpacing(SPACE_S)
 
         form = QGridLayout()
-        form.setVerticalSpacing(10)
-        form.setHorizontalSpacing(12)
+        form.setVerticalSpacing(SPACE_M)
+        form.setHorizontalSpacing(SPACE_L)
 
         self.input_name = QLineEdit(name)
         self.input_name.setPlaceholderText(tr("e.g. photoshop"))
@@ -171,7 +178,7 @@ class AppProfileDialog(QDialog):
         btn_row.addStretch()
 
         cancel = QPushButton(tr("Cancel"))
-        cancel.setStyleSheet(BTN_GHOST)
+        cancel.setStyleSheet(BTN_SECONDARY)
         cancel.clicked.connect(self._on_cancel)
         btn_row.addWidget(cancel)
 

--- a/src/winpodx/gui/debloat_picker.py
+++ b/src/winpodx/gui/debloat_picker.py
@@ -28,17 +28,25 @@ from PySide6.QtWidgets import (
 
 from winpodx.core.debloat import DebloatCatalog
 from winpodx.core.i18n import tr
+from winpodx.gui.theme import (
+    BTN_PRIMARY,
+    BTN_SECONDARY,
+    CHECKBOX,
+    DIALOG,
+    RADIO,
+    SCROLL_AREA,
+    SPACE_L,
+    SPACE_M,
+    SPACE_S,
+    C,
+)
 
 # Color tokens for the risk badge. Pulled inline rather than imported
 # from ``winpodx.gui.theme`` so this module stays usable from tests /
 # standalone screenshots without the rest of the theme infrastructure
 # (the theme module pulls in palette globals + Qt-specific helpers
 # that aren't needed for a leaf dialog).
-_RISK_COLOR = {
-    "low": "#7FB069",  # muted green
-    "medium": "#E5C07B",  # amber
-    "high": "#E06C75",  # red
-}
+_RISK_COLOR = {"low": C.GREEN, "medium": C.PEACH, "high": C.RED}
 
 # Hover text for each risk badge, mirroring the legend.
 _RISK_TOOLTIP = {
@@ -101,14 +109,15 @@ class DebloatPickerDialog(QDialog):
         self.setWindowTitle(tr("Debloat picker"))
         self.setMinimumWidth(560)
         self.setModal(True)
+        self.setStyleSheet(DIALOG + CHECKBOX + RADIO + SCROLL_AREA)
 
         outer = QVBoxLayout(self)
         outer.setContentsMargins(20, 18, 20, 18)
-        outer.setSpacing(12)
+        outer.setSpacing(SPACE_M)
 
         # --- Title + subtitle --------------------------------------------
         title = QLabel(tr("Debloat picker"))
-        title.setStyleSheet("font-size: 18px; font-weight: bold;")
+        title.setStyleSheet(f"font-size: 18px; font-weight: bold; color: {C.TEXT};")
         outer.addWidget(title)
 
         subtitle = QLabel(
@@ -120,7 +129,7 @@ class DebloatPickerDialog(QDialog):
             )
         )
         subtitle.setWordWrap(True)
-        subtitle.setStyleSheet("color: #888; font-size: 12px;")
+        subtitle.setStyleSheet(f"color: {C.OVERLAY0}; font-size: 12px;")
         outer.addWidget(subtitle)
 
         # Risk-scale legend so the per-item badges read clearly.
@@ -138,13 +147,14 @@ class DebloatPickerDialog(QDialog):
         )
         legend.setTextFormat(Qt.TextFormat.RichText)
         legend.setWordWrap(True)
-        legend.setStyleSheet("font-size: 11px;")
+        legend.setStyleSheet(f"font-size: 11px; color: {C.SUBTEXT0};")
         outer.addWidget(legend)
 
         # --- Preset radio group ------------------------------------------
         preset_row = QHBoxLayout()
+        preset_row.setSpacing(SPACE_L)
         preset_label = QLabel(tr("Preset:"))
-        preset_label.setStyleSheet("font-weight: 600;")
+        preset_label.setStyleSheet(f"font-weight: 600; color: {C.SUBTEXT0};")
         preset_row.addWidget(preset_label)
 
         self._preset_group = QButtonGroup(self)
@@ -172,7 +182,7 @@ class DebloatPickerDialog(QDialog):
         # refreshed by the preset/custom toggles.
         self._preset_desc = QLabel("")
         self._preset_desc.setWordWrap(True)
-        self._preset_desc.setStyleSheet("color: #aaa; font-size: 11px;")
+        self._preset_desc.setStyleSheet(f"color: {C.SUBTEXT0}; font-size: 11px;")
         outer.addWidget(self._preset_desc)
 
         # --- Item list ---------------------------------------------------
@@ -181,12 +191,12 @@ class DebloatPickerDialog(QDialog):
         scroll.setFrameShape(QFrame.Shape.StyledPanel)
         content = QWidget()
         items_layout = QVBoxLayout(content)
-        items_layout.setContentsMargins(8, 8, 8, 8)
-        items_layout.setSpacing(6)
+        items_layout.setContentsMargins(SPACE_S, SPACE_S, SPACE_S, SPACE_S)
+        items_layout.setSpacing(SPACE_S)
 
         for item in catalog.items.values():
             row = QHBoxLayout()
-            row.setSpacing(8)
+            row.setSpacing(SPACE_S)
 
             box = QCheckBox()
             box.toggled.connect(self._on_item_toggled)
@@ -199,7 +209,7 @@ class DebloatPickerDialog(QDialog):
             badge.setToolTip(_RISK_TOOLTIP.get(item.risk, ""))
             badge.setStyleSheet(
                 f"background: {_RISK_COLOR.get(item.risk, '#888')};"
-                " color: white; border-radius: 4px;"
+                f" color: {C.CRUST}; border-radius: 6px;"
                 " padding: 2px 4px; font-size: 11px; font-weight: bold;"
             )
             row.addWidget(badge)
@@ -208,13 +218,13 @@ class DebloatPickerDialog(QDialog):
             # Full purpose on hover so every item is explainable even when the
             # short label can't carry it.
             label.setToolTip(item.description)
-            label.setStyleSheet("font-size: 13px;")
+            label.setStyleSheet(f"font-size: 13px; color: {C.TEXT};")
             row.addWidget(label, 1)
 
             one_way = QLabel(tr("(one-way)")) if not item.is_reversible else QLabel("")
             if not item.is_reversible:
                 one_way.setToolTip(tr("Cannot be undone — this item has no reverse script."))
-            one_way.setStyleSheet("color: #888; font-size: 11px;")
+            one_way.setStyleSheet(f"color: {C.OVERLAY0}; font-size: 11px;")
             row.addWidget(one_way)
 
             items_layout.addLayout(row)
@@ -225,11 +235,14 @@ class DebloatPickerDialog(QDialog):
 
         # --- Footer (count + buttons) ------------------------------------
         self._count_label = QLabel("")
+        self._count_label.setStyleSheet(f"color: {C.SUBTEXT0}; font-size: 12px;")
         outer.addWidget(self._count_label)
 
         buttons = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Apply
         )
+        buttons.button(QDialogButtonBox.StandardButton.Apply).setStyleSheet(BTN_PRIMARY)
+        buttons.button(QDialogButtonBox.StandardButton.Cancel).setStyleSheet(BTN_SECONDARY)
         buttons.button(QDialogButtonBox.StandardButton.Apply).clicked.connect(self._on_apply)
         buttons.rejected.connect(self.reject)
         outer.addWidget(buttons)

--- a/src/winpodx/gui/reverse_open_panel.py
+++ b/src/winpodx/gui/reverse_open_panel.py
@@ -178,20 +178,39 @@ def build_panel(cfg: Config, parent: QWidget | None = None) -> QWidget:
         _cmd_start_listener,
         _cmd_stop_listener,
     )
+    from winpodx.gui.theme import (
+        BTN_GHOST,
+        BTN_PRIMARY,
+        BTN_SECONDARY,
+        CHECKBOX,
+        LIST_WIDGET,
+        SETTINGS_SECTION,
+        SPACE_L,
+        SPACE_S,
+        SPACE_XL,
+        C,
+    )
 
     card = QFrame(parent)
     card.setObjectName("settingsSection")
     card.setFrameShape(QFrame.Shape.NoFrame)
+    card.setStyleSheet(
+        SETTINGS_SECTION
+        + CHECKBOX
+        + LIST_WIDGET
+        + f"QLabel {{ color: {C.TEXT}; font-size: 13px; background: transparent; }}"
+    )
     layout = QVBoxLayout(card)
-    layout.setContentsMargins(16, 16, 16, 16)
-    layout.setSpacing(8)
+    layout.setContentsMargins(SPACE_XL, SPACE_XL, SPACE_XL, SPACE_XL)
+    layout.setSpacing(SPACE_S)
 
     title = QLabel(tr("▦  Reverse File Associations"))
-    title.setStyleSheet("font-size: 16px; font-weight: bold;")
+    title.setStyleSheet(f"color: {C.BLUE}; font-size: 15px; font-weight: bold;")
     layout.addWidget(title)
 
     sub = QLabel(tr("Linux apps appear in the Windows guest's right-click ‘Open with…’ menu."))
     sub.setWordWrap(True)
+    sub.setStyleSheet(f"color: {C.OVERLAY0}; font-size: 11px;")
     layout.addWidget(sub)
 
     enable_box = QCheckBox(tr("Enable reverse-open"))
@@ -200,6 +219,9 @@ def build_panel(cfg: Config, parent: QWidget | None = None) -> QWidget:
 
     status_label = QLabel("")
     status_label.setWordWrap(True)
+    status_label.setStyleSheet(
+        f"background: {C.MANTLE}; color: {C.SUBTEXT1}; border-radius: 8px; padding: 8px 10px;"
+    )
     layout.addWidget(status_label)
 
     # --- action buttons ------------------------------------------------------
@@ -208,6 +230,9 @@ def build_panel(cfg: Config, parent: QWidget | None = None) -> QWidget:
     btn_start = QPushButton(tr("Start daemon"))
     btn_stop = QPushButton(tr("Stop daemon"))
     btn_status = QPushButton(tr("Refresh status"))
+    btn_refresh.setStyleSheet(BTN_PRIMARY)
+    for b in (btn_start, btn_stop, btn_status):
+        b.setStyleSheet(BTN_GHOST)
     for b in (btn_refresh, btn_start, btn_stop, btn_status):
         buttons_row.addWidget(b)
     buttons_row.addStretch()
@@ -216,11 +241,16 @@ def build_panel(cfg: Config, parent: QWidget | None = None) -> QWidget:
     # --- allow / deny lists --------------------------------------------------
     lists_hint = QLabel(tr("Allowlist = only these apps are offered; Denylist = these are hidden."))
     lists_hint.setWordWrap(True)
+    lists_hint.setStyleSheet(f"color: {C.OVERLAY0}; font-size: 11px;")
     layout.addWidget(lists_hint)
 
     lists_grid = QGridLayout()
+    lists_grid.setHorizontalSpacing(SPACE_L)
+    lists_grid.setVerticalSpacing(SPACE_S)
     allow_label = QLabel(tr("Allowlist (empty = show all discovered apps)"))
     deny_label = QLabel(tr("Denylist (apps to hide)"))
+    allow_label.setStyleSheet(f"color: {C.SUBTEXT0}; font-size: 12px; font-weight: bold;")
+    deny_label.setStyleSheet(f"color: {C.SUBTEXT0}; font-size: 12px; font-weight: bold;")
     allow_list = QListWidget()
     deny_list = QListWidget()
     for slug in cfg.reverse_open.allowlist:
@@ -233,15 +263,21 @@ def build_panel(cfg: Config, parent: QWidget | None = None) -> QWidget:
     lists_grid.addWidget(deny_list, 1, 1)
 
     allow_btns = QHBoxLayout()
+    allow_btns.setSpacing(SPACE_S)
     btn_allow_add = QPushButton(tr("+ Add"))
     btn_allow_rm = QPushButton(tr("− Remove"))
+    btn_allow_add.setStyleSheet(BTN_SECONDARY)
+    btn_allow_rm.setStyleSheet(BTN_GHOST)
     allow_btns.addWidget(btn_allow_add)
     allow_btns.addWidget(btn_allow_rm)
     allow_btns.addStretch()
 
     deny_btns = QHBoxLayout()
+    deny_btns.setSpacing(SPACE_S)
     btn_deny_add = QPushButton(tr("+ Add"))
     btn_deny_rm = QPushButton(tr("− Remove"))
+    btn_deny_add.setStyleSheet(BTN_SECONDARY)
+    btn_deny_rm.setStyleSheet(BTN_GHOST)
     deny_btns.addWidget(btn_deny_add)
     deny_btns.addWidget(btn_deny_rm)
     deny_btns.addStretch()

--- a/src/winpodx/gui/theme.py
+++ b/src/winpodx/gui/theme.py
@@ -36,6 +36,15 @@ class C:
     CRUST = "#010409"
 
 
+def rgba(hex_color: str, alpha: float) -> str:
+    """Return a Qt stylesheet rgba() color from ``#rrggbb`` and 0..1 alpha."""
+    value = hex_color.lstrip("#")
+    r = int(value[0:2], 16)
+    g = int(value[2:4], 16)
+    b = int(value[4:6], 16)
+    return f"rgba({r}, {g}, {b}, {alpha:.2f})"
+
+
 # --------------------------------------------------------------------------- #
 # Design tokens.
 #
@@ -53,6 +62,7 @@ SPACE_M = 12
 SPACE_L = 16
 SPACE_XL = 24
 SPACE_XXL = 32
+SPACE_XXXL = 40
 
 # Border radius scale. Match button / card / input visual weight.
 RADIUS_XS = 4  # inline chips, badges
@@ -69,6 +79,13 @@ FONT_SUBHEAD = 14  # section labels, search bar
 FONT_HEADER = 15  # card headers
 FONT_TITLE = 18  # page titles
 FONT_HERO = 22  # main window title, top-of-page heroes
+FONT_DISPLAY = 24  # sparse page hero title
+
+CONTROL_HEIGHT = 36
+CONTROL_HEIGHT_L = 40
+CARD_BORDER = f"1px solid {C.SURFACE1}"
+CARD_BORDER_HOVER = f"1px solid {C.SURFACE2}"
+FOCUS_RING = f"1px solid {C.BLUE}"
 
 
 _AVATAR_PALETTE = [
@@ -105,9 +122,43 @@ def accent_color(index: int) -> str:
 
 
 # Global: applied to central widget, cascades to children.
-GLOBAL_STYLE = """
-    * { background: transparent; }
-    QLabel { background: transparent; }
+GLOBAL_STYLE = f"""
+    * {{ background: transparent; }}
+    QLabel {{ background: transparent; }}
+    QToolTip {{
+        background: {C.SURFACE0};
+        color: {C.TEXT};
+        border: 1px solid {C.SURFACE2};
+        border-radius: {RADIUS_S}px;
+        padding: 6px 8px;
+        font-size: {FONT_CAPTION}px;
+    }}
+    QMenu {{
+        background: {C.SURFACE0};
+        color: {C.TEXT};
+        border: 1px solid {C.SURFACE2};
+        border-radius: {RADIUS_M}px;
+        padding: 6px;
+    }}
+    QMenu::item {{
+        padding: 7px 18px;
+        border-radius: {RADIUS_S}px;
+    }}
+    QMenu::item:selected {{
+        background: {rgba(C.BLUE, 0.16)};
+        color: {C.BLUE};
+    }}
+    QProgressBar {{
+        background: {C.SURFACE0};
+        border: none;
+        border-radius: 3px;
+        min-height: 6px;
+        max-height: 6px;
+    }}
+    QProgressBar::chunk {{
+        background: {C.BLUE};
+        border-radius: 3px;
+    }}
 """
 
 # Top Navigation Bar
@@ -116,8 +167,8 @@ TOP_BAR = f"""
         background: {C.BASE};
         border-top: 1px solid rgba(255, 255, 255, 0.04);
         border-bottom: 1px solid {C.SURFACE1};
-        min-height: 52px;
-        max-height: 52px;
+        min-height: 56px;
+        max-height: 56px;
     }}
 """
 
@@ -127,19 +178,23 @@ TAB_BTN = f"""
         background: transparent;
         border: none;
         border-bottom: 2px solid transparent;
-        padding: 14px 18px;
+        padding: 15px 16px 14px 16px;
         font-size: 13px;
         font-weight: 500;
     }}
     QPushButton:hover {{
         color: {C.SUBTEXT1};
-        background: rgba(48, 54, 61, 0.4);
+        background: {rgba(C.SURFACE1, 0.42)};
         border-bottom: 2px solid {C.SURFACE2};
+    }}
+    QPushButton:focus {{
+        color: {C.TEXT};
+        background: {rgba(C.SURFACE1, 0.34)};
     }}
     QPushButton:checked {{
         color: {C.BLUE};
         border-bottom: 2px solid {C.BLUE};
-        background: rgba(88, 166, 255, 0.08);
+        background: {rgba(C.BLUE, 0.10)};
         font-weight: bold;
     }}
 """
@@ -149,8 +204,9 @@ POD_CHIP = f"""
         background: {C.SURFACE0};
         border: 1px solid {C.SURFACE1};
         border-top: 1px solid rgba(255, 255, 255, 0.05);
-        border-radius: 14px;
-        max-height: 28px;
+        border-radius: 16px;
+        min-height: 30px;
+        max-height: 30px;
     }}
 """
 
@@ -159,16 +215,18 @@ POD_CTRL = f"""
         background: transparent;
         color: {C.SUBTEXT0};
         border: none;
-        border-radius: 4px;
+        border-radius: {RADIUS_S}px;
         padding: 4px 8px;
         font-size: 16px;
+        min-width: 26px;
+        max-height: 24px;
     }}
     QPushButton:hover {{
         color: {C.TEXT};
         background: {C.SURFACE1};
     }}
     QPushButton:disabled {{
-        color: {C.SURFACE1};
+        color: {C.SURFACE2};
     }}
 """
 
@@ -188,10 +246,16 @@ INPUT = f"""
         background: {C.MANTLE};
         color: {C.TEXT};
         border: 1px solid {C.SURFACE1};
-        border-radius: 8px;
-        padding: 10px 14px;
+        border-radius: {RADIUS_M}px;
+        padding: 9px 13px;
         font-size: 13px;
+        min-height: 18px;
         selection-background-color: {C.BLUE};
+        selection-color: {C.CRUST};
+    }}
+    QLineEdit:hover {{
+        border-color: {C.SURFACE2};
+        background: {C.BASE};
     }}
     QLineEdit:focus {{
         border-color: {C.BLUE};
@@ -209,16 +273,30 @@ COMBO = f"""
         background: {C.MANTLE};
         color: {C.TEXT};
         border: 1px solid {C.SURFACE1};
-        border-radius: 8px;
-        padding: 10px 14px;
+        border-radius: {RADIUS_M}px;
+        padding: 8px 30px 8px 13px;
         font-size: 13px;
+        min-height: 20px;
+    }}
+    QComboBox:hover {{
+        border-color: {C.SURFACE2};
+        background: {C.BASE};
     }}
     QComboBox:focus {{
         border-color: {C.BLUE};
     }}
     QComboBox::drop-down {{
         border: none;
-        padding-right: 10px;
+        width: 26px;
+    }}
+    QComboBox::down-arrow {{
+        image: none;
+        border-left: 4px solid transparent;
+        border-right: 4px solid transparent;
+        border-top: 5px solid {C.SUBTEXT0};
+        width: 0;
+        height: 0;
+        margin-right: 10px;
     }}
     QComboBox QAbstractItemView {{
         background: {C.SURFACE0};
@@ -237,9 +315,13 @@ SEARCH_BAR = f"""
         background: {C.SURFACE0};
         color: {C.TEXT};
         border: 2px solid transparent;
-        border-radius: 10px;
+        border-radius: {RADIUS_L}px;
         padding: 10px 16px 10px 14px;
         font-size: 14px;
+        min-height: 20px;
+    }}
+    QLineEdit:hover {{
+        border-color: {C.SURFACE1};
     }}
     QLineEdit:focus {{
         border-color: {C.BLUE};
@@ -256,8 +338,9 @@ BTN_PRIMARY = f"""
         font-weight: bold;
         border: 1px solid rgba(255, 255, 255, 0.1);
         border-bottom: 1px solid rgba(0, 0, 0, 0.2);
-        border-radius: 8px;
-        padding: 10px 24px;
+        border-radius: {RADIUS_M}px;
+        padding: 9px 20px;
+        min-height: 18px;
     }}
     QPushButton:hover {{ background: {C.SAPPHIRE}; }}
     QPushButton:pressed {{
@@ -277,8 +360,9 @@ BTN_SECONDARY = f"""
         color: {C.TEXT};
         font-size: 13px;
         border: 1px solid {C.SURFACE1};
-        border-radius: 8px;
-        padding: 9px 20px;
+        border-radius: {RADIUS_M}px;
+        padding: 8px 16px;
+        min-height: 18px;
     }}
     QPushButton:hover {{
         background: {C.SURFACE1};
@@ -294,25 +378,42 @@ BTN_ACCENT = f"""
         font-weight: bold;
         border: 1px solid rgba(255, 255, 255, 0.1);
         border-bottom: 1px solid rgba(0, 0, 0, 0.2);
-        border-radius: 8px;
+        border-radius: {RADIUS_M}px;
         padding: 8px 18px;
+        min-height: 18px;
     }}
     QPushButton:hover {{ background: {C.TEAL}; }}
+    QPushButton:pressed {{ background: {C.GREEN}; }}
+    QPushButton:disabled {{
+        background: {C.SURFACE1};
+        color: {C.OVERLAY0};
+        border: 1px solid transparent;
+    }}
 """
 
 BTN_DANGER = f"""
     QPushButton {{
         background: transparent;
-        color: {C.OVERLAY0};
+        color: {C.PEACH};
         font-size: 13px;
-        border: 1px solid {C.SURFACE0};
-        border-radius: 8px;
-        padding: 6px 12px;
+        border: 1px solid {rgba(C.RED, 0.24)};
+        border-radius: {RADIUS_M}px;
+        padding: 7px 12px;
+        min-height: 16px;
     }}
     QPushButton:hover {{
+        background: {rgba(C.RED, 0.18)};
+        color: {C.RED};
+        border-color: {C.RED};
+    }}
+    QPushButton:pressed {{
         background: {C.RED};
         color: {C.CRUST};
-        border-color: {C.RED};
+    }}
+    QPushButton:disabled {{
+        color: {C.OVERLAY0};
+        border-color: {C.SURFACE1};
+        background: transparent;
     }}
 """
 
@@ -322,8 +423,9 @@ BTN_GHOST = f"""
         color: {C.SUBTEXT0};
         font-size: 12px;
         border: none;
-        border-radius: 6px;
-        padding: 6px 12px;
+        border-radius: {RADIUS_S}px;
+        padding: 7px 12px;
+        min-height: 16px;
     }}
     QPushButton:hover {{
         color: {C.TEXT};
@@ -331,7 +433,10 @@ BTN_GHOST = f"""
     }}
     QPushButton:checked {{
         color: {C.BLUE};
-        background: {C.SURFACE0};
+        background: {rgba(C.BLUE, 0.12)};
+    }}
+    QPushButton:disabled {{
+        color: {C.SURFACE2};
     }}
 """
 
@@ -342,8 +447,9 @@ FILTER_CHIP = f"""
         color: {C.SUBTEXT0};
         font-size: 12px;
         border: 1px solid {C.SURFACE1};
-        border-radius: 12px;
+        border-radius: 13px;
         padding: 5px 16px;
+        min-height: 18px;
     }}
     QPushButton:hover {{
         color: {C.TEXT};
@@ -353,7 +459,7 @@ FILTER_CHIP = f"""
     QPushButton:checked {{
         color: {C.BLUE};
         border-color: {C.BLUE};
-        background: rgba(88, 166, 255, 0.12);
+        background: {rgba(C.BLUE, 0.12)};
         font-weight: bold;
     }}
 """
@@ -364,14 +470,15 @@ VIEW_TOGGLE = f"""
         background: {C.SURFACE0};
         color: {C.OVERLAY0};
         font-size: 14px;
-        border: none;
+        border: 1px solid transparent;
         border-radius: 6px;
         padding: 6px 10px;
         min-width: 32px;
     }}
     QPushButton:hover {{
         color: {C.TEXT};
-        background: {C.SURFACE1};
+        background: {rgba(C.BLUE, 0.14)};
+        border-color: {rgba(C.BLUE, 0.26)};
     }}
     QPushButton:checked {{
         color: {C.BLUE};
@@ -385,10 +492,10 @@ APP_CARD = f"""
         background: {C.SURFACE0};
         border: 1px solid {C.SURFACE1};
         border-top: 1px solid rgba(255, 255, 255, 0.06);
-        border-radius: 12px;
+        border-radius: {RADIUS_XXL}px;
     }}
     QFrame#appCard:hover {{
-        background: rgba(48, 54, 61, 0.85);
+        background: {rgba(C.SURFACE1, 0.82)};
         border-color: {C.BLUE};
         border-top: 1px solid rgba(255, 255, 255, 0.1);
     }}
@@ -400,10 +507,10 @@ APP_TILE = f"""
         background: {C.SURFACE0};
         border: 1px solid {C.SURFACE1};
         border-top: 1px solid rgba(255, 255, 255, 0.06);
-        border-radius: 10px;
+        border-radius: {RADIUS_L}px;
     }}
     QFrame#appTile:hover {{
-        background: rgba(48, 54, 61, 0.85);
+        background: {rgba(C.SURFACE1, 0.82)};
         border-color: {C.BLUE};
     }}
 """
@@ -414,10 +521,10 @@ ACTION_ROW = f"""
         background: {C.SURFACE0};
         border: 1px solid {C.SURFACE1};
         border-top: 1px solid rgba(255, 255, 255, 0.06);
-        border-radius: 12px;
+        border-radius: {RADIUS_XL}px;
     }}
     QFrame#actionRow:hover {{
-        background: rgba(48, 54, 61, 0.85);
+        background: {rgba(C.SURFACE1, 0.82)};
         border-color: {C.SURFACE2};
     }}
 """
@@ -428,7 +535,116 @@ SETTINGS_SECTION = f"""
         background: {C.SURFACE0};
         border: 1px solid {C.SURFACE1};
         border-top: 1px solid rgba(255, 255, 255, 0.06);
-        border-radius: 14px;
+        border-radius: {RADIUS_XXL}px;
+    }}
+"""
+
+SECTION_CARD = SETTINGS_SECTION
+
+EMPTY_STATE = f"""
+    QFrame#emptyState {{
+        background: {rgba(C.SURFACE0, 0.72)};
+        border: 1px dashed {C.SURFACE2};
+        border-radius: {RADIUS_XL}px;
+    }}
+"""
+
+SECTION_LABEL = f"""
+    QLabel {{
+        background: transparent;
+        color: {C.SUBTEXT0};
+        font-size: {FONT_CAPTION}px;
+        font-weight: bold;
+        text-transform: uppercase;
+    }}
+"""
+
+PAGE_TITLE = f"""
+    QLabel {{
+        background: transparent;
+        color: {C.TEXT};
+        font-size: {FONT_HERO}px;
+        font-weight: bold;
+    }}
+"""
+
+PAGE_SUBTITLE = f"""
+    QLabel {{
+        background: transparent;
+        color: {C.OVERLAY0};
+        font-size: {FONT_BODY}px;
+    }}
+"""
+
+BADGE = f"""
+    QLabel {{
+        border-radius: {RADIUS_S}px;
+        padding: 2px 7px;
+        font-size: {FONT_CAPTION}px;
+        font-weight: bold;
+    }}
+"""
+
+CHECKBOX = f"""
+    QCheckBox {{
+        color: {C.SUBTEXT1};
+        font-size: {FONT_BODY}px;
+        spacing: 8px;
+    }}
+    QCheckBox::indicator {{
+        width: 16px;
+        height: 16px;
+        border-radius: 4px;
+        border: 1px solid {C.SURFACE2};
+        background: {C.MANTLE};
+    }}
+    QCheckBox::indicator:hover {{
+        border-color: {C.BLUE};
+    }}
+    QCheckBox::indicator:checked {{
+        background: {C.BLUE};
+        border-color: {C.BLUE};
+    }}
+    QCheckBox:disabled {{
+        color: {C.OVERLAY0};
+    }}
+"""
+
+RADIO = f"""
+    QRadioButton {{
+        color: {C.SUBTEXT1};
+        font-size: {FONT_BODY}px;
+        spacing: 8px;
+    }}
+    QRadioButton::indicator {{
+        width: 15px;
+        height: 15px;
+        border-radius: 8px;
+        border: 1px solid {C.SURFACE2};
+        background: {C.MANTLE};
+    }}
+    QRadioButton::indicator:checked {{
+        border: 4px solid {C.BLUE};
+        background: {C.CRUST};
+    }}
+"""
+
+LIST_WIDGET = f"""
+    QListWidget {{
+        background: {C.MANTLE};
+        color: {C.TEXT};
+        border: 1px solid {C.SURFACE1};
+        border-radius: {RADIUS_M}px;
+        padding: 6px;
+        outline: none;
+    }}
+    QListWidget::item {{
+        padding: 6px 8px;
+        border-radius: {RADIUS_S}px;
+    }}
+    QListWidget::item:selected {{
+        background: {rgba(C.BLUE, 0.18)};
+        color: {C.BLUE};
     }}
 """
 
@@ -440,14 +656,14 @@ SCROLL_AREA = f"""
     }}
     QScrollBar:vertical {{
         background: transparent;
-        width: 6px;
+        width: 8px;
         margin: 0;
-        border-radius: 3px;
+        border-radius: 4px;
     }}
     QScrollBar::handle:vertical {{
         background: {C.SURFACE1};
         min-height: 24px;
-        border-radius: 3px;
+        border-radius: 4px;
     }}
     QScrollBar::handle:vertical:hover {{
         background: {C.SURFACE2};
@@ -460,6 +676,24 @@ SCROLL_AREA = f"""
     QScrollBar::sub-page:vertical {{
         background: none;
     }}
+    QScrollBar:horizontal {{
+        background: transparent;
+        height: 8px;
+        margin: 0;
+        border-radius: 4px;
+    }}
+    QScrollBar::handle:horizontal {{
+        background: {C.SURFACE1};
+        min-width: 24px;
+        border-radius: 4px;
+    }}
+    QScrollBar::handle:horizontal:hover {{
+        background: {C.SURFACE2};
+    }}
+    QScrollBar::add-line:horizontal,
+    QScrollBar::sub-line:horizontal {{
+        width: 0;
+    }}
 """
 
 # Terminal Dock
@@ -471,9 +705,34 @@ TERMINAL = f"""
                      'Cascadia Code', monospace;
         font-size: 12px;
         border: 1px solid {C.SURFACE0};
-        border-radius: 10px;
+        border-radius: {RADIUS_L}px;
         padding: 14px;
         selection-background-color: {C.SURFACE1};
+    }}
+"""
+
+PLAIN_TEXT = f"""
+    QPlainTextEdit {{
+        background: {C.CRUST};
+        color: {C.SUBTEXT1};
+        font-family: 'JetBrains Mono', 'Fira Code',
+                     'Cascadia Code', monospace;
+        font-size: 12px;
+        border: 1px solid {C.SURFACE0};
+        border-radius: {RADIUS_L}px;
+        padding: 12px;
+        selection-background-color: {C.SURFACE1};
+    }}
+"""
+
+DIALOG = f"""
+    QDialog {{
+        background: {C.MANTLE};
+        color: {C.TEXT};
+    }}
+    QLabel {{
+        background: transparent;
+        color: {C.TEXT};
     }}
 """
 


### PR DESCRIPTION
Design + usability pass over the entire PySide6 GUI (codex-assisted; full audit at `.priv-storage/sessions/gui_ux_audit.md`). **Not merged — for your review** (run `winpodx gui` on this branch to see it).

## What changed
- **Design system (`theme.py`)** — one visual language: consistent styling for buttons / combo boxes / scrollbars / text edits / checkboxes / menus / tooltips, real **focus rings + disabled / checked / pressed states**, unified selection colors, a single **spacing scale + type scale**, and shared **card / border / radius / shadow** tokens (the card pattern was duplicated across 6 pages).
- **Persistent chrome** — clearer nav tab hit/focus/pressed states; pod chip gets visual separation; status-banner button matches the primary style; tidier bottom info/log bars.
- **Per page** — Apps/Library, Tools/Maintenance (incl. RDP Sessions), Settings, Terminal/Logs, Info/Health, License, Devices, and the dialogs (app-profile, debloat picker, bring-up, busy): shared card + control language, stronger section grouping, proper **empty / loading / error panels**, even spacing/alignment.

## Safety
- **No `tr()` source strings changed** — verified +0/-0 vs main, so all 6 locale catalogs stay intact.
- **`gui/` only** — no core/backend/cli/tests touched (14 files, +742/-323).
- Mixin architecture, signals, slots, and `QStackedWidget` page indices preserved.
- Proportions measured offscreen (render + PIL), not guessed.

## Test
- `ruff check` + `ruff format --check` — clean.
- All 14 gui modules import; `pytest tests/test_main_window_bringup.py tests/test_devices_gui.py` — **16 passed** (window builds).
- Full `pytest` — see CI.

## Follow-up (not done here)
Some visible copy could read better but changing a `tr()` source needs syncing all 6 catalogs — left for a separate translation-aware pass.