### PR TITLE
fix(rdp): re-list UWP RemoteApp windows in the Linux taskbar

### DIFF
--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -851,6 +851,55 @@ def _wait_session_interactive(cfg: Config, *, timeout: int = 20) -> bool:
     return False
 
 
+def _relist_uwp_taskbar(wm_class: str) -> None:
+    """Best-effort: clear FreeRDP's SKIP_TASKBAR/SKIP_PAGER on a UWP RAIL window
+    so it shows in the Linux taskbar.
+
+    A UWP app's visible frame is owned by ``ApplicationFrameHost.exe`` and
+    arrives over RAIL as a ``WS_POPUP`` / dialog window, so FreeRDP's
+    ``xf_SetWindowStyle()`` calls ``xf_SetWindowUnlisted()`` and stamps the X11
+    window ``_NET_WM_STATE_SKIP_TASKBAR`` + ``_NET_WM_STATE_SKIP_PAGER`` (the
+    same path behind the long-standing Webex Teams "not in taskbar" bug). The
+    window is otherwise fine: ``/wm-class`` is session-wide so its ``res_class``
+    already matches the launcher's ``StartupWMClass`` -- it's just hidden from
+    the panel. We re-list it via ``wmctrl``.
+
+    FreeRDP can re-stamp the state right after the window first maps (a single
+    ``remove`` often doesn't stick -- it takes effect on the second pass), so we
+    retry over a short window. X11 / XWayland only; a clean no-op when wmctrl is
+    absent, no window matches, or the WM ignores the request. Never raises.
+    """
+    import time
+
+    wmctrl = shutil.which("wmctrl")
+    if not wmctrl:
+        log.debug("wmctrl not found; cannot re-list UWP window %r in the taskbar", wm_class)
+        return
+
+    # wmctrl -lx column 3 is "<res_name>.<res_class>"; FreeRDP RAIL windows use
+    # res_name "RAIL" and res_class == the /wm-class token (our app_name slug).
+    target = f"RAIL.{wm_class}"
+    for _ in range(12):  # ~10s at 0.8s cadence -- covers late map + re-stamp
+        try:
+            out = subprocess.run(
+                [wmctrl, "-lx"], capture_output=True, text=True, timeout=4, check=False
+            ).stdout
+        except (OSError, subprocess.SubprocessError):
+            return
+        for line in out.splitlines():
+            parts = line.split(None, 4)  # id, desktop, wm_class, host, title
+            if len(parts) >= 3 and parts[2] == target:
+                try:
+                    subprocess.run(
+                        [wmctrl, "-i", "-r", parts[0], "-b", "remove,skip_taskbar,skip_pager"],
+                        timeout=4,
+                        check=False,
+                    )
+                except (OSError, subprocess.SubprocessError):
+                    return
+        time.sleep(0.8)
+
+
 def launch_app(
     cfg: Config,
     app_executable: str | None = None,
@@ -989,6 +1038,16 @@ def launch_app(
         daemon=True,
     )
     t.start()
+
+    # UWP frames come over RAIL marked SKIP_TASKBAR/SKIP_PAGER (owned by
+    # ApplicationFrameHost, surfaced as a popup/dialog) -- re-list them so they
+    # show in the Linux taskbar. app_name == the /wm-class token for UWP.
+    if launch_uri is not None:
+        threading.Thread(
+            target=_relist_uwp_taskbar,
+            args=(session.app_name,),
+            daemon=True,
+        ).start()
 
     _raise_if_exited_immediately(session)
 

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -658,3 +658,47 @@ class TestResolveWmClass:
         token = resolve_wm_class(uwp.executable, uwp.wm_class_hint or None, uwp.launch_uri or None)
         assert token.startswith("winpodx-uwp-")
         assert token != "microsoft"
+
+
+class _FakeRun:
+    def __init__(self, stdout: str = "") -> None:
+        self.stdout = stdout
+        self.returncode = 0
+
+
+def test_relist_uwp_taskbar_clears_skip_states(monkeypatch):
+    import time
+
+    import winpodx.core.rdp as rdp
+
+    monkeypatch.setattr(rdp.shutil, "which", lambda _name: "/usr/bin/wmctrl")
+    monkeypatch.setattr(time, "sleep", lambda _s: None)
+
+    lx = (
+        "0x0140003f  0 RAIL.winpodx-uwp-foo-bar  host Calculator\n"
+        "0x02000010  0 RAIL.other-app  host Notepad\n"
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **_kw):
+        calls.append(cmd)
+        return _FakeRun(lx if cmd[1] == "-lx" else "")
+
+    monkeypatch.setattr(rdp.subprocess, "run", fake_run)
+    rdp._relist_uwp_taskbar("winpodx-uwp-foo-bar")
+
+    removes = [c for c in calls if c[-1] == "remove,skip_taskbar,skip_pager"]
+    assert removes, "expected a wmctrl remove for the matching RAIL window"
+    # Only the matching window id is re-listed, never the unrelated RAIL app.
+    assert all("0x0140003f" in c for c in removes)
+    assert not any("0x02000010" in c for c in removes)
+
+
+def test_relist_uwp_taskbar_noop_without_wmctrl(monkeypatch):
+    import winpodx.core.rdp as rdp
+
+    monkeypatch.setattr(rdp.shutil, "which", lambda _name: None)
+    calls: list = []
+    monkeypatch.setattr(rdp.subprocess, "run", lambda *a, **k: calls.append(a))
+    rdp._relist_uwp_taskbar("winpodx-uwp-foo-bar")
+    assert calls == []


### PR DESCRIPTION
UWP apps (Calculator, etc.) launched as RemoteApp did not appear in the Linux taskbar.

**Root cause** (verified against FreeRDP source + a live session): a UWP app's visible frame is owned by `ApplicationFrameHost.exe` and arrives over FreeRDP RAIL as a `WS_POPUP`/dialog window, so FreeRDP's `xf_SetWindowStyle()` calls `xf_SetWindowUnlisted()` and stamps the X11 window `_NET_WM_STATE_SKIP_TASKBAR` + `_NET_WM_STATE_SKIP_PAGER` (the same path behind the long-standing Webex Teams 'not in taskbar' bug). The window is otherwise fine — `/wm-class` is session-wide so its `res_class` already matches the launcher's `StartupWMClass`; it is just hidden from the panel. On a real session the Calculator RAIL window showed `WM_STATE = SKIP_TASKBAR, SKIP_PAGER` (type DIALOG), and `wmctrl -b remove,skip_taskbar,skip_pager` made it appear (a single pass didn't stick — FreeRDP re-stamps right after map).

**Fix:** after a UWP launch (`launch_uri` set), spawn a short best-effort thread that finds the RAIL window (`res_class` == the app's `/wm-class` slug) via `wmctrl` and clears the skip states, retrying for ~10s to beat FreeRDP's re-stamp. X11/XWayland only; a clean no-op without wmctrl or a matching window. Win32 apps are unaffected (their windows are NORMAL type, already listed).

Tests: added `test_relist_uwp_taskbar_clears_skip_states` + `test_relist_uwp_taskbar_noop_without_wmctrl`; `ruff` clean; test_rdp 48 passed.