### PR TITLE
fix: clearance nits — SPDX, UNC comma injection, web link hardening

### DIFF
--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -531,10 +531,13 @@ def build_rdp_command(
                     unc_path = linux_to_unc(file_path)
                 except ValueError as e:
                     raise RuntimeError(f"Cannot open file: {e}") from e
-                # Quote the UNC path: the guest splits the RAIL command line on
-                # spaces, so a path with spaces ("BRMP Rawa/...xlsx") would
-                # reach the app as several args -> "path not found" (#473).
-                app_arg += f',cmd:"{unc_path}"'
+                # Quote the UNC path so the guest doesn't split it on spaces
+                # ("BRMP Rawa/...xlsx" -> several args -> "path not found", #473).
+                # Also strip commas: FreeRDP 3 splits the /app: value into
+                # sub-keys on commas BEFORE the quotes apply, so a comma in the
+                # filename would inject a spurious sub-key (security review).
+                safe_unc = unc_path.replace(",", " ")
+                app_arg += f',cmd:"{safe_unc}"'
             elif default_args:
                 sanitized = default_args.replace(",", " ")
                 app_arg += f",cmd:{sanitized}"

--- a/src/winpodx/gui/icons/__init__.py
+++ b/src/winpodx/gui/icons/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 from __future__ import annotations
 
 from importlib import resources

--- a/web/faq.html
+++ b/web/faq.html
@@ -35,7 +35,7 @@
       <a href="features.html" data-i18n="nav.features">Features</a>
       <a href="get-started.html" data-i18n="nav.get_started">Get started</a>
       <a href="faq.html" class="active" data-i18n="nav.faq">FAQ</a>
-      <a class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg" width="16" height="16" viewBox="0 0 24 24"><use href="#i-github"/></svg> GitHub</a>
+      <a target="_blank" rel="noopener noreferrer" class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg" width="16" height="16" viewBox="0 0 24 24"><use href="#i-github"/></svg> GitHub</a>
       <span class="lang-wrap"><svg class="isvg" width="15" height="15" viewBox="0 0 24 24"><use href="#i-globe"/></svg><select id="lang-select" aria-label="Language"></select></span>
     </nav>
   </div>
@@ -45,14 +45,14 @@
   <section class="page-hero wrap">
     <span class="eyebrow" data-i18n="faq.hero.eyebrow">FAQ</span>
     <h1 data-i18n="faq.hero.h1">Common questions</h1>
-    <p data-i18n-html="faq.hero.sub">Still stuck? Open an issue on <a href="https://github.com/kernalix7/winpodx/issues">GitHub</a>.</p>
+    <p data-i18n-html="faq.hero.sub">Still stuck? Open an issue on <a target="_blank" rel="noopener noreferrer" href="https://github.com/kernalix7/winpodx/issues">GitHub</a>.</p>
   </section>
 
   <section class="wrap">
     <div class="faq">
       <details open>
         <summary data-i18n="faq.q.vm.q">Is this a VM, Wine, or something else?</summary>
-        <div class="a" data-i18n-html="faq.q.vm.a">It's a real Windows VM presented as native windows. WinPodX runs Windows in a KVM-backed container (via <a href="https://github.com/dockur/windows">dockur/windows</a>) and surfaces each app as its own Linux window over FreeRDP RemoteApp (RAIL). So you get full Windows compatibility — unlike Wine — without staring at a full-screen Windows desktop.</div>
+        <div class="a" data-i18n-html="faq.q.vm.a">It's a real Windows VM presented as native windows. WinPodX runs Windows in a KVM-backed container (via <a target="_blank" rel="noopener noreferrer" href="https://github.com/dockur/windows">dockur/windows</a>) and surfaces each app as its own Linux window over FreeRDP RemoteApp (RAIL). So you get full Windows compatibility — unlike Wine — without staring at a full-screen Windows desktop.</div>
       </details>
       <details>
         <summary data-i18n="faq.q.license.q">Do I need a Windows license?</summary>
@@ -96,7 +96,7 @@
       </details>
       <details>
         <summary data-i18n="faq.q.status.q">Is it stable? What's the project status?</summary>
-        <div class="a" data-i18n-html="faq.q.status.a">It's in active <b>beta</b> (v0.6.0) — usable day-to-day, with ongoing polish. Bug reports and PRs are welcome on <a href="https://github.com/kernalix7/winpodx/issues">GitHub</a>.</div>
+        <div class="a" data-i18n-html="faq.q.status.a">It's in active <b>beta</b> (v0.6.0) — usable day-to-day, with ongoing polish. Bug reports and PRs are welcome on <a target="_blank" rel="noopener noreferrer" href="https://github.com/kernalix7/winpodx/issues">GitHub</a>.</div>
       </details>
     </div>
   </section>
@@ -109,13 +109,13 @@
         <div class="footer-tagline" data-i18n="footer.tagline">Windows apps, as native Linux citizens.</div></div>
       <div class="links">
         <a href="features.html">Features</a><a href="get-started.html">Get started</a><a href="faq.html">FAQ</a>
-        <a href="https://github.com/kernalix7/winpodx">GitHub</a>
-        <a href="https://github.com/kernalix7/winpodx/releases">Releases</a>
-        <a href="https://github.com/sponsors/kernalix7">Sponsor</a>
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/kernalix7/winpodx">GitHub</a>
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/kernalix7/winpodx/releases">Releases</a>
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/sponsors/kernalix7">Sponsor</a>
       </div>
     </div>
     <div class="legal" data-i18n-html="footer.legal">MIT licensed — Kim DaeHyun · Powered by
-      <a href="https://github.com/dockur/windows">dockur/windows</a> + <a href="https://www.freerdp.com/">FreeRDP</a>.
+      <a target="_blank" rel="noopener noreferrer" href="https://github.com/dockur/windows">dockur/windows</a> + <a target="_blank" rel="noopener noreferrer" href="https://www.freerdp.com/">FreeRDP</a>.
       Not affiliated with Microsoft.</div>
   </div>
 </footer>

--- a/web/features.html
+++ b/web/features.html
@@ -35,7 +35,7 @@
       <a href="features.html" class="active" data-i18n="nav.features">Features</a>
       <a href="get-started.html" data-i18n="nav.get_started">Get started</a>
       <a href="faq.html" data-i18n="nav.faq">FAQ</a>
-      <a class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg" width="16" height="16" viewBox="0 0 24 24"><use href="#i-github"/></svg> GitHub</a>
+      <a target="_blank" rel="noopener noreferrer" class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg" width="16" height="16" viewBox="0 0 24 24"><use href="#i-github"/></svg> GitHub</a>
       <span class="lang-wrap"><svg class="isvg" width="15" height="15" viewBox="0 0 24 24"><use href="#i-globe"/></svg><select id="lang-select" aria-label="Language"></select></span>
     </nav>
   </div>
@@ -69,7 +69,7 @@
       </div>
       <div class="block">
         <h3 data-i18n="feat.seamless.multi.title">Multi-session RDP</h3>
-        <p data-i18n-html="feat.seamless.multi.body">The bundled <a href="https://github.com/kernalix7/rdprrap">rdprrap</a> auto-enables up to 25 independent RDP sessions, so multiple apps run truly in parallel. RAIL prerequisites are set automatically during the unattended install.</p>
+        <p data-i18n-html="feat.seamless.multi.body">The bundled <a target="_blank" rel="noopener noreferrer" href="https://github.com/kernalix7/rdprrap">rdprrap</a> auto-enables up to 25 independent RDP sessions, so multiple apps run truly in parallel. RAIL prerequisites are set automatically during the unattended install.</p>
       </div>
       <div class="block">
         <h3 data-i18n="feat.seamless.multimon.title">Multi-monitor RAIL</h3>
@@ -164,7 +164,7 @@
         <li data-i18n="feat.automation.polish.li4">Start-menu Qt6 GUI: Dashboard (live Pod / RAM / CPU / disk) · All apps · Devices · Settings + tray</li>
       </ul></div>
     </div>
-    <p class="lead cta-lead"><a href="https://github.com/kernalix7/winpodx/blob/main/docs/FEATURES.md" data-i18n="feat.automation.docs_link">Deep dives in the docs →</a></p>
+    <p class="lead cta-lead"><a target="_blank" rel="noopener noreferrer" href="https://github.com/kernalix7/winpodx/blob/main/docs/FEATURES.md" data-i18n="feat.automation.docs_link">Deep dives in the docs →</a></p>
   </section>
 </main>
 
@@ -175,13 +175,13 @@
         <div class="footer-tagline" data-i18n="footer.tagline">Windows apps, as native Linux citizens.</div></div>
       <div class="links">
         <a href="features.html" data-i18n="nav.features">Features</a><a href="get-started.html" data-i18n="nav.get_started">Get started</a><a href="faq.html" data-i18n="nav.faq">FAQ</a>
-        <a href="https://github.com/kernalix7/winpodx">GitHub</a>
-        <a href="https://github.com/kernalix7/winpodx/releases">Releases</a>
-        <a href="https://github.com/sponsors/kernalix7">Sponsor</a>
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/kernalix7/winpodx">GitHub</a>
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/kernalix7/winpodx/releases">Releases</a>
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/sponsors/kernalix7">Sponsor</a>
       </div>
     </div>
     <div class="legal" data-i18n-html="footer.legal">MIT licensed — Kim DaeHyun · Powered by
-      <a href="https://github.com/dockur/windows">dockur/windows</a> + <a href="https://www.freerdp.com/">FreeRDP</a>.
+      <a target="_blank" rel="noopener noreferrer" href="https://github.com/dockur/windows">dockur/windows</a> + <a target="_blank" rel="noopener noreferrer" href="https://www.freerdp.com/">FreeRDP</a>.
       Not affiliated with Microsoft.</div>
   </div>
 </footer>

--- a/web/get-started.html
+++ b/web/get-started.html
@@ -35,7 +35,7 @@
       <a href="features.html" data-i18n="nav.features">Features</a>
       <a href="get-started.html" class="active" data-i18n="nav.get_started">Get started</a>
       <a href="faq.html" data-i18n="nav.faq">FAQ</a>
-      <a class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg" width="16" height="16" viewBox="0 0 24 24"><use href="#i-github"/></svg> GitHub</a>
+      <a target="_blank" rel="noopener noreferrer" class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg" width="16" height="16" viewBox="0 0 24 24"><use href="#i-github"/></svg> GitHub</a>
       <span class="lang-wrap"><svg class="isvg" width="15" height="15" viewBox="0 0 24 24"><use href="#i-globe"/></svg><select id="lang-select" aria-label="Language"></select></span>
     </nav>
   </div>
@@ -126,7 +126,7 @@ winpodx pod wait-ready --logs    <span class="code-comment" data-i18n="gs.setup.
       </div>
     </div>
     <p class="lead cta-lead">
-      <a class="btn primary" href="https://github.com/kernalix7/winpodx/blob/main/docs/INSTALL.md" data-i18n="gs.req.docs_btn">Full install docs →</a>
+      <a target="_blank" rel="noopener noreferrer" class="btn primary" href="https://github.com/kernalix7/winpodx/blob/main/docs/INSTALL.md" data-i18n="gs.req.docs_btn">Full install docs →</a>
     </p>
   </section>
 </main>
@@ -138,13 +138,13 @@ winpodx pod wait-ready --logs    <span class="code-comment" data-i18n="gs.setup.
         <div class="footer-tagline" data-i18n="footer.tagline">Windows apps, as native Linux citizens.</div></div>
       <div class="links">
         <a href="features.html">Features</a><a href="get-started.html">Get started</a><a href="faq.html">FAQ</a>
-        <a href="https://github.com/kernalix7/winpodx">GitHub</a>
-        <a href="https://github.com/kernalix7/winpodx/releases">Releases</a>
-        <a href="https://github.com/sponsors/kernalix7">Sponsor</a>
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/kernalix7/winpodx">GitHub</a>
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/kernalix7/winpodx/releases">Releases</a>
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/sponsors/kernalix7">Sponsor</a>
       </div>
     </div>
     <div class="legal" data-i18n-html="footer.legal">MIT licensed — Kim DaeHyun · Powered by
-      <a href="https://github.com/dockur/windows">dockur/windows</a> + <a href="https://www.freerdp.com/">FreeRDP</a>.
+      <a target="_blank" rel="noopener noreferrer" href="https://github.com/dockur/windows">dockur/windows</a> + <a target="_blank" rel="noopener noreferrer" href="https://www.freerdp.com/">FreeRDP</a>.
       Not affiliated with Microsoft.</div>
   </div>
 </footer>

--- a/web/index.html
+++ b/web/index.html
@@ -47,7 +47,7 @@
       <a href="features.html" data-i18n="nav.features">Features</a>
       <a href="get-started.html" data-i18n="nav.get_started">Get started</a>
       <a href="faq.html" data-i18n="nav.faq">FAQ</a>
-      <a class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg" width="16" height="16" viewBox="0 0 24 24"><use href="#i-github"/></svg> GitHub</a>
+      <a target="_blank" rel="noopener noreferrer" class="gh" href="https://github.com/kernalix7/winpodx"><svg class="isvg" width="16" height="16" viewBox="0 0 24 24"><use href="#i-github"/></svg> GitHub</a>
       <span class="lang-wrap"><svg class="isvg" width="15" height="15" viewBox="0 0 24 24"><use href="#i-globe"/></svg><select id="lang-select" aria-label="Language"></select></span>
     </nav>
   </div>
@@ -82,7 +82,7 @@
 
     <div class="cta">
       <a class="btn primary" href="get-started.html" data-i18n="index.cta.get_started">Get started →</a>
-      <a class="btn ghost" href="https://github.com/kernalix7/winpodx" data-i18n-html="index.cta.star"><svg class="isvg" width="16" height="16" viewBox="0 0 24 24"><use href="#i-github"/></svg> Star on GitHub</a>
+      <a target="_blank" rel="noopener noreferrer" class="btn ghost" href="https://github.com/kernalix7/winpodx" data-i18n-html="index.cta.star"><svg class="isvg" width="16" height="16" viewBox="0 0 24 24"><use href="#i-github"/></svg> Star on GitHub</a>
     </div>
   </section>
 
@@ -108,7 +108,7 @@
         <div class="step">
           <div class="head"><span class="n">1</span><span class="ico"><svg width="22" height="22" viewBox="0 0 24 24"><use href="#i-download"/></svg></span></div>
           <h3 data-i18n="index.how.step1.title">Install &amp; setup</h3>
-          <p data-i18n-html="index.how.step1.body">One command pulls a Windows container (<a href="https://github.com/dockur/windows">dockur/windows</a>) in rootless Podman, runs an unattended Windows install, and applies the RemoteApp + agent setup.</p>
+          <p data-i18n-html="index.how.step1.body">One command pulls a Windows container (<a target="_blank" rel="noopener noreferrer" href="https://github.com/dockur/windows">dockur/windows</a>) in rootless Podman, runs an unattended Windows install, and applies the RemoteApp + agent setup.</p>
         </div>
         <div class="step">
           <div class="head"><span class="n">2</span><span class="ico green"><svg width="22" height="22" viewBox="0 0 24 24"><use href="#i-grid"/></svg></span></div>
@@ -217,16 +217,16 @@
         <a href="features.html">Features</a>
         <a href="get-started.html">Get started</a>
         <a href="faq.html">FAQ</a>
-        <a href="https://github.com/kernalix7/winpodx">GitHub</a>
-        <a href="https://github.com/kernalix7/winpodx/releases">Releases</a>
-        <a href="https://github.com/kernalix7/winpodx/issues">Issues</a>
-        <a href="https://github.com/sponsors/kernalix7">Sponsor</a>
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/kernalix7/winpodx">GitHub</a>
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/kernalix7/winpodx/releases">Releases</a>
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/kernalix7/winpodx/issues">Issues</a>
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/sponsors/kernalix7">Sponsor</a>
       </div>
     </div>
     <div class="legal" data-i18n-html="footer.legal">
       MIT licensed — Kim DaeHyun ·
-      Powered by <a href="https://github.com/dockur/windows">dockur/windows</a> +
-      <a href="https://www.freerdp.com/">FreeRDP</a>.
+      Powered by <a target="_blank" rel="noopener noreferrer" href="https://github.com/dockur/windows">dockur/windows</a> +
+      <a target="_blank" rel="noopener noreferrer" href="https://www.freerdp.com/">FreeRDP</a>.
       Not affiliated with Microsoft. "Windows" is a trademark of Microsoft Corporation.
     </div>
   </div>


### PR DESCRIPTION
Confirmed low-severity items from the 0.6.0 pre-release clearance review: missing SPDX header on `gui/icons/__init__.py`; comma sanitization in the FreeRDP 3 `/app:` UNC path (sub-key injection follow-up to #473); and `target=_blank rel=noopener noreferrer` on the website's 33 external links. Docs/web + two tiny code edits; test_rdp 50 passed, ruff clean.