### PR TITLE
chore(aur): add winpodx-git PKGBUILD (build from main)

### DIFF
--- a/packaging/aur-git/.SRCINFO
+++ b/packaging/aur-git/.SRCINFO
@@ -1,0 +1,24 @@
+pkgbase = winpodx-git
+	pkgdesc = Windows app integration for Linux desktop (Podman/FreeRDP RemoteApp) -- built from the main branch
+	pkgver = 0.6.0.r0.g0000000
+	pkgrel = 1
+	url = https://github.com/kernalix7/winpodx
+	install = winpodx.install
+	arch = any
+	license = MIT
+	makedepends = git
+	makedepends = python-build
+	makedepends = python-installer
+	makedepends = python-hatchling
+	makedepends = python-wheel
+	depends = python
+	depends = freerdp
+	optdepends = podman: default container backend
+	optdepends = docker: alternative container backend
+	optdepends = pyside6: Qt6 GUI and system tray
+	provides = winpodx
+	conflicts = winpodx
+	source = winpodx-git::git+https://github.com/kernalix7/winpodx.git
+	sha256sums = SKIP
+
+pkgname = winpodx-git

--- a/packaging/aur-git/PKGBUILD
+++ b/packaging/aur-git/PKGBUILD
@@ -1,0 +1,77 @@
+# Maintainer: Kim DaeHyun <kernalix7@kodenet.io>
+#
+# VCS package: builds winpodx from the GitHub main branch. Unlike the stable
+# `winpodx` package (release tarballs), the version is derived from git at
+# build time by pkgver() -- never hand-edit it. Publish this PKGBUILD to the
+# separate AUR repo `winpodx-git`; users get the newest main on each rebuild
+# (`yay -Syu --devel`).
+
+pkgname=winpodx-git
+pkgver=0.6.0.r0.g0000000
+pkgrel=1
+pkgdesc="Windows app integration for Linux desktop (Podman/FreeRDP RemoteApp) -- built from the main branch"
+arch=('any')
+url="https://github.com/kernalix7/winpodx"
+license=('MIT')
+# Arch's `python` is rolling and already >= 3.13, so tomllib is stdlib and the
+# tomli fallback is a marker-gated no-op (see pyproject.toml).
+depends=(
+  'python'
+  'freerdp'
+)
+optdepends=(
+  'podman: default container backend'
+  'docker: alternative container backend'
+  'pyside6: Qt6 GUI and system tray'
+)
+makedepends=(
+  'git'
+  'python-build'
+  'python-installer'
+  'python-hatchling'
+  'python-wheel'
+)
+provides=('winpodx')
+conflicts=('winpodx')
+# Default ref is the repo's default branch (main). Pin to a commit/tag with a
+# fragment, e.g. ...winpodx.git#commit=<sha> or #tag=v0.6.0, if you ever want
+# this package frozen instead of tracking main.
+source=("$pkgname::git+https://github.com/kernalix7/winpodx.git")
+sha256sums=('SKIP')
+install=winpodx.install
+
+pkgver() {
+  cd "$srcdir/$pkgname"
+  # <last tag without the v> . r<commits since tag> . g<short hash>
+  # e.g. 0.6.0.r12.gabc1234 -- monotonic and unique per commit. Falls back to a
+  # tagless r<count>.g<hash> form if the clone has no tags.
+  git describe --long --tags --abbrev=7 2>/dev/null \
+    | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g' \
+    || printf '0.r%s.g%s' "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
+}
+
+build() {
+  cd "$srcdir/$pkgname"
+  python -m build --wheel --no-isolation
+}
+
+package() {
+  cd "$srcdir/$pkgname"
+  python -m installer --destdir="$pkgdir" dist/*.whl
+  # License dir uses $pkgname (namcap); app-facing paths use the real app id.
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 THIRD_PARTY_LICENSES.md \
+    "$pkgdir/usr/share/licenses/$pkgname/THIRD_PARTY_LICENSES.md"
+  install -Dm644 README.md "$pkgdir/usr/share/doc/winpodx/README.md"
+  install -Dm644 CHANGELOG.md "$pkgdir/usr/share/doc/winpodx/CHANGELOG.md"
+  install -Dm644 data/winpodx.desktop \
+    "$pkgdir/usr/share/applications/winpodx.desktop"
+  install -Dm644 data/winpodx-icon.svg \
+    "$pkgdir/usr/share/icons/hicolor/256x256/apps/winpodx.svg"
+  install -Dm644 data/winpodx.toml.example \
+    "$pkgdir/usr/share/winpodx/winpodx.toml.example"
+  install -Dm755 packaging/scripts/postrm-common.sh \
+    "$pkgdir/usr/share/winpodx/packaging/postrm-common.sh"
+  install -Dm755 uninstall.sh \
+    "$pkgdir/usr/share/winpodx/uninstall.sh"
+}

--- a/packaging/aur-git/README.md
+++ b/packaging/aur-git/README.md
@@ -1,0 +1,55 @@
+# `winpodx-git` — AUR development package
+
+Builds winpodx from the GitHub **main** branch (latest, unreleased code), as a
+separate AUR package from the stable [`winpodx`](../aur/) (which uses tagged
+release tarballs).
+
+## How it stays current
+
+The version is **not** hand-maintained. `pkgver()` derives it from git at build
+time:
+
+```
+0.6.0.r12.gabc1234   =  <last tag> . r<commits since tag> . g<short hash>
+```
+
+So you publish this PKGBUILD to AUR **once**. Every rebuild re-runs `pkgver()`
+against fresh `main`, so the version tracks the newest commit automatically.
+
+- **Users get updates** with `yay -Syu --devel` / `paru -Syu --devel` (the
+  `--devel` pass re-checks VCS packages and rebuilds when `main` moved).
+  Without `--devel`, a user reinstalls (`yay -S winpodx-git`) to pull latest.
+- **`winpodx-git` and `winpodx` can't coexist** (`provides`/`conflicts`).
+- **Pin instead of tracking main:** add a fragment to `source`, e.g.
+  `…winpodx.git#commit=<sha>` or `#tag=v0.6.0`. (If you want a fixed version,
+  the stable `winpodx` package is the better choice.)
+
+## Publishing to AUR (maintainer steps)
+
+Requires an AUR account with your SSH public key registered
+(https://aur.archlinux.org/account → My Account → SSH Public Key).
+
+```bash
+# 1. Clone the (empty) AUR repo — created on first push.
+git clone ssh://aur@aur.archlinux.org/winpodx-git.git
+cd winpodx-git
+
+# 2. Copy the package files from this repo.
+cp /path/to/winpodx/packaging/aur-git/PKGBUILD .
+cp /path/to/winpodx/packaging/aur-git/winpodx.install .
+
+# 3. Regenerate .SRCINFO from the PKGBUILD (AUR validates it; the one in this
+#    repo is a starting point — always regenerate on an Arch box).
+makepkg --printsrcinfo > .SRCINFO
+
+# 4. (recommended) Test-build locally first.
+makepkg -si
+
+# 5. Commit + push — this publishes / updates the AUR package.
+git add PKGBUILD .SRCINFO winpodx.install
+git commit -m "winpodx-git: build from main"
+git push
+```
+
+Re-push only when the **build recipe** changes (deps, install steps) — not per
+upstream commit; the git source + `pkgver()` handle commit tracking.

--- a/packaging/aur-git/winpodx.install
+++ b/packaging/aur-git/winpodx.install
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MIT
+#
+# Pacman scriptlet for winpodx (#255 PR 4).
+# Referenced from PKGBUILD's `install=winpodx.install`.
+
+# Post-install banner. pacman shows this output above the progress bar
+# right after the package files land. Keep terse -- full guidance is in
+# docs/INSTALL.md.
+post_install() {
+    cat <<'EOF'
+
+[WinPodX] Package installed. Next step:
+  - Open WinPodX from your application menu (GUI) OR
+  - Run 'winpodx' in a terminal
+First-run prompt will offer auto setup / customize wizard / skip.
+
+For the curl-like all-in-one experience, run:
+  winpodx setup
+
+Full docs: https://github.com/kernalix7/winpodx/blob/main/docs/INSTALL.md
+
+EOF
+}
+
+post_upgrade() {
+    # No banner on upgrade; existing users don't need the first-run hint.
+    :
+}
+
+# Pacman has no purge concept; both pacman -R and pacman -Rns drop the
+# package files but leave user state. We still run the stage-1 cleanup
+# (kill processes + stop listener) so the user isn't left with stale
+# tray pointing at a deleted binary, and we tell them how to do the
+# full wipe themselves.
+post_remove() {
+    if [ -x /usr/share/winpodx/packaging/postrm-common.sh ]; then
+        /usr/share/winpodx/packaging/postrm-common.sh remove || true
+    fi
+    cat <<'EOF'
+
+[WinPodX] Package removed. User-side state (containers, configs,
+reverse-open daemon, autostart) was NOT touched. To wipe everything:
+  winpodx uninstall --purge --yes
+
+EOF
+}


### PR DESCRIPTION
Adds `packaging/aur-git/` — a VCS (`-git`) AUR package that builds winpodx from the **main** branch, separate from the stable `winpodx` package.

- `pkgver()` derives the version from git (`<tag>.r<commits>.g<hash>`) at build time — no manual version bumps; tracks main automatically.
- `provides`/`conflicts` `winpodx` (interchangeable, can't coexist).
- `source` is the git repo (default = main); pin with `#commit=`/`#tag=` if ever needed.
- README documents the AUR-publish maintainer steps; `.SRCINFO` is a starter (regenerate with `makepkg --printsrcinfo` on Arch).

Packaging-only; no code/test/runtime changes.