### PR TITLE
chore(release): finalize 0.6.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0] - 2026-06-04
+## [0.6.0] - 2026-06-05
 
 ### Removed
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -7,7 +7,7 @@ winpodx (0.6.0) unstable; urgency=medium
     QEMU/KVM-in-a-container backend now covers passthrough too. See the
     CHANGELOG / GitHub release notes for the full list (#286, #300, #460+).
 
- -- Kim DaeHyun <kernalix7@kodenet.io>  Thu, 04 Jun 2026 12:00:00 +0000
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Fri, 05 Jun 2026 12:00:00 +0000
 
 winpodx (0.5.9) unstable; urgency=medium
 

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -7,7 +7,7 @@
 형식은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)를 기반으로 하며,
 버전 정책은 [Semantic Versioning](https://semver.org/lang/ko/)을 지향합니다.
 
-## [0.6.0] - 2026-06-04
+## [0.6.0] - 2026-06-05
 
 ### Removed
 


### PR DESCRIPTION
Stamp the 0.6.0 release date (2026-06-05) in CHANGELOG.md, docs/CHANGELOG.ko.md, and debian/changelog ahead of tagging. Docs-only.