### PR TITLE
feat(gui): Start-menu launcher layout + new strings translated

### DIFF
--- a/src/winpodx/gui/_main_window_apps.py
+++ b/src/winpodx/gui/_main_window_apps.py
@@ -108,9 +108,9 @@ class AppCrudMixin:
     def _reload_apps(self) -> None:
         self.apps = list_available_apps()
         self._refresh_hidden_button()
-        visible = self._visible_apps()
-        self._populate_app_view(visible)
         self.search_box.clear()
+        self._refresh_launcher_home()
+        visible = self._visible_apps()
         # "X of Y" mirrors the library toolbar format (Task 5); no search is
         # active right after a reload, so shown == total.
         self.app_count_label.setText(

--- a/src/winpodx/gui/_main_window_header.py
+++ b/src/winpodx/gui/_main_window_header.py
@@ -2,7 +2,7 @@
 """Header-chrome builder mixin for ``WinpodxWindow``.
 
 Holds the methods that build the persistent top-of-window chrome:
-the top navigation bar (logo + tabs + pod chip + start/stop buttons),
+the top launcher bar (logo + pod chip + start/stop buttons + menu),
 the warning banner shown while the pod is not running, and the slim
 info bar (status text + backend + resource summary). Pulled out of
 ``main_window.py`` to keep that file focused on overall window
@@ -13,22 +13,24 @@ Host-class contract (only listed for readers; not enforced):
     apps: list[AppInfo]
     _switch_page(idx) -> None       — defined on the host class.
     _on_start_pod() / _on_stop_pod()  — defined on PodStatusMixin.
-    Widgets created here (nav_buttons, pod_dot, pod_label, agent_dot,
-    rdp_dot, btn_start, btn_stop, banner_icon, banner_text, banner_btn,
-    info_label, info_pod_dot, info_pod_addr) are accessed from sibling
-    mixins via the shared ``self`` instance.
+    Widgets created here (nav_buttons, nav_menu_actions, pod_dot,
+    pod_label, agent_dot, rdp_dot, btn_start, btn_stop, banner_icon,
+    banner_text, banner_btn, info_label, info_pod_dot, info_pod_addr)
+    are accessed from sibling mixins via the shared ``self`` instance.
 """
 
 from __future__ import annotations
 
 from PySide6.QtCore import QSize, Qt
-from PySide6.QtGui import QPainter, QPixmap
+from PySide6.QtGui import QIcon, QPainter, QPixmap
 from PySide6.QtSvg import QSvgRenderer
 from PySide6.QtWidgets import (
     QFrame,
     QHBoxLayout,
     QLabel,
+    QMenu,
     QPushButton,
+    QToolButton,
     QVBoxLayout,
     QWidget,
 )
@@ -41,7 +43,6 @@ from winpodx.gui.theme import (
     POD_CHIP,
     POD_CTRL,
     STATUS_BANNER_WARN,
-    TAB_BTN,
     TOP_BAR,
     C,
 )
@@ -59,6 +60,28 @@ class HeaderMixin:
         layout.setContentsMargins(24, 0, 24, 0)
         layout.setSpacing(0)
 
+        logo_btn = QPushButton("WinPodX")
+        logo_btn.setObjectName("logoHomeButton")
+        logo_btn.setToolTip(tr("Home / Apps"))
+        logo_btn.clicked.connect(lambda: self._switch_page(0))
+        logo_btn.setStyleSheet(
+            f"""
+            QPushButton#logoHomeButton {{
+                background: transparent;
+                color: {C.TEXT};
+                border: none;
+                border-radius: 8px;
+                padding: 7px 10px;
+                font-size: 16px;
+                font-weight: 600;
+                letter-spacing: 0px;
+            }}
+            QPushButton#logoHomeButton:hover {{
+                background: {C.SURFACE0};
+            }}
+            """
+        )
+
         from winpodx.desktop.icons import bundled_data_path
 
         icon_path = bundled_data_path("winpodx-icon.svg")
@@ -69,47 +92,41 @@ class HeaderMixin:
             painter = QPainter(pixmap)
             renderer.render(painter)
             painter.end()
-            logo_icon = QLabel()
-            logo_icon.setPixmap(pixmap)
-            logo_icon.setStyleSheet("background: transparent;")
-            layout.addWidget(logo_icon)
-            layout.addSpacing(8)
+            logo_btn.setIcon(QIcon(pixmap))
+            logo_btn.setIconSize(QSize(28, 24))
 
-        logo_text = QLabel("WinPodX")
-        logo_text.setStyleSheet(
-            f"background: transparent; color: {C.TEXT};"
-            " font-size: 16px; font-weight: 600;"
-            " letter-spacing: 0px;"
-        )
-        layout.addWidget(logo_text)
-        layout.addSpacing(28)
-
-        tab_container = QWidget()
-        tab_container.setStyleSheet(TAB_BTN)
-        tabs = QHBoxLayout(tab_container)
-        tabs.setContentsMargins(0, 0, 0, 0)
-        tabs.setSpacing(0)
+        layout.addWidget(logo_btn)
 
         self.nav_buttons: list[QPushButton] = []
-        for label, idx in [
-            ("Apps", 0),
-            ("Settings", 1),
-            ("Tools", 2),
-            ("Terminal", 3),
-            ("Info", 4),
-            ("Devices", 5),
+        self.nav_menu_actions = []
+        nav_items = [
+            (tr("Home / Apps"), 0, "home"),
+            (tr("Settings"), 1, "gear"),
+            (tr("Tools"), 2, "clean"),
+            (tr("Terminal / Logs"), 3, "prompt"),
+            (tr("Info"), 4, "pending"),
+            (tr("Devices"), 5, "hardware"),
             # License page is appended last so the nav-position == page-index
             # invariant _switch_page relies on holds (see _main_window_nav).
-            ("License", 6),
-        ]:
-            btn = QPushButton(tr(label))
+            (tr("License"), 6, "diamond"),
+        ]
+
+        nav_menu = QMenu(self)
+        for row, (label, idx, icon_name) in enumerate(nav_items):
+            btn = QPushButton(label, self)
             btn.setCheckable(True)
             btn.clicked.connect(lambda _, i=idx: self._switch_page(i))
-            tabs.addWidget(btn)
             self.nav_buttons.append(btn)
 
+            action = nav_menu.addAction(load_icon(icon_name, C.SUBTEXT1, 16), label)
+            action.setCheckable(True)
+            action.triggered.connect(lambda _checked=False, i=idx: self._switch_page(i))
+            self.nav_menu_actions.append(action)
+            if row == 0:
+                nav_menu.addSeparator()
+
         self.nav_buttons[0].setChecked(True)
-        layout.addWidget(tab_container)
+        self.nav_menu_actions[0].setChecked(True)
         layout.addStretch()
 
         chip = QFrame()
@@ -173,6 +190,37 @@ class HeaderMixin:
 
         chip_l.addWidget(ctrl_w)
         layout.addWidget(chip)
+        layout.addSpacing(8)
+
+        nav_btn = QToolButton()
+        nav_btn.setObjectName("navMenuButton")
+        nav_btn.setIcon(load_icon("gear", C.SUBTEXT1, 18))
+        nav_btn.setIconSize(QSize(18, 18))
+        nav_btn.setToolTip(tr("Navigation"))
+        nav_btn.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+        nav_btn.setMenu(nav_menu)
+        nav_btn.setStyleSheet(
+            f"""
+            QToolButton#navMenuButton {{
+                background: transparent;
+                color: {C.SUBTEXT1};
+                border: none;
+                border-radius: 14px;
+                padding: 6px;
+                min-width: 30px;
+                min-height: 30px;
+            }}
+            QToolButton#navMenuButton:hover {{
+                background: {C.SURFACE0};
+                color: {C.TEXT};
+            }}
+            QToolButton#navMenuButton::menu-indicator {{
+                image: none;
+                width: 0px;
+            }}
+            """
+        )
+        layout.addWidget(nav_btn)
 
         return bar
 

--- a/src/winpodx/gui/_main_window_library.py
+++ b/src/winpodx/gui/_main_window_library.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: MIT
 """Library-page mixin for ``WinpodxWindow``.
 
-Holds the methods that build and drive the Apps tab: the toolbar
-(search / view toggle / refresh / hidden / add), the category chip row,
-the grid / list view populators, individual card/tile builders, and
-the visibility / filter / hidden-toggle state. Pulled out of
+Holds the methods that build and drive the Home launcher: the search
+bar, pinned/recent rows, category chip row, the grid / list view
+populators, individual card/tile builders, and the visibility /
+filter / hidden-toggle state. Pulled out of
 ``main_window.py`` to keep that file focused on overall window
 orchestration.
 
@@ -43,11 +43,13 @@ from PySide6.QtWidgets import (
 
 from winpodx.core.app import AppInfo
 from winpodx.core.i18n import tr
+from winpodx.gui import launcher_state
 from winpodx.gui._widget_helpers import (
     add_shadow,
     make_app_avatar,
     make_empty_panel,
     make_page_header,
+    make_section_label,
     make_source_badge,
 )
 from winpodx.gui.icons import load_icon
@@ -87,8 +89,7 @@ class LibraryPageMixin:
         layout.setContentsMargins(SPACE_XXL, 0, SPACE_XXL, SPACE_L)
         layout.setSpacing(SPACE_M)
 
-        apps_title = self.nav_buttons[0].text() if hasattr(self, "nav_buttons") else "Apps"
-        layout.addWidget(make_page_header(apps_title))
+        layout.addWidget(make_page_header(tr("Apps")))
 
         toolbar = QHBoxLayout()
         toolbar.setSpacing(16)
@@ -100,7 +101,12 @@ class LibraryPageMixin:
         self.search_box = QLineEdit()
         self.search_box.setPlaceholderText(tr("Search apps by name..."))
         self.search_box.setStyleSheet(SEARCH_BAR)
-        self.search_box.setFixedWidth(340)
+        self.search_box.setMinimumWidth(360)
+        self.search_box.setMaximumWidth(620)
+        self.search_box.addAction(
+            load_icon("search", C.OVERLAY0, 16),
+            QLineEdit.ActionPosition.LeadingPosition,
+        )
         self.search_box.setClearButtonEnabled(True)
         self.search_box.textChanged.connect(self._filter_apps)
         left_group.addWidget(self.search_box)
@@ -184,29 +190,64 @@ class LibraryPageMixin:
         )
         layout.addWidget(self.refresh_progress)
 
-        category_wrap = QWidget()
-        self._category_row = QHBoxLayout(category_wrap)
-        self._category_row.setContentsMargins(0, SPACE_S, 0, 0)
-        self._category_row.setSpacing(8)
-        self._category_btns: list[QPushButton] = []
-        self._build_category_chips()
-        layout.addWidget(category_wrap)
-
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setStyleSheet(SCROLL_AREA)
 
         self.app_list_container = QWidget()
         self.app_list_container.setStyleSheet("background: transparent;")
-        self.app_list_layout = QVBoxLayout(self.app_list_container)
+        launcher_layout = QVBoxLayout(self.app_list_container)
+        launcher_layout.setContentsMargins(0, 0, 0, 0)
+        launcher_layout.setSpacing(SPACE_XL)
+
+        self._pinned_section, self._pinned_row = self._make_launcher_section(tr("Pinned"))
+        launcher_layout.addWidget(self._pinned_section)
+
+        self._recent_section, self._recent_row = self._make_launcher_section(tr("Recent"))
+        launcher_layout.addWidget(self._recent_section)
+
+        all_apps_header = QWidget()
+        all_apps_layout = QVBoxLayout(all_apps_header)
+        all_apps_layout.setContentsMargins(0, 0, 0, 0)
+        all_apps_layout.setSpacing(SPACE_M)
+        all_apps_layout.addWidget(make_section_label(tr("All apps")))
+
+        category_wrap = QWidget()
+        self._category_row = QHBoxLayout(category_wrap)
+        self._category_row.setContentsMargins(0, 0, 0, 0)
+        self._category_row.setSpacing(8)
+        self._category_btns: list[QPushButton] = []
+        self._build_category_chips()
+        all_apps_layout.addWidget(category_wrap)
+        launcher_layout.addWidget(all_apps_header)
+
+        self.app_list_layout = QVBoxLayout()
         self.app_list_layout.setContentsMargins(0, 0, 0, 0)
         self.app_list_layout.setSpacing(SPACE_XL)
+        launcher_layout.addLayout(self.app_list_layout)
         self._refresh_hidden_button()
-        self._populate_app_view(self._visible_apps())
+        self._refresh_launcher_home()
 
         scroll.setWidget(self.app_list_container)
         layout.addWidget(scroll)
         return page
+
+    def _make_launcher_section(self, title: str) -> tuple[QWidget, QHBoxLayout]:
+        section = QWidget()
+        section.setStyleSheet("background: transparent;")
+        outer = QVBoxLayout(section)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(SPACE_M)
+        outer.addWidget(make_section_label(title))
+
+        row_wrap = QWidget()
+        row_wrap.setStyleSheet("background: transparent;")
+        row = QHBoxLayout(row_wrap)
+        row.setContentsMargins(0, 0, 0, 0)
+        row.setSpacing(SPACE_M)
+        outer.addWidget(row_wrap)
+        section.setVisible(False)
+        return section, row
 
     def _build_category_chips(self) -> None:
         """Build category filter chips from available apps.
@@ -256,6 +297,48 @@ class LibraryPageMixin:
 
         self._category_row.addStretch()
 
+    def _clear_layout(self, layout: QHBoxLayout | QVBoxLayout | QGridLayout) -> None:
+        while layout.count():
+            item = layout.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+            elif item.layout():
+                self._clear_layout(item.layout())
+
+    def _apps_by_names(self, names: list[str], candidates: list[AppInfo]) -> list[AppInfo]:
+        by_name = {app.name: app for app in candidates}
+        return [by_name[name] for name in names if name in by_name]
+
+    def _populate_launcher_row(
+        self,
+        section: QWidget,
+        row: QHBoxLayout,
+        apps: list[AppInfo],
+    ) -> None:
+        self._clear_layout(row)
+        section.setVisible(bool(apps))
+        if not apps:
+            return
+        for app in apps:
+            row.addWidget(self._make_app_card(app))
+        row.addStretch()
+
+    def _refresh_launcher_sections(self, filtered: list[AppInfo]) -> None:
+        pinned = self._apps_by_names(launcher_state.get_pinned(), filtered)
+        recent = self._apps_by_names(launcher_state.get_recent(), filtered)
+        self._populate_launcher_row(self._pinned_section, self._pinned_row, pinned)
+        self._populate_launcher_row(self._recent_section, self._recent_row, recent)
+
+    def _refresh_launcher_home(self) -> None:
+        self._filter_apps(self.search_box.text())
+
+    def _on_toggle_pin_app(self, app: AppInfo) -> None:
+        if launcher_state.is_pinned(app.name):
+            launcher_state.unpin(app.name)
+        else:
+            launcher_state.pin(app.name)
+        self._refresh_launcher_home()
+
     def _set_category(self, category: str) -> None:
         self._active_category = category
         more_btn = getattr(self, "_category_more_btn", None)
@@ -277,15 +360,7 @@ class LibraryPageMixin:
 
     def _populate_app_view(self, apps: list[AppInfo]) -> None:
         """Populate apps in grid or list layout."""
-        while self.app_list_layout.count():
-            item = self.app_list_layout.takeAt(0)
-            if item.widget():
-                item.widget().deleteLater()
-            elif item.layout():
-                while item.layout().count():
-                    sub = item.layout().takeAt(0)
-                    if sub.widget():
-                        sub.widget().deleteLater()
+        self._clear_layout(self.app_list_layout)
 
         if not apps:
             self.app_list_layout.addWidget(self._make_empty_state())
@@ -477,6 +552,12 @@ class LibraryPageMixin:
         )
 
         menu = QMenu(more_btn)
