### PR TITLE
refactor(gui): calmer visuals + consistent layout (License last)

### DIFF
--- a/src/winpodx/gui/_main_window_bringup.py
+++ b/src/winpodx/gui/_main_window_bringup.py
@@ -215,7 +215,7 @@ class BringUpProgressDialog(QDialog):
 
         # ----- header row (phase progress + label) -----------------------
         self.header = QLabel(tr("Starting..."))
-        self.header.setStyleSheet(f"font-size: {FONT_SUBHEAD}px; font-weight: bold;")
+        self.header.setStyleSheet(f"font-size: {FONT_SUBHEAD}px; font-weight: 600;")
         self.header.setWordWrap(True)
         layout.addWidget(self.header)
 
@@ -433,7 +433,7 @@ class BringUpProgressDialog(QDialog):
             # determinate full bar so the progress no longer reads as busy.
             self.header.setText(tr("✓ Ready"))
             self.header.setStyleSheet(
-                f"font-size: {FONT_SUBHEAD}px; font-weight: bold; color: {C.GREEN};"
+                f"font-size: {FONT_SUBHEAD}px; font-weight: 600; color: {C.GREEN};"
             )
             self.sub_detail.setText(tr("Windows is ready — you can launch apps now."))
             self.bar.setMaximum(1)
@@ -441,7 +441,7 @@ class BringUpProgressDialog(QDialog):
         else:
             self.header.setText(tr("Bring-up did not complete"))
             self.header.setStyleSheet(
-                f"font-size: {FONT_SUBHEAD}px; font-weight: bold; color: {C.RED};"
+                f"font-size: {FONT_SUBHEAD}px; font-weight: 600; color: {C.RED};"
             )
             self.sub_detail.setText(error_msg or tr("(no error message)"))
         self.cancel_btn.setText(tr("Close"))
@@ -496,7 +496,7 @@ class BringUpProgressDialog(QDialog):
             elif started is not None:
                 glyph.setText(">  ")
                 glyph.setStyleSheet(f"color: {C.BLUE};")
-                name.setStyleSheet("font-weight: bold;")
+                name.setStyleSheet("font-weight: 500;")
                 elapsed.setText(_format_mmss(now - started))
             else:
                 glyph.setText("   ")

--- a/src/winpodx/gui/_main_window_devices.py
+++ b/src/winpodx/gui/_main_window_devices.py
@@ -39,7 +39,7 @@ from winpodx.core.i18n import tr
 from winpodx.gui._widget_helpers import (
     add_shadow,
     make_empty_panel,
-    make_page_heading,
+    make_page_header,
     make_warning_callout,
     show_toast,
 )
@@ -88,33 +88,36 @@ class DevicesMixin:
     def _build_devices_page(self) -> QWidget:
         page = QWidget()
         outer = QVBoxLayout(page)
-        outer.setContentsMargins(SPACE_XXL, SPACE_XL, SPACE_XXL, SPACE_XL)
+        outer.setContentsMargins(SPACE_XXL, 0, SPACE_XXL, SPACE_XL)
         outer.setSpacing(SPACE_M)
 
-        outer.addWidget(
-            make_page_heading(
-                tr("Devices"),
-                tr(
-                    "Pass host USB / PCI devices through to the Windows guest. "
-                    "USB hot-plugs live; PCI needs a guest restart and confirmation."
-                ),
-            )
-        )
-
-        bar = QHBoxLayout()
-        bar.setSpacing(SPACE_M)
         refresh = QPushButton(tr("Refresh"))
         refresh.setStyleSheet(BTN_SECONDARY)
         refresh.clicked.connect(self._render_devices)
-        bar.addWidget(refresh)
         self._devices_status = QLabel("")
         self._devices_status.setStyleSheet(
             f"color: {C.SUBTEXT1}; font-size: 12px; "
             f"background: {C.SURFACE0}; border: 1px solid {C.SURFACE1}; "
             "border-radius: 8px; padding: 7px 10px;"
         )
-        bar.addWidget(self._devices_status, 1)
-        outer.addLayout(bar)
+
+        actions = QWidget()
+        actions_l = QHBoxLayout(actions)
+        actions_l.setContentsMargins(0, 0, 0, 0)
+        actions_l.setSpacing(8)
+        actions_l.addWidget(self._devices_status)
+        actions_l.addWidget(refresh)
+
+        outer.addWidget(
+            make_page_header(
+                tr("Devices"),
+                tr(
+                    "Pass host USB / PCI devices through to the Windows guest. "
+                    "USB hot-plugs live; PCI needs a guest restart and confirmation."
+                ),
+                actions_widget=actions,
+            )
+        )
 
         columns = QHBoxLayout()
         columns.setSpacing(SPACE_L)

--- a/src/winpodx/gui/_main_window_header.py
+++ b/src/winpodx/gui/_main_window_header.py
@@ -96,10 +96,10 @@ class HeaderMixin:
             ("Tools", 2),
             ("Terminal", 3),
             ("Info", 4),
-            ("License", 5),
-            # Devices page is appended last so the nav-position == page-index
+            ("Devices", 5),
+            # License page is appended last so the nav-position == page-index
             # invariant _switch_page relies on holds (see _main_window_nav).
-            ("Devices", 6),
+            ("License", 6),
         ]:
             btn = QPushButton(tr(label))
             btn.setCheckable(True)

--- a/src/winpodx/gui/_main_window_header.py
+++ b/src/winpodx/gui/_main_window_header.py
@@ -77,7 +77,7 @@ class HeaderMixin:
         logo_text = QLabel("WinPodX")
         logo_text.setStyleSheet(
             f"background: transparent; color: {C.TEXT};"
-            " font-size: 16px; font-weight: bold;"
+            " font-size: 16px; font-weight: 600;"
             " letter-spacing: 0px;"
         )
         layout.addWidget(logo_text)
@@ -138,14 +138,14 @@ class HeaderMixin:
         # 15s status_timer that drives pod_dot, plus a quick agent probe.
         self.agent_dot = QLabel("A")
         self.agent_dot.setStyleSheet(
-            f"background: transparent; color: {C.OVERLAY0}; font-size: 10px; font-weight: bold;"
+            f"background: transparent; color: {C.OVERLAY0}; font-size: 10px; font-weight: 500;"
         )
         self.agent_dot.setToolTip(tr("Guest agent (HTTP /health) — probing…"))
         chip_l.addWidget(self.agent_dot)
 
         self.rdp_dot = QLabel("R")
         self.rdp_dot.setStyleSheet(
-            f"background: transparent; color: {C.OVERLAY0}; font-size: 10px; font-weight: bold;"
+            f"background: transparent; color: {C.OVERLAY0}; font-size: 10px; font-weight: 500;"
         )
         self.rdp_dot.setToolTip(tr("RDP port (3390) — probing…"))
         chip_l.addWidget(self.rdp_dot)

--- a/src/winpodx/gui/_main_window_info.py
+++ b/src/winpodx/gui/_main_window_info.py
@@ -148,7 +148,7 @@ class InfoPageMixin:
 
         header = QLabel(tr(title))
         header.setStyleSheet(
-            f"background: transparent; color: {C.BLUE}; font-size: 15px; font-weight: bold;"
+            f"background: transparent; color: {C.BLUE}; font-size: 15px; font-weight: 600;"
         )
         layout.addWidget(header)
 
@@ -192,7 +192,7 @@ class InfoPageMixin:
 
         overall_color = self._HEALTH_BADGE_COLORS.get(overall, C.SUBTEXT0)
         verdict = QLabel(tr("Overall: {status}").format(status=overall.upper() or tr("UNKNOWN")))
-        verdict.setStyleSheet(f"color: {overall_color}; font-size: 13px; font-weight: bold;")
+        verdict.setStyleSheet(f"color: {overall_color}; font-size: 13px; font-weight: 500;")
         body.addWidget(verdict)
         body.addSpacing(4)
 
@@ -203,7 +203,7 @@ class InfoPageMixin:
             badge = QLabel(status.upper())
             badge.setFixedWidth(48)
             badge.setStyleSheet(
-                f"color: {color}; font-size: 11px; font-weight: bold; "
+                f"color: {color}; font-size: 11px; font-weight: 500; "
                 f"background: {rgba(color, 0.12)}; border: 1px solid {rgba(color, 0.35)}; "
                 "border-radius: 6px; padding: 2px 6px;"
             )

--- a/src/winpodx/gui/_main_window_info.py
+++ b/src/winpodx/gui/_main_window_info.py
@@ -28,7 +28,7 @@ from PySide6.QtWidgets import (
 )
 
 from winpodx.core.i18n import tr
