### PR TITLE
fix(install): say 'winpodx gui' not bare 'winpodx' to open the GUI (#480)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1010,7 +1010,7 @@ else
     log "  Will install: nothing — all required system packages already present"
 fi
 if [ "${WINPODX_MANUAL:-0}" = "1" ] || [ "$WINPODX_BACKEND" = "manual" ]; then
-    log "  Windows VM:  NOT provisioned (manual mode); run 'winpodx' later to finish"
+    log "  Windows VM:  NOT provisioned (manual mode); run 'winpodx setup' later to finish"
 else
     log "  Windows VM:  setup -> first-boot (~7.5GB ISO on a fresh install)"
     log "               -> apply-fixes -> discovery -> reverse-open"
@@ -1328,7 +1328,7 @@ fi
 # `winpodx` invocation (CLI Y/C/n or GUI modal -- #255 PR 1).
 if [ "${WINPODX_MANUAL:-0}" = "1" ]; then
     log "Manual mode (--manual / WINPODX_MANUAL=1 / --backend manual) — skipping setup + Windows provisioning."
-    log "  Run 'winpodx' (CLI or GUI) to finish setup. Prompt will offer auto, customize, or skip."
+    log "  Run 'winpodx setup' to finish setup (or 'winpodx gui' for the graphical first-run with auto / customize / skip)."
 else
     log "Running winpodx setup..."
     # 0.6.0 item B: --create-only is gone. setup writes config + creates the
@@ -1583,7 +1583,7 @@ echo -e "${GREEN}  └───────────────────�
 echo ""
 echo "  Next steps:"
 if [ -z "$WINPODX_NO_GUI" ]; then
-    echo "    winpodx                    # open the GUI — system tray + app manager"
+    echo "    winpodx gui                # open the GUI — system tray + app manager"
 fi
 echo "    winpodx app run desktop    # the full Windows desktop"
 echo "    winpodx app refresh        # rescan the apps installed in Windows"

--- a/src/winpodx/cli/doctor.py
+++ b/src/winpodx/cli/doctor.py
@@ -293,7 +293,7 @@ def _check_config_state() -> Finding:
             "winpodx binary present but config missing",
             detail=f"binary: {binary_path}; expected config: {config_path}",
             suggestion=(
-                "Run `winpodx setup` (or just `winpodx` -- first-run prompt will offer setup)."
+                "Run `winpodx setup` (or `winpodx gui` for the graphical first-run prompt)."
             ),
         )
     if config_path.exists() and not binary_path:


### PR DESCRIPTION
Bare `winpodx` (no subcommand) prints `--help` and returns (`main.py:860`) — it does not open the GUI/tray or fire the first-run prompt (that only runs for an actual command). But the install output told users otherwise, so on an **upgrade** the 'open the GUI' instruction just dumped the help text (issue #480).

Fixed three messages:
- install 'Next steps' box: `winpodx` → **`winpodx gui`** (# open the GUI — system tray + app manager).
- manual-mode hint: `Run 'winpodx' ...` → **`winpodx setup`** (or `winpodx gui` for the graphical first-run).
- plan-summary manual line + `doctor` 'config missing' suggestion likewise point at `winpodx setup` / `winpodx gui`.

The `.desktop` launcher already uses `winpodx gui`. Behaviour is unchanged — only the instructions are corrected. Refs #480 (no auto-close; left for per-issue review).