+        pin_action = menu.addAction(
+            tr("Unpin") if launcher_state.is_pinned(app.name) else tr("Pin")
+        )
+        pin_action.setIcon(load_icon("pin", C.SUBTEXT1, 16))
+        pin_action.triggered.connect(lambda _, a=app: self._on_toggle_pin_app(a))
+
         edit_action = menu.addAction(tr("Edit"))
         edit_action.triggered.connect(lambda _, a=app: self._on_edit_app(a))
 
@@ -618,6 +699,7 @@ class LibraryPageMixin:
         filtered = [a for a in base if q in a.full_name.lower() or q in a.name.lower()]
         if self._active_category:
             filtered = [a for a in filtered if self._active_category in a.categories]
+        self._refresh_launcher_sections(filtered)
         self._populate_app_view(filtered)
         # "X of Y" so the toolbar count reconciles with the info bar's total
         # after a search/filter (Task 5).

--- a/src/winpodx/gui/_main_window_nav.py
+++ b/src/winpodx/gui/_main_window_nav.py
@@ -2,7 +2,7 @@
 """Navigation + first-launch mixin for ``WinpodxWindow``.
 
 Holds page-switch behaviour (start/stop the app-log tail and the
-Info-page auto-refresh based on which tab is showing) and the
+Info-page auto-refresh based on which page is showing) and the
 first-run quick-start wizard (resume pending install steps + show
 the one-shot Welcome dialog).
 
@@ -40,6 +40,8 @@ class NavigationMixin:
         self.pages.setCurrentIndex(index)
         for i, btn in enumerate(self.nav_buttons):
             btn.setChecked(i == index)
+        for i, action in enumerate(getattr(self, "nav_menu_actions", [])):
+            action.setChecked(i == index)
         # v0.5.1: tail processes are now always-on (started at
         # WinpodxWindow.__init__) and feed both the Terminal full
         # history AND the always-visible bottom log bar. We no
@@ -72,7 +74,7 @@ class NavigationMixin:
             self._sessions_timer.stop()
 
     def _install_shortcuts(self) -> None:
-        """Wire keyboard navigation: Alt+1..N switch top-nav pages and
+        """Wire keyboard navigation: Alt+1..N switch launcher pages and
         Ctrl+F focuses the library search box.
 
         Idempotent — guarded so the once-on-startup caller (or any future
@@ -89,7 +91,7 @@ class NavigationMixin:
         search_sc = QShortcut(QKeySequence(QKeySequence.StandardKey.Find), self)
 
         def _focus_search() -> None:
-            # Search lives on the library page; jump there first so the box
+            # Search lives on Home; jump there first so the box
             # is visible, then focus + select-all for an immediate retype.
             self._switch_page(0)
             self.search_box.setFocus(Qt.FocusReason.ShortcutFocusReason)

--- a/src/winpodx/gui/_main_window_pod.py
+++ b/src/winpodx/gui/_main_window_pod.py
@@ -35,6 +35,7 @@ from winpodx.core.app import AppInfo
 from winpodx.core.config import Config
 from winpodx.core.i18n import tr
 from winpodx.core.pod import pod_status
+from winpodx.gui import launcher_state
 from winpodx.gui._widget_helpers import show_toast
 from winpodx.gui.icons import load_icon
 from winpodx.gui.theme import C
@@ -94,6 +95,7 @@ class PodStatusMixin:
                 rc = session.process.returncode
                 # 0 = normal exit, 128+signal = killed by signal.
                 if rc == 0 or rc > 128:
+                    launcher_state.record_recent(app.name)
                     self.app_launched.emit(app.full_name)
                 else:
                     time.sleep(0.2)  # let reaper drain stderr
@@ -103,6 +105,7 @@ class PodStatusMixin:
                         msg += f"\n{stderr}"
                     self.app_launch_failed.emit(msg)
             else:
+                launcher_state.record_recent(app.name)
                 self.app_launched.emit(app.full_name)
 
         threading.Thread(target=_do, daemon=True).start()
@@ -370,6 +373,8 @@ class PodStatusMixin:
     @Slot(str)
     def _on_app_launched(self, name: str) -> None:
         self.info_label.setText(tr("{name} launched").format(name=name))
+        if hasattr(self, "_refresh_launcher_home"):
+            self._refresh_launcher_home()
         show_toast(self, tr("{name} launched").format(name=name), kind="success")
 
     @Slot(str)

--- a/src/winpodx/gui/icons/home.svg
+++ b/src/winpodx/gui/icons/home.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M4 11.5 12 4l8 7.5' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M6.5 10.5V20h5v-5h3v5h5v-9.5' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/pin.svg
+++ b/src/winpodx/gui/icons/pin.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <path d='M8 4h8l-1 6 3 3v2H6v-2l3-3z' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M12 15v6' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/icons/search.svg
+++ b/src/winpodx/gui/icons/search.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+  <circle cx='11' cy='11' r='7' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+  <path d='M16 16l5 5' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/>
+</svg>

--- a/src/winpodx/gui/launcher_state.py
+++ b/src/winpodx/gui/launcher_state.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: MIT
+"""Persistent launcher pin and recent-app state for the WinPodX GUI."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from winpodx.utils.paths import APP_NAME, data_dir
+
+_STATE_FILENAME = "launcher_state.json"
+_RECENT_LIMIT = 8
+
+
+def _state_dir() -> Path:
+    """Return the XDG state directory, falling back to the data dir."""
+    base = os.environ.get("XDG_STATE_HOME")
+    if base:
+        return Path(base) / APP_NAME
+    home = Path.home()
+    if str(home):
+        return home / ".local" / "state" / APP_NAME
+    return data_dir()
+
+
+def _state_path() -> Path:
+    return _state_dir() / _STATE_FILENAME
+
+
+def _normalize(raw: Any) -> dict:
+    state = raw if isinstance(raw, dict) else {}
+    pinned = _clean_names(state.get("pinned", []))
+    recent = _clean_names(state.get("recent", []))[:_RECENT_LIMIT]
+    return {"pinned": pinned, "recent": recent}
+
+
+def _clean_names(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        name = item.strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        out.append(name)
+    return out
+
+
+def load() -> dict:
+    """Load launcher state, creating the JSON file if it is missing."""
+    path = _state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        state = {"pinned": [], "recent": []}
+        save(state)
+        return state
+    try:
+        state = _normalize(json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError):
+        state = {"pinned": [], "recent": []}
+    save(state)
+    return state
+
+
+def save(state: dict) -> None:
+    """Persist launcher state."""
+    normalized = _normalize(state)
+    path = _state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(normalized, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def pin(name: str) -> None:
+    """Pin an app by its stable app name."""
+    app_name = name.strip()
+    if not app_name:
+        return
+    state = load()
+    pinned = state["pinned"]
+    if app_name not in pinned:
+        pinned.append(app_name)
+        save(state)
+
+
+def unpin(name: str) -> None:
+    """Remove an app from the pinned row."""
+    app_name = name.strip()
+    if not app_name:
+        return
+    state = load()
+    state["pinned"] = [item for item in state["pinned"] if item != app_name]
+    save(state)
+
+
+def is_pinned(name: str) -> bool:
+    """Return whether an app is pinned."""
+    return name.strip() in load()["pinned"]
+
+
+def record_recent(name: str) -> None:
+    """Record a successful launch, capped at 8 most-recent unique apps."""
+    app_name = name.strip()
+    if not app_name:
+        return
+    state = load()
+    state["recent"] = [app_name] + [item for item in state["recent"] if item != app_name]
+    state["recent"] = state["recent"][:_RECENT_LIMIT]
+    save(state)
+
+
+def get_pinned() -> list[str]:
+    """Return pinned app names in user-defined order."""
+    return list(load()["pinned"])
+
+
+def get_recent() -> list[str]:
+    """Return recent app names, most recent first."""
+    return list(load()["recent"])

--- a/src/winpodx/gui/main_window.py
+++ b/src/winpodx/gui/main_window.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-"""winpodx main GUI: top-nav app launcher and pod manager."""
+"""winpodx main GUI: launcher home and pod manager."""
 
 from __future__ import annotations
 
@@ -54,7 +54,7 @@ class WinpodxWindow(
     SettingsPageMixin,
     QMainWindow,
 ):
-    """Main window with horizontal top navigation bar."""
+    """Main window with launcher home and overflow-menu navigation."""
 
     # Thread-safe signals
     pod_status_updated = Signal(str, str)

--- a/src/winpodx/locale/de.json
+++ b/src/winpodx/locale/de.json
@@ -822,5 +822,14 @@
   "Failed to terminate {name}": "{name} konnte nicht beendet werden",
   "Terminate Session": "Sitzung beenden",
   "(no active sessions)": "(keine aktiven Sitzungen)",
-  "Terminate: {name}": "Beenden: {name}"
+  "Terminate: {name}": "Beenden: {name}",
+  "Home / Apps": "Start / Apps",
+  "Apps": "Apps",
+  "Terminal / Logs": "Terminal / Protokolle",
+  "Navigation": "Navigation",
+  "Pinned": "Angeheftet",
+  "Recent": "Zuletzt",
+  "All apps": "Alle Apps",
+  "Pin": "Anheften",
+  "Unpin": "Lösen"
 }

--- a/src/winpodx/locale/fr.json
+++ b/src/winpodx/locale/fr.json
@@ -822,5 +822,14 @@
   "Failed to terminate {name}": "Échec de l'arrêt de {name}",
   "Terminate Session": "Arrêter la session",
   "(no active sessions)": "(aucune session active)",
-  "Terminate: {name}": "Arrêter : {name}"
+  "Terminate: {name}": "Arrêter : {name}",
+  "Home / Apps": "Accueil / Apps",
+  "Apps": "Applications",
+  "Terminal / Logs": "Terminal / Journaux",
+  "Navigation": "Navigation",
+  "Pinned": "Épinglés",
+  "Recent": "Récents",
+  "All apps": "Toutes les apps",
+  "Pin": "Épingler",
+  "Unpin": "Détacher"
 }

