### PR TITLE
fix(gui): dashboard resource gauges show + stop lagging

### DIFF
--- a/src/winpodx/core/stats.py
+++ b/src/winpodx/core/stats.py
@@ -23,6 +23,7 @@ import json
 import logging
 import re
 import subprocess
+import threading
 from dataclasses import dataclass
 
 from winpodx.core.config import Config
@@ -120,24 +121,58 @@ def _stats_cli(cfg: Config) -> str | None:
     return None
 
 
+def _resolve_container_name(cli: str, base: str, env: dict) -> str | None:
+    """Return the actual running container name for ``base``.
+
+    podman-compose can override the explicit ``container_name`` with the
+    project-prefixed form (``winpodx_<base>_1``), so a bare ``stats <base>``
+    misses it. ``ps --filter name=`` substring-matches, so it finds the real
+    name. Fast + best-effort; None if nothing matches or the probe fails.
+    """
+    try:
+        result = subprocess.run(
+            [cli, "ps", "--filter", f"name={base}", "--format", "{{.Names}}"],
+            capture_output=True,
+            text=True,
+            timeout=4,
+            check=False,
+            env=env,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    names = [n for n in result.stdout.split() if n]
+    return names[0] if names else None
+
+
 def _live_cpu_ram(cfg: Config) -> tuple[float | None, float | None, float | None]:
     """Probe live CPU%/RAM via ``<cli> stats --no-stream --format json``.
 
-    Returns ``(cpu_pct, ram_used_gb, ram_pct)``, with any field ``None``
-    when the probe fails or the value can't be parsed. Never raises.
+    Resolves the real (possibly compose-prefixed) container name first, runs
+    under ``host_env`` so an AppImage build uses the host's podman + libs (not
+    the bundled ones), and times out fast. Returns ``(cpu_pct, ram_used_gb,
+    ram_pct)``; any field ``None`` when the probe fails or can't be parsed.
+    Never raises. (Rootless cgroup v2 can leave CPU% unavailable — that's a
+    podman limitation, surfaced as ``None`` rather than an error.)
     """
     cli = _stats_cli(cfg)
     if cli is None:
         return None, None, None
 
-    container = cfg.pod.container_name
+    from winpodx.backend._hostenv import host_env
+
+    env = host_env()
+    base = cfg.pod.container_name
+    container = _resolve_container_name(cli, base, env) or base
     try:
         result = subprocess.run(
             [cli, "stats", "--no-stream", "--format", "json", container],
             capture_output=True,
             text=True,
-            timeout=10,
+            timeout=5,
             check=False,
+            env=env,
         )
     except (OSError, subprocess.SubprocessError) as e:
         log.debug("stats probe (%s) failed to run: %s", cli, e)
@@ -187,7 +222,10 @@ def _guest_disk(cfg: Config) -> tuple[float | None, float | None, float | None]:
     try:
         from winpodx.core.disk import get_guest_disk_usage
 
-        usage = get_guest_disk_usage(cfg)
+        # Short timeout: this spawns PowerShell in the guest, so a non-
+        # interactive guest (login screen) must fail fast, not hang the
+        # dashboard for the 30 s default.
+        usage = get_guest_disk_usage(cfg, timeout=6)
     except Exception as e:  # noqa: BLE001 -- never let a probe break the snapshot
         log.debug("guest disk probe failed: %s", e)
         return None, None, None
@@ -232,15 +270,25 @@ def _pod_state(cfg: Config) -> str:
     return "unknown"
 
 
-def pod_resource_snapshot(cfg: Config) -> ResourceSnapshot:
+def pod_resource_snapshot(
+    cfg: Config,
+    *,
+    pod_state: str | None = None,
+    with_disk: bool = True,
+) -> ResourceSnapshot:
     """Build a best-effort :class:`ResourceSnapshot` for the dashboard.
 
     Always returns a snapshot -- never raises. Configured caps come from
-    ``cfg.pod``; live CPU/RAM and guest disk are probed only when the pod
-    is running (and the backend has a container to query), with every
-    external call wrapped so a failure leaves that field ``None``.
+    ``cfg.pod``. Live CPU/RAM and guest disk are probed only when the pod is
+    running, and they run **concurrently** with a hard time cap so a slow
+    guest (e.g. sitting at the login screen) can't stall the dashboard.
+
+    ``pod_state`` lets the caller pass the already-known state (the GUI keeps
+    it fresh on its own timer) so we skip a redundant, slow re-probe.
+    ``with_disk=False`` skips the expensive guest probe entirely (the caller
+    polls disk on a slower cadence and caches it).
     """
-    pod_state = _pod_state(cfg)
+    state = pod_state if pod_state is not None else _pod_state(cfg)
 
     try:
         cpu_cores = int(cfg.pod.cpu_cores)
@@ -258,12 +306,35 @@ def pod_resource_snapshot(cfg: Config) -> ResourceSnapshot:
     disk_used_gb: float | None = None
     disk_pct: float | None = None
 
-    if pod_state == "running":
-        cpu_pct, ram_used_gb, ram_pct = _live_cpu_ram(cfg)
-        disk_total_gb, disk_used_gb, disk_pct = _guest_disk(cfg)
+    if state == "running":
+        box: dict[str, tuple] = {}
+
+        def _cr() -> None:
+            try:
+                box["cr"] = _live_cpu_ram(cfg)
+            except Exception:  # noqa: BLE001 -- best-effort probe
+                box["cr"] = (None, None, None)
+
+        def _dk() -> None:
+            try:
+                box["dk"] = _guest_disk(cfg) if with_disk else (None, None, None)
+            except Exception:  # noqa: BLE001 -- best-effort probe
+                box["dk"] = (None, None, None)
+
+        workers = [
+            threading.Thread(target=_cr, daemon=True),
+            threading.Thread(target=_dk, daemon=True),
+        ]
+        for w in workers:
+            w.start()
+        for w in workers:
+            w.join(timeout=8)  # hard cap regardless of any single probe hanging
+
+        cpu_pct, ram_used_gb, ram_pct = box.get("cr", (None, None, None))
+        disk_total_gb, disk_used_gb, disk_pct = box.get("dk", (None, None, None))
 
     return ResourceSnapshot(
-        pod_state=pod_state,
+        pod_state=state,
         cpu_cores=cpu_cores,
         cpu_pct=cpu_pct,
         ram_gb=ram_gb,

--- a/src/winpodx/gui/_main_window_dashboard.py
+++ b/src/winpodx/gui/_main_window_dashboard.py
@@ -313,16 +313,22 @@ class DashboardMixin:
     def _refresh_dashboard(self) -> None:
         """Probe pod resources off-thread; results land via ``dashboard_updated``.
 
-        Guarded so an in-flight probe (``podman stats`` can take a second or
-        two) isn't stacked by the 5 s timer. Never raises.
+        Reuses the GUI's already-tracked ``self._pod_state`` (no redundant, slow
+        pod re-probe) and only runs the expensive guest disk probe every ~6th
+        tick (~30 s) — disk changes slowly and the guest /exec round-trip is the
+        slow part, so hammering it every 5 s made the whole dashboard lag.
+        Guarded so an in-flight probe isn't stacked by the timer. Never raises.
         """
         if getattr(self, "_dashboard_refreshing", False):
             return
         self._dashboard_refreshing = True
+        self._dashboard_tick = getattr(self, "_dashboard_tick", 0) + 1
+        with_disk = self._dashboard_tick % 6 == 1  # ~every 30 s at the 5 s cadence
+        pod_state = getattr(self, "_pod_state", None)
 
         def _work() -> None:
             try:
-                snap = pod_resource_snapshot(self.cfg)
+                snap = pod_resource_snapshot(self.cfg, pod_state=pod_state, with_disk=with_disk)
             except Exception as e:  # noqa: BLE001 -- snapshot is best-effort
                 log.debug("dashboard snapshot failed: %s", e)
                 snap = None
@@ -355,8 +361,15 @@ class DashboardMixin:
             self._gauge_ram.set_value(snap.ram_pct, f"{snap.ram_pct:.0f}%")
 
         if snap.disk_pct is None or snap.disk_total_gb is None:
-            self._bar_disk.set_value(None, tr("n/a"))
+            # Disk is probed on a slower cadence; keep showing the last value
+            # between probes instead of blanking back to "n/a".
+            cached = getattr(self, "_last_disk", None)
+            if cached is not None:
+                self._bar_disk.set_value(cached[2], f"{cached[1]:.0f} / {cached[0]:.0f} GB")
+            else:
+                self._bar_disk.set_value(None, tr("n/a"))
         else:
+            self._last_disk = (snap.disk_total_gb, snap.disk_used_gb, snap.disk_pct)
             self._bar_disk.set_value(
                 snap.disk_pct,
                 f"{snap.disk_used_gb:.0f} / {snap.disk_total_gb:.0f} GB",

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -55,6 +55,9 @@ def test_snapshot_parses_live_cpu_ram_disk(monkeypatch: pytest.MonkeyPatch) -> N
 
     def fake_run(cmd, **_kwargs):
         assert cmd[0] == "podman"
+        if "ps" in cmd:
+            # Container-name resolution (compose may prefix the name).
+            return _FakeProc(returncode=0, stdout="winpodx-windows\n")
         assert "stats" in cmd
         assert "winpodx-windows" in cmd
         return _FakeProc(returncode=0, stdout=stats_json)
@@ -91,6 +94,8 @@ def test_snapshot_handles_docker_single_object(monkeypatch: pytest.MonkeyPatch) 
 
     def fake_run(cmd, **_kwargs):
         assert cmd[0] == "docker"
+        if "ps" in cmd:
+            return _FakeProc(returncode=0, stdout="winpodx-windows\n")
         return _FakeProc(returncode=0, stdout=stats_json)
 
     monkeypatch.setattr(stats.subprocess, "run", fake_run)


### PR DESCRIPTION
The 0.6.0 Dashboard's CPU / RAM gauges stayed blank and the page felt sluggish.

**Causes:**
- `_live_cpu_ram` ran `podman stats <cfg.pod.container_name>` with the bare configured name, but podman-compose can prefix the real container as `winpodx_<name>_1` (base.py already works around this for the uptime probe). The stats call hit a non-existent name → CPU + RAM both came back `None` (blank gauges). It also ran without `host_env`. Now it resolves the actual running container via `podman ps --filter name=` and runs under `host_env`.
- The snapshot probed pod-state, cpu/ram, and the guest disk (a slow guest `/exec`, 30 s default timeout) **serially every 5 s** — up to ~40 s per refresh. Now: pod-state is reused from the GUI's already-tracked state (no re-probe); cpu/ram + disk run **concurrently** with an 8 s hard cap and short timeouts (cpu/ram 5 s, disk 6 s); and the expensive guest disk probe runs only **~every 30 s** with its last value cached so the bar doesn't blank between probes.

Test updated for the new container-name resolution call. Full suite: 1774 passed, 1 skipped.