### PR TITLE
feat(gui): Live Launcher — Start-menu home, running-session strip, cohesive pages

### DIFF
--- a/src/winpodx/gui/_main_window_devices.py
+++ b/src/winpodx/gui/_main_window_devices.py
@@ -49,6 +49,11 @@ from winpodx.gui.theme import (
     BTN_GHOST,
     BTN_PRIMARY,
     BTN_SECONDARY,
+    FONT_BODY,
+    FONT_CAPTION,
+    FONT_HEADER,
+    RADIUS_M,
+    RADIUS_S,
     SCROLL_AREA,
     SETTINGS_SECTION,
     SPACE_L,
@@ -57,6 +62,7 @@ from winpodx.gui.theme import (
     SPACE_XL,
     SPACE_XXL,
     C,
+    rgba,
 )
 
 
@@ -94,18 +100,21 @@ class DevicesMixin:
 
         refresh = QPushButton(tr("Refresh"))
         refresh.setStyleSheet(BTN_SECONDARY)
+        refresh.setIcon(load_icon("refresh", C.SUBTEXT1, 16))
+        refresh.setIconSize(QSize(16, 16))
         refresh.clicked.connect(self._render_devices)
         self._devices_status = QLabel("")
         self._devices_status.setStyleSheet(
-            f"color: {C.SUBTEXT1}; font-size: 12px; "
-            f"background: {C.SURFACE0}; border: 1px solid {C.SURFACE1}; "
-            "border-radius: 8px; padding: 7px 10px;"
+            f"color: {C.SUBTEXT1}; font-size: {FONT_CAPTION}px; font-weight: 500;"
+            f" background: {rgba(C.SURFACE0, 0.72)};"
+            f" border: 1px solid {rgba(C.SURFACE2, 0.38)};"
+            f" border-radius: {RADIUS_M}px; padding: 7px 12px;"
         )
 
         actions = QWidget()
         actions_l = QHBoxLayout(actions)
         actions_l.setContentsMargins(0, 0, 0, 0)
-        actions_l.setSpacing(8)
+        actions_l.setSpacing(SPACE_S)
         actions_l.addWidget(self._devices_status)
         actions_l.addWidget(refresh)
 
@@ -139,9 +148,20 @@ class DevicesMixin:
         lay = QVBoxLayout(card)
         lay.setContentsMargins(SPACE_L, SPACE_L, SPACE_L, SPACE_L)
         lay.setSpacing(SPACE_M)
+
+        head_row = QWidget()
+        head_l = QHBoxLayout(head_row)
+        head_l.setContentsMargins(0, 0, 0, 0)
+        head_l.setSpacing(SPACE_S)
+        head_icon = QLabel()
+        head_icon.setFixedSize(16, 16)
+        head_icon.setPixmap(load_icon("hardware", C.SUBTEXT0, 16).pixmap(16, 16))
+        head_l.addWidget(head_icon)
         head = QLabel(heading)
-        head.setStyleSheet(f"font-weight: 700; color: {C.BLUE}; font-size: 14px;")
-        lay.addWidget(head)
+        head.setStyleSheet(f"color: {C.TEXT}; font-size: {FONT_HEADER}px; font-weight: 600;")
+        head_l.addWidget(head)
+        head_l.addStretch(1)
+        lay.addWidget(head_row)
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
@@ -208,28 +228,41 @@ class DevicesMixin:
         row.setObjectName("actionRow")
         row.setStyleSheet(ACTION_ROW)
         h = QHBoxLayout(row)
-        h.setContentsMargins(SPACE_M, SPACE_S, SPACE_M, SPACE_S)
+        h.setContentsMargins(SPACE_M, SPACE_M, SPACE_M, SPACE_M)
         h.setSpacing(SPACE_M)
 
         badge = QLabel(host.dtype.upper())
-        badge_color = C.GREEN if safety.safe else C.RED
+        badge_color = C.GREEN if safety.safe else C.PEACH
         badge.setStyleSheet(
-            f"background: {badge_color}; color: #0d1117; border-radius: 6px;"
-            " padding: 1px 6px; font-size: 11px; font-weight: 700;"
+            f"background: {rgba(badge_color, 0.16)}; color: {badge_color};"
+            f" border: 1px solid {rgba(badge_color, 0.30)};"
+            f" border-radius: {RADIUS_S}px; padding: 2px 8px;"
+            f" font-size: {FONT_CAPTION}px; font-weight: 600;"
         )
         badge.setAlignment(Qt.AlignCenter)
-        h.addWidget(badge)
+        h.addWidget(badge, 0, Qt.AlignTop)
 
         full_label = host.label or tr("(unknown)")
         text = QLabel()
-        text.setStyleSheet(f"color: {C.TEXT}; font-size: 12px;")
-        # Elide the (often long) device label with a real "…" rather than a
-        # hard slice, and expose the full text on hover so nothing is lost.
+        # Device id reads as the primary line; the (often long) label sits
+        # below as calmer secondary text.
+        did_lbl = QLabel(host.did)
+        did_lbl.setStyleSheet(f"color: {C.TEXT}; font-size: {FONT_BODY}px; font-weight: 500;")
+        # Elide the label with a real "…" rather than a hard slice, and expose
+        # the full text on hover so nothing is lost.
         metrics = QFontMetrics(text.font())
         elided = metrics.elidedText(full_label, Qt.TextElideMode.ElideRight, 240)
-        text.setText(f"{host.did}\n{elided}")
-        text.setToolTip(f"{host.did}\n{full_label}")
-        h.addWidget(text, 1)
+        label_lbl = QLabel(elided)
+        label_lbl.setStyleSheet(f"color: {C.SUBTEXT0}; font-size: {FONT_CAPTION}px;")
+
+        text_host = QWidget()
+        text_l = QVBoxLayout(text_host)
+        text_l.setContentsMargins(0, 0, 0, 0)
+        text_l.setSpacing(2)
+        text_l.addWidget(did_lbl)
+        text_l.addWidget(label_lbl)
+        text_host.setToolTip(f"{host.did}\n{full_label}")
+        h.addWidget(text_host, 1)
 
         if assigned:
             btn = QPushButton(tr("← Detach"))
@@ -332,14 +365,16 @@ class DevicesMixin:
         dlg.setModal(True)
         dlg.setMinimumWidth(460)
         lay = QVBoxLayout(dlg)
-        lay.setContentsMargins(20, 18, 20, 16)
-        lay.setSpacing(12)
+        lay.setContentsMargins(SPACE_L, SPACE_L, SPACE_L, SPACE_L)
+        lay.setSpacing(SPACE_M)
 
         lay.addWidget(make_warning_callout(plain, level="danger"))
 
         reasons = QLabel(tr("Why this is flagged:\n") + "\n".join(f"• {r}" for r in safety.reasons))
         reasons.setWordWrap(True)
-        reasons.setStyleSheet(f"color: {C.SUBTEXT1}; font-size: 12px; background: transparent;")
+        reasons.setStyleSheet(
+            f"color: {C.SUBTEXT1}; font-size: {FONT_BODY}px; background: transparent;"
+        )
         lay.addWidget(reasons)
 
         buttons = QDialogButtonBox(

--- a/src/winpodx/gui/_main_window_header.py
+++ b/src/winpodx/gui/_main_window_header.py
@@ -111,13 +111,13 @@ class HeaderMixin:
             (tr("License"), 6, "diamond"),
         ]
 
+        # Navigation lives entirely in the gear overflow menu now. We do NOT
+        # create per-page QPushButtons: the old top tab bar is gone, and an
+        # un-laid-out QPushButton(parent=self) renders as a stray box at (0,0)
+        # over the logo (the "License" ghost bug). nav_buttons stays empty for
+        # back-compat; _switch_page / shortcuts drive off nav_menu_actions.
         nav_menu = QMenu(self)
         for row, (label, idx, icon_name) in enumerate(nav_items):
-            btn = QPushButton(label, self)
-            btn.setCheckable(True)
-            btn.clicked.connect(lambda _, i=idx: self._switch_page(i))
-            self.nav_buttons.append(btn)
-
             action = nav_menu.addAction(load_icon(icon_name, C.SUBTEXT1, 16), label)
             action.setCheckable(True)
             action.triggered.connect(lambda _checked=False, i=idx: self._switch_page(i))
@@ -125,7 +125,6 @@ class HeaderMixin:
             if row == 0:
                 nav_menu.addSeparator()
 
-        self.nav_buttons[0].setChecked(True)
         self.nav_menu_actions[0].setChecked(True)
         layout.addStretch()
 

--- a/src/winpodx/gui/_main_window_header.py
+++ b/src/winpodx/gui/_main_window_header.py
@@ -86,14 +86,26 @@ class HeaderMixin:
 
         icon_path = bundled_data_path("winpodx-icon.svg")
         if icon_path is not None:
+            from PySide6.QtCore import QRectF
+
             renderer = QSvgRenderer(str(icon_path))
-            pixmap = QPixmap(QSize(28, 24))
+            size = 24
+            pixmap = QPixmap(size, size)
             pixmap.fill(Qt.GlobalColor.transparent)
             painter = QPainter(pixmap)
-            renderer.render(painter)
+            # Preserve the icon's aspect ratio inside a square box -- rendering
+            # a square logo into a 28x24 pixmap stretched it horizontally
+            # ("the logo looks squished"). Fit + center instead.
+            ds = renderer.defaultSize()
+            if ds.width() > 0 and ds.height() > 0:
+                scale = min(size / ds.width(), size / ds.height())
+                w, h = ds.width() * scale, ds.height() * scale
+                renderer.render(painter, QRectF((size - w) / 2, (size - h) / 2, w, h))
+            else:
+                renderer.render(painter)
             painter.end()
             logo_btn.setIcon(QIcon(pixmap))
-            logo_btn.setIconSize(QSize(28, 24))
+            logo_btn.setIconSize(QSize(size, size))
 
         layout.addWidget(logo_btn)
 

--- a/src/winpodx/gui/_main_window_info.py
+++ b/src/winpodx/gui/_main_window_info.py
@@ -15,8 +15,7 @@ Host-class contract (only listed for readers; not enforced):
 
 from __future__ import annotations
 
-from PySide6.QtCore import QThread, QTimer, Slot
-from PySide6.QtGui import QIcon
+from PySide6.QtCore import Qt, QThread, QTimer, Slot
 from PySide6.QtWidgets import (
     QFrame,
     QHBoxLayout,
@@ -29,15 +28,21 @@ from PySide6.QtWidgets import (
 
 from winpodx.core.i18n import tr
 from winpodx.gui._widget_helpers import add_shadow, make_empty_panel, make_page_header
+from winpodx.gui.icons import load_icon
 from winpodx.gui.theme import (
     BTN_GHOST,
+    FONT_HEADER,
     SCROLL_AREA,
     SETTINGS_SECTION,
     SPACE_L,
     SPACE_M,
     SPACE_S,
     SPACE_XL,
+    SPACE_XS,
     SPACE_XXL,
+    TOOL_ICON_BG,
+    TOOL_ICON_BORDER,
+    TOOL_ICON_FG,
     C,
     rgba,
 )
@@ -59,11 +64,25 @@ class InfoPageMixin:
         "kvm": "enable KVM (load the kvm module; add yourself to the 'kvm' group)",
     }
 
+    # Status colors drawn from the shared GitHub-Dark palette so the badges
+    # sit calm against the rest of the app rather than reading as loud
+    # saturated fills.
     _HEALTH_BADGE_COLORS: dict[str, str] = {
-        "ok": "#a6e3a1",  # Catppuccin GREEN
-        "warn": "#f9e2af",  # YELLOW
-        "fail": "#f38ba8",  # RED
-        "skip": "#9399b2",  # SUBTEXT0
+        "ok": C.GREEN,
+        "warn": C.YELLOW,
+        "fail": C.RED,
+        "skip": C.OVERLAY1,
+    }
+
+    # One restrained SVG glyph per section, rendered in a soft tinted chip in
+    # the card header — replaces the old bare blue text headers.
+    _INFO_CARD_ICONS: dict[str, str] = {
+        "health": "check",
+        "system": "hardware",
+        "display": "desktop",
+        "dependencies": "diamond",
+        "pod": "rdp",
+        "config": "gear",
     }
 
     def _build_info_page(self) -> QWidget:
@@ -90,10 +109,16 @@ class InfoPageMixin:
         layout.setSpacing(SPACE_L)
 
         refresh_btn = QPushButton(tr("Refresh Info"))
-        refresh_btn.setIcon(QIcon.fromTheme("view-refresh"))
+        refresh_btn.setIcon(load_icon("refresh", C.SUBTEXT0, 16))
         refresh_btn.setStyleSheet(BTN_GHOST)
         refresh_btn.clicked.connect(self._refresh_info)
-        layout.addWidget(make_page_header(tr("Info"), actions_widget=refresh_btn))
+        layout.addWidget(
+            make_page_header(
+                tr("Info"),
+                tr("A live snapshot of your system, display, dependencies, and pod."),
+                actions_widget=refresh_btn,
+            )
+        )
 
         # Containers for the 5 cards. Initial population goes through
         # _refresh_info which dispatches a worker thread; until that thread
@@ -111,7 +136,7 @@ class InfoPageMixin:
             ("pod", "Pod"),
             ("config", "Config"),
         ]:
-            card = self._info_card(label)
+            card = self._info_card(label, key)
             self._info_cards[key] = card
             layout.addWidget(card)
 
@@ -127,31 +152,48 @@ class InfoPageMixin:
         QTimer.singleShot(0, self._refresh_info)
         return page
 
-    def _info_card(self, title: str) -> QFrame:
-        """Card scaffold with a title bar + an empty body layout we mutate later."""
+    def _info_card(self, title: str, key: str = "") -> QFrame:
+        """Card scaffold with an icon-chip title + an empty body we mutate later."""
         card = QFrame()
-        card.setObjectName("infoSection")
+        card.setObjectName("settingsSection")
         card.setStyleSheet(
             SETTINGS_SECTION
             + f"QLabel {{ color: {C.TEXT}; font-size: 13px; background: transparent; }}"
         )
-        add_shadow(card)
+        add_shadow(card, blur=14, y=2, alpha=35)
 
         layout = QVBoxLayout(card)
-        layout.setContentsMargins(SPACE_XL, SPACE_XL, SPACE_XL, SPACE_XL)
-        layout.setSpacing(SPACE_S)
+        layout.setContentsMargins(SPACE_XL, SPACE_L, SPACE_XL, SPACE_XL)
+        layout.setSpacing(SPACE_M)
 
-        header = QLabel(tr(title))
-        header.setStyleSheet(
-            f"background: transparent; color: {C.BLUE}; font-size: 15px; font-weight: 600;"
+        # Header: a soft tinted icon chip + a semibold section title. Keeping
+        # the weight restrained (semibold, neutral text colour) reads calmer
+        # than the old loud-blue header it replaces.
+        header = QHBoxLayout()
+        header.setSpacing(SPACE_S)
+
+        chip = QLabel()
+        chip.setFixedSize(30, 30)
+        chip.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        icon_name = self._INFO_CARD_ICONS.get(key or title.lower(), "diamond")
+        chip.setPixmap(load_icon(icon_name, TOOL_ICON_FG, 16).pixmap(16, 16))
+        chip.setStyleSheet(
+            f"background: {TOOL_ICON_BG}; border: 1px solid {TOOL_ICON_BORDER}; border-radius: 9px;"
         )
-        layout.addWidget(header)
+        header.addWidget(chip, 0)
+
+        title_lbl = QLabel(tr(title))
+        title_lbl.setStyleSheet(
+            f"background: transparent; color: {C.TEXT};"
+            f" font-size: {FONT_HEADER}px; font-weight: 600;"
+        )
+        header.addWidget(title_lbl, 1, Qt.AlignmentFlag.AlignVCenter)
+        layout.addLayout(header)
 
         accent = QFrame()
         accent.setFixedHeight(1)
-        accent.setStyleSheet(f"background: {C.SURFACE1};")
+        accent.setStyleSheet(f"background: {rgba(C.SURFACE2, 0.40)};")
         layout.addWidget(accent)
-        layout.addSpacing(SPACE_S)
 
         body = QVBoxLayout()
         body.setSpacing(SPACE_S)
@@ -185,21 +227,35 @@ class InfoPageMixin:
             body.addWidget(make_empty_panel(tr("No probes ran (health module unavailable).")))
             return
 
+        # Overall verdict line: a small status dot + a calm summary, rather
+        # than a single loud coloured sentence.
         overall_color = self._HEALTH_BADGE_COLORS.get(overall, C.SUBTEXT0)
+        verdict_row = QHBoxLayout()
+        verdict_row.setSpacing(SPACE_S)
+        dot = QLabel()
+        dot.setFixedSize(8, 8)
+        dot.setStyleSheet(f"background: {overall_color}; border-radius: 4px;")
+        verdict_row.addWidget(dot, 0, Qt.AlignmentFlag.AlignVCenter)
         verdict = QLabel(tr("Overall: {status}").format(status=overall.upper() or tr("UNKNOWN")))
-        verdict.setStyleSheet(f"color: {overall_color}; font-size: 13px; font-weight: 500;")
-        body.addWidget(verdict)
-        body.addSpacing(4)
+        verdict.setStyleSheet(f"color: {C.SUBTEXT1}; font-size: 13px; font-weight: 500;")
+        verdict_row.addWidget(verdict, 1, Qt.AlignmentFlag.AlignVCenter)
+        verdict_holder = QWidget()
+        verdict_holder.setLayout(verdict_row)
+        body.addWidget(verdict_holder)
+        body.addSpacing(SPACE_XS)
 
         for p in probes:
             status = p.get("status", "")
             color = self._HEALTH_BADGE_COLORS.get(status, C.SUBTEXT0)
             row = QHBoxLayout()
+            row.setContentsMargins(SPACE_S, SPACE_XS, SPACE_S, SPACE_XS)
+            row.setSpacing(SPACE_M)
             badge = QLabel(status.upper())
             badge.setFixedWidth(48)
+            badge.setAlignment(Qt.AlignmentFlag.AlignCenter)
             badge.setStyleSheet(
                 f"color: {color}; font-size: 11px; font-weight: 500; "
-                f"background: {rgba(color, 0.12)}; border: 1px solid {rgba(color, 0.35)}; "
+                f"background: {rgba(color, 0.10)}; border: 1px solid {rgba(color, 0.28)}; "
                 "border-radius: 6px; padding: 2px 6px;"
             )
             name = QLabel(p.get("name", ""))
@@ -213,12 +269,10 @@ class InfoPageMixin:
             row.addWidget(badge, 0)
             row.addWidget(name, 0)
             row.addWidget(detail, 1)
-            row.addWidget(duration, 0)
+            row.addWidget(duration, 0, Qt.AlignmentFlag.AlignVCenter)
             holder = QWidget()
             holder.setLayout(row)
-            holder.setStyleSheet(
-                f"background: {rgba(C.MANTLE, 0.55)}; border-radius: 8px; padding: 2px;"
-            )
+            holder.setStyleSheet(f"background: {rgba(C.MANTLE, 0.45)}; border-radius: 8px;")
             body.addWidget(holder)
 
     def _set_info_card_rows(self, key: str, rows: list[tuple[str, str]]) -> None:
@@ -234,6 +288,7 @@ class InfoPageMixin:
                 w.deleteLater()
         for label, value in rows:
             row = QHBoxLayout()
+            row.setContentsMargins(0, SPACE_XS, 0, SPACE_XS)
             row.setSpacing(SPACE_M)
             lbl = QLabel(label)
             lbl.setStyleSheet(f"color: {C.SUBTEXT0}; font-size: 12px;")
@@ -241,9 +296,9 @@ class InfoPageMixin:
             val = QLabel(value)
             val.setStyleSheet(f"color: {C.TEXT}; font-size: 12px;")
             val.setWordWrap(True)
-            row.addWidget(lbl, 0)
+            row.addWidget(lbl, 0, Qt.AlignmentFlag.AlignTop)
             row.addStretch()
-            row.addWidget(val, 1)
+            row.addWidget(val, 1, Qt.AlignmentFlag.AlignTop)
             holder = QWidget()
             holder.setLayout(row)
             body.addWidget(holder)

--- a/src/winpodx/gui/_main_window_library.py
+++ b/src/winpodx/gui/_main_window_library.py
@@ -36,7 +36,6 @@ from PySide6.QtWidgets import (
     QProgressBar,
     QPushButton,
     QScrollArea,
-    QSizePolicy,
     QVBoxLayout,
     QWidget,
 )
@@ -48,13 +47,11 @@ from winpodx.gui._widget_helpers import (
     add_shadow,
     make_app_avatar,
     make_empty_panel,
-    make_page_header,
     make_section_label,
     make_source_badge,
 )
 from winpodx.gui.icons import load_icon
 from winpodx.gui.theme import (
-    APP_CARD,
     APP_TILE,
     BTN_ACCENT,
     BTN_DANGER,
@@ -80,36 +77,87 @@ from winpodx.gui.theme import (
 _MAX_CATEGORY_CHIPS = 8
 
 
+class _AppTile(QFrame):
+    """Windows-Start-style launcher tile: icon above name, the whole tile is
+    clickable (left-click launches), right-click opens the context menu. No
+    border / badge / launch button on the face -- minimal, like the Start-menu.
+    """
+
+    def __init__(self, app: AppInfo, *, on_launch, on_menu) -> None:
+        super().__init__()
+        self._app = app
+        self._on_launch = on_launch
+        self._on_menu = on_menu
+        self.setObjectName("appTileBtn")
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setToolTip(app.full_name)
+        self.setStyleSheet(
+            "QFrame#appTileBtn { background: transparent; border: none;"
+            " border-radius: 10px; }"
+            f"QFrame#appTileBtn:hover {{ background: {C.SURFACE1}; }}"
+        )
+        v = QVBoxLayout(self)
+        v.setContentsMargins(SPACE_S, SPACE_M, SPACE_S, SPACE_M)
+        v.setSpacing(SPACE_S)
+        v.setAlignment(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignHCenter)
+
+        avatar = make_app_avatar(app, size=48, radius=12, font_size=20)
+        v.addWidget(avatar, 0, Qt.AlignmentFlag.AlignHCenter)
+
+        name = QLabel(app.full_name)
+        name.setAlignment(Qt.AlignmentFlag.AlignHCenter)
+        name.setWordWrap(True)
+        name.setFixedWidth(104)
+        name.setStyleSheet(f"background: transparent; color: {C.TEXT}; font-size: 12px;")
+        v.addWidget(name, 0, Qt.AlignmentFlag.AlignHCenter)
+
+        self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.customContextMenuRequested.connect(
+            lambda pos: self._on_menu(self._app, self.mapToGlobal(pos))
+        )
+
+    def mousePressEvent(self, event) -> None:  # noqa: N802 (Qt override)
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._on_launch(self._app)
+        super().mousePressEvent(event)
+
+
 class LibraryPageMixin:
     """Builds the Apps page + drives grid/list view + filter state."""
 
     def _build_library_page(self) -> QWidget:
         page = QWidget()
         layout = QVBoxLayout(page)
-        layout.setContentsMargins(SPACE_XXL, 0, SPACE_XXL, SPACE_L)
-        layout.setSpacing(SPACE_M)
+        layout.setContentsMargins(SPACE_XXL, SPACE_XL, SPACE_XXL, SPACE_L)
+        layout.setSpacing(SPACE_L)
 
-        layout.addWidget(make_page_header(tr("Apps")))
+        # Launcher hero: one large, centered search is the focal point (Start-
+        # menu feel) -- no redundant page title.
+        hero = QHBoxLayout()
+        hero.addStretch(1)
+        self.search_box = QLineEdit()
+        self.search_box.setPlaceholderText(tr("Search apps by name..."))
+        self.search_box.setStyleSheet(SEARCH_BAR)
+        self.search_box.setMinimumHeight(46)
+        self.search_box.setMinimumWidth(420)
+        self.search_box.setMaximumWidth(720)
+        self.search_box.addAction(
+            load_icon("search", C.SUBTEXT0, 18),
+            QLineEdit.ActionPosition.LeadingPosition,
+        )
+        self.search_box.setClearButtonEnabled(True)
+        self.search_box.textChanged.connect(self._filter_apps)
+        hero.addWidget(self.search_box, 3)
+        hero.addStretch(1)
+        layout.addLayout(hero)
 
+        # Secondary action row -- small + quiet, under the hero search.
         toolbar = QHBoxLayout()
         toolbar.setSpacing(16)
 
         left_group = QHBoxLayout()
         left_group.setContentsMargins(0, 0, 0, 0)
         left_group.setSpacing(8)
-
-        self.search_box = QLineEdit()
-        self.search_box.setPlaceholderText(tr("Search apps by name..."))
-        self.search_box.setStyleSheet(SEARCH_BAR)
-        self.search_box.setMinimumWidth(360)
-        self.search_box.setMaximumWidth(620)
-        self.search_box.addAction(
-            load_icon("search", C.OVERLAY0, 16),
-            QLineEdit.ActionPosition.LeadingPosition,
-        )
-        self.search_box.setClearButtonEnabled(True)
-        self.search_box.textChanged.connect(self._filter_apps)
-        left_group.addWidget(self.search_box)
 
         self.app_count_label = QLabel(
             tr("{shown} of {total} apps").format(shown=len(self.apps), total=len(self.apps))
@@ -424,12 +472,12 @@ class LibraryPageMixin:
         return panel
 
     def _populate_grid(self, apps: list[AppInfo]) -> None:
-        """Grid view - cards."""
-        cols = 4
-        self.app_list_layout.setSpacing(SPACE_XL)
+        """Grid view - Start-menu-style icon tiles (dense)."""
+        cols = 6
+        self.app_list_layout.setSpacing(SPACE_L)
         grid = QGridLayout()
-        grid.setHorizontalSpacing(SPACE_XL)
-        grid.setVerticalSpacing(SPACE_XL)
+        grid.setHorizontalSpacing(SPACE_S)
+        grid.setVerticalSpacing(SPACE_S)
         grid.setContentsMargins(0, 0, 0, 0)
         for col in range(cols):
             grid.setColumnStretch(col, 1)
@@ -458,125 +506,28 @@ class LibraryPageMixin:
         self.app_list_layout.addStretch()
 
     def _make_app_card(self, app: AppInfo) -> QWidget:
-        """Grid card with compact app identity, status, and launch footer."""
-        card = QFrame()
-        card.setObjectName("appCard")
-        card.setStyleSheet(APP_CARD)
-        card.setMinimumWidth(188)
-        card.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Maximum)
-        add_shadow(card, blur=12, y=2, alpha=28)
+        """A Start-menu-style launcher tile (icon + name, click to launch)."""
+        return _AppTile(app, on_launch=self._launch_app, on_menu=self._show_app_menu)
 
-        vl = QVBoxLayout(card)
-        vl.setContentsMargins(SPACE_L, SPACE_L, SPACE_L, SPACE_L)
-        vl.setSpacing(SPACE_M)
-
-        top_row = QHBoxLayout()
-        top_row.setContentsMargins(0, 0, 0, 0)
-        top_row.setSpacing(SPACE_M)
-
-        avatar = make_app_avatar(app, size=44, radius=12, font_size=19)
-        top_row.addWidget(avatar, alignment=Qt.AlignmentFlag.AlignLeft)
-
-        identity = QVBoxLayout()
-        identity.setContentsMargins(0, 0, 0, 0)
-        identity.setSpacing(4)
-
-        name_lbl = QLabel(app.full_name)
-        name_lbl.setStyleSheet(
-            f"background: transparent; color: {C.TEXT}; font-size: 13px; font-weight: 500;"
-        )
-        name_lbl.setWordWrap(False)
-        name_lbl.setMaximumWidth(156)
-        fm = name_lbl.fontMetrics()
-        elided = fm.elidedText(app.full_name, Qt.TextElideMode.ElideRight, 156)
-        name_lbl.setText(elided)
-        name_lbl.setToolTip(app.full_name)
-        identity.addWidget(name_lbl)
-
-        meta_parts = []
-        if app.categories:
-            meta_parts.append(", ".join(app.categories[:2]))
-        meta_parts.append(app.name)
-        if app.hidden:
-            meta_parts.append(tr("Hidden"))
-        meta_lbl = QLabel(" • ".join(meta_parts))
-        meta_lbl.setStyleSheet(f"background: transparent; color: {C.OVERLAY0}; font-size: 11px;")
-        meta_lbl.setWordWrap(False)
-        meta_lbl.setMaximumWidth(156)
-        meta_elided = meta_lbl.fontMetrics().elidedText(
-            meta_lbl.text(), Qt.TextElideMode.ElideRight, 156
-        )
-        meta_lbl.setText(meta_elided)
-        identity.addWidget(meta_lbl)
-
-        top_row.addLayout(identity, 1)
-
-        badge = make_source_badge(app)
-        if badge is not None:
-            top_row.addWidget(badge, alignment=Qt.AlignmentFlag.AlignTop)
-
-        vl.addLayout(top_row)
-
-        launch_btn = QPushButton(tr("▶  Launch"))
-        launch_btn.setText(launch_btn.text().removeprefix("▶  "))
-        launch_btn.setIcon(load_icon("play", C.CRUST, 16))
-        launch_btn.setIconSize(QSize(16, 16))
-        launch_btn.setStyleSheet(BTN_ACCENT)
-        launch_btn.setMinimumWidth(118)
-        launch_btn.setToolTip(tr("Launch {app}").format(app=app.full_name))
-        launch_btn.clicked.connect(lambda _, a=app: self._launch_app(a))
-
-        more_btn = QPushButton("")
-        more_btn.setIcon(load_icon("overflow", C.OVERLAY0, 16))
-        more_btn.setIconSize(QSize(16, 16))
-        more_btn.setFixedSize(30, 30)
-        more_btn.setToolTip(tr("Edit"))
-        more_btn.setStyleSheet(
-            f"""
-            QPushButton {{
-                background: transparent;
-                color: {C.OVERLAY0};
-                border: none;
-                border-radius: 15px;
-                font-size: 16px;
-            }}
-            QPushButton:hover {{
-                color: {C.TEXT};
-                background: {C.SURFACE1};
-            }}
-            QPushButton::menu-indicator {{
-                image: none;
-                width: 0px;
-            }}
-            """
-        )
-
-        menu = QMenu(more_btn)
+    def _show_app_menu(self, app: AppInfo, global_pos) -> None:
+        """Right-click context menu for a launcher tile: Pin / Edit / Hide /
+        Delete. Launch is the left-click (the whole tile)."""
+        menu = QMenu(self)
         pin_action = menu.addAction(
             tr("Unpin") if launcher_state.is_pinned(app.name) else tr("Pin")
         )
         pin_action.setIcon(load_icon("pin", C.SUBTEXT1, 16))
-        pin_action.triggered.connect(lambda _, a=app: self._on_toggle_pin_app(a))
+        pin_action.triggered.connect(lambda _=False, a=app: self._on_toggle_pin_app(a))
 
         edit_action = menu.addAction(tr("Edit"))
-        edit_action.triggered.connect(lambda _, a=app: self._on_edit_app(a))
+        edit_action.triggered.connect(lambda _=False, a=app: self._on_edit_app(a))
 
         hide_action = menu.addAction(tr("Show") if app.hidden else tr("Hide"))
-        hide_action.setToolTip(tr("Show in menu") if app.hidden else tr("Hide from menu"))
-        hide_action.triggered.connect(lambda _, a=app: self._on_toggle_app_hidden(a))
+        hide_action.triggered.connect(lambda _=False, a=app: self._on_toggle_app_hidden(a))
 
         delete_action = menu.addAction(tr("Delete"))
-        delete_action.triggered.connect(lambda _, a=app: self._on_delete_app(a))
-        more_btn.setMenu(menu)
-
-        footer = QHBoxLayout()
-        footer.setContentsMargins(0, 0, 0, 0)
-        footer.setSpacing(SPACE_S)
-        footer.addWidget(launch_btn, 0, Qt.AlignmentFlag.AlignLeft)
-        footer.addStretch()
-        footer.addWidget(more_btn, 0, Qt.AlignmentFlag.AlignRight)
-        vl.addLayout(footer)
-        return card
+        delete_action.triggered.connect(lambda _=False, a=app: self._on_delete_app(a))
+        menu.exec(global_pos)
 
     def _make_app_tile(self, app: AppInfo) -> QWidget:
         """Horizontal app tile with colored accent stripe."""

--- a/src/winpodx/gui/_main_window_library.py
+++ b/src/winpodx/gui/_main_window_library.py
@@ -42,6 +42,7 @@ from PySide6.QtWidgets import (
 
 from winpodx.core.app import AppInfo
 from winpodx.core.i18n import tr
+from winpodx.core.process import kill_session, list_active_sessions
 from winpodx.gui import launcher_state
 from winpodx.gui._widget_helpers import (
     add_shadow,
@@ -248,6 +249,12 @@ class LibraryPageMixin:
         launcher_layout.setContentsMargins(0, 0, 0, 0)
         launcher_layout.setSpacing(SPACE_XL)
 
+        # "Running" live-session strip -- winpodx knows what's actually running
+        # (RDP session tracking), so surface it at the very top: a chip per live
+        # session with a one-click terminate. Hidden when nothing is running.
+        self._running_section, self._running_row = self._make_launcher_section(tr("Running"))
+        launcher_layout.addWidget(self._running_section)
+
         self._pinned_section, self._pinned_row = self._make_launcher_section(tr("Pinned"))
         launcher_layout.addWidget(self._pinned_section)
 
@@ -378,7 +385,70 @@ class LibraryPageMixin:
         self._populate_launcher_row(self._recent_section, self._recent_row, recent)
 
     def _refresh_launcher_home(self) -> None:
+        self._refresh_running_strip()
         self._filter_apps(self.search_box.text())
+
+    def _running_display_name(self, stem: str) -> str:
+        """Best-effort friendly name for a tracked session stem."""
+        for a in self.apps:
+            if a.name == stem:
+                return a.full_name
+        cleaned = stem.removeprefix("winpodx-uwp-").split("_")[0].replace("-", " ").strip()
+        return cleaned.title() if cleaned else stem
+
+    def _make_running_chip(self, app_name: str) -> QWidget:
+        chip = QFrame()
+        chip.setObjectName("runChip")
+        chip.setStyleSheet(
+            f"QFrame#runChip {{ background: {C.SURFACE0}; border: 1px solid {C.SURFACE2};"
+            " border-radius: 16px; }"
+        )
+        h = QHBoxLayout(chip)
+        h.setContentsMargins(SPACE_M, SPACE_S, SPACE_S, SPACE_S)
+        h.setSpacing(SPACE_S)
+
+        dot = QLabel("●")
+        dot.setStyleSheet(f"color: {C.GREEN}; font-size: 9px; background: transparent;")
+        h.addWidget(dot)
+
+        name = QLabel(self._running_display_name(app_name))
+        name.setStyleSheet(f"color: {C.TEXT}; font-size: 12px; background: transparent;")
+        h.addWidget(name)
+
+        kill_btn = QPushButton("")
+        kill_btn.setIcon(load_icon("close", C.OVERLAY0, 14))
+        kill_btn.setIconSize(QSize(14, 14))
+        kill_btn.setFixedSize(22, 22)
+        kill_btn.setToolTip(tr("Terminate"))
+        kill_btn.setStyleSheet(
+            "QPushButton { background: transparent; border: none; border-radius: 11px; }"
+            f"QPushButton:hover {{ background: {C.SURFACE2}; }}"
+        )
+        kill_btn.clicked.connect(lambda _=False, n=app_name: self._terminate_session(n))
+        h.addWidget(kill_btn)
+        return chip
+
+    def _refresh_running_strip(self) -> None:
+        """Rebuild the 'Running' strip from the live RDP sessions."""
+        if not hasattr(self, "_running_row"):
+            return
+        self._clear_layout(self._running_row)
+        try:
+            sessions = list_active_sessions()
+        except Exception:  # noqa: BLE001 -- never break the home on enumeration
+            sessions = []
+        self._running_section.setVisible(bool(sessions))
+        for s in sessions:
+            self._running_row.addWidget(self._make_running_chip(s.app_name))
+        if sessions:
+            self._running_row.addStretch()
+
+    def _terminate_session(self, app_name: str) -> None:
+        try:
+            kill_session(app_name)
+        except Exception:  # noqa: BLE001 -- best-effort; refresh either way
+            pass
+        self._refresh_running_strip()
 
     def _on_toggle_pin_app(self, app: AppInfo) -> None:
         if launcher_state.is_pinned(app.name):

--- a/src/winpodx/gui/_main_window_library.py
+++ b/src/winpodx/gui/_main_window_library.py
@@ -399,10 +399,16 @@ class LibraryPageMixin:
     def _make_running_chip(self, app_name: str) -> QWidget:
         chip = QFrame()
         chip.setObjectName("runChip")
+        chip.setCursor(Qt.CursorShape.PointingHandCursor)
+        chip.setToolTip(tr("Focus window"))
         chip.setStyleSheet(
             f"QFrame#runChip {{ background: {C.SURFACE0}; border: 1px solid {C.SURFACE2};"
             " border-radius: 16px; }"
+            f"QFrame#runChip:hover {{ border-color: {C.GREEN}; }}"
         )
+        # Left-click the chip body -> raise/focus that app's window (the kill
+        # button consumes its own clicks, so it won't trigger a focus).
+        chip.mousePressEvent = lambda _e, n=app_name: self._focus_session(n)
         h = QHBoxLayout(chip)
         h.setContentsMargins(SPACE_M, SPACE_S, SPACE_S, SPACE_S)
         h.setSpacing(SPACE_S)
@@ -449,6 +455,28 @@ class LibraryPageMixin:
         except Exception:  # noqa: BLE001 -- best-effort; refresh either way
             pass
         self._refresh_running_strip()
+
+    def _focus_session(self, app_name: str) -> None:
+        """Best-effort raise/focus of the app's window on the Linux desktop.
+
+        FreeRDP RemoteApp windows are X11 (XWayland), so wmctrl / xdotool can
+        activate them by WM_CLASS (== the session's wm-class token). Degrades
+        quietly when neither tool is present.
+        """
+        import shutil
+        import subprocess
+
+        try:
+            if shutil.which("wmctrl"):
+                subprocess.run(["wmctrl", "-x", "-a", app_name], timeout=3, check=False)
+            elif shutil.which("xdotool"):
+                subprocess.run(
+                    ["xdotool", "search", "--class", app_name, "windowactivate"],
+                    timeout=3,
+                    check=False,
+                )
+        except Exception:  # noqa: BLE001 -- best-effort, never break the UI
+            pass
 
     def _on_toggle_pin_app(self, app: AppInfo) -> None:
         if launcher_state.is_pinned(app.name):

--- a/src/winpodx/gui/_main_window_license.py
+++ b/src/winpodx/gui/_main_window_license.py
@@ -21,6 +21,7 @@ import logging
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QFrame,
+    QHBoxLayout,
     QLabel,
     QScrollArea,
     QTextEdit,
@@ -29,16 +30,25 @@ from PySide6.QtWidgets import (
 )
 
 from winpodx.core.i18n import tr
-from winpodx.gui._widget_helpers import add_shadow, make_page_header
+from winpodx.gui._widget_helpers import add_shadow, make_page_header, make_section_label
+from winpodx.gui.icons import load_icon
 from winpodx.gui.theme import (
+    FONT_BODY,
+    FONT_CAPTION,
+    FONT_HEADER,
+    RADIUS_XS,
     SCROLL_AREA,
     SETTINGS_SECTION,
     SPACE_L,
     SPACE_M,
     SPACE_S,
+    SPACE_XS,
     SPACE_XXL,
     TERMINAL,
+    TOOL_ACCENT,
+    TOOL_ICON_FG,
     C,
+    rgba,
 )
 from winpodx.utils.paths import bundle_dir
 
@@ -167,6 +177,7 @@ class LicensePageMixin:
         page = QWidget()
         outer = QVBoxLayout(page)
         outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
@@ -176,9 +187,9 @@ class LicensePageMixin:
         content = QWidget()
         layout = QVBoxLayout(content)
         layout.setContentsMargins(SPACE_XXL, 0, SPACE_XXL, SPACE_XXL)
-        layout.setSpacing(SPACE_M)
+        layout.setSpacing(SPACE_L)
 
-        # --- License title -------------------------------------------------
+        # --- Page header ---------------------------------------------------
         layout.addWidget(
             make_page_header(
                 tr("License"),
@@ -188,23 +199,13 @@ class LicensePageMixin:
                 ),
             )
         )
-        layout.addSpacing(SPACE_S)
 
         # --- MIT license text ----------------------------------------------
-        license_text = self._read_license_text()
-        license_view = QTextEdit()
-        license_view.setReadOnly(True)
-        license_view.setStyleSheet(TERMINAL)
-        license_view.setPlainText(license_text)
-        license_view.setFixedHeight(260)
-        layout.addWidget(license_view)
+        layout.addWidget(make_section_label(tr("License text")))
+        layout.addWidget(self._build_license_section())
 
         # --- Third-party acknowledgments -----------------------------------
-        ack_header = QLabel(tr("Third-party components"))
-        ack_header.setStyleSheet(
-            f"background: transparent; color: {C.BLUE}; font-size: 15px; font-weight: 600;"
-        )
-        layout.addWidget(ack_header)
+        layout.addWidget(make_section_label(tr("Third-party components")))
 
         ack_intro = QLabel(
             tr(
@@ -215,46 +216,104 @@ class LicensePageMixin:
                 "source tree)."
             )
         )
-        ack_intro.setStyleSheet(f"background: transparent; color: {C.OVERLAY0}; font-size: 12px;")
+        ack_intro.setStyleSheet(
+            f"background: transparent; color: {C.SUBTEXT0}; font-size: {FONT_CAPTION}px;"
+        )
         ack_intro.setWordWrap(True)
         layout.addWidget(ack_intro)
 
-        for name, license_, purpose, url in _THIRD_PARTY_ACK:
-            row = QFrame()
-            row.setObjectName("settingsSection")
-            row.setStyleSheet(SETTINGS_SECTION)
-            add_shadow(row, blur=10, y=1, alpha=28)
-            row_layout = QVBoxLayout(row)
-            row_layout.setContentsMargins(SPACE_L, SPACE_M, SPACE_L, SPACE_M)
-            row_layout.setSpacing(SPACE_S)
-
-            heading = QLabel(f"{name}  ·  {license_}")
-            heading.setStyleSheet(
-                f"background: transparent; color: {C.TEXT}; font-size: 13px; font-weight: 500;"
-            )
-            row_layout.addWidget(heading)
-
-            detail = QLabel(tr(purpose))
-            detail.setStyleSheet(f"background: transparent; color: {C.SUBTEXT1}; font-size: 12px;")
-            detail.setWordWrap(True)
-            row_layout.addWidget(detail)
-
-            # Upstream source link. Rendered as selectable text (not an
-            # auto-opening hyperlink) so winpodx never initiates a network
-            # call — the user copies the URL to find the source + its
-            # license themselves.
-            link = QLabel(url)
-            link.setStyleSheet(f"background: transparent; color: {C.BLUE}; font-size: 11px;")
-            link.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
-            link.setWordWrap(True)
-            row_layout.addWidget(link)
-
-            layout.addWidget(row)
+        for entry in _THIRD_PARTY_ACK:
+            layout.addWidget(self._build_ack_card(*entry))
 
         layout.addStretch()
         scroll.setWidget(content)
         outer.addWidget(scroll)
         return page
+
+    def _build_license_section(self) -> QFrame:
+        """Card wrapping the read-only MIT license text in the terminal panel."""
+        card = QFrame()
+        card.setObjectName("settingsSection")
+        card.setStyleSheet(SETTINGS_SECTION)
+        add_shadow(card, blur=12, y=2, alpha=26)
+
+        card_layout = QVBoxLayout(card)
+        card_layout.setContentsMargins(SPACE_L, SPACE_L, SPACE_L, SPACE_L)
+        card_layout.setSpacing(0)
+
+        license_view = QTextEdit()
+        license_view.setReadOnly(True)
+        license_view.setStyleSheet(TERMINAL)
+        license_view.setPlainText(self._read_license_text())
+        license_view.setFixedHeight(260)
+        card_layout.addWidget(license_view)
+        return card
+
+    def _build_ack_card(self, name: str, license_: str, purpose: str, url: str) -> QFrame:
+        """Build one third-party acknowledgment card (name + license + link)."""
+        row = QFrame()
+        row.setObjectName("settingsSection")
+        row.setStyleSheet(SETTINGS_SECTION)
+        add_shadow(row, blur=10, y=1, alpha=28)
+        row_layout = QVBoxLayout(row)
+        row_layout.setContentsMargins(SPACE_L, SPACE_M, SPACE_L, SPACE_M)
+        row_layout.setSpacing(SPACE_S)
+
+        # Header line: project name (medium) + a calm license chip.
+        header_row = QHBoxLayout()
+        header_row.setContentsMargins(0, 0, 0, 0)
+        header_row.setSpacing(SPACE_S)
+
+        heading = QLabel(name)
+        heading.setStyleSheet(
+            f"background: transparent; color: {C.TEXT};"
+            f" font-size: {FONT_HEADER}px; font-weight: 500;"
+        )
+        header_row.addWidget(heading, 0)
+
+        chip = QLabel(license_)
+        chip.setStyleSheet(
+            f"background: {rgba(TOOL_ACCENT, 0.12)}; color: {TOOL_ICON_FG};"
+            f" border: 1px solid {rgba(TOOL_ACCENT, 0.26)};"
+            f" border-radius: {RADIUS_XS}px; padding: 1px 7px;"
+            f" font-size: {FONT_CAPTION}px; font-weight: 400;"
+        )
+        header_row.addWidget(chip, 0, Qt.AlignmentFlag.AlignVCenter)
+        header_row.addStretch(1)
+        row_layout.addLayout(header_row)
+
+        detail = QLabel(tr(purpose))
+        detail.setStyleSheet(
+            f"background: transparent; color: {C.SUBTEXT1}; font-size: {FONT_BODY}px;"
+        )
+        detail.setWordWrap(True)
+        row_layout.addWidget(detail)
+
+        # Upstream source link. Rendered as selectable text (not an
+        # auto-opening hyperlink) so winpodx never initiates a network
+        # call — the user copies the URL to find the source + its
+        # license themselves. The globe glyph reads as "external source"
+        # without the loud saturated link-blue.
+        link_row = QHBoxLayout()
+        link_row.setContentsMargins(0, SPACE_XS, 0, 0)
+        link_row.setSpacing(SPACE_S)
+
+        globe = QLabel()
+        globe.setFixedSize(14, 14)
+        globe.setPixmap(load_icon("globe", TOOL_ICON_FG, 14).pixmap(14, 14))
+        globe.setStyleSheet("background: transparent;")
+        globe.setAlignment(Qt.AlignmentFlag.AlignTop)
+        link_row.addWidget(globe, 0, Qt.AlignmentFlag.AlignTop)
+
+        link = QLabel(url)
+        link.setStyleSheet(
+            f"background: transparent; color: {C.SUBTEXT0}; font-size: {FONT_CAPTION}px;"
+        )
+        link.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        link.setWordWrap(True)
+        link_row.addWidget(link, 1)
+        row_layout.addLayout(link_row)
+        return row
 
     def _read_license_text(self) -> str:
         """Return the project LICENSE contents, or a stub on failure.

--- a/src/winpodx/gui/_main_window_maintenance.py
+++ b/src/winpodx/gui/_main_window_maintenance.py
@@ -53,6 +53,7 @@ from winpodx.gui.theme import (
     BTN_PRIMARY,
     BTN_SECONDARY,
     SCROLL_AREA,
+    SETTINGS_SECTION,
     SPACE_L,
     SPACE_M,
     SPACE_S,
@@ -128,47 +129,42 @@ class MaintenanceMixin:
         content = QWidget()
         layout = QVBoxLayout(content)
         layout.setContentsMargins(SPACE_XXL, 0, SPACE_XXL, SPACE_XL)
-        layout.setSpacing(0)
+        layout.setSpacing(SPACE_L)
 
         layout.addWidget(make_page_header(tr("Tools"), tr("System maintenance and pod management")))
-        layout.addSpacing(SPACE_XL)
 
-        layout.addWidget(make_section_label(tr("Pod Management")))
-        layout.addSpacing(SPACE_S)
-
+        # Each tool group lives in its own card so the page reads as a few
+        # calm, contained sections rather than a long flat list of rows.
         pod_tools = [
-            ("⏸", tr("Suspend Pod"), tr("Pause container (keeps memory)"), self._on_suspend),
-            ("▶", tr("Resume Pod"), tr("Unpause a suspended container"), self._on_resume),
-            ("▣", tr("Full Desktop"), tr("Launch full Windows desktop"), self._on_open_desktop),
+            ("pause", tr("Suspend Pod"), tr("Pause container (keeps memory)"), self._on_suspend),
+            ("play", tr("Resume Pod"), tr("Unpause a suspended container"), self._on_resume),
+            (
+                "desktop",
+                tr("Full Desktop"),
+                tr("Launch full Windows desktop"),
+                self._on_open_desktop,
+            ),
         ]
-        for i, (icon, label, desc, handler) in enumerate(pod_tools):
-            layout.addWidget(self._make_action_row(icon, label, desc, handler, i))
-            if i < len(pod_tools) - 1:
-                layout.addSpacing(SPACE_M)
-
-        layout.addSpacing(SPACE_XL)
-
-        layout.addWidget(make_section_label(tr("System")))
-        layout.addSpacing(SPACE_S)
+        layout.addWidget(self._make_tool_card(tr("Pod Management"), pod_tools, base_idx=0))
 
         sys_tools = [
-            ("✧", tr("Clean Locks"), tr("Remove Office lock files"), self._on_cleanup),
-            ("◷", tr("Sync Time"), tr("Force Windows clock sync"), self._on_timesync),
-            ("◆", tr("Debloat"), tr("Disable telemetry & ads"), self._on_debloat),
+            ("clean", tr("Clean Locks"), tr("Remove Office lock files"), self._on_cleanup),
+            ("clock", tr("Sync Time"), tr("Force Windows clock sync"), self._on_timesync),
+            ("diamond", tr("Debloat"), tr("Disable telemetry & ads"), self._on_debloat),
             (
-                "⚙",
+                "gear",
                 tr("Apply Windows Fixes"),
                 tr("Re-apply network + remote-desktop service fixes to the guest (safe to repeat)"),
                 self._on_apply_fixes,
             ),
             (
-                "⊕",
+                "plus",
                 tr("Grow Disk"),
                 tr("Add space to the Windows disk and extend C: to fill it"),
                 self._on_grow_disk,
             ),
             (
-                "↻",
+                "refresh",
                 tr("Sync Guest"),
                 tr(
                     "Push WinPodX's updated guest files into the running Windows "
@@ -177,25 +173,27 @@ class MaintenanceMixin:
                 self._on_sync_guest,
             ),
         ]
-        for i, (icon, label, desc, handler) in enumerate(sys_tools):
-            layout.addWidget(self._make_action_row(icon, label, desc, handler, i + 3))
-            if i < len(sys_tools) - 1:
-                layout.addSpacing(SPACE_M)
-
-        layout.addSpacing(SPACE_XL)
-
-        layout.addWidget(make_section_label(tr("RDP Sessions")))
-        layout.addSpacing(SPACE_S)
+        layout.addWidget(self._make_tool_card(tr("System"), sys_tools, base_idx=3))
 
         # The tray's "Terminate Session" menu isn't always reachable --
         # on some DEs (stock GNOME, occasional Wayland startup races) the
         # tray icon never appears. Mirror that capability here so the
         # dashboard is a reliable way to close a live RDP session (#450).
+        sessions_card = QFrame()
+        sessions_card.setObjectName("settingsSection")
+        sessions_card.setStyleSheet(SETTINGS_SECTION)
+        add_shadow(sessions_card)
+        sessions_layout = QVBoxLayout(sessions_card)
+        sessions_layout.setContentsMargins(SPACE_L, SPACE_L, SPACE_L, SPACE_L)
+        sessions_layout.setSpacing(SPACE_M)
+        sessions_layout.addWidget(make_section_label(tr("RDP Sessions")))
+
         sessions_box_host = QWidget()
         self._sessions_box = QVBoxLayout(sessions_box_host)
         self._sessions_box.setContentsMargins(0, 0, 0, 0)
         self._sessions_box.setSpacing(SPACE_M)
-        layout.addWidget(sessions_box_host)
+        sessions_layout.addWidget(sessions_box_host)
+        layout.addWidget(sessions_card)
 
         # Live refresh: poll while the Tools page is visible so launching or
         # closing a Windows app shows up within a couple of seconds without
@@ -213,6 +211,33 @@ class MaintenanceMixin:
         scroll.setWidget(content)
         outer.addWidget(scroll)
         return page
+
+    def _make_tool_card(
+        self,
+        section: str,
+        tools: list,
+        *,
+        base_idx: int,
+    ) -> QFrame:
+        """Wrap a labelled group of tool action rows in a shared section card.
+
+        Mirrors the Settings-page card pattern (rounded ``settingsSection``
+        frame, generous padding, even gaps) so the Tools page reads as a few
+        calm cards instead of a flat list of floating rows.
+        """
+        card = QFrame()
+        card.setObjectName("settingsSection")
+        card.setStyleSheet(SETTINGS_SECTION)
+        add_shadow(card)
+
+        layout = QVBoxLayout(card)
+        layout.setContentsMargins(SPACE_L, SPACE_L, SPACE_L, SPACE_L)
+        layout.setSpacing(SPACE_M)
+        layout.addWidget(make_section_label(section))
+
+        for i, (icon, label, desc, handler) in enumerate(tools):
+            layout.addWidget(self._make_action_row(icon, label, desc, handler, base_idx + i))
+        return card
 
     def _refresh_sessions_panel(self, force: bool = False) -> None:
         """Rebuild the Tools-page list of live RDP sessions (#450).
@@ -266,7 +291,6 @@ class MaintenanceMixin:
         icon.setStyleSheet(
             f"background: {TOOL_ICON_BG}; color: {TOOL_ICON_FG};"
             f" border: 1px solid {TOOL_ICON_BORDER}; border-radius: 14px;"
-            f" font-size: 16px; font-weight: 500;"
         )
         rl.addWidget(icon)
 
@@ -333,6 +357,9 @@ class MaintenanceMixin:
         icon_circle = QLabel()
         icon_circle.setFixedSize(38, 38)
         icon_circle.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        # ``icon`` is an SVG icon name from the bundled set (load_icon recolors
+        # it to the calm tool accent); a single legacy glyph map is kept as a
+        # fallback so older callers passing a unicode glyph still resolve.
         icon_name = {
             "⏸": "pause",
             "▶": "play",
@@ -348,7 +375,7 @@ class MaintenanceMixin:
         icon_circle.setStyleSheet(
             f"background: {TOOL_ICON_BG}; color: {TOOL_ICON_FG};"
             f" border: 1px solid {TOOL_ICON_BORDER}; border-left: 2px solid {rgba(color, 0.42)};"
-            f" border-radius: 14px; font-size: 16px; font-weight: 500;"
+            f" border-radius: 14px;"
         )
         rl.addWidget(icon_circle)
 

--- a/src/winpodx/gui/_main_window_nav.py
+++ b/src/winpodx/gui/_main_window_nav.py
@@ -40,6 +40,11 @@ class NavigationMixin:
         self.pages.setCurrentIndex(index)
         for i, action in enumerate(getattr(self, "nav_menu_actions", [])):
             action.setChecked(i == index)
+
+        # Refresh the Home launcher's "Running" live-session strip whenever Home
+        # is opened so it reflects what's actually running.
+        if index == 0 and hasattr(self, "_refresh_running_strip"):
+            self._refresh_running_strip()
         # v0.5.1: tail processes are now always-on (started at
         # WinpodxWindow.__init__) and feed both the Terminal full
         # history AND the always-visible bottom log bar. We no

--- a/src/winpodx/gui/_main_window_nav.py
+++ b/src/winpodx/gui/_main_window_nav.py
@@ -38,8 +38,6 @@ class NavigationMixin:
 
     def _switch_page(self, index: int) -> None:
         self.pages.setCurrentIndex(index)
-        for i, btn in enumerate(self.nav_buttons):
-            btn.setChecked(i == index)
         for i, action in enumerate(getattr(self, "nav_menu_actions", [])):
             action.setChecked(i == index)
         # v0.5.1: tail processes are now always-on (started at
@@ -84,7 +82,7 @@ class NavigationMixin:
             return
         self._shortcuts_installed = True
 
-        for i, _btn in enumerate(self.nav_buttons):
+        for i in range(len(getattr(self, "nav_menu_actions", []))):
             sc = QShortcut(QKeySequence(f"Alt+{i + 1}"), self)
             sc.activated.connect(lambda idx=i: self._switch_page(idx))
 

--- a/src/winpodx/gui/_main_window_settings.py
+++ b/src/winpodx/gui/_main_window_settings.py
@@ -39,7 +39,12 @@ from PySide6.QtWidgets import (
 
 from winpodx.core.config import Config
 from winpodx.core.i18n import tr
-from winpodx.gui._widget_helpers import add_shadow, make_page_header, make_warning_callout
+from winpodx.gui._widget_helpers import (
+    add_shadow,
+    make_page_header,
+    make_section_label,
+    make_warning_callout,
+)
 from winpodx.gui.icons import load_icon
 from winpodx.gui.theme import (
     BTN_DANGER,
@@ -533,9 +538,15 @@ class SettingsPageMixin:
             ),
             level="warn",
         )
+
+        layout.addSpacing(SPACE_S)
+        layout.addWidget(make_section_label(tr("Connection & resources")))
         layout.addWidget(recreate_callout)
 
         layout.addLayout(cols)
+
+        layout.addSpacing(SPACE_M)
+        layout.addWidget(make_section_label(tr("Windows guest")))
 
         # Language / Region / Keyboard are first-install-only env knobs:
         # applying a change destroys the Windows disk and reinstalls.
@@ -608,24 +619,17 @@ class SettingsPageMixin:
         # "Applies immediately" subsection. The controls below (autostart,
         # UI language; the reverse-open enable checkbox above behaves the
         # same) persist the moment you change them — unlike the form fields
-        # above, which only commit when you click "Save Settings". The
-        # header makes that split explicit so the Save button's scope isn't
-        # ambiguous.
+        # above, which only commit when you click "Save Settings". Grouping
+        # them inside their own card (rather than floating loose on the page)
+        # makes the Save button's scope unambiguous and keeps the visual
+        # rhythm consistent with the form cards above.
         layout.addSpacing(SPACE_M)
-        applies_now_header = QLabel(tr("Applies immediately"))
-        applies_now_header.setStyleSheet(
-            f"background: transparent; color: {C.SUBTEXT0}; "
-            f"font-size: {FONT_CAPTION}px; font-weight: 500;"
+        layout.addWidget(make_section_label(tr("WinPodX preferences")))
+        applies_card, applies_layout = self._settings_card_shell(
+            "gear",
+            tr("Applies immediately"),
+            tr("These take effect right away — no need to click Save Settings."),
         )
-        layout.addWidget(applies_now_header)
-        applies_now_caption = QLabel(
-            tr("These take effect right away — no need to click Save Settings.")
-        )
-        applies_now_caption.setWordWrap(True)
-        applies_now_caption.setStyleSheet(
-            f"background: transparent; color: {C.OVERLAY0}; font-size: {FONT_CAPTION}px;"
-        )
-        layout.addWidget(applies_now_caption)
 
         # Autostart-at-login toggle. File existence under
         # ``~/.config/autostart/winpodx-tray.desktop`` is the source of
@@ -654,7 +658,8 @@ class SettingsPageMixin:
                 logging.getLogger(__name__).warning("Could not toggle autostart: %s", e)
 
         self.checkbox_autostart_tray.toggled.connect(_on_autostart_toggled)
-        layout.addWidget(self.checkbox_autostart_tray)
+        applies_layout.addWidget(self.checkbox_autostart_tray)
+        applies_layout.addSpacing(SPACE_M)
 
         # winpodx UI language (the tray / GUI / CLI text itself -- distinct
         # from the *guest* install language above). Default 'auto' follows
@@ -674,7 +679,12 @@ class SettingsPageMixin:
             "it": "Italiano",
         }
         lang_row = QHBoxLayout()
-        lang_row.addWidget(QLabel(tr("WinPodX UI language")))
+        lang_row.setSpacing(SPACE_M)
+        lang_label = QLabel(tr("WinPodX UI language"))
+        lang_label.setStyleSheet(
+            f"background: transparent; color: {C.SUBTEXT0}; font-size: {FONT_BODY}px;"
+        )
+        lang_row.addWidget(lang_label)
         self.input_ui_language = QComboBox()
         self.input_ui_language.setStyleSheet(COMBO)
         for code in _UI_LANGUAGES:
@@ -700,8 +710,14 @@ class SettingsPageMixin:
 
         self.input_ui_language.currentIndexChanged.connect(_on_ui_language_changed)
         lang_row.addWidget(self.input_ui_language, 1)
-        layout.addLayout(lang_row)
-        layout.addWidget(QLabel(tr("Restart WinPodX (tray / GUI) to apply the language change.")))
+        applies_layout.addLayout(lang_row)
+        ui_lang_note = QLabel(tr("Restart WinPodX (tray / GUI) to apply the language change."))
+        ui_lang_note.setWordWrap(True)
+        ui_lang_note.setStyleSheet(
+            f"background: transparent; color: {C.OVERLAY0}; font-size: {FONT_CAPTION}px;"
+        )
+        applies_layout.addWidget(ui_lang_note)
+        layout.addWidget(applies_card)
 
         # Budget warning — only visible when max_sessions over-subscribes ram_gb.
         # Live-updates as the user types in either field.
@@ -717,7 +733,7 @@ class SettingsPageMixin:
         self.input_max_sessions.textChanged.connect(self._update_budget_warning)
         self._update_budget_warning()
 
-        layout.addSpacing(SPACE_L)
+        layout.addSpacing(SPACE_S)
 
         save_caption = QLabel(
             tr("Persists the form fields above. The ‘Applies immediately’ controls save on change.")
@@ -732,6 +748,64 @@ class SettingsPageMixin:
         scroll.setWidget(content)
         outer.addWidget(scroll)
         return page
+
+    def _settings_card_shell(
+        self,
+        icon_name: str,
+        title: str,
+        subtitle: str,
+    ) -> tuple[QFrame, QVBoxLayout]:
+        """Build the shared card shell (icon header + subtitle + divider).
+
+        Returns the framed card and its content layout so callers can append
+        free-form body widgets below the divider — the same visual shell as
+        :meth:`_settings_card` but without the fixed two-column form grid.
+        """
+        card = QFrame()
+        card.setObjectName("settingsSection")
+        card.setStyleSheet(
+            SETTINGS_SECTION
+            + f"QLabel {{ color: {C.TEXT}; font-size: {FONT_BODY}px; background: transparent; }}"
+            + INPUT
+            + COMBO
+        )
+        add_shadow(card)
+
+        layout = QVBoxLayout(card)
+        layout.setContentsMargins(SPACE_XL, SPACE_XL, SPACE_XL, SPACE_XL)
+        layout.setSpacing(SPACE_XS)
+
+        header = QLabel(title)
+        header.setStyleSheet(
+            f"background: transparent; color: {C.BLUE}; "
+            f"font-size: {FONT_HEADER}px; font-weight: 600;"
+        )
+        header_row = QHBoxLayout()
+        header_row.setContentsMargins(0, 0, 0, 0)
+        header_row.setSpacing(SPACE_S)
+        header_icon = QLabel()
+        header_icon.setFixedSize(18, 18)
+        header_icon.setPixmap(load_icon(icon_name, C.BLUE, 18).pixmap(18, 18))
+        header_icon.setStyleSheet("background: transparent;")
+        header_row.addWidget(header_icon)
+        header_row.addWidget(header)
+        header_row.addStretch()
+        layout.addLayout(header_row)
+
+        if subtitle:
+            sub = QLabel(subtitle)
+            sub.setStyleSheet(
+                f"background: transparent; color: {C.OVERLAY0}; font-size: {FONT_CAPTION}px;"
+            )
+            layout.addWidget(sub)
+
+        accent_line = QFrame()
+        accent_line.setFixedHeight(1)
+        accent_line.setStyleSheet(f"background: {C.SURFACE1};")
+        layout.addWidget(accent_line)
+        layout.addSpacing(SPACE_M)
+
+        return card, layout
 
     def _build_tuning_card(self, profile_combo: QComboBox, summary_text: str) -> QFrame:
         """Build the Performance Tuning settings card (#245, PR A).

--- a/src/winpodx/locale/de.json
+++ b/src/winpodx/locale/de.json
@@ -831,5 +831,11 @@
   "Recent": "Zuletzt",
   "All apps": "Alle Apps",
   "Pin": "Anheften",
-  "Unpin": "Lösen"
+  "Unpin": "Lösen",
+  "Running": "Aktiv",
+  "Connection & resources": "Verbindung & Ressourcen",
+  "Windows guest": "Windows-Gast",
+  "WinPodX preferences": "WinPodX-Einstellungen",
+  "License text": "Lizenztext",
+  "A live snapshot of your system, display, dependencies, and pod.": "Eine Live-Übersicht über System, Anzeige, Abhängigkeiten und Pod."
 }

--- a/src/winpodx/locale/fr.json
+++ b/src/winpodx/locale/fr.json
@@ -831,5 +831,11 @@
   "Recent": "Récents",
   "All apps": "Toutes les apps",
   "Pin": "Épingler",
-  "Unpin": "Détacher"
+  "Unpin": "Détacher",
+  "Running": "En cours",
+  "Connection & resources": "Connexion et ressources",
+  "Windows guest": "Invité Windows",
+  "WinPodX preferences": "Préférences WinPodX",
+  "License text": "Texte de licence",
+  "A live snapshot of your system, display, dependencies, and pod.": "Un aperçu en direct de votre système, affichage, dépendances et pod."
 }

--- a/src/winpodx/locale/it.json
+++ b/src/winpodx/locale/it.json
@@ -831,5 +831,11 @@
   "Recent": "Recenti",
   "All apps": "Tutte le app",
   "Pin": "Aggiungi",
-  "Unpin": "Rimuovi"
+  "Unpin": "Rimuovi",
+  "Running": "In esecuzione",
+  "Connection & resources": "Connessione e risorse",
+  "Windows guest": "Guest Windows",
+  "WinPodX preferences": "Preferenze WinPodX",
+  "License text": "Testo della licenza",
+  "A live snapshot of your system, display, dependencies, and pod.": "Una panoramica in tempo reale di sistema, display, dipendenze e pod."
 }

--- a/src/winpodx/locale/ja.json
+++ b/src/winpodx/locale/ja.json
@@ -831,5 +831,11 @@
   "Recent": "最近",
   "All apps": "すべてのアプリ",
   "Pin": "ピン留め",
-  "Unpin": "ピン留め解除"
+  "Unpin": "ピン留め解除",
+  "Running": "実行中",
+  "Connection & resources": "接続とリソース",
+  "Windows guest": "Windows ゲスト",
+  "WinPodX preferences": "WinPodX 設定",
+  "License text": "ライセンス本文",
+  "A live snapshot of your system, display, dependencies, and pod.": "システム・ディスプレイ・依存関係・Pod のライブスナップショット。"
 }

--- a/src/winpodx/locale/ko.json
+++ b/src/winpodx/locale/ko.json
@@ -831,5 +831,11 @@
   "Recent": "최근",
   "All apps": "모든 앱",
   "Pin": "고정",
-  "Unpin": "고정 해제"
+  "Unpin": "고정 해제",
+  "Running": "실행 중",
+  "Connection & resources": "연결 및 리소스",
+  "Windows guest": "Windows 게스트",
+  "WinPodX preferences": "WinPodX 환경설정",
+  "License text": "라이선스 전문",
+  "A live snapshot of your system, display, dependencies, and pod.": "시스템·디스플레이·의존성·Pod의 실시간 스냅샷."
 }

--- a/src/winpodx/locale/zh.json
+++ b/src/winpodx/locale/zh.json
@@ -831,5 +831,11 @@
   "Recent": "最近",
   "All apps": "所有应用",
   "Pin": "固定",
-  "Unpin": "取消固定"
+  "Unpin": "取消固定",
+  "Running": "运行中",
+  "Connection & resources": "连接和资源",
+  "Windows guest": "Windows 客户机",
+  "WinPodX preferences": "WinPodX 偏好设置",
+  "License text": "许可证文本",
+  "A live snapshot of your system, display, dependencies, and pod.": "系统、显示、依赖项和 Pod 的实时快照。"
 }


### PR DESCRIPTION
A full, all-Claude GUI overhaul. **Complete + verified** (window builds, all 7 pages switch + render, tests pass) — for review.

## Home → "Live Launcher"
- **Logo fixes**: removed the stray "License" ghost box over the logo (orphaned nav button); fixed the logo being horizontally stretched (was rendered into a non-square pixmap).
- **Hero search** (large, centered) as the focal point; no page title.
- **"Running" strip** — winpodx tracks live RDP sessions, so the launcher surfaces them: a chip per running app (green dot + name + one-click terminate). Hidden when nothing runs; refreshes on Home open / launch / terminate.
- **Start-menu icon tiles** — the app grid is minimal tiles (icon over name); whole tile clicks to launch, right-click = Pin/Edit/Hide/Delete. Dense 6-col grid. Plus Pinned / Recent rows.

## Other pages (Settings / Tools / Info / Devices / License)
Grouped into the shared rounded card + section-label pattern, glyphs → `load_icon` SVGs, saturated badges/headers softened to the calm palette, even spacing — cohesive with the new Home.

## Safety / test
- `gui/` + `locale/` only. **No existing `tr()` source string changed**; the 6 new strings are translated into all 6 catalogs.
- `ruff` clean; `pytest` GUI + i18n — 22 passed; full window builds and every page switches + renders with no errors. Full suite — see CI.

Separately filed: #469 (Windows app menu on Linux taskbar right-click, enhancement).