--- a/src/winpodx/locale/it.json
+++ b/src/winpodx/locale/it.json
@@ -822,5 +822,14 @@
   "Failed to terminate {name}": "Terminazione di {name} non riuscita",
   "Terminate Session": "Termina sessione",
   "(no active sessions)": "(nessuna sessione attiva)",
-  "Terminate: {name}": "Termina: {name}"
+  "Terminate: {name}": "Termina: {name}",
+  "Home / Apps": "Home / App",
+  "Apps": "App",
+  "Terminal / Logs": "Terminale / Log",
+  "Navigation": "Navigazione",
+  "Pinned": "Aggiunti",
+  "Recent": "Recenti",
+  "All apps": "Tutte le app",
+  "Pin": "Aggiungi",
+  "Unpin": "Rimuovi"
 }

--- a/src/winpodx/locale/ja.json
+++ b/src/winpodx/locale/ja.json
@@ -822,5 +822,14 @@
   "Failed to terminate {name}": "{name} の終了に失敗しました",
   "Terminate Session": "セッションを終了",
   "(no active sessions)": "（アクティブなセッションなし）",
-  "Terminate: {name}": "終了: {name}"
+  "Terminate: {name}": "終了: {name}",
+  "Home / Apps": "ホーム / アプリ",
+  "Apps": "アプリ",
+  "Terminal / Logs": "ターミナル / ログ",
+  "Navigation": "ナビゲーション",
+  "Pinned": "ピン留め",
+  "Recent": "最近",
+  "All apps": "すべてのアプリ",
+  "Pin": "ピン留め",
+  "Unpin": "ピン留め解除"
 }