-from winpodx.gui._widget_helpers import add_shadow, make_empty_panel, make_page_heading
+from winpodx.gui._widget_helpers import add_shadow, make_empty_panel, make_page_header
 from winpodx.gui.theme import (
     BTN_GHOST,
     SCROLL_AREA,
@@ -86,19 +86,14 @@ class InfoPageMixin:
 
         content = QWidget()
         layout = QVBoxLayout(content)
-        layout.setContentsMargins(SPACE_XXL, SPACE_XL, SPACE_XXL, SPACE_XXL)
+        layout.setContentsMargins(SPACE_XXL, 0, SPACE_XXL, SPACE_XXL)
         layout.setSpacing(SPACE_L)
-
-        header = QHBoxLayout()
-        header.addWidget(make_page_heading(tr("Info")))
-        header.addStretch()
 
         refresh_btn = QPushButton(tr("Refresh Info"))
         refresh_btn.setIcon(QIcon.fromTheme("view-refresh"))
         refresh_btn.setStyleSheet(BTN_GHOST)
         refresh_btn.clicked.connect(self._refresh_info)
-        header.addWidget(refresh_btn)
-        layout.addLayout(header)
+        layout.addWidget(make_page_header(tr("Info"), actions_widget=refresh_btn))
 
         # Containers for the 5 cards. Initial population goes through
         # _refresh_info which dispatches a worker thread; until that thread

--- a/src/winpodx/gui/_main_window_library.py
+++ b/src/winpodx/gui/_main_window_library.py
@@ -64,6 +64,8 @@ from winpodx.gui.theme import (
     SPACE_L,
     SPACE_M,
     SPACE_S,
+    SPACE_XL,
+    SPACE_XXL,
     VIEW_TOGGLE,
     C,
     avatar_color,
@@ -81,11 +83,11 @@ class LibraryPageMixin:
     def _build_library_page(self) -> QWidget:
         page = QWidget()
         layout = QVBoxLayout(page)
-        layout.setContentsMargins(32, 24, 32, 20)
+        layout.setContentsMargins(SPACE_XXL, SPACE_XL, SPACE_XXL, SPACE_L)
         layout.setSpacing(0)
 
         toolbar = QHBoxLayout()
-        toolbar.setSpacing(SPACE_M)
+        toolbar.setSpacing(SPACE_L)
 
         # Leading magnifier glyph so the box reads as a search field rather
         # than a bare input (Task 3). Kept as a sibling label — the shared
@@ -165,7 +167,7 @@ class LibraryPageMixin:
         toolbar.addWidget(add_btn)
 
         layout.addLayout(toolbar)
-        layout.addSpacing(SPACE_M)
+        layout.addSpacing(SPACE_L)
 
         self.refresh_progress = QProgressBar()
         self.refresh_progress.setRange(0, 0)  # indeterminate
@@ -179,11 +181,11 @@ class LibraryPageMixin:
         layout.addWidget(self.refresh_progress)
 
         self._category_row = QHBoxLayout()
-        self._category_row.setSpacing(6)
+        self._category_row.setSpacing(SPACE_S)
         self._category_btns: list[QPushButton] = []
         self._build_category_chips()
         layout.addLayout(self._category_row)
-        layout.addSpacing(SPACE_L)
+        layout.addSpacing(SPACE_XL)
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
@@ -193,7 +195,7 @@ class LibraryPageMixin:
         self.app_list_container.setStyleSheet("background: transparent;")
         self.app_list_layout = QVBoxLayout(self.app_list_container)
         self.app_list_layout.setContentsMargins(0, 0, 0, 0)
-        self.app_list_layout.setSpacing(0)
+        self.app_list_layout.setSpacing(SPACE_XL)
         self._refresh_hidden_button()
         self._populate_app_view(self._visible_apps())
 
@@ -344,9 +346,10 @@ class LibraryPageMixin:
     def _populate_grid(self, apps: list[AppInfo]) -> None:
         """Grid view - cards."""
         cols = 4
+        self.app_list_layout.setSpacing(SPACE_XL)
         grid = QGridLayout()
-        grid.setHorizontalSpacing(SPACE_L)
-        grid.setVerticalSpacing(SPACE_L)
+        grid.setHorizontalSpacing(SPACE_XL)
+        grid.setVerticalSpacing(SPACE_XL)
         grid.setContentsMargins(0, 0, 0, 0)
         for col in range(cols):
             grid.setColumnStretch(col, 1)
@@ -369,7 +372,7 @@ class LibraryPageMixin:
 
     def _populate_list(self, apps: list[AppInfo]) -> None:
         """List view - horizontal tiles."""
-        self.app_list_layout.setSpacing(8)
+        self.app_list_layout.setSpacing(SPACE_M)
         for app in apps:
             self.app_list_layout.addWidget(self._make_app_tile(app))
         self.app_list_layout.addStretch()
@@ -379,13 +382,13 @@ class LibraryPageMixin:
         card = QFrame()
         card.setObjectName("appCard")
         card.setStyleSheet(APP_CARD)
-        card.setMinimumHeight(220)
-        card.setMinimumWidth(180)
-        add_shadow(card)
+        card.setMinimumHeight(238)
+        card.setMinimumWidth(188)
+        add_shadow(card, blur=12, y=2, alpha=28)
 
         vl = QVBoxLayout(card)
         vl.setContentsMargins(SPACE_L, SPACE_L, SPACE_L, SPACE_L)
-        vl.setSpacing(0)
+        vl.setSpacing(SPACE_S)
 
         top_row = QHBoxLayout()
         top_row.setContentsMargins(0, 0, 0, 0)
@@ -400,11 +403,10 @@ class LibraryPageMixin:
             top_row.addWidget(badge, alignment=Qt.AlignmentFlag.AlignTop)
 
         vl.addLayout(top_row)
-        vl.addSpacing(SPACE_M)
 
         name_lbl = QLabel(app.full_name)
         name_lbl.setStyleSheet(
-            f"background: transparent; color: {C.TEXT}; font-size: 13px; font-weight: bold;"
+            f"background: transparent; color: {C.TEXT}; font-size: 13px; font-weight: 500;"
         )
         name_lbl.setWordWrap(False)
         name_lbl.setMaximumWidth(200)
@@ -430,13 +432,15 @@ class LibraryPageMixin:
         # The secondary actions (edit / hide / delete) sit on a compact row
         # beneath it.
         bottom = QVBoxLayout()
-        bottom.setSpacing(SPACE_S)
+        bottom.setSpacing(SPACE_M)
 
         launch_btn = QPushButton(tr("▶  Launch"))
         launch_btn.setStyleSheet(BTN_ACCENT)
+        launch_btn.setMinimumWidth(116)
+        launch_btn.setMaximumWidth(132)
         launch_btn.setToolTip(tr("Launch {app}").format(app=app.full_name))
         launch_btn.clicked.connect(lambda _, a=app: self._launch_app(a))
-        bottom.addWidget(launch_btn)
+        bottom.addWidget(launch_btn, alignment=Qt.AlignmentFlag.AlignRight)
 
         actions = QHBoxLayout()
         actions.setSpacing(SPACE_S)
@@ -487,11 +491,11 @@ class LibraryPageMixin:
         tile = QFrame()
         tile.setObjectName("appTile")
         tile.setStyleSheet(APP_TILE)
-        tile.setMinimumHeight(72)
-        add_shadow(tile, blur=12, y=2, alpha=35)
+        tile.setMinimumHeight(86)
+        add_shadow(tile, blur=10, y=2, alpha=28)
 
         layout = QHBoxLayout(tile)
-        layout.setContentsMargins(0, 0, SPACE_L, 0)
+        layout.setContentsMargins(0, SPACE_S, SPACE_L, SPACE_S)
         layout.setSpacing(0)
 
         stripe = QFrame()
@@ -509,7 +513,7 @@ class LibraryPageMixin:
 
         name_lbl = QLabel(app.full_name)
         name_lbl.setStyleSheet(
-            f"background: transparent; color: {C.TEXT}; font-size: 14px; font-weight: bold;"
+            f"background: transparent; color: {C.TEXT}; font-size: 14px; font-weight: 500;"
         )
         name_row = QHBoxLayout()
         name_row.setContentsMargins(0, 0, 0, 0)
@@ -534,6 +538,7 @@ class LibraryPageMixin:
 
         launch_btn = QPushButton(tr("▶  Launch"))
         launch_btn.setStyleSheet(BTN_ACCENT)
+        launch_btn.setMinimumWidth(116)
         launch_btn.clicked.connect(lambda: self._launch_app(app))
         layout.addWidget(launch_btn)
         layout.addSpacing(8)

--- a/src/winpodx/gui/_main_window_library.py
+++ b/src/winpodx/gui/_main_window_library.py
@@ -37,6 +37,7 @@ from PySide6.QtWidgets import (
     QProgressBar,
     QPushButton,
     QScrollArea,
+    QSizePolicy,
     QVBoxLayout,
     QWidget,
 )
@@ -47,6 +48,7 @@ from winpodx.gui._widget_helpers import (
     add_shadow,
     make_app_avatar,
     make_empty_panel,
+    make_page_header,
     make_source_badge,
 )
 from winpodx.gui.theme import (
@@ -58,7 +60,6 @@ from winpodx.gui.theme import (
     BTN_PRIMARY,
     BTN_SECONDARY,
     FILTER_CHIP,
-    FONT_CAPTION,
     SCROLL_AREA,
     SEARCH_BAR,
     SPACE_L,
@@ -83,20 +84,18 @@ class LibraryPageMixin:
     def _build_library_page(self) -> QWidget:
         page = QWidget()
         layout = QVBoxLayout(page)
-        layout.setContentsMargins(SPACE_XXL, SPACE_XL, SPACE_XXL, SPACE_L)
-        layout.setSpacing(0)
+        layout.setContentsMargins(SPACE_XXL, 0, SPACE_XXL, SPACE_L)
+        layout.setSpacing(SPACE_M)
+
+        apps_title = self.nav_buttons[0].text() if hasattr(self, "nav_buttons") else "Apps"
+        layout.addWidget(make_page_header(apps_title))
 
         toolbar = QHBoxLayout()
-        toolbar.setSpacing(SPACE_L)
+        toolbar.setSpacing(16)
 
-        # Leading magnifier glyph so the box reads as a search field rather
-        # than a bare input (Task 3). Kept as a sibling label — the shared
-        # SEARCH_BAR stylesheet already pads room on the left.
-        search_icon = QLabel("\U0001f50d")  # magnifying glass
-        search_icon.setStyleSheet(
-            f"background: transparent; color: {C.OVERLAY0}; font-size: {FONT_CAPTION}px;"
-        )
-        toolbar.addWidget(search_icon)
+        left_group = QHBoxLayout()
+        left_group.setContentsMargins(0, 0, 0, 0)
+        left_group.setSpacing(8)
 
         self.search_box = QLineEdit()
         self.search_box.setPlaceholderText(tr("Search apps by name..."))
@@ -104,9 +103,7 @@ class LibraryPageMixin:
         self.search_box.setFixedWidth(340)
         self.search_box.setClearButtonEnabled(True)
         self.search_box.textChanged.connect(self._filter_apps)
-        toolbar.addWidget(self.search_box)
-
-        toolbar.addStretch()
+        left_group.addWidget(self.search_box)
 
         self.app_count_label = QLabel(
             tr("{shown} of {total} apps").format(shown=len(self.apps), total=len(self.apps))
@@ -114,8 +111,11 @@ class LibraryPageMixin:
         self.app_count_label.setStyleSheet(
             f"background: transparent; color: {C.OVERLAY0}; font-size: 12px;"
         )
-        toolbar.addWidget(self.app_count_label)
-        toolbar.addSpacing(4)
+        left_group.addWidget(self.app_count_label)
+
+        right_group = QHBoxLayout()
+        right_group.setContentsMargins(0, 0, 0, 0)
+        right_group.setSpacing(8)
 
         toggle_wrap = QWidget()
         toggle_wrap.setStyleSheet(VIEW_TOGGLE)
@@ -135,16 +135,14 @@ class LibraryPageMixin:
         self.btn_list.setToolTip(tr("List view"))
         self.btn_list.clicked.connect(lambda: self._set_view("list"))
         tgl.addWidget(self.btn_list)
-        toolbar.addWidget(toggle_wrap)
-        toolbar.addSpacing(SPACE_S)
+        right_group.addWidget(toggle_wrap)
 
         self.refresh_btn = QPushButton(tr("Refresh Apps"))
         self.refresh_btn.setIcon(QIcon.fromTheme("view-refresh"))
         self.refresh_btn.setStyleSheet(BTN_GHOST)
         self.refresh_btn.setToolTip(tr("Scan the running pod for installed Windows apps"))
         self.refresh_btn.clicked.connect(self._on_refresh_apps)
-        toolbar.addWidget(self.refresh_btn)
-        toolbar.addSpacing(SPACE_S)
+        right_group.addWidget(self.refresh_btn)
 
         # Hybrid filter UX — hidden apps (system shims auto-filtered by the
         # noise denylist, plus anything the user manually hid) collapse by
@@ -158,16 +156,17 @@ class LibraryPageMixin:
             tr("Show apps filtered by the noise denylist or manually hidden")
         )
         self.btn_show_hidden.clicked.connect(self._on_toggle_hidden)
-        toolbar.addWidget(self.btn_show_hidden)
-        toolbar.addSpacing(SPACE_S)
+        right_group.addWidget(self.btn_show_hidden)
 
         add_btn = QPushButton(tr("+  Add App"))
         add_btn.setStyleSheet(BTN_PRIMARY)
         add_btn.clicked.connect(self._on_add_app)
-        toolbar.addWidget(add_btn)
+        right_group.addWidget(add_btn)
+
+        toolbar.addLayout(left_group, 1)
+        toolbar.addLayout(right_group, 0)
 
         layout.addLayout(toolbar)
-        layout.addSpacing(SPACE_L)
 
         self.refresh_progress = QProgressBar()
         self.refresh_progress.setRange(0, 0)  # indeterminate
@@ -180,12 +179,13 @@ class LibraryPageMixin:
         )
         layout.addWidget(self.refresh_progress)
 
-        self._category_row = QHBoxLayout()
-        self._category_row.setSpacing(SPACE_S)
+        category_wrap = QWidget()
+        self._category_row = QHBoxLayout(category_wrap)
+        self._category_row.setContentsMargins(0, SPACE_S, 0, 0)
+        self._category_row.setSpacing(8)
         self._category_btns: list[QPushButton] = []
         self._build_category_chips()
-        layout.addLayout(self._category_row)
-        layout.addSpacing(SPACE_XL)
+        layout.addWidget(category_wrap)
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
@@ -378,25 +378,58 @@ class LibraryPageMixin:
         self.app_list_layout.addStretch()
 
     def _make_app_card(self, app: AppInfo) -> QWidget:
-        """Grid card with large avatar, name, and launch."""
+        """Grid card with compact app identity, status, and launch footer."""
         card = QFrame()
         card.setObjectName("appCard")
         card.setStyleSheet(APP_CARD)
-        card.setMinimumHeight(238)
         card.setMinimumWidth(188)
+        card.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Maximum)
         add_shadow(card, blur=12, y=2, alpha=28)
 
         vl = QVBoxLayout(card)
         vl.setContentsMargins(SPACE_L, SPACE_L, SPACE_L, SPACE_L)
-        vl.setSpacing(SPACE_S)
+        vl.setSpacing(SPACE_M)
 
         top_row = QHBoxLayout()
         top_row.setContentsMargins(0, 0, 0, 0)
-        top_row.setSpacing(0)
+        top_row.setSpacing(SPACE_M)
 
-        avatar = make_app_avatar(app, size=52, radius=14, font_size=22)
+        avatar = make_app_avatar(app, size=44, radius=12, font_size=19)
         top_row.addWidget(avatar, alignment=Qt.AlignmentFlag.AlignLeft)
-        top_row.addStretch()
+
+        identity = QVBoxLayout()
+        identity.setContentsMargins(0, 0, 0, 0)
+        identity.setSpacing(4)
+
+        name_lbl = QLabel(app.full_name)
+        name_lbl.setStyleSheet(
+            f"background: transparent; color: {C.TEXT}; font-size: 13px; font-weight: 500;"
+        )
+        name_lbl.setWordWrap(False)
+        name_lbl.setMaximumWidth(156)
+        fm = name_lbl.fontMetrics()
+        elided = fm.elidedText(app.full_name, Qt.TextElideMode.ElideRight, 156)
+        name_lbl.setText(elided)
+        name_lbl.setToolTip(app.full_name)
+        identity.addWidget(name_lbl)
+
+        meta_parts = []
+        if app.categories:
+            meta_parts.append(", ".join(app.categories[:2]))
+        meta_parts.append(app.name)
+        if app.hidden:
+            meta_parts.append(tr("Hidden"))
+        meta_lbl = QLabel(" • ".join(meta_parts))
+        meta_lbl.setStyleSheet(f"background: transparent; color: {C.OVERLAY0}; font-size: 11px;")
+        meta_lbl.setWordWrap(False)
+        meta_lbl.setMaximumWidth(156)
+        meta_elided = meta_lbl.fontMetrics().elidedText(
+            meta_lbl.text(), Qt.TextElideMode.ElideRight, 156
+        )
+        meta_lbl.setText(meta_elided)
+        identity.addWidget(meta_lbl)
+
+        top_row.addLayout(identity, 1)
 
         badge = make_source_badge(app)
         if badge is not None:
@@ -404,84 +437,54 @@ class LibraryPageMixin:
 
         vl.addLayout(top_row)
 
-        name_lbl = QLabel(app.full_name)
-        name_lbl.setStyleSheet(
-            f"background: transparent; color: {C.TEXT}; font-size: 13px; font-weight: 500;"
-        )
-        name_lbl.setWordWrap(False)
-        name_lbl.setMaximumWidth(200)
-        fm = name_lbl.fontMetrics()
-        elided = fm.elidedText(app.full_name, Qt.TextElideMode.ElideRight, 200)
-        name_lbl.setText(elided)
-        name_lbl.setToolTip(app.full_name)
-        vl.addWidget(name_lbl)
-
-        cat_text = app.categories[0] if app.categories else ""
-        if cat_text:
-            cat_lbl = QLabel(cat_text)
-            cat_lbl.setStyleSheet(f"background: transparent; color: {C.OVERLAY0}; font-size: 11px;")
-            vl.addWidget(cat_lbl)
-        vl.addStretch()
-
-        # Unified affordances with the list view (Task 2): a labeled
-        # "▶ Launch" button, a text Show/Hide toggle, and the same
-        # confirmed delete. Edit stays a compact "⋯" to keep the narrow
-        # card uncluttered.
-        # Launch is the primary action and gets its own full-width row so
-        # the "▶  Launch" label is never clipped in a narrow 4-column card.
-        # The secondary actions (edit / hide / delete) sit on a compact row
-        # beneath it.
-        bottom = QVBoxLayout()
-        bottom.setSpacing(SPACE_M)
-
         launch_btn = QPushButton(tr("▶  Launch"))
         launch_btn.setStyleSheet(BTN_ACCENT)
-        launch_btn.setMinimumWidth(116)
-        launch_btn.setMaximumWidth(132)
+        launch_btn.setMinimumWidth(118)
         launch_btn.setToolTip(tr("Launch {app}").format(app=app.full_name))
         launch_btn.clicked.connect(lambda _, a=app: self._launch_app(a))
-        bottom.addWidget(launch_btn, alignment=Qt.AlignmentFlag.AlignRight)
 
-        actions = QHBoxLayout()
-        actions.setSpacing(SPACE_S)
-
-        edit_btn = QPushButton("⋯")
-        edit_btn.setFixedSize(28, 28)
-        edit_btn.setToolTip(tr("Edit"))
-        edit_btn.setStyleSheet(
+        more_btn = QPushButton("⋯")
+        more_btn.setFixedSize(30, 30)
+        more_btn.setToolTip(tr("Edit"))
+        more_btn.setStyleSheet(
             f"""
             QPushButton {{
                 background: transparent;
                 color: {C.OVERLAY0};
                 border: none;
-                border-radius: 14px;
+                border-radius: 15px;
                 font-size: 16px;
             }}
             QPushButton:hover {{
                 color: {C.TEXT};
                 background: {C.SURFACE1};
             }}
+            QPushButton::menu-indicator {{
+                image: none;
+                width: 0px;
+            }}
             """
         )
-        edit_btn.clicked.connect(lambda _, a=app: self._on_edit_app(a))
-        actions.addWidget(edit_btn)
 
-        hide_btn = QPushButton(tr("Show") if app.hidden else tr("Hide"))
-        hide_btn.setToolTip(tr("Show in menu") if app.hidden else tr("Hide from menu"))
-        hide_btn.setStyleSheet(BTN_SECONDARY)
-        hide_btn.clicked.connect(lambda _, a=app: self._on_toggle_app_hidden(a))
-        actions.addWidget(hide_btn)
-        actions.addStretch()
+        menu = QMenu(more_btn)
+        edit_action = menu.addAction(tr("Edit"))
+        edit_action.triggered.connect(lambda _, a=app: self._on_edit_app(a))
 
-        del_btn = QPushButton("✕")
-        del_btn.setFixedSize(28, 28)
-        del_btn.setToolTip(tr("Delete"))
-        del_btn.setStyleSheet(BTN_DANGER)
-        del_btn.clicked.connect(lambda _, a=app: self._on_delete_app(a))
-        actions.addWidget(del_btn)
+        hide_action = menu.addAction(tr("Show") if app.hidden else tr("Hide"))
+        hide_action.setToolTip(tr("Show in menu") if app.hidden else tr("Hide from menu"))
+        hide_action.triggered.connect(lambda _, a=app: self._on_toggle_app_hidden(a))
 
-        bottom.addLayout(actions)
-        vl.addLayout(bottom)
+        delete_action = menu.addAction(tr("Delete"))
+        delete_action.triggered.connect(lambda _, a=app: self._on_delete_app(a))
+        more_btn.setMenu(menu)
+
+        footer = QHBoxLayout()
+        footer.setContentsMargins(0, 0, 0, 0)
+        footer.setSpacing(SPACE_S)
+        footer.addWidget(launch_btn, 0, Qt.AlignmentFlag.AlignLeft)
+        footer.addStretch()
+        footer.addWidget(more_btn, 0, Qt.AlignmentFlag.AlignRight)
+        vl.addLayout(footer)
         return card
 
     def _make_app_tile(self, app: AppInfo) -> QWidget:

--- a/src/winpodx/gui/_main_window_license.py
+++ b/src/winpodx/gui/_main_window_license.py
@@ -29,14 +29,13 @@ from PySide6.QtWidgets import (
 )
 
 from winpodx.core.i18n import tr
-from winpodx.gui._widget_helpers import add_shadow, make_page_heading
+from winpodx.gui._widget_helpers import add_shadow, make_page_header
 from winpodx.gui.theme import (
     SCROLL_AREA,
     SETTINGS_SECTION,
     SPACE_L,
     SPACE_M,
     SPACE_S,
-    SPACE_XL,
     SPACE_XXL,
     TERMINAL,
     C,
@@ -176,12 +175,12 @@ class LicensePageMixin:
 
         content = QWidget()
         layout = QVBoxLayout(content)
-        layout.setContentsMargins(SPACE_XXL, SPACE_XL, SPACE_XXL, SPACE_XXL)
+        layout.setContentsMargins(SPACE_XXL, 0, SPACE_XXL, SPACE_XXL)
         layout.setSpacing(SPACE_M)
 
         # --- License title -------------------------------------------------
         layout.addWidget(
-            make_page_heading(
+            make_page_header(
                 tr("License"),
                 tr(
                     "WinPodX is MIT-licensed open source. See LICENSE in the source "

--- a/src/winpodx/gui/_main_window_license.py
+++ b/src/winpodx/gui/_main_window_license.py
@@ -203,7 +203,7 @@ class LicensePageMixin:
         # --- Third-party acknowledgments -----------------------------------
         ack_header = QLabel(tr("Third-party components"))
         ack_header.setStyleSheet(
-            f"background: transparent; color: {C.BLUE}; font-size: 15px; font-weight: bold;"
+            f"background: transparent; color: {C.BLUE}; font-size: 15px; font-weight: 600;"
         )
         layout.addWidget(ack_header)
 
@@ -231,7 +231,7 @@ class LicensePageMixin:
 
             heading = QLabel(f"{name}  ·  {license_}")
             heading.setStyleSheet(
-                f"background: transparent; color: {C.TEXT}; font-size: 13px; font-weight: bold;"
+                f"background: transparent; color: {C.TEXT}; font-size: 13px; font-weight: 500;"
             )
             row_layout.addWidget(heading)
 

--- a/src/winpodx/gui/_main_window_logs.py
+++ b/src/winpodx/gui/_main_window_logs.py
@@ -35,7 +35,7 @@ from PySide6.QtWidgets import (
 
 from winpodx.core.config import Config
 from winpodx.core.i18n import tr
-from winpodx.gui._widget_helpers import make_page_heading
+from winpodx.gui._widget_helpers import make_page_header
 from winpodx.gui.theme import (
     BTN_GHOST,
     BTN_PRIMARY,
@@ -256,13 +256,13 @@ class LogsMixin:
     def _build_logs_page(self) -> QWidget:
         page = QWidget()
         layout = QVBoxLayout(page)
-        layout.setContentsMargins(SPACE_XXL, SPACE_XL, SPACE_XXL, SPACE_XL)
+        layout.setContentsMargins(SPACE_XXL, 0, SPACE_XXL, SPACE_XL)
         layout.setSpacing(SPACE_M)
 
-        header = QHBoxLayout()
-        header.setSpacing(SPACE_S)
-        header.addWidget(make_page_heading(tr("Terminal")))
-        header.addSpacing(SPACE_M)
+        actions = QWidget()
+        actions_l = QHBoxLayout(actions)
+        actions_l.setContentsMargins(0, 0, 0, 0)
+        actions_l.setSpacing(SPACE_S)
 
         # Log level dropdown — changes both what gets written to
         # ``~/.config/winpodx/winpodx.log`` (which the "Live (app)"
@@ -273,7 +273,7 @@ class LogsMixin:
         # when triaging an "agent not ready" / "starting" stuck state).
         level_label = QLabel(tr("Log level:"))
         level_label.setStyleSheet(f"background: transparent; color: {C.SUBTEXT0}; font-size: 12px;")
-        header.addWidget(level_label)
+        actions_l.addWidget(level_label)
         self.input_log_level = QComboBox()
         self.input_log_level.setStyleSheet(COMBO)
         self.input_log_level.setFixedWidth(140)
@@ -308,8 +308,7 @@ class LogsMixin:
             )
         )
         self.input_log_level.currentIndexChanged.connect(self._on_log_level_changed)
-        header.addWidget(self.input_log_level)
-        header.addStretch()
+        actions_l.addWidget(self.input_log_level)
 
         # Route container name through cfg so renamed pods still work.
         # v0.5.1: dropped the "Live (app)" / "Live (pod)" / "Stop tail"
@@ -349,10 +348,9 @@ class LogsMixin:
                 btn.clicked.connect(self._on_tail_app_log)
             else:
                 btn.clicked.connect(lambda _, c=cmd: self._run_log_cmd(c))
-            header.addWidget(btn)
+            actions_l.addWidget(btn)
 
-        layout.addLayout(header)
-        layout.addSpacing(SPACE_S)
+        layout.addWidget(make_page_header(tr("Terminal"), actions_widget=actions))
 
         self.log_output = QTextEdit()
         self.log_output.setReadOnly(True)

--- a/src/winpodx/gui/_main_window_logs.py
+++ b/src/winpodx/gui/_main_window_logs.py
@@ -364,7 +364,7 @@ class LogsMixin:
 
         prompt = QLabel("❯")
         prompt.setStyleSheet(
-            f"background: transparent; color: {C.BLUE}; font-size: 16px; font-weight: bold;"
+            f"background: transparent; color: {C.BLUE}; font-size: 16px; font-weight: 500;"
         )
         cmd_row.addWidget(prompt)
 

--- a/src/winpodx/gui/_main_window_maintenance.py
+++ b/src/winpodx/gui/_main_window_maintenance.py
@@ -53,11 +53,16 @@ from winpodx.gui.theme import (
     BTN_SECONDARY,
     SCROLL_AREA,
     SPACE_L,
+    SPACE_M,
     SPACE_S,
     SPACE_XL,
     SPACE_XXL,
+    TOOL_ICON_BG,
+    TOOL_ICON_BORDER,
+    TOOL_ICON_FG,
     C,
     accent_color,
+    rgba,
 )
 
 log = logging.getLogger(__name__)
@@ -139,6 +144,8 @@ class MaintenanceMixin:
         ]
         for i, (icon, label, desc, handler) in enumerate(pod_tools):
             layout.addWidget(self._make_action_row(icon, label, desc, handler, i))
+            if i < len(pod_tools) - 1:
+                layout.addSpacing(SPACE_M)
 
         layout.addSpacing(SPACE_XL)
 
@@ -173,6 +180,8 @@ class MaintenanceMixin:
         ]
         for i, (icon, label, desc, handler) in enumerate(sys_tools):
             layout.addWidget(self._make_action_row(icon, label, desc, handler, i + 3))
+            if i < len(sys_tools) - 1:
+                layout.addSpacing(SPACE_M)
 
         layout.addSpacing(SPACE_XL)
 
@@ -182,24 +191,26 @@ class MaintenanceMixin:
         update_row = QFrame()
         update_row.setObjectName("actionRow")
         update_row.setStyleSheet(ACTION_ROW)
-        update_row.setMinimumHeight(64)
+        update_row.setMinimumHeight(76)
         rl = QHBoxLayout(update_row)
         rl.setContentsMargins(SPACE_L, SPACE_S, SPACE_L, SPACE_S)
         rl.setSpacing(SPACE_L)
 
         update_icon = QLabel("⇅")
-        update_icon.setFixedSize(36, 36)
+        update_icon.setFixedSize(38, 38)
         update_icon.setAlignment(Qt.AlignmentFlag.AlignCenter)
         update_icon.setStyleSheet(
-            f"background: {accent_color(7)}; color: {C.TEXT}; border-radius: 8px; font-size: 16px;"
+            f"background: {TOOL_ICON_BG}; color: {TOOL_ICON_FG};"
+            f" border: 1px solid {TOOL_ICON_BORDER}; border-radius: 14px;"
+            f" font-size: 16px; font-weight: 500;"
         )
         rl.addWidget(update_icon)
 
         col = QVBoxLayout()
-        col.setSpacing(2)
+        col.setSpacing(4)
         lbl = QLabel(tr("Windows Update"))
         lbl.setStyleSheet(
-            f"background: transparent; color: {C.TEXT}; font-size: 14px; font-weight: 600;"
+            f"background: transparent; color: {C.TEXT}; font-size: 14px; font-weight: 500;"
         )
         col.addWidget(lbl)
         self._update_status_label = QLabel(tr("Checking..."))
@@ -247,7 +258,7 @@ class MaintenanceMixin:
         sessions_box_host = QWidget()
         self._sessions_box = QVBoxLayout(sessions_box_host)
         self._sessions_box.setContentsMargins(0, 0, 0, 0)
-        self._sessions_box.setSpacing(8)
+        self._sessions_box.setSpacing(SPACE_M)
         layout.addWidget(sessions_box_host)
 
         # Live refresh: poll while the Tools page is visible so launching or
@@ -307,16 +318,18 @@ class MaintenanceMixin:
         row = QFrame()
         row.setObjectName("actionRow")
         row.setStyleSheet(ACTION_ROW)
-        row.setMinimumHeight(56)
+        row.setMinimumHeight(68)
         rl = QHBoxLayout(row)
         rl.setContentsMargins(SPACE_L, SPACE_S, SPACE_L, SPACE_S)
         rl.setSpacing(SPACE_L)
 
         icon = QLabel("▢")
-        icon.setFixedSize(36, 36)
+        icon.setFixedSize(38, 38)
         icon.setAlignment(Qt.AlignmentFlag.AlignCenter)
         icon.setStyleSheet(
-            f"background: {accent_color(0)}; color: {C.TEXT}; border-radius: 8px; font-size: 16px;"
+            f"background: {TOOL_ICON_BG}; color: {TOOL_ICON_FG};"
+            f" border: 1px solid {TOOL_ICON_BORDER}; border-radius: 14px;"
+            f" font-size: 16px; font-weight: 500;"
         )
         rl.addWidget(icon)
 
@@ -324,7 +337,7 @@ class MaintenanceMixin:
         col.setSpacing(2)
         name = QLabel(app_name)
         name.setStyleSheet(
-            f"background: transparent; color: {C.TEXT}; font-size: 14px; font-weight: 600;"
+            f"background: transparent; color: {C.TEXT}; font-size: 14px; font-weight: 500;"
         )
         col.addWidget(name)
         meta = QLabel(tr("PID {pid}").format(pid=pid))
@@ -371,28 +384,30 @@ class MaintenanceMixin:
         row = QFrame()
         row.setObjectName("actionRow")
         row.setStyleSheet(ACTION_ROW)
-        row.setMinimumHeight(64)
+        row.setMinimumHeight(76)
         row.setCursor(Qt.CursorShape.PointingHandCursor)
-        add_shadow(row, blur=12, y=2, alpha=35)
+        add_shadow(row, blur=10, y=2, alpha=26)
 
         rl = QHBoxLayout(row)
-        rl.setContentsMargins(SPACE_L, 0, SPACE_XL, 0)
+        rl.setContentsMargins(SPACE_L, SPACE_S, SPACE_XL, SPACE_S)
         rl.setSpacing(SPACE_L)
 
         color = accent_color(color_idx)
         icon_circle = QLabel(icon)
-        icon_circle.setFixedSize(36, 36)
+        icon_circle.setFixedSize(38, 38)
         icon_circle.setAlignment(Qt.AlignmentFlag.AlignCenter)
         icon_circle.setStyleSheet(
-            f"background: {color}; color: {C.CRUST}; border-radius: 18px; font-size: 16px;"
+            f"background: {TOOL_ICON_BG}; color: {TOOL_ICON_FG};"
+            f" border: 1px solid {TOOL_ICON_BORDER}; border-left: 2px solid {rgba(color, 0.42)};"
+            f" border-radius: 14px; font-size: 16px; font-weight: 500;"
         )
         rl.addWidget(icon_circle)
 
         text_col = QVBoxLayout()
-        text_col.setSpacing(1)
+        text_col.setSpacing(4)
         title_lbl = QLabel(label)
         title_lbl.setStyleSheet(
-            f"background: transparent; color: {C.TEXT}; font-size: 14px; font-weight: bold;"
+            f"background: transparent; color: {C.TEXT}; font-size: 14px; font-weight: 500;"
         )
         text_col.addWidget(title_lbl)
         desc_lbl = QLabel(desc)

--- a/src/winpodx/gui/_main_window_maintenance.py
+++ b/src/winpodx/gui/_main_window_maintenance.py
@@ -42,7 +42,7 @@ from winpodx.gui._widget_helpers import (
     BusyDialog,
     add_shadow,
     make_empty_panel,
-    make_page_heading,
+    make_page_header,
     make_section_label,
     make_warning_callout,
 )
@@ -126,12 +126,10 @@ class MaintenanceMixin:
 
         content = QWidget()
         layout = QVBoxLayout(content)
-        layout.setContentsMargins(SPACE_XXL, SPACE_XL, SPACE_XXL, SPACE_XL)
+        layout.setContentsMargins(SPACE_XXL, 0, SPACE_XXL, SPACE_XL)
         layout.setSpacing(0)
 
-        layout.addWidget(
-            make_page_heading(tr("Tools"), tr("System maintenance and pod management"))
-        )
+        layout.addWidget(make_page_header(tr("Tools"), tr("System maintenance and pod management")))
         layout.addSpacing(SPACE_XL)
 
         layout.addWidget(make_section_label(tr("Pod Management")))

--- a/src/winpodx/gui/_main_window_pod.py
+++ b/src/winpodx/gui/_main_window_pod.py
@@ -216,7 +216,7 @@ class PodStatusMixin:
         else:
             agent_color = red
         self.agent_dot.setStyleSheet(
-            f"background: transparent; color: {agent_color}; font-size: 10px; font-weight: bold;"
+            f"background: transparent; color: {agent_color}; font-size: 10px; font-weight: 500;"
         )
         if agent_ok:
             tip = (
@@ -232,7 +232,7 @@ class PodStatusMixin:
 
         self.rdp_dot.setStyleSheet(
             f"background: transparent; color: {green if rdp_ok else red}; "
-            f"font-size: 10px; font-weight: bold;"
+            f"font-size: 10px; font-weight: 500;"
         )
         self.rdp_dot.setToolTip(
             tr("RDP port 3390 reachable")

--- a/src/winpodx/gui/_main_window_settings.py
+++ b/src/winpodx/gui/_main_window_settings.py
@@ -602,7 +602,7 @@ class SettingsPageMixin:
         applies_now_header = QLabel(tr("Applies immediately"))
         applies_now_header.setStyleSheet(
             f"background: transparent; color: {C.SUBTEXT0}; "
-            f"font-size: {FONT_CAPTION}px; font-weight: bold;"
+            f"font-size: {FONT_CAPTION}px; font-weight: 500;"
         )
         layout.addWidget(applies_now_header)
         applies_now_caption = QLabel(
@@ -752,7 +752,7 @@ class SettingsPageMixin:
         header = QLabel(tr("◨  Performance Tuning"))
         header.setStyleSheet(
             f"background: transparent; color: {C.BLUE}; "
-            f"font-size: {FONT_HEADER}px; font-weight: bold;"
+            f"font-size: {FONT_HEADER}px; font-weight: 600;"
         )
         layout.addWidget(header)
 
@@ -785,7 +785,7 @@ class SettingsPageMixin:
         summary_header = QLabel(tr("Detection summary (this host)"))
         summary_header.setStyleSheet(
             f"background: transparent; color: {C.SUBTEXT0}; "
-            f"font-size: {FONT_CAPTION}px; font-weight: bold;"
+            f"font-size: {FONT_CAPTION}px; font-weight: 500;"
         )
         layout.addWidget(summary_header)
 
@@ -836,7 +836,7 @@ class SettingsPageMixin:
         header = QLabel(title)
         header.setStyleSheet(
             f"background: transparent; color: {C.BLUE}; "
-            f"font-size: {FONT_HEADER}px; font-weight: bold;"
+            f"font-size: {FONT_HEADER}px; font-weight: 600;"
         )
         layout.addWidget(header)
 

--- a/src/winpodx/gui/_main_window_settings.py
+++ b/src/winpodx/gui/_main_window_settings.py
@@ -39,7 +39,7 @@ from PySide6.QtWidgets import (
 
 from winpodx.core.config import Config
 from winpodx.core.i18n import tr
-from winpodx.gui._widget_helpers import add_shadow, make_page_heading, make_warning_callout
+from winpodx.gui._widget_helpers import add_shadow, make_page_header, make_warning_callout
 from winpodx.gui.theme import (
     BTN_PRIMARY,
     CHECKBOX,
@@ -201,11 +201,19 @@ class SettingsPageMixin:
 
         content = QWidget()
         layout = QVBoxLayout(content)
-        layout.setContentsMargins(SPACE_XXL, SPACE_XL, SPACE_XXL, SPACE_XL)
+        layout.setContentsMargins(SPACE_XXL, 0, SPACE_XXL, SPACE_XL)
         layout.setSpacing(SPACE_M)
 
+        save_btn = QPushButton(tr("Save Settings"))
+        save_btn.setStyleSheet(BTN_PRIMARY)
+        save_btn.setFixedWidth(180)
+        save_btn.clicked.connect(self._save_settings)
         layout.addWidget(
-            make_page_heading(tr("Settings"), tr("Configure RDP and container settings"))
+            make_page_header(
+                tr("Settings"),
+                tr("Configure RDP and container settings"),
+                actions_widget=save_btn,
+            )
         )
 
         cols = QHBoxLayout()
@@ -705,12 +713,6 @@ class SettingsPageMixin:
         self._update_budget_warning()
 
         layout.addSpacing(SPACE_L)
-
-        save_btn = QPushButton(tr("Save Settings"))
-        save_btn.setStyleSheet(BTN_PRIMARY)
-        save_btn.setFixedWidth(180)
-        save_btn.clicked.connect(self._save_settings)
-        layout.addWidget(save_btn)
 
         save_caption = QLabel(
             tr("Persists the form fields above. The ‘Applies immediately’ controls save on change.")

--- a/src/winpodx/gui/_widget_helpers.py
+++ b/src/winpodx/gui/_widget_helpers.py
@@ -47,6 +47,7 @@ from winpodx.gui.theme import (
     SPACE_M,
     SPACE_S,
     SPACE_XL,
+    SPACE_XS,
     C,
     avatar_color,
 )
@@ -317,11 +318,11 @@ def make_warning_callout(text: str, *, level: str = "warn") -> QFrame:
 
 
 def make_page_heading(title: str, subtitle: str = "") -> QWidget:
-    """Build a consistent page title/subtitle block."""
+    """Build a title/subtitle block for use inside a page header."""
     holder = QWidget()
     layout = QVBoxLayout(holder)
     layout.setContentsMargins(0, 0, 0, 0)
-    layout.setSpacing(SPACE_S)
+    layout.setSpacing(SPACE_XS)
 
     title_lbl = QLabel(title)
     title_lbl.setStyleSheet(PAGE_TITLE)
@@ -334,6 +335,25 @@ def make_page_heading(title: str, subtitle: str = "") -> QWidget:
         layout.addWidget(subtitle_lbl)
 
     return holder
+
+
+def make_page_header(
+    title: str,
+    subtitle: str = "",
+    *,
+    actions_widget: QWidget | None = None,
+) -> QWidget:
+    """Build the shared page header with optional right-aligned actions."""
+    header = QWidget()
+    layout = QHBoxLayout(header)
+    layout.setContentsMargins(0, 16, 0, 0)
+    layout.setSpacing(16)
+
+    layout.addWidget(make_page_heading(title, subtitle), 1, Qt.AlignmentFlag.AlignTop)
+    if actions_widget is not None:
+        layout.addWidget(actions_widget, 0, Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignTop)
+
+    return header
 
 
 def make_section_label(text: str) -> QLabel:

--- a/src/winpodx/gui/_widget_helpers.py
+++ b/src/winpodx/gui/_widget_helpers.py
@@ -97,7 +97,7 @@ def make_source_badge(app: AppInfo) -> QLabel | None:
     badge.setStyleSheet(
         f"background: {bg}; color: {fg};"
         " border-radius: 7px;"
-        " font-size: 9px; font-weight: bold;"
+        " font-size: 9px; font-weight: 500;"
         " padding: 2px 7px;"
         " letter-spacing: 0px;"
     )
@@ -156,7 +156,7 @@ def make_app_avatar(app: AppInfo, size: int, *, radius: int, font_size: int) -> 
         f"background: {color};"
         f" color: {C.CRUST};"
         f" border-radius: {radius}px;"
-        f" font-size: {font_size}px; font-weight: bold;"
+        f" font-size: {font_size}px; font-weight: 600;"
     )
     return avatar
 
@@ -192,7 +192,7 @@ def show_toast(
         f"QLabel#winpodxToast {{"
         f" background: {C.SURFACE0}; color: {accent};"
         f" border: 1px solid {accent}; border-radius: {RADIUS_M}px;"
-        f" font-size: {FONT_BODY}px; font-weight: 600; padding: 8px 16px; }}"
+        f" font-size: {FONT_BODY}px; font-weight: 500; padding: 8px 16px; }}"
     )
     toast.adjustSize()
     add_shadow(toast, blur=18, y=4, alpha=70)
@@ -306,7 +306,7 @@ def make_warning_callout(text: str, *, level: str = "warn") -> QFrame:
     row.setContentsMargins(12, 10, 12, 10)
     row.setSpacing(10)
     icon = QLabel(glyph)
-    icon.setStyleSheet(f"color: {accent}; font-size: 15px; font-weight: bold;")
+    icon.setStyleSheet(f"color: {accent}; font-size: 15px; font-weight: 600;")
     icon.setAlignment(Qt.AlignmentFlag.AlignTop)
     row.addWidget(icon)
     label = QLabel(text)
@@ -364,8 +364,7 @@ def make_empty_panel(
     title_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
     title_lbl.setWordWrap(True)
     title_lbl.setStyleSheet(
-        f"background: transparent; color: {C.SUBTEXT1}; "
-        f"font-size: {FONT_BODY}px; font-weight: bold;"
+        f"background: transparent; color: {C.SUBTEXT1}; font-size: {FONT_BODY}px; font-weight: 500;"
     )
     layout.addWidget(title_lbl)
 

--- a/src/winpodx/gui/app_dialog.py
+++ b/src/winpodx/gui/app_dialog.py
@@ -82,14 +82,14 @@ class AppProfileDialog(QDialog):
         self._avatar.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._avatar.setStyleSheet(
             f"background: {color}; color: {C.CRUST};"
-            f" border-radius: 12px; font-size: 20px; font-weight: bold;"
+            f" border-radius: 12px; font-size: 20px; font-weight: 600;"
         )
         header_l.addWidget(self._avatar)
 
         title_col = QVBoxLayout()
         title_col.setSpacing(2)
         title = QLabel(tr("Edit App Profile") if edit_mode else tr("New App Profile"))
-        title.setStyleSheet(f"color: {C.TEXT}; font-size: 18px; font-weight: bold;")
+        title.setStyleSheet(f"color: {C.TEXT}; font-size: 18px; font-weight: 600;")
         title_col.addWidget(title)
         sub = QLabel(tr("Define a Windows application for WinPodX"))
         sub.setStyleSheet(f"color: {C.OVERLAY0}; font-size: 12px;")
@@ -227,7 +227,7 @@ class AppProfileDialog(QDialog):
         self._avatar.setText(letter)
         self._avatar.setStyleSheet(
             f"background: {color}; color: {C.CRUST};"
-            f" border-radius: 12px; font-size: 20px; font-weight: bold;"
+            f" border-radius: 12px; font-size: 20px; font-weight: 600;"
         )
 
     def _on_accept(self) -> None:

--- a/src/winpodx/gui/debloat_picker.py
+++ b/src/winpodx/gui/debloat_picker.py
@@ -117,7 +117,7 @@ class DebloatPickerDialog(QDialog):
 
         # --- Title + subtitle --------------------------------------------
         title = QLabel(tr("Debloat picker"))
-        title.setStyleSheet(f"font-size: 18px; font-weight: bold; color: {C.TEXT};")
+        title.setStyleSheet(f"font-size: 18px; font-weight: 600; color: {C.TEXT};")
         outer.addWidget(title)
 
         subtitle = QLabel(
@@ -154,7 +154,7 @@ class DebloatPickerDialog(QDialog):
         preset_row = QHBoxLayout()
         preset_row.setSpacing(SPACE_L)
         preset_label = QLabel(tr("Preset:"))
-        preset_label.setStyleSheet(f"font-weight: 600; color: {C.SUBTEXT0};")
+        preset_label.setStyleSheet(f"font-weight: 500; color: {C.SUBTEXT0};")
         preset_row.addWidget(preset_label)
 
         self._preset_group = QButtonGroup(self)
@@ -210,7 +210,7 @@ class DebloatPickerDialog(QDialog):
             badge.setStyleSheet(
                 f"background: {_RISK_COLOR.get(item.risk, '#888')};"
                 f" color: {C.CRUST}; border-radius: 6px;"
-                " padding: 2px 4px; font-size: 11px; font-weight: bold;"
+                " padding: 2px 4px; font-size: 11px; font-weight: 500;"
             )
             row.addWidget(badge)
 

--- a/src/winpodx/gui/main_window.py
+++ b/src/winpodx/gui/main_window.py
@@ -154,8 +154,8 @@ class WinpodxWindow(
         self.pages.addWidget(self._build_maintenance_page())
         self.pages.addWidget(self._build_logs_page())
         self.pages.addWidget(self._build_info_page())
-        self.pages.addWidget(self._build_license_page())
         self.pages.addWidget(self._build_devices_page())
+        self.pages.addWidget(self._build_license_page())
         root.addWidget(self.pages)
 
         root.addWidget(self._build_info_bar())

--- a/src/winpodx/gui/reverse_open_panel.py
+++ b/src/winpodx/gui/reverse_open_panel.py
@@ -205,7 +205,7 @@ def build_panel(cfg: Config, parent: QWidget | None = None) -> QWidget:
     layout.setSpacing(SPACE_S)
 
     title = QLabel(tr("▦  Reverse File Associations"))
-    title.setStyleSheet(f"color: {C.BLUE}; font-size: 15px; font-weight: bold;")
+    title.setStyleSheet(f"color: {C.BLUE}; font-size: 15px; font-weight: 600;")
     layout.addWidget(title)
 
     sub = QLabel(tr("Linux apps appear in the Windows guest's right-click ‘Open with…’ menu."))
@@ -249,8 +249,8 @@ def build_panel(cfg: Config, parent: QWidget | None = None) -> QWidget:
     lists_grid.setVerticalSpacing(SPACE_S)
     allow_label = QLabel(tr("Allowlist (empty = show all discovered apps)"))
     deny_label = QLabel(tr("Denylist (apps to hide)"))
-    allow_label.setStyleSheet(f"color: {C.SUBTEXT0}; font-size: 12px; font-weight: bold;")
-    deny_label.setStyleSheet(f"color: {C.SUBTEXT0}; font-size: 12px; font-weight: bold;")
+    allow_label.setStyleSheet(f"color: {C.SUBTEXT0}; font-size: 12px; font-weight: 500;")
+    deny_label.setStyleSheet(f"color: {C.SUBTEXT0}; font-size: 12px; font-weight: 500;")
     allow_list = QListWidget()
     deny_list = QListWidget()
     for slug in cfg.reverse_open.allowlist:

--- a/src/winpodx/gui/theme.py
+++ b/src/winpodx/gui/theme.py
@@ -15,8 +15,8 @@ class C:
     MAROON = "#da3633"
     PEACH = "#ffa657"
     YELLOW = "#d29922"
-    GREEN = "#3fb950"
-    TEAL = "#56d364"
+    GREEN = "#74b985"
+    TEAL = "#8ac994"
     SKY = "#79c0ff"
     SAPPHIRE = "#388bfd"
     BLUE = "#58a6ff"
@@ -57,12 +57,12 @@ def rgba(hex_color: str, alpha: float) -> str:
 # setContentsMargins.
 # --------------------------------------------------------------------------- #
 SPACE_XS = 4
-SPACE_S = 8
-SPACE_M = 12
-SPACE_L = 16
-SPACE_XL = 24
-SPACE_XXL = 32
-SPACE_XXXL = 40
+SPACE_S = 10
+SPACE_M = 14
+SPACE_L = 20
+SPACE_XL = 30
+SPACE_XXL = 40
+SPACE_XXXL = 52
 
 # Border radius scale. Match button / card / input visual weight.
 RADIUS_XS = 4  # inline chips, badges
@@ -83,9 +83,16 @@ FONT_DISPLAY = 24  # sparse page hero title
 
 CONTROL_HEIGHT = 36
 CONTROL_HEIGHT_L = 40
-CARD_BORDER = f"1px solid {C.SURFACE1}"
-CARD_BORDER_HOVER = f"1px solid {C.SURFACE2}"
+CARD_BORDER = f"1px solid {rgba(C.SURFACE2, 0.44)}"
+CARD_BORDER_HOVER = f"1px solid {rgba(C.BLUE, 0.42)}"
 FOCUS_RING = f"1px solid {C.BLUE}"
+ACCENT_GREEN = "#74b985"
+ACCENT_GREEN_HOVER = "#85c694"
+ACCENT_GREEN_PRESSED = "#669f73"
+TOOL_ACCENT = "#8aa4be"
+TOOL_ICON_BG = rgba(TOOL_ACCENT, 0.12)
+TOOL_ICON_BORDER = rgba(TOOL_ACCENT, 0.28)
+TOOL_ICON_FG = "#b8c8d7"
 
 
 _AVATAR_PALETTE = [
@@ -100,14 +107,7 @@ _AVATAR_PALETTE = [
 ]
 
 _ACCENT_PALETTE = [
-    C.BLUE,
-    C.MAUVE,
-    C.PEACH,
-    C.GREEN,
-    C.PINK,
-    C.TEAL,
-    C.SAPPHIRE,
-    C.LAVENDER,
+    TOOL_ACCENT,
 ]
 
 
@@ -117,7 +117,7 @@ def avatar_color(name: str) -> str:
 
 
 def accent_color(index: int) -> str:
-    """Rotating accent for tool icons."""
+    """Muted accent for tool icons."""
     return _ACCENT_PALETTE[index % len(_ACCENT_PALETTE)]
 
 
@@ -195,7 +195,7 @@ TAB_BTN = f"""
         color: {C.BLUE};
         border-bottom: 2px solid {C.BLUE};
         background: {rgba(C.BLUE, 0.10)};
-        font-weight: bold;
+        font-weight: 600;
     }}
 """
 
@@ -332,20 +332,19 @@ SEARCH_BAR = f"""
 # Buttons
 BTN_PRIMARY = f"""
     QPushButton {{
-        background: {C.BLUE};
+        background: {rgba(C.BLUE, 0.88)};
         color: {C.CRUST};
         font-size: 13px;
-        font-weight: bold;
-        border: 1px solid rgba(255, 255, 255, 0.1);
-        border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+        font-weight: 500;
+        border: 1px solid {rgba(C.LAVENDER, 0.22)};
         border-radius: {RADIUS_M}px;
-        padding: 9px 20px;
+        padding: 8px 18px;
         min-height: 18px;
     }}
-    QPushButton:hover {{ background: {C.SAPPHIRE}; }}
+    QPushButton:hover {{ background: {C.BLUE}; }}
     QPushButton:pressed {{
         background: {C.SAPPHIRE};
-        border: 1px solid rgba(0, 0, 0, 0.2);
+        border: 1px solid {rgba(C.BLUE, 0.34)};
     }}
     QPushButton:disabled {{
         background: {C.SURFACE1};
@@ -356,34 +355,34 @@ BTN_PRIMARY = f"""
 
 BTN_SECONDARY = f"""
     QPushButton {{
-        background: {C.SURFACE0};
+        background: {rgba(C.SURFACE0, 0.72)};
         color: {C.TEXT};
         font-size: 13px;
-        border: 1px solid {C.SURFACE1};
+        font-weight: 400;
+        border: 1px solid {rgba(C.SURFACE2, 0.38)};
         border-radius: {RADIUS_M}px;
-        padding: 8px 16px;
+        padding: 8px 15px;
         min-height: 18px;
     }}
     QPushButton:hover {{
-        background: {C.SURFACE1};
+        background: {rgba(C.SURFACE1, 0.72)};
     }}
     QPushButton:pressed {{ background: {C.SURFACE2}; }}
 """
 
 BTN_ACCENT = f"""
     QPushButton {{
-        background: {C.GREEN};
+        background: {ACCENT_GREEN};
         color: {C.CRUST};
         font-size: 13px;
-        font-weight: bold;
-        border: 1px solid rgba(255, 255, 255, 0.1);
-        border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+        font-weight: 500;
+        border: 1px solid {rgba(C.TEXT, 0.10)};
         border-radius: {RADIUS_M}px;
-        padding: 8px 18px;
-        min-height: 18px;
+        padding: 7px 16px;
+        min-height: 16px;
     }}
-    QPushButton:hover {{ background: {C.TEAL}; }}
-    QPushButton:pressed {{ background: {C.GREEN}; }}
+    QPushButton:hover {{ background: {ACCENT_GREEN_HOVER}; }}
+    QPushButton:pressed {{ background: {ACCENT_GREEN_PRESSED}; }}
     QPushButton:disabled {{
         background: {C.SURFACE1};
         color: {C.OVERLAY0};
@@ -396,6 +395,7 @@ BTN_DANGER = f"""
         background: transparent;
         color: {C.PEACH};
         font-size: 13px;
+        font-weight: 400;
         border: 1px solid {rgba(C.RED, 0.24)};
         border-radius: {RADIUS_M}px;
         padding: 7px 12px;
@@ -422,6 +422,7 @@ BTN_GHOST = f"""
         background: transparent;
         color: {C.SUBTEXT0};
         font-size: 12px;
+        font-weight: 400;
         border: none;
         border-radius: {RADIUS_S}px;
         padding: 7px 12px;
@@ -443,10 +444,11 @@ BTN_GHOST = f"""
 # Filter chip.
 FILTER_CHIP = f"""
     QPushButton {{
-        background: {C.SURFACE0};
+        background: {rgba(C.SURFACE0, 0.72)};
         color: {C.SUBTEXT0};
         font-size: 12px;
-        border: 1px solid {C.SURFACE1};
+        font-weight: 400;
+        border: 1px solid {rgba(C.SURFACE2, 0.36)};
         border-radius: 13px;
         padding: 5px 16px;
         min-height: 18px;
@@ -460,7 +462,7 @@ FILTER_CHIP = f"""
         color: {C.BLUE};
         border-color: {C.BLUE};
         background: {rgba(C.BLUE, 0.12)};
-        font-weight: bold;
+        font-weight: 500;
     }}
 """
 
@@ -489,52 +491,52 @@ VIEW_TOGGLE = f"""
 # App Card (grid view).
 APP_CARD = f"""
     QFrame#appCard {{
-        background: {C.SURFACE0};
-        border: 1px solid {C.SURFACE1};
-        border-top: 1px solid rgba(255, 255, 255, 0.06);
+        background: {rgba(C.SURFACE0, 0.72)};
+        border: {CARD_BORDER};
+        border-top: 1px solid rgba(255, 255, 255, 0.045);
         border-radius: {RADIUS_XXL}px;
     }}
     QFrame#appCard:hover {{
-        background: {rgba(C.SURFACE1, 0.82)};
-        border-color: {C.BLUE};
-        border-top: 1px solid rgba(255, 255, 255, 0.1);
+        background: {rgba(C.SURFACE1, 0.54)};
+        border: {CARD_BORDER_HOVER};
+        border-top: 1px solid rgba(255, 255, 255, 0.075);
     }}
 """
 
 # App Tile (list view).
 APP_TILE = f"""
     QFrame#appTile {{
-        background: {C.SURFACE0};
-        border: 1px solid {C.SURFACE1};
-        border-top: 1px solid rgba(255, 255, 255, 0.06);
+        background: {rgba(C.SURFACE0, 0.70)};
+        border: {CARD_BORDER};
+        border-top: 1px solid rgba(255, 255, 255, 0.045);
         border-radius: {RADIUS_L}px;
     }}
     QFrame#appTile:hover {{
-        background: {rgba(C.SURFACE1, 0.82)};
-        border-color: {C.BLUE};
+        background: {rgba(C.SURFACE1, 0.52)};
+        border: {CARD_BORDER_HOVER};
     }}
 """
 
 # Tool Action Row (maintenance page).
 ACTION_ROW = f"""
     QFrame#actionRow {{
-        background: {C.SURFACE0};
-        border: 1px solid {C.SURFACE1};
-        border-top: 1px solid rgba(255, 255, 255, 0.06);
+        background: {rgba(C.SURFACE0, 0.68)};
+        border: {CARD_BORDER};
+        border-top: 1px solid rgba(255, 255, 255, 0.04);
         border-radius: {RADIUS_XL}px;
     }}
     QFrame#actionRow:hover {{
-        background: {rgba(C.SURFACE1, 0.82)};
-        border-color: {C.SURFACE2};
+        background: {rgba(C.SURFACE1, 0.50)};
+        border-color: {rgba(C.SURFACE2, 0.64)};
     }}
 """
 
 # Settings Section
 SETTINGS_SECTION = f"""
     QFrame#settingsSection {{
-        background: {C.SURFACE0};
-        border: 1px solid {C.SURFACE1};
-        border-top: 1px solid rgba(255, 255, 255, 0.06);
+        background: {rgba(C.SURFACE0, 0.70)};
+        border: {CARD_BORDER};
+        border-top: 1px solid rgba(255, 255, 255, 0.045);
         border-radius: {RADIUS_XXL}px;
     }}
 """
@@ -554,7 +556,7 @@ SECTION_LABEL = f"""
         background: transparent;
         color: {C.SUBTEXT0};
         font-size: {FONT_CAPTION}px;
-        font-weight: bold;
+        font-weight: 600;
         text-transform: uppercase;
     }}
 """
@@ -564,7 +566,7 @@ PAGE_TITLE = f"""
         background: transparent;
         color: {C.TEXT};
         font-size: {FONT_HERO}px;
-        font-weight: bold;
+        font-weight: 600;
     }}
 """
 
@@ -581,7 +583,7 @@ BADGE = f"""
         border-radius: {RADIUS_S}px;
         padding: 2px 7px;
         font-size: {FONT_CAPTION}px;
-        font-weight: bold;
+        font-weight: 500;
     }}
 """
 

--- a/src/winpodx/gui/theme.py
+++ b/src/winpodx/gui/theme.py
@@ -565,8 +565,8 @@ PAGE_TITLE = f"""
     QLabel {{
         background: transparent;
         color: {C.TEXT};
-        font-size: {FONT_HERO}px;
-        font-weight: 600;
+        font-size: 20pt;
+        font-weight: 700;
     }}
 """
 
@@ -574,7 +574,8 @@ PAGE_SUBTITLE = f"""
     QLabel {{
         background: transparent;
         color: {C.OVERLAY0};
-        font-size: {FONT_BODY}px;
+        font-size: 11pt;
+        font-weight: 400;
     }}
 """
 


### PR DESCRIPTION
Follow-up to #460, addressing the owner's feedback that the GUI felt "too bold / too cramped" and that menus were "jumbled / no regularity". Two rounds, codex-assisted, reviewed by rendering each page offscreen.

## Round 1 — calmer, airier
- theme: spacing scale bumped (S 8→10, L 16→20, XL 24→30, XXL 32→40); primary/launch green desaturated (`#3fb950`→`#74b985`); Tools action-row icon circles drop the saturated rainbow rotation for one muted neutral tint.
- library: bigger card/grid gaps, lighter shadows, medium-weight card titles, Launch button narrowed + weight 500 (no full-width bold bar).
- maintenance / dialogs / info / settings / license / header: bold labels reduced to medium (500) / semibold (600 for true section headers).

## Round 2 — layout consistency + License last
- shared `make_page_header(title, subtitle, actions)` helper → every page uses one header pattern (same top margin, title size/weight, right-aligned actions).
- Apps toolbar regrouped: left = search + count, right = view toggle / Refresh / Hidden / Add (fixed spacing); category chips on a tidy row (no orphaned gaps).
- grid app-card: removed the dead empty band (min-height + stretch); footer is one row → Launch (left) + overflow menu (right). Balanced, not floating.
- **nav order: Devices before License so License is LAST**; all hardcoded page-index refs updated (devices 6→5, license 5→6) in `main_window.py` + `_main_window_header.py`.

## Safety
- **No `tr()` source strings changed** (verified +0/-0 vs base) — 6 locale catalogs intact.
- **`gui/` only** — no core/backend/cli/tests touched.
- Mixin architecture, signals/slots, and page-switching preserved.

## Test
- `ruff check` + `ruff format --check` — clean.
- `pytest tests/test_main_window_bringup.py tests/test_devices_gui.py` — 16 passed (window builds, devices page).
- Full `pytest` — see CI.

## Not in this PR (queued)
SVG icon set to replace unicode glyphs; menu IA item-moves (e.g. Windows Update toggle → Settings) pending owner decision.