### PR TITLE
refactor(gui): consistent SVG icon set (replaces unicode glyphs)

### DIFF
--- a/src/winpodx/gui/_main_window_bringup.py
+++ b/src/winpodx/gui/_main_window_bringup.py
@@ -85,6 +85,7 @@ from PySide6.QtWidgets import (
 
 from winpodx.core.i18n import tr
 from winpodx.gui._widget_helpers import BusyDialog
+from winpodx.gui.icons import load_icon
 from winpodx.gui.theme import (
     BTN_PRIMARY,
     BTN_SECONDARY,
@@ -98,6 +99,25 @@ from winpodx.gui.theme import (
 )
 
 log = logging.getLogger(__name__)
+
+
+class _ChecklistIconLabel(QLabel):
+    """SVG checklist marker that keeps a lightweight state string for tests."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._state_text = ""
+
+    def set_status_icon(self, state_text: str, icon_name: str, color: str, size: int = 16) -> None:
+        self._state_text = state_text
+        self.setPixmap(load_icon(icon_name, color, size).pixmap(size, size))
+
+    def clear_status_icon(self) -> None:
+        self._state_text = ""
+        self.clear()
+
+    def text(self) -> str:
+        return self._state_text
 
 
 # Per-phase poll cadence (seconds) -- short enough that the cancel
@@ -214,10 +234,20 @@ class BringUpProgressDialog(QDialog):
         layout.setSpacing(SPACE_M)
 
         # ----- header row (phase progress + label) -----------------------
+        header_row = QHBoxLayout()
+        header_row.setContentsMargins(0, 0, 0, 0)
+        header_row.setSpacing(SPACE_S)
+        self.header_icon = QLabel()
+        self.header_icon.setFixedSize(20, 20)
+        self.header_icon.setStyleSheet("background: transparent;")
+        self.header_icon.hide()
+        header_row.addWidget(self.header_icon)
+
         self.header = QLabel(tr("Starting..."))
         self.header.setStyleSheet(f"font-size: {FONT_SUBHEAD}px; font-weight: 600;")
         self.header.setWordWrap(True)
-        layout.addWidget(self.header)
+        header_row.addWidget(self.header, 1)
+        layout.addLayout(header_row)
 
         # Sub-detail: attempt counters / probe outcomes go here. Kept on
         # its own line so the header stays scannable.
@@ -234,16 +264,16 @@ class BringUpProgressDialog(QDialog):
         # ----- phase checklist ------------------------------------------
         self._mono_font = QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont)
 
-        self._row_widgets: list[tuple[QLabel, QLabel, QLabel]] = []
+        self._row_widgets: list[tuple[_ChecklistIconLabel, QLabel, QLabel]] = []
         for idx, (_pid, label, eta_hint, _cancellable) in enumerate(_PHASE_DEFS):
             row = QWidget()
             row_layout = QHBoxLayout(row)
             row_layout.setContentsMargins(0, 0, 0, 0)
             row_layout.setSpacing(SPACE_S)
 
-            glyph = QLabel("   ")
+            glyph = _ChecklistIconLabel()
             glyph.setFont(self._mono_font)
-            glyph.setFixedWidth(20)
+            glyph.setFixedSize(20, 20)
             glyph.setAlignment(Qt.AlignmentFlag.AlignTop)
 
             # Name + a static "usually ~N" hint stacked beneath it so a
@@ -432,6 +462,9 @@ class BringUpProgressDialog(QDialog):
             # plain-language "you can launch apps now" sub-line, and a
             # determinate full bar so the progress no longer reads as busy.
             self.header.setText(tr("✓ Ready"))
+            self.header.setText(self.header.text().removeprefix("✓ "))
+            self.header_icon.setPixmap(load_icon("check", C.GREEN, 20).pixmap(20, 20))
+            self.header_icon.show()
             self.header.setStyleSheet(
                 f"font-size: {FONT_SUBHEAD}px; font-weight: 600; color: {C.GREEN};"
             )
@@ -439,6 +472,7 @@ class BringUpProgressDialog(QDialog):
             self.bar.setMaximum(1)
             self.bar.setValue(1)
         else:
+            self.header_icon.hide()
             self.header.setText(tr("Bring-up did not complete"))
             self.header.setStyleSheet(
                 f"font-size: {FONT_SUBHEAD}px; font-weight: 600; color: {C.RED};"
@@ -489,17 +523,17 @@ class BringUpProgressDialog(QDialog):
             started = self._phase_started_at.get(idx)
             done = self._phase_done_at.get(idx)
             if done is not None and started is not None:
-                glyph.setText("✓  ")
+                glyph.set_status_icon("✓  ", "check", C.GREEN)
                 glyph.setStyleSheet(f"color: {C.GREEN};")
                 name.setStyleSheet("")
                 elapsed.setText(_format_mmss(done - started))
             elif started is not None:
-                glyph.setText(">  ")
+                glyph.set_status_icon(">  ", "play", C.BLUE)
                 glyph.setStyleSheet(f"color: {C.BLUE};")
                 name.setStyleSheet("font-weight: 500;")
                 elapsed.setText(_format_mmss(now - started))
             else:
-                glyph.setText("   ")
+                glyph.clear_status_icon()
                 glyph.setStyleSheet("")
                 name.setStyleSheet(f"color: {C.SUBTEXT0};")
                 elapsed.setText("")

--- a/src/winpodx/gui/_main_window_devices.py
+++ b/src/winpodx/gui/_main_window_devices.py
@@ -18,7 +18,7 @@ CLI never drift.
 
 from __future__ import annotations
 
-from PySide6.QtCore import QObject, QRunnable, Qt, QThreadPool, Signal
+from PySide6.QtCore import QObject, QRunnable, QSize, Qt, QThreadPool, Signal
 from PySide6.QtGui import QFontMetrics
 from PySide6.QtWidgets import (
     QDialog,
@@ -43,6 +43,7 @@ from winpodx.gui._widget_helpers import (
     make_warning_callout,
     show_toast,
 )
+from winpodx.gui.icons import load_icon
 from winpodx.gui.theme import (
     ACTION_ROW,
     BTN_GHOST,
@@ -232,10 +233,16 @@ class DevicesMixin:
 
         if assigned:
             btn = QPushButton(tr("← Detach"))
+            btn.setText(btn.text().removeprefix("← "))
+            btn.setIcon(load_icon("chevron-left", C.TEXT, 16))
+            btn.setIconSize(QSize(16, 16))
             btn.setStyleSheet(BTN_GHOST)
             btn.clicked.connect(lambda _=False, dev=host: self._on_detach(dev))
         else:
             btn = QPushButton(tr("Attach →"))
+            btn.setText(btn.text().removesuffix(" →"))
+            btn.setIcon(load_icon("chevron-right", C.CRUST, 16))
+            btn.setIconSize(QSize(16, 16))
             btn.setStyleSheet(BTN_PRIMARY)
             btn.clicked.connect(lambda _=False, dev=host: self._on_attach(dev))
         h.addWidget(btn)

--- a/src/winpodx/gui/_main_window_header.py
+++ b/src/winpodx/gui/_main_window_header.py
@@ -34,6 +34,7 @@ from PySide6.QtWidgets import (
 )
 
 from winpodx.core.i18n import tr
+from winpodx.gui.icons import load_icon
 from winpodx.gui.theme import (
     BTN_PRIMARY,
     INFO_BAR,
@@ -118,10 +119,10 @@ class HeaderMixin:
         chip_l.setContentsMargins(12, 4, 8, 4)
         chip_l.setSpacing(8)
 
-        self.pod_dot = QLabel("●")
-        self.pod_dot.setStyleSheet(
-            f"background: transparent; color: {C.SUBTEXT0}; font-size: 10px;"
-        )
+        self.pod_dot = QLabel()
+        self.pod_dot.setFixedSize(10, 10)
+        self.pod_dot.setPixmap(load_icon("dot", C.SUBTEXT0, 10).pixmap(10, 10))
+        self.pod_dot.setStyleSheet(f"background: transparent; color: {C.SUBTEXT0};")
         self.pod_dot.setToolTip(tr("Pod state"))
         chip_l.addWidget(self.pod_dot)
 
@@ -156,12 +157,16 @@ class HeaderMixin:
         ctrl_l.setContentsMargins(4, 0, 0, 0)
         ctrl_l.setSpacing(2)
 
-        self.btn_start = QPushButton("▶")
+        self.btn_start = QPushButton("")
+        self.btn_start.setIcon(load_icon("play", C.SUBTEXT0, 16))
+        self.btn_start.setIconSize(QSize(16, 16))
         self.btn_start.setToolTip(tr("Start Pod"))
         self.btn_start.clicked.connect(self._on_start_pod)
         ctrl_l.addWidget(self.btn_start)
 
-        self.btn_stop = QPushButton("■")
+        self.btn_stop = QPushButton("")
+        self.btn_stop.setIcon(load_icon("stop", C.SUBTEXT0, 16))
+        self.btn_stop.setIconSize(QSize(16, 16))
         self.btn_stop.setToolTip(tr("Stop Pod"))
         self.btn_stop.clicked.connect(self._on_stop_pod)
         ctrl_l.addWidget(self.btn_stop)
@@ -180,10 +185,10 @@ class HeaderMixin:
         layout.setContentsMargins(24, 0, 24, 0)
         layout.setSpacing(12)
 
-        self.banner_icon = QLabel("⚠")
-        self.banner_icon.setStyleSheet(
-            f"background: transparent; color: {C.YELLOW}; font-size: 14px;"
-        )
+        self.banner_icon = QLabel()
+        self.banner_icon.setFixedSize(16, 16)
+        self.banner_icon.setPixmap(load_icon("warning", C.YELLOW, 16).pixmap(16, 16))
+        self.banner_icon.setStyleSheet(f"background: transparent; color: {C.YELLOW};")
         layout.addWidget(self.banner_icon)
 
         self.banner_text = QLabel(tr("Pod is not running"))
@@ -225,10 +230,10 @@ class HeaderMixin:
         # only the tiny colour dot (a glanceable health indicator, not a
         # word) and show the pod IP/address instead — complementary info
         # the chip/banner don't surface. _on_pod_status fills it in.
-        self.info_pod_dot = QLabel("●")
-        self.info_pod_dot.setStyleSheet(
-            f"background: transparent; color: {C.OVERLAY0}; font-size: 8px;"
-        )
+        self.info_pod_dot = QLabel()
+        self.info_pod_dot.setFixedSize(8, 8)
+        self.info_pod_dot.setPixmap(load_icon("dot", C.OVERLAY0, 8).pixmap(8, 8))
+        self.info_pod_dot.setStyleSheet(f"background: transparent; color: {C.OVERLAY0};")
         layout.addWidget(self.info_pod_dot)
 
         self.info_pod_addr = QLabel("")

--- a/src/winpodx/gui/_main_window_library.py
+++ b/src/winpodx/gui/_main_window_library.py
@@ -25,8 +25,7 @@ Host-class contract (only listed for readers; not enforced):
 
 from __future__ import annotations
 
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QIcon
+from PySide6.QtCore import QSize, Qt
 from PySide6.QtWidgets import (
     QFrame,
     QGridLayout,
@@ -51,6 +50,7 @@ from winpodx.gui._widget_helpers import (
     make_page_header,
     make_source_badge,
 )
+from winpodx.gui.icons import load_icon
 from winpodx.gui.theme import (
     APP_CARD,
     APP_TILE,
@@ -123,14 +123,18 @@ class LibraryPageMixin:
         tgl.setContentsMargins(0, 0, 0, 0)
         tgl.setSpacing(2)
 
-        self.btn_grid = QPushButton("▦")
+        self.btn_grid = QPushButton("")
+        self.btn_grid.setIcon(load_icon("grid", C.OVERLAY0, 16))
+        self.btn_grid.setIconSize(QSize(16, 16))
         self.btn_grid.setCheckable(True)
         self.btn_grid.setChecked(True)
         self.btn_grid.setToolTip(tr("Grid view"))
         self.btn_grid.clicked.connect(lambda: self._set_view("grid"))
         tgl.addWidget(self.btn_grid)
 
-        self.btn_list = QPushButton("≡")
+        self.btn_list = QPushButton("")
+        self.btn_list.setIcon(load_icon("list", C.OVERLAY0, 16))
+        self.btn_list.setIconSize(QSize(16, 16))
         self.btn_list.setCheckable(True)
         self.btn_list.setToolTip(tr("List view"))
         self.btn_list.clicked.connect(lambda: self._set_view("list"))
@@ -138,7 +142,8 @@ class LibraryPageMixin:
         right_group.addWidget(toggle_wrap)
 
         self.refresh_btn = QPushButton(tr("Refresh Apps"))
-        self.refresh_btn.setIcon(QIcon.fromTheme("view-refresh"))
+        self.refresh_btn.setIcon(load_icon("refresh", C.TEXT, 16))
+        self.refresh_btn.setIconSize(QSize(16, 16))
         self.refresh_btn.setStyleSheet(BTN_GHOST)
         self.refresh_btn.setToolTip(tr("Scan the running pod for installed Windows apps"))
         self.refresh_btn.clicked.connect(self._on_refresh_apps)
@@ -438,12 +443,17 @@ class LibraryPageMixin:
         vl.addLayout(top_row)
 
         launch_btn = QPushButton(tr("▶  Launch"))
+        launch_btn.setText(launch_btn.text().removeprefix("▶  "))
+        launch_btn.setIcon(load_icon("play", C.CRUST, 16))
+        launch_btn.setIconSize(QSize(16, 16))
         launch_btn.setStyleSheet(BTN_ACCENT)
         launch_btn.setMinimumWidth(118)
         launch_btn.setToolTip(tr("Launch {app}").format(app=app.full_name))
         launch_btn.clicked.connect(lambda _, a=app: self._launch_app(a))
 
-        more_btn = QPushButton("⋯")
+        more_btn = QPushButton("")
+        more_btn.setIcon(load_icon("overflow", C.OVERLAY0, 16))
+        more_btn.setIconSize(QSize(16, 16))
         more_btn.setFixedSize(30, 30)
         more_btn.setToolTip(tr("Edit"))
         more_btn.setStyleSheet(
@@ -540,6 +550,9 @@ class LibraryPageMixin:
         layout.addStretch()
 
         launch_btn = QPushButton(tr("▶  Launch"))
+        launch_btn.setText(launch_btn.text().removeprefix("▶  "))
+        launch_btn.setIcon(load_icon("play", C.CRUST, 16))
+        launch_btn.setIconSize(QSize(16, 16))
         launch_btn.setStyleSheet(BTN_ACCENT)
         launch_btn.setMinimumWidth(116)
         launch_btn.clicked.connect(lambda: self._launch_app(app))
@@ -558,7 +571,9 @@ class LibraryPageMixin:
         layout.addWidget(hide_btn)
         layout.addSpacing(6)
 
-        del_btn = QPushButton("✕")
+        del_btn = QPushButton("")
+        del_btn.setIcon(load_icon("close", C.PEACH, 16))
+        del_btn.setIconSize(QSize(16, 16))
         del_btn.setFixedSize(32, 32)
         del_btn.setStyleSheet(BTN_DANGER)
         del_btn.clicked.connect(lambda: self._on_delete_app(app))

--- a/src/winpodx/gui/_main_window_logs.py
+++ b/src/winpodx/gui/_main_window_logs.py
@@ -36,6 +36,7 @@ from PySide6.QtWidgets import (
 from winpodx.core.config import Config
 from winpodx.core.i18n import tr
 from winpodx.gui._widget_helpers import make_page_header
+from winpodx.gui.icons import load_icon
 from winpodx.gui.theme import (
     BTN_GHOST,
     BTN_PRIMARY,
@@ -360,10 +361,10 @@ class LogsMixin:
         cmd_row = QHBoxLayout()
         cmd_row.setSpacing(SPACE_S)
 
-        prompt = QLabel("❯")
-        prompt.setStyleSheet(
-            f"background: transparent; color: {C.BLUE}; font-size: 16px; font-weight: 500;"
-        )
+        prompt = QLabel()
+        prompt.setFixedSize(16, 16)
+        prompt.setPixmap(load_icon("prompt", C.BLUE, 16).pixmap(16, 16))
+        prompt.setStyleSheet(f"background: transparent; color: {C.BLUE};")
         cmd_row.addWidget(prompt)
 
         self.cmd_input = QLineEdit()

--- a/src/winpodx/gui/_main_window_maintenance.py
+++ b/src/winpodx/gui/_main_window_maintenance.py
@@ -46,6 +46,7 @@ from winpodx.gui._widget_helpers import (
     make_section_label,
     make_warning_callout,
 )
+from winpodx.gui.icons import load_icon
 from winpodx.gui.theme import (
     ACTION_ROW,
     BTN_DANGER,
@@ -194,9 +195,10 @@ class MaintenanceMixin:
         rl.setContentsMargins(SPACE_L, SPACE_S, SPACE_L, SPACE_S)
         rl.setSpacing(SPACE_L)
 
-        update_icon = QLabel("⇅")
+        update_icon = QLabel()
         update_icon.setFixedSize(38, 38)
         update_icon.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        update_icon.setPixmap(load_icon("update-arrows", TOOL_ICON_FG, 18).pixmap(18, 18))
         update_icon.setStyleSheet(
             f"background: {TOOL_ICON_BG}; color: {TOOL_ICON_FG};"
             f" border: 1px solid {TOOL_ICON_BORDER}; border-radius: 14px;"
@@ -321,9 +323,10 @@ class MaintenanceMixin:
         rl.setContentsMargins(SPACE_L, SPACE_S, SPACE_L, SPACE_S)
         rl.setSpacing(SPACE_L)
 
-        icon = QLabel("▢")
+        icon = QLabel()
         icon.setFixedSize(38, 38)
         icon.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        icon.setPixmap(load_icon("session", TOOL_ICON_FG, 18).pixmap(18, 18))
         icon.setStyleSheet(
             f"background: {TOOL_ICON_BG}; color: {TOOL_ICON_FG};"
             f" border: 1px solid {TOOL_ICON_BORDER}; border-radius: 14px;"
@@ -391,9 +394,21 @@ class MaintenanceMixin:
         rl.setSpacing(SPACE_L)
 
         color = accent_color(color_idx)
-        icon_circle = QLabel(icon)
+        icon_circle = QLabel()
         icon_circle.setFixedSize(38, 38)
         icon_circle.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        icon_name = {
+            "⏸": "pause",
+            "▶": "play",
+            "▣": "desktop",
+            "✧": "clean",
+            "◷": "clock",
+            "◆": "diamond",
+            "⚙": "gear",
+            "⊕": "plus",
+            "↻": "refresh",
+        }.get(icon, icon)
+        icon_circle.setPixmap(load_icon(icon_name, TOOL_ICON_FG, 18).pixmap(18, 18))
         icon_circle.setStyleSheet(
             f"background: {TOOL_ICON_BG}; color: {TOOL_ICON_FG};"
             f" border: 1px solid {TOOL_ICON_BORDER}; border-left: 2px solid {rgba(color, 0.42)};"
@@ -414,8 +429,10 @@ class MaintenanceMixin:
         rl.addLayout(text_col)
         rl.addStretch()
 
-        arrow = QLabel("›")
-        arrow.setStyleSheet(f"background: transparent; color: {C.OVERLAY0}; font-size: 20px;")
+        arrow = QLabel()
+        arrow.setFixedSize(16, 16)
+        arrow.setPixmap(load_icon("chevron-right", C.OVERLAY0, 16).pixmap(16, 16))
+        arrow.setStyleSheet(f"background: transparent; color: {C.OVERLAY0};")
         rl.addWidget(arrow)
 
         row.mousePressEvent = lambda ev, h=handler: h()

--- a/src/winpodx/gui/_main_window_pod.py
+++ b/src/winpodx/gui/_main_window_pod.py
@@ -36,6 +36,7 @@ from winpodx.core.config import Config
 from winpodx.core.i18n import tr
 from winpodx.core.pod import pod_status
 from winpodx.gui._widget_helpers import show_toast
+from winpodx.gui.icons import load_icon
 from winpodx.gui.theme import C
 
 log = logging.getLogger(__name__)
@@ -276,14 +277,16 @@ class PodStatusMixin:
         ip_suffix = f" ({ip})" if ip and state == "running" else ""
         display = label + ip_suffix
 
-        self.pod_dot.setStyleSheet(f"background: transparent; color: {color}; font-size: 10px;")
+        self.pod_dot.setPixmap(load_icon("dot", color, 10).pixmap(10, 10))
+        self.pod_dot.setStyleSheet(f"background: transparent; color: {color};")
         self.pod_label.setText(display)
         self.pod_label.setStyleSheet(f"background: transparent; color: {color}; font-size: 12px;")
 
         # Info bar no longer repeats the state word (chip + banner own it);
         # it shows the pod IP instead. Keep the colour dot as a glanceable
         # health cue.
-        self.info_pod_dot.setStyleSheet(f"background: transparent; color: {color}; font-size: 8px;")
+        self.info_pod_dot.setPixmap(load_icon("dot", color, 8).pixmap(8, 8))
+        self.info_pod_dot.setStyleSheet(f"background: transparent; color: {color};")
         self.info_pod_addr.setText(ip if ip and state == "running" else "")
 
         self.btn_start.setEnabled(state == "stopped")
@@ -293,10 +296,15 @@ class PodStatusMixin:
 
     def _set_banner(self, icon: str, icon_color: str, text: str, *, restart: bool = False) -> None:
         """Paint the status banner row (icon + text + button label)."""
-        self.banner_icon.setText(icon)
-        self.banner_icon.setStyleSheet(
-            f"background: transparent; color: {icon_color}; font-size: 14px;"
-        )
+        icon_name = {
+            "⏸": "pause",
+            "⚠": "warning",
+            "▶": "play",
+            "✗": "error",
+            "…": "pending",
+        }.get(icon, icon)
+        self.banner_icon.setPixmap(load_icon(icon_name, icon_color, 16).pixmap(16, 16))
+        self.banner_icon.setStyleSheet(f"background: transparent; color: {icon_color};")
         self.banner_text.setText(text)
         # Same ensure_ready() action either way; only the label differs so a
         # running-but-degraded pod reads as a repair, not a cold start.

--- a/src/winpodx/gui/_main_window_settings.py
+++ b/src/winpodx/gui/_main_window_settings.py
@@ -40,6 +40,7 @@ from PySide6.QtWidgets import (
 from winpodx.core.config import Config
 from winpodx.core.i18n import tr
 from winpodx.gui._widget_helpers import add_shadow, make_page_header, make_warning_callout
+from winpodx.gui.icons import load_icon
 from winpodx.gui.theme import (
     BTN_PRIMARY,
     CHECKBOX,
@@ -752,11 +753,22 @@ class SettingsPageMixin:
         layout.setSpacing(SPACE_XS)
 
         header = QLabel(tr("◨  Performance Tuning"))
+        header.setText(header.text().removeprefix("◨  "))
         header.setStyleSheet(
             f"background: transparent; color: {C.BLUE}; "
             f"font-size: {FONT_HEADER}px; font-weight: 600;"
         )
-        layout.addWidget(header)
+        header_row = QHBoxLayout()
+        header_row.setContentsMargins(0, 0, 0, 0)
+        header_row.setSpacing(SPACE_S)
+        header_icon = QLabel()
+        header_icon.setFixedSize(18, 18)
+        header_icon.setPixmap(load_icon("performance", C.BLUE, 18).pixmap(18, 18))
+        header_icon.setStyleSheet("background: transparent;")
+        header_row.addWidget(header_icon)
+        header_row.addWidget(header)
+        header_row.addStretch()
+        layout.addLayout(header_row)
 
         sub = QLabel(tr("QEMU + Windows-on-KVM knob preset"))
         sub.setStyleSheet(
@@ -814,6 +826,19 @@ class SettingsPageMixin:
 
         return card
 
+    @staticmethod
+    def _split_settings_title_icon(title: str) -> tuple[str | None, str]:
+        """Return the in-house icon name and display title for old glyph-prefixed labels."""
+        prefixes = {
+            "▣  ": "rdp",
+            "▨  ": "hardware",
+            "🌐  ": "globe",
+        }
+        for prefix, icon_name in prefixes.items():
+            if title.startswith(prefix):
+                return icon_name, title[len(prefix) :]
+        return None, title
+
     def _settings_card(
         self,
         title: str,
@@ -835,12 +860,26 @@ class SettingsPageMixin:
         layout.setContentsMargins(SPACE_XL, SPACE_XL, SPACE_XL, SPACE_XL)
         layout.setSpacing(SPACE_XS)
 
-        header = QLabel(title)
+        header_icon_name, header_title = self._split_settings_title_icon(title)
+        header = QLabel(header_title)
         header.setStyleSheet(
             f"background: transparent; color: {C.BLUE}; "
             f"font-size: {FONT_HEADER}px; font-weight: 600;"
         )
-        layout.addWidget(header)
+        if header_icon_name is not None:
+            header_row = QHBoxLayout()
+            header_row.setContentsMargins(0, 0, 0, 0)
+            header_row.setSpacing(SPACE_S)
+            header_icon = QLabel()
+            header_icon.setFixedSize(18, 18)
+            header_icon.setPixmap(load_icon(header_icon_name, C.BLUE, 18).pixmap(18, 18))
+            header_icon.setStyleSheet("background: transparent;")
+            header_row.addWidget(header_icon)
+            header_row.addWidget(header)
+            header_row.addStretch()
+            layout.addLayout(header_row)
+        else:
+            layout.addWidget(header)
 
         sub = QLabel(subtitle)
         sub.setStyleSheet(

--- a/src/winpodx/gui/_widget_helpers.py
+++ b/src/winpodx/gui/_widget_helpers.py
@@ -32,6 +32,7 @@ from PySide6.QtWidgets import (
 
 from winpodx.core.app import AppInfo
 from winpodx.core.i18n import tr
+from winpodx.gui.icons import load_icon
 from winpodx.gui.theme import (
     BTN_PRIMARY,
     BTN_SECONDARY,
@@ -293,7 +294,6 @@ def make_warning_callout(text: str, *, level: str = "warn") -> QFrame:
     visible *before* the user acts, not buried in a modal body.
     """
     accent = C.RED if level == "danger" else C.PEACH
-    glyph = "⚠"  # warning sign
     frame = QFrame()
     frame.setObjectName("winpodxCallout")
     frame.setStyleSheet(
@@ -306,8 +306,10 @@ def make_warning_callout(text: str, *, level: str = "warn") -> QFrame:
     row = QHBoxLayout(frame)
     row.setContentsMargins(12, 10, 12, 10)
     row.setSpacing(10)
-    icon = QLabel(glyph)
-    icon.setStyleSheet(f"color: {accent}; font-size: 15px; font-weight: 600;")
+    icon = QLabel()
+    icon.setFixedSize(16, 16)
+    icon.setPixmap(load_icon("warning", accent, 16).pixmap(16, 16))
+    icon.setStyleSheet(f"color: {accent};")
     icon.setAlignment(Qt.AlignmentFlag.AlignTop)
     row.addWidget(icon)
     label = QLabel(text)

--- a/src/winpodx/gui/icons/README
+++ b/src/winpodx/gui/icons/README
@@ -1,0 +1,1 @@
+Original in-house MIT icons for WinPodX GUI controls; each asset is a 24x24 stroke-based SVG using currentColor so Qt can render a consistent themed icon set.

--- a/src/winpodx/gui/icons/__init__.py
+++ b/src/winpodx/gui/icons/__init__.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from importlib import resources
+from pathlib import Path
+
+from PySide6.QtCore import QByteArray, QSize, Qt
+from PySide6.QtGui import QIcon, QPainter, QPixmap
+from PySide6.QtSvg import QSvgRenderer
+
+_ICON_CACHE: dict[tuple[str, str, int], QIcon] = {}
+
+
+def _read_svg(name: str) -> bytes:
+    filename = f"{name}.svg"
+    try:
+        return resources.files(__package__).joinpath(filename).read_bytes()
+    except (AttributeError, FileNotFoundError, ModuleNotFoundError, OSError):
+        return Path(__file__).with_name(filename).read_bytes()
+
+
+def load_icon(name: str, color: str = "#ffffff", size: int = 16) -> QIcon:
+    """Load, recolor, render, and cache a bundled WinPodX SVG icon."""
+    key = (name, color, size)
+    cached = _ICON_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    svg = _read_svg(name).replace(b"currentColor", color.encode("utf-8"))
+    renderer = QSvgRenderer(QByteArray(svg))
+    pixmap = QPixmap(QSize(size, size))
+    pixmap.fill(Qt.GlobalColor.transparent)
+    painter = QPainter(pixmap)
+    try:
+        renderer.render(painter)
+    finally:
+        painter.end()
+
+    icon = QIcon(pixmap)
+    _ICON_CACHE[key] = icon
+    return icon

--- a/src/winpodx/gui/icons/check.svg
+++ b/src/winpodx/gui/icons/check.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M5 13l4 4L19 7' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/chevron-left.svg
+++ b/src/winpodx/gui/icons/chevron-left.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M15 6l-6 6 6 6' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/chevron-right.svg
+++ b/src/winpodx/gui/icons/chevron-right.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M9 6l6 6-6 6' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/clean.svg
+++ b/src/winpodx/gui/icons/clean.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M5 19l7-7' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M10 4l2 4 4 2-4 2-2 4-2-4-4-2 4-2z' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M17 15l1 2 2 1-2 1-1 2-1-2-2-1 2-1z' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/clock.svg
+++ b/src/winpodx/gui/icons/clock.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <circle cx='12' cy='12' r='8' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M12 8v5l3 2' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/close.svg
+++ b/src/winpodx/gui/icons/close.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M6 6l12 12' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M18 6 6 18' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/desktop.svg
+++ b/src/winpodx/gui/icons/desktop.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <rect x='3' y='5' width='18' height='12' rx='2' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M8 21h8' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M12 17v4' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/diamond.svg
+++ b/src/winpodx/gui/icons/diamond.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M12 3l9 9-9 9-9-9z' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/dot.svg
+++ b/src/winpodx/gui/icons/dot.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <circle cx='12' cy='12' r='4' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/error.svg
+++ b/src/winpodx/gui/icons/error.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <circle cx='12' cy='12' r='9' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M9 9l6 6' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M15 9l-6 6' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/gear.svg
+++ b/src/winpodx/gui/icons/gear.svg
@@ -1,0 +1,11 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <circle cx='12' cy='12' r='3' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M12 2v3' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M12 19v3' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M4.9 4.9 7 7' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M17 17l2.1 2.1' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M2 12h3' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M19 12h3' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M4.9 19.1 7 17' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M17 7l2.1-2.1' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/globe.svg
+++ b/src/winpodx/gui/icons/globe.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <circle cx='12' cy='12' r='9' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M3 12h18' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M12 3a13 13 0 0 1 0 18' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M12 3a13 13 0 0 0 0 18' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/grid.svg
+++ b/src/winpodx/gui/icons/grid.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <rect x='4' y='4' width='6' height='6' rx='1' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <rect x='14' y='4' width='6' height='6' rx='1' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <rect x='4' y='14' width='6' height='6' rx='1' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <rect x='14' y='14' width='6' height='6' rx='1' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/hardware.svg
+++ b/src/winpodx/gui/icons/hardware.svg
@@ -1,0 +1,11 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <rect x='7' y='7' width='10' height='10' rx='2' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M4 9h3' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M4 15h3' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M17 9h3' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M17 15h3' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M9 4v3' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M15 4v3' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M9 17v3' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M15 17v3' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/list.svg
+++ b/src/winpodx/gui/icons/list.svg
@@ -1,0 +1,8 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M8 6h12' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M8 12h12' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M8 18h12' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M4 6h.01' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M4 12h.01' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M4 18h.01' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/minus.svg
+++ b/src/winpodx/gui/icons/minus.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M5 12h14' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/overflow.svg
+++ b/src/winpodx/gui/icons/overflow.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M6 12h.01' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M12 12h.01' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M18 12h.01' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/pause.svg
+++ b/src/winpodx/gui/icons/pause.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M9 5v14' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M15 5v14' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/pending.svg
+++ b/src/winpodx/gui/icons/pending.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <circle cx='12' cy='12' r='8' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M8 12h.01' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M12 12h.01' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M16 12h.01' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/performance.svg
+++ b/src/winpodx/gui/icons/performance.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M4 14a8 8 0 1 1 16 0' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M12 14l4-4' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M8 20h8' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/play.svg
+++ b/src/winpodx/gui/icons/play.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M8 5v14l11-7z' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/plus.svg
+++ b/src/winpodx/gui/icons/plus.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M12 5v14' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M5 12h14' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/prompt.svg
+++ b/src/winpodx/gui/icons/prompt.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M7 7l5 5-5 5' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M13 17h5' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/rdp.svg
+++ b/src/winpodx/gui/icons/rdp.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <rect x='3' y='5' width='8' height='6' rx='1' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <rect x='13' y='13' width='8' height='6' rx='1' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M11 8h3' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M10 15h3' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/refresh.svg
+++ b/src/winpodx/gui/icons/refresh.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M20 6v5h-5' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M4 18v-5h5' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M18 9a7 7 0 0 0-11.6-2.6L4 9' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M6 15a7 7 0 0 0 11.6 2.6L20 15' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/reverse-associations.svg
+++ b/src/winpodx/gui/icons/reverse-associations.svg
@@ -1,0 +1,7 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M7 7h10v10H7z' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M3 12h4' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M17 12h4' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M12 3v4' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M12 17v4' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/session.svg
+++ b/src/winpodx/gui/icons/session.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <rect x='4' y='5' width='16' height='12' rx='2' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M8 21h8' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/stop.svg
+++ b/src/winpodx/gui/icons/stop.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <rect x='6' y='6' width='12' height='12' rx='2' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/update-arrows.svg
+++ b/src/winpodx/gui/icons/update-arrows.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M7 4v14' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M4 15l3 3 3-3' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M17 20V6' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M14 9l3-3 3 3' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/warning.svg
+++ b/src/winpodx/gui/icons/warning.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M12 4 21 20H3z' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M12 9v5' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M12 18h.01' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/reverse_open_panel.py
+++ b/src/winpodx/gui/reverse_open_panel.py
@@ -157,7 +157,7 @@ def build_panel(cfg: Config, parent: QWidget | None = None) -> QWidget:
     responsible for calling ``cfg.save()`` when the user clicks
     "Save Settings".
     """
-    from PySide6.QtCore import Qt
+    from PySide6.QtCore import QSize, Qt
     from PySide6.QtWidgets import (
         QCheckBox,
         QFrame,
@@ -178,6 +178,7 @@ def build_panel(cfg: Config, parent: QWidget | None = None) -> QWidget:
         _cmd_start_listener,
         _cmd_stop_listener,
     )
+    from winpodx.gui.icons import load_icon
     from winpodx.gui.theme import (
         BTN_GHOST,
         BTN_PRIMARY,
@@ -205,8 +206,19 @@ def build_panel(cfg: Config, parent: QWidget | None = None) -> QWidget:
     layout.setSpacing(SPACE_S)
 
     title = QLabel(tr("▦  Reverse File Associations"))
+    title.setText(title.text().removeprefix("▦  "))
     title.setStyleSheet(f"color: {C.BLUE}; font-size: 15px; font-weight: 600;")
-    layout.addWidget(title)
+    title_row = QHBoxLayout()
+    title_row.setContentsMargins(0, 0, 0, 0)
+    title_row.setSpacing(SPACE_S)
+    title_icon = QLabel()
+    title_icon.setFixedSize(18, 18)
+    title_icon.setPixmap(load_icon("reverse-associations", C.BLUE, 18).pixmap(18, 18))
+    title_icon.setStyleSheet("background: transparent;")
+    title_row.addWidget(title_icon)
+    title_row.addWidget(title)
+    title_row.addStretch()
+    layout.addLayout(title_row)
 
     sub = QLabel(tr("Linux apps appear in the Windows guest's right-click ‘Open with…’ menu."))
     sub.setWordWrap(True)
@@ -266,6 +278,12 @@ def build_panel(cfg: Config, parent: QWidget | None = None) -> QWidget:
     allow_btns.setSpacing(SPACE_S)
     btn_allow_add = QPushButton(tr("+ Add"))
     btn_allow_rm = QPushButton(tr("− Remove"))
+    btn_allow_add.setText(btn_allow_add.text().removeprefix("+ "))
+    btn_allow_add.setIcon(load_icon("plus", C.TEXT, 16))
+    btn_allow_add.setIconSize(QSize(16, 16))
+    btn_allow_rm.setText(btn_allow_rm.text().removeprefix("− "))
+    btn_allow_rm.setIcon(load_icon("minus", C.TEXT, 16))
+    btn_allow_rm.setIconSize(QSize(16, 16))
     btn_allow_add.setStyleSheet(BTN_SECONDARY)
     btn_allow_rm.setStyleSheet(BTN_GHOST)
     allow_btns.addWidget(btn_allow_add)
@@ -276,6 +294,12 @@ def build_panel(cfg: Config, parent: QWidget | None = None) -> QWidget:
     deny_btns.setSpacing(SPACE_S)
     btn_deny_add = QPushButton(tr("+ Add"))
     btn_deny_rm = QPushButton(tr("− Remove"))
+    btn_deny_add.setText(btn_deny_add.text().removeprefix("+ "))
+    btn_deny_add.setIcon(load_icon("plus", C.TEXT, 16))
+    btn_deny_add.setIconSize(QSize(16, 16))
+    btn_deny_rm.setText(btn_deny_rm.text().removeprefix("− "))
+    btn_deny_rm.setIcon(load_icon("minus", C.TEXT, 16))
+    btn_deny_rm.setIconSize(QSize(16, 16))
     btn_deny_add.setStyleSheet(BTN_SECONDARY)
     btn_deny_rm.setStyleSheet(BTN_GHOST)
     deny_btns.addWidget(btn_deny_add)


### PR DESCRIPTION
Follow-up to #462. The GUI used unicode/emoji glyph characters (`▶ ⏸ ▣ ✦ ◷ ⚙ ⊕ ↻ ⋯ ✕` …) as icons, which render inconsistently across fonts/DEs (some as color emoji, varying weights) — the owner wanted one consistent icon language.

## What
- **In-house SVG icon set** under `src/winpodx/gui/icons/*.svg` (30 icons): simple 24px stroke-based line icons, `currentColor`, consistent family. Original, MIT (this repo's license) — no external library, no network, no new pip dep.
- **Loader** `load_icon(name, color, size) -> QIcon` (QtSvg `QSvgRenderer` recolor + cache), works from source and from the installed package.
- **Swapped** every glyph "icon" to `setIcon()` / pixmap across the GUI (nav, toolbar, action rows, buttons, cards). Button **text** labels (the `tr()` words) are unchanged.

## Safety
- **No `tr()` source string changed** (verified +0/-0) — locale catalogs intact.
- **`gui/` only** — no core/backend/cli/tests touched. Hatch auto-includes the new `gui/icons/*.svg` in the wheel (same as `locale/*.json`); no `pyproject` change needed.
- Mixins / signals / page indices preserved.

## Test
- `ruff check` + `ruff format --check` — clean.
- `pytest tests/test_main_window_bringup.py tests/test_devices_gui.py` — 16 passed.
- Rendered Apps + Tools offscreen and confirmed icons draw (non-blank, themed): Launch = play, Suspend = pause, Full Desktop = monitor, Sync Time = clock, Refresh = cycle, etc.
- Full `pytest` — see CI.