--- a/src/winpodx/locale/ko.json
+++ b/src/winpodx/locale/ko.json
@@ -822,5 +822,14 @@
   "Failed to terminate {name}": "{name} 종료 실패",
   "Terminate Session": "세션 종료",
   "(no active sessions)": "(활성 세션 없음)",
-  "Terminate: {name}": "종료: {name}"
+  "Terminate: {name}": "종료: {name}",
+  "Home / Apps": "홈 / 앱",
+  "Apps": "앱",
+  "Terminal / Logs": "터미널 / 로그",
+  "Navigation": "탐색",
+  "Pinned": "고정됨",
+  "Recent": "최근",
+  "All apps": "모든 앱",
+  "Pin": "고정",
+  "Unpin": "고정 해제"
 }

--- a/src/winpodx/locale/zh.json
+++ b/src/winpodx/locale/zh.json
@@ -822,5 +822,14 @@
   "Failed to terminate {name}": "终止 {name} 失败",
   "Terminate Session": "终止会话",
   "(no active sessions)": "（无活动会话）",
-  "Terminate: {name}": "终止：{name}"
+  "Terminate: {name}": "终止：{name}",
+  "Home / Apps": "主页 / 应用",
+  "Apps": "应用",
+  "Terminal / Logs": "终端 / 日志",
+  "Navigation": "导航",
+  "Pinned": "已固定",
+  "Recent": "最近",
+  "All apps": "所有应用",
+  "Pin": "固定",
+  "Unpin": "取消固定"
 }


