### PR TITLE
fix(rdp): quote file path so paths with spaces open

### DIFF
--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -531,7 +531,10 @@ def build_rdp_command(
                     unc_path = linux_to_unc(file_path)
                 except ValueError as e:
                     raise RuntimeError(f"Cannot open file: {e}") from e
-                app_arg += f",cmd:{unc_path}"
+                # Quote the UNC path: the guest splits the RAIL command line on
+                # spaces, so a path with spaces ("BRMP Rawa/...xlsx") would
+                # reach the app as several args -> "path not found" (#473).
+                app_arg += f',cmd:"{unc_path}"'
             elif default_args:
                 sanitized = default_args.replace(",", " ")
                 app_arg += f",cmd:{sanitized}"
@@ -546,7 +549,9 @@ def build_rdp_command(
                     unc_path = linux_to_unc(file_path)
                 except ValueError as e:
                     raise RuntimeError(f"Cannot open file: {e}") from e
-                cmd.append(f"/app-cmd:{unc_path}")
+                # Quote the UNC path so a space in it isn't split into separate
+                # args by the guest when it parses the RAIL command line (#473).
+                cmd.append(f'/app-cmd:"{unc_path}"')
             elif default_args:
                 cmd.append(f"/app-cmd:{default_args}")
         cmd.append(f"/wm-class:{name_token}")

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -360,6 +360,34 @@ class TestBuildRdpCommand:
         )
         assert "/app-cmd:shell:Desktop" in cmd
 
+    def test_file_path_with_space_is_quoted_freerdp3(self, cfg, monkeypatch, tmp_path):
+        """#473: a file path containing a space must reach the guest quoted,
+        or the RAIL command line splits and the app gets 'path not found'."""
+        monkeypatch.setattr(
+            "winpodx.core.rdp.find_freerdp",
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
+        )
+        monkeypatch.setattr("winpodx.core.rdp.freerdp_major_version", lambda: 3)
+        monkeypatch.setattr("winpodx.core.rdp.Path.home", staticmethod(lambda: tmp_path))
+        f = tmp_path / "BRMP Rawa" / "01 KK.xlsx"
+        f.parent.mkdir(parents=True)
+        f.touch()
+        cmd, _ = build_rdp_command(cfg, app_executable="excel.exe", file_path=str(f))
+        assert any(',cmd:"\\\\tsclient\\home\\BRMP Rawa\\01 KK.xlsx"' in c for c in cmd)
+
+    def test_file_path_with_space_is_quoted_freerdp2(self, cfg, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "winpodx.core.rdp.find_freerdp",
+            lambda *a, **k: ("/usr/bin/xfreerdp", "xfreerdp"),
+        )
+        monkeypatch.setattr("winpodx.core.rdp.freerdp_major_version", lambda: 2)
+        monkeypatch.setattr("winpodx.core.rdp.Path.home", staticmethod(lambda: tmp_path))
+        f = tmp_path / "BRMP Rawa" / "01 KK.xlsx"
+        f.parent.mkdir(parents=True)
+        f.touch()
+        cmd, _ = build_rdp_command(cfg, app_executable="excel.exe", file_path=str(f))
+        assert '/app-cmd:"\\\\tsclient\\home\\BRMP Rawa\\01 KK.xlsx"' in cmd
+
     def test_dpi_flag_when_set(self, cfg, monkeypatch):
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",


### PR DESCRIPTION
Opening a host file whose path contains a space (reported in #473, e.g. `/home/.../BRMP Rawa/.../01.KK PM SPIP KL.xlsx`) failed with **"path not found"**.

**Cause:** the Linux path is converted to a UNC (`\tsclient\home\...`) and injected into FreeRDP's RemoteApp command — FreeRDP 3 `/app:...,cmd:<UNC>` or FreeRDP 2 `/app-cmd:<UNC>` — **without quoting**. The guest splits the RAIL command line on the space, so the app (Excel) receives only `\tsclient\home\Jobs\BRMP` and reports path-not-found. Space-free paths worked, so it went unnoticed.

**Fix:** wrap the UNC path in double quotes in both the FreeRDP 3 and FreeRDP 2 branches so the guest parses it as one argument. Only the file-path (UNC) value is quoted; `default_args` (e.g. `shell:Desktop`) is untouched. Quoting is harmless for space-free paths.

Tests: `test_file_path_with_space_is_quoted_freerdp3` + `_freerdp2`; ruff clean; test_rdp 50 passed.

Known follow-up (separate, rarer): a **comma** in the filename still collides with FreeRDP 3's `/app:` sub-arg separator and isn't fixed by quoting.