### PR TITLE
feat(install): restart running WinPodX (tray/GUI) after an upgrade

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1542,6 +1542,37 @@ INSTALLED_VER="$("$VENV_PY" -c 'import winpodx; print(winpodx.__version__)' 2>/d
 GUI_LABEL="yes"
 [ -n "$WINPODX_NO_GUI" ] && GUI_LABEL="no (--no-gui)"
 
+# Apply the update to an already-RUNNING WinPodX immediately. A long-lived tray
+# or GUI keeps the OLD code in memory, so on an upgrade the new code otherwise
+# only takes effect after the user manually restarts or re-logs in (this caused
+# repeated "the fix didn't work" confusion). Restart ONLY the winpodx APP
+# processes by targeting the 'tray' / 'gui' entrypoints precisely.
+#
+# NEVER use a bare `pkill -f winpodx`: that also matches conmon (the container
+# monitor for the 'winpodx-windows' pod) and would tear down the running
+# Windows VM + every live RDP session. The 'tray'/'gui' patterns below do not
+# match conmon, the QEMU process, or this installer's own provision/migrate run.
+# A fresh install has nothing running here, so this is a no-op.
+if command -v pgrep >/dev/null 2>&1; then
+    _wpx_was_tray=0
+    _wpx_was_gui=0
+    pgrep -f 'winpodx tray' >/dev/null 2>&1 && _wpx_was_tray=1
+    pgrep -f 'winpodx gui' >/dev/null 2>&1 && _wpx_was_gui=1
+    if [ "$_wpx_was_tray" = 1 ] || [ "$_wpx_was_gui" = 1 ]; then
+        log "Restarting WinPodX (tray/GUI) to apply the update (the pod keeps running)…"
+        pkill -f 'winpodx tray' 2>/dev/null || true
+        pkill -f 'winpodx gui' 2>/dev/null || true
+        sleep 1
+        # If the GUI was up, relaunch it (the GUI auto-spawns its own tray);
+        # otherwise just relaunch the tray. Avoids a double tray.
+        if [ "$_wpx_was_gui" = 1 ]; then
+            setsid "$SYMLINK" gui >/dev/null 2>&1 </dev/null &
+        elif [ "$_wpx_was_tray" = 1 ]; then
+            setsid "$SYMLINK" tray >/dev/null 2>&1 </dev/null &
+        fi
+    fi
+fi
+
 echo ""
 echo -e "${GREEN}  ┌─ WinPodX installed ──────────────────────────────────────${NC}"
 printf "  │  version   %s\n" "$INSTALLED_VER"


### PR DESCRIPTION
## Why
A long-lived **tray/GUI keeps the OLD code in memory**, so on an upgrade the new code only took effect after a manual restart or re-login. Across this work that repeatedly read as "the fix didn't work" — the merged fix was correct, but the running process was stale.

## What
At the end of `install.sh`, restart the running WinPodX **app** processes so the update applies immediately:
- Detects a running `winpodx tray` / `winpodx gui` via `pgrep` (fresh install → nothing running → no-op).
- Restarts: relaunch the **GUI** if it was up (it auto-spawns its own tray), else just the **tray**; detached via `setsid` so it survives the installer exiting.
- **The pod keeps running** — only the winpodx app is restarted.

## Safety
- Targets the `tray` / `gui` entrypoints **precisely**. **Never** a bare `pkill -f winpodx` — that also matches **conmon** (the monitor for the `winpodx-windows` container) and would kill the Windows VM + every live RDP session. The patterns also don't match the installer's own `winpodx provision`/`migrate`.
- `bash -n` clean; `shellcheck -S error` clean; `pytest tests/test_install_sh_provision.py` — 20 passed.