### PR DESCRIPTION
Fundamental nav restructure (owner-chosen direction after comparing 4 paradigms): from top-tab bar → **Start-menu / launcher**.

## What
- **Home = launcher**: prominent search + optional **Pinned** row + optional **Recent** row + the All-apps grid (reuses the existing app-card visuals). The old horizontal tab bar is gone.
- **Top-right ⚙ overflow menu**: Settings / Tools / Terminal·Logs / Info / Devices / License; clicking the **WinPodX logo returns Home**.
- **Pinned + Recent persistence**: gui-side JSON (`winpodx.gui.launcher_state` → `~/.local/state/winpodx/launcher_state.json`); pin/unpin via the app-card overflow menu; `record_recent()` hooked into the GUI launch path (cap 8). **No core/config or winpodx.toml change.**
- Pod-status banner + bottom always-on log bar **kept**.
- **i18n**: the 9 new launcher labels (Pinned / Recent / All apps / Pin / Unpin / Navigation / Home·Apps / Terminal·Logs) translated into all 6 catalogs (de/fr/it/ja/ko/zh) — no English fallback.

## Safety
- `gui/` + `locale/` only — no core/backend/cli/tests touched. No **existing** `tr()` source string changed (only additions).
- Mixin page-builders, signals/slots, bring-up flow, devices page all preserved (the QStackedWidget keeps the same pages; only the nav chrome changed).

## Test
- `ruff check` + `ruff format --check` — clean.
- `pytest tests/test_main_window_bringup.py tests/test_devices_gui.py` — 16 passed; `tests/test_i18n.py` — 6 passed.
- Rendered Home + Settings offscreen — search/grid + ⚙ menu (7 entries) + Home-return + banner + log bar confirmed.
- Full `pytest` — see CI.