### PR TITLE
ci(release): single-writer release notes + decouple OBS publish

### DIFF
--- a/.github/workflows/appimage-publish.yml
+++ b/.github/workflows/appimage-publish.yml
@@ -217,11 +217,39 @@ jobs:
           path: ${{ steps.locate.outputs.appimage_path }}
           if-no-files-found: error
 
-      - name: Attach to GitHub Release (tag push only)
+      # Single-writer rule: release.yml (REL- marker tag) is the SOLE creator
+      # of the GitHub Release and the only writer of its title/notes. This
+      # workflow only attaches the AppImage to an already-created release —
+      # it never creates or edits the notes. (softprops/action-gh-release
+      # would create-or-update the release even with only `files:` set, which
+      # contributed to the "edited N times" churn; `gh release upload` to an
+      # existing release does not.) Wait up to 12 min for release.yml — which
+      # runs the full test suite first — to create the release; skip
+      # gracefully if it never appears (the AppImage stays a build artifact).
+      - name: Wait for release (release.yml owns creation)
         if: github.event_name == 'push'
-        uses: softprops/action-gh-release@v2
-        with:
-          files: ${{ steps.locate.outputs.appimage_path }}
-          # Don't create the release if it doesn't already exist --
-          # release.yml (REL- marker tag) owns release creation.
-          fail_on_unmatched_files: true
+        id: wait
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ github.ref_name }}"
+          for _ in $(seq 1 48); do
+            if gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+              echo "Release $tag exists — attaching AppImage."
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Release $tag not created yet (release.yml owns creation) — waiting…"
+            sleep 15
+          done
+          echo "::warning::Release $tag never appeared (REL-$tag marker tag not pushed?). Skipping AppImage upload; it remains as a build artifact."
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+
+      - name: Attach AppImage to GitHub Release (tag push only)
+        if: github.event_name == 'push' && steps.wait.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            "${{ steps.locate.outputs.appimage_path }}" --clobber \
+            --repo "${{ github.repository }}"

--- a/.github/workflows/debs-publish.yml
+++ b/.github/workflows/debs-publish.yml
@@ -112,37 +112,41 @@ jobs:
       - name: List collected debs
         run: ls -la all-debs/
 
-      # Publish workflows and release.yml run in parallel on tag push. If this
-      # job finishes before release.yml creates the GitHub Release,
-      # `gh release upload` fails with "release not found". Create a minimal
-      # release here if it doesn't exist yet; release.yml's
-      # softprops/action-gh-release will populate title, notes, and
-      # sdist/wheel when it completes.
+      # Single-writer rule: release.yml (REL- marker tag) is the SOLE creator
+      # of the GitHub Release and the only writer of its title/notes. This
+      # packaging workflow never creates or edits the release — it waits for
+      # release.yml to create it, then attaches its assets. (The old per-
+      # workflow `gh release create --notes "Release artifacts…"` stubs both
+      # raced to produce duplicate releases — kernalix7 hit this on v0.4.1
+      # push 2026-05-05 — and churned the notes with placeholder text that
+      # release.yml then overwrote, so the release showed as "edited" many
+      # times. Waiting instead of creating eliminates both.)
       #
-      # Race-tolerant: debs-publish and rhel-publish both run this step in
-      # parallel. The previous `view || create` form let both paths through
-      # the view-failed branch, both call create, both succeed (GitHub's
-      # release-create POST isn't atomic on tag uniqueness), producing
-      # duplicate releases that then break softprops's update path with
-      # "tag_name: already_exists" — kernalix7 saw this on v0.4.1 push
-      # (2026-05-05). Now: try to create, swallow any already-exists error,
-      # then verify the release is reachable. If it isn't, fail the step.
-      - name: Ensure release exists
+      # release.yml runs the full test suite before creating the release, so
+      # it typically appears ~5-6 min after the push; poll up to 12 min. If it
+      # never appears (e.g. only the v-tag was pushed, no REL- marker), skip
+      # the upload gracefully — the .debs remain available as build-job
+      # artifacts — rather than failing the run.
+      - name: Wait for release (release.yml owns creation)
+        id: wait
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag="${{ steps.tag.outputs.tag }}"
-          gh release create "$tag" \
-              --title "$tag" \
-              --notes "Release artifacts — see CHANGELOG.md for details." \
-              --repo "${{ github.repository }}" \
-              2>&1 | tee /tmp/release-create.log || true
-          if ! grep -qE "already_exists|already exists|Release.created" /tmp/release-create.log; then
-            : # neither success nor known-tolerable failure — fall through to verify
-          fi
-          gh release view "$tag" --repo "${{ github.repository }}" >/dev/null
+          for _ in $(seq 1 48); do
+            if gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+              echo "Release $tag exists — attaching .debs."
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Release $tag not created yet (release.yml owns creation) — waiting…"
+            sleep 15
+          done
+          echo "::warning::Release $tag never appeared (REL-$tag marker tag not pushed?). Skipping .deb upload; .debs remain as build-job artifacts."
+          echo "exists=false" >> "$GITHUB_OUTPUT"
 
       - name: Upload .deb to release
+        if: steps.wait.outputs.exists == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/obs-publish.yml
+++ b/.github/workflows/obs-publish.yml
@@ -1,13 +1,38 @@
 name: OBS Publish
 
+# OBS builds RPMs asynchronously on shared openSUSE infrastructure
+# (~30-60 min per rebuild). Trying to trigger the rebuild AND download the
+# freshly-built RPMs in the same tag-push run was structurally broken: the
+# download ran minutes after the trigger, long before OBS had published the
+# new version, so every release push failed with "No RPMs were downloaded".
+#
+# This workflow is split to match OBS's async reality:
+#   * `trigger` (tag push / dispatch) — fire the OBS rebuild, then exit
+#     green. It never tries to download, so a release push can't go red here.
+#   * `attach` (hourly schedule / dispatch) — once OBS has published the
+#     RPMs for the latest release's version, download them and attach them to
+#     the existing GitHub Release. It is a no-op (green) when the RPMs aren't
+#     built yet (retries next hour) or are already attached (no churn).
+#
+# Single-writer rule: this workflow NEVER creates the GitHub Release or edits
+# its title/notes — release.yml (REL- marker tag) is the sole creator and the
+# only writer of the release body. `attach` only uploads assets to a release
+# that already exists, so it can't cause the "edited N times" / placeholder-
+# notes churn the old per-workflow `gh release create --notes …` stubs did.
+
 on:
   push:
     tags:
       - "v*.*.*"
+  schedule:
+    # Hourly sweep: attach OBS RPMs to the latest release once OBS finishes
+    # building them. A no-op the rest of the time (already attached / not
+    # built yet), so it never edits a release it has nothing new for.
+    - cron: "17 * * * *"
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to attach RPMs to (e.g. v0.1.0)"
+        description: "Release tag to trigger / attach RPMs to (e.g. v0.6.0)"
         required: true
       force:
         description: "Force OBS runservice even if Tumbleweed RPM exists (use when source bumped without version change)"
@@ -27,7 +52,11 @@ permissions:
   contents: write
 
 jobs:
-  publish:
+  # Fire the OBS rebuild and exit. Runs on tag push and manual dispatch only.
+  # Never downloads — so a release push is always green here; the RPMs land
+  # asynchronously via the `attach` job once OBS finishes the server-side build.
+  trigger:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -58,12 +87,6 @@ jobs:
         # byte-identical to what's already on the server. Probe a representative
         # shipping repo (Tumbleweed) for a winpodx-<version>-*.rpm filename in
         # the public download index; if found, OBS has the build cached.
-        #
-        # Works uniformly for both push (fresh tag — probe fails, we trigger)
-        # and workflow_dispatch (re-run on already-built tag — probe succeeds,
-        # we skip). If a fresh rebuild is genuinely needed (corrupted OBS
-        # cache), delete the noarch RPM via the OBS web UI then re-run the
-        # workflow, or push a new tag.
         id: probe
         run: |
           version="${{ steps.tag.outputs.version }}"
@@ -94,44 +117,71 @@ jobs:
           curl -sS -f -X POST \
             -H "Authorization: Token $OBS_TOKEN" \
             "$OBS_API/trigger/runservice?project=$OBS_PROJECT&package=$OBS_PACKAGE"
+          echo "OBS rebuild triggered for v${{ steps.tag.outputs.version }}. RPMs will be attached by the hourly 'attach' job once OBS finishes (~30-60 min)."
 
-      - name: Wait for OBS shipping repos to finish
-        # Exit as soon as the repos we actually ship are in a terminal-OK
-        # state. Niche-arch noise (RISCV, Factory PowerPC, Slowroll aarch64)
-        # stuck on `blocked`/`broken` indefinitely is ignored — we don't ship
-        # those. Shipping repos: Tumbleweed, Leap 15.6, Leap 16.0, Slowroll,
-        # Fedora 42 / 43 / 44. Reduces the wait from "wait for every (repo,
-        # arch) combination in the project" to "wait for the seven we ship."
+  # Download OBS-built RPMs once they're published and attach them to the
+  # existing GitHub Release. Runs hourly (sweeps the latest release) and on
+  # manual dispatch (targets inputs.tag). Never creates or edits the release.
+  attach:
+    if: github.event_name != 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install curl + jq
+        run: sudo apt-get update && sudo apt-get install -y curl jq
+
+      - name: Resolve target tag
+        id: tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          deadline=$(( $(date +%s) + 60 * 60 ))
-          sleep 15
-          while :; do
-            now=$(date +%s)
-            if [ "$now" -ge "$deadline" ]; then
-              echo "Timed out waiting for OBS shipping repos" >&2
-              curl -sS "$OBS_PUBLIC_API/build/$OBS_PROJECT/_result?package=$OBS_PACKAGE" || true
-              exit 1
-            fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            # schedule: sweep the most recent published release.
+            tag=$(gh release list --repo "${{ github.repository }}" --limit 1 \
+                    --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+          fi
+          if [ -z "$tag" ]; then
+            echo "No target tag (no releases yet?) — nothing to attach."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          version="${tag#v}"
+          version="${version%%-RTM*}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
-            xml=$(curl -sS -f "$OBS_PUBLIC_API/build/$OBS_PROJECT/_result?package=$OBS_PACKAGE" || true)
-            if [ -z "$xml" ]; then
-              sleep 15
-              continue
-            fi
-
-            set +e
-            report=$(echo "$xml" | python3 scripts/ci/obs_check_shipping.py)
-            rc=$?
-            set -e
-            echo "$report"
-            case $rc in
-              0) echo "All shipping repos ready — proceeding to download."; break ;;
-              1) echo "Failure in one or more shipping repos." >&2; exit 1 ;;
-              *) sleep 30; continue ;;
-            esac
-          done
+      - name: Skip if release already has OBS RPMs attached
+        id: gate
+        if: steps.tag.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ steps.tag.outputs.tag }}"
+          # release.yml owns creation — only attach to a release that exists.
+          if ! gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Release $tag does not exist yet (release.yml owns creation) — nothing to attach."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Tumbleweed is always built and is the canary for "OBS RPMs already
+          # attached". If its asset is present, the sweep already ran for this
+          # release — exit green without re-uploading (no edit churn).
+          assets=$(gh release view "$tag" --repo "${{ github.repository }}" \
+                     --json assets --jq '.assets[].name' 2>/dev/null || echo "")
+          if echo "$assets" | grep -q "openSUSE_Tumbleweed\.rpm$"; then
+            echo "OBS RPMs already attached to $tag — no-op."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Discover repos and download RPMs
+        id: download
+        if: steps.gate.outputs.skip == 'false'
         run: |
           mkdir -p dist-rpms
           version="${{ steps.tag.outputs.version }}"
@@ -177,9 +227,7 @@ jobs:
               # stale older RPM still in the OBS publish index (Tumbleweed /
               # Slowroll rolling-release repos are slow to garbage-collect)
               # doesn't get downloaded and re-uploaded as a v${version}
-              # release asset. The release-asset rename further down would
-              # otherwise produce e.g. winpodx-0.5.4-...openSUSE_Tumbleweed.rpm
-              # alongside the real 0.5.5 RPMs, which already happened on v0.5.5.
+              # release asset.
               rpms=$(echo "$listing" | grep -oE "winpodx-${version}-[^\"]+\.rpm" | sort -u)
               for f in $rpms; do
                 case "$f" in
@@ -194,32 +242,23 @@ jobs:
 
           ls -la dist-rpms/
           if ! ls dist-rpms/*.rpm >/dev/null 2>&1; then
-            echo "No RPMs were downloaded" >&2
-            exit 1
+            echo "::notice::OBS hasn't published RPMs for v${version} yet — they build asynchronously (~30-60 min). The hourly sweep will retry; or re-run this workflow once the build finishes."
+            echo "have_rpms=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_rpms=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Publish workflows and release.yml run in parallel on tag push. If this job
-      # finishes before release.yml creates the GitHub Release, `gh release upload`
-      # fails with "release not found". Create a minimal release here if it doesn't
-      # exist yet; release.yml's softprops/action-gh-release will populate title,
-      # notes, and sdist/wheel when it completes.
-      - name: Ensure release exists
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          tag="${{ steps.tag.outputs.tag }}"
-          gh release view "$tag" >/dev/null 2>&1 \
-            || gh release create "$tag" \
-                 --title "$tag" \
-                 --notes "Release artifacts — see CHANGELOG.md for details."
-
       - name: Attach RPMs to GitHub release
+        if: steps.download.outputs.have_rpms == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ steps.tag.outputs.tag }}" dist-rpms/*.rpm --clobber
+          gh release upload "${{ steps.tag.outputs.tag }}" dist-rpms/*.rpm --clobber \
+            --repo "${{ github.repository }}"
+          echo "Attached OBS RPMs to ${{ steps.tag.outputs.tag }}."
 
       - uses: actions/upload-artifact@v4
+        if: steps.download.outputs.have_rpms == 'true'
         with:
           name: rpms-${{ steps.tag.outputs.version }}
           path: dist-rpms/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,15 @@ jobs:
           tag_name: v${{ steps.version.outputs.value }}
           name: v${{ steps.version.outputs.value }}
           prerelease: ${{ steps.prerelease.outputs.value }}
+          # The hand-written CHANGELOG section is the body; generate_release_notes
+          # appends GitHub's auto "## What's Changed / New Contributors / Full
+          # Changelog" block underneath it, so the release page credits every PR
+          # author (avatars + @handles) — the CHANGELOG itself only cites PR
+          # numbers. This is the SOLE writer of the release body: the packaging
+          # workflows (.deb / RPM / OBS / AppImage) only attach assets, never
+          # touch the notes, so the release isn't edited/rewritten repeatedly.
           body: ${{ steps.changelog.outputs.notes }}
+          generate_release_notes: true
           files: |
             dist/*.tar.gz
             dist/*.whl

--- a/.github/workflows/rhel-publish.yml
+++ b/.github/workflows/rhel-publish.yml
@@ -164,34 +164,41 @@ jobs:
       - name: List collected RPMs
         run: ls -la all-rpms/
 
-      # Publish workflows and release.yml run in parallel on tag push. If this
-      # job finishes before release.yml creates the GitHub Release,
-      # `gh release upload` fails with "release not found". Create a minimal
-      # release here if it doesn't exist yet; release.yml's
-      # softprops/action-gh-release will populate title, notes, and
-      # sdist/wheel when it completes.
+      # Single-writer rule: release.yml (REL- marker tag) is the SOLE creator
+      # of the GitHub Release and the only writer of its title/notes. This
+      # packaging workflow never creates or edits the release — it waits for
+      # release.yml to create it, then attaches its assets. (The old per-
+      # workflow `gh release create --notes "Release artifacts…"` stubs both
+      # raced to produce duplicate releases — kernalix7 hit this on v0.4.1
+      # push 2026-05-05 — and churned the notes with placeholder text that
+      # release.yml then overwrote, so the release showed as "edited" many
+      # times. Waiting instead of creating eliminates both.)
       #
-      # Race-tolerant: see debs-publish.yml's matching step. The previous
-      # `view || create` form let both packaging workflows reach create at
-      # the same time and produce duplicate releases (kernalix7 hit this on
-      # v0.4.1 push 2026-05-05). Now: try to create, swallow already-exists
-      # errors, then verify the release is reachable.
-      - name: Ensure release exists
+      # release.yml runs the full test suite before creating the release, so
+      # it typically appears ~5-6 min after the push; poll up to 12 min. If it
+      # never appears (e.g. only the v-tag was pushed, no REL- marker), skip
+      # the upload gracefully — the RPMs remain available as build-job
+      # artifacts — rather than failing the run.
+      - name: Wait for release (release.yml owns creation)
+        id: wait
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag="${{ steps.tag.outputs.tag }}"
-          gh release create "$tag" \
-              --title "$tag" \
-              --notes "Release artifacts — see CHANGELOG.md for details." \
-              --repo "${{ github.repository }}" \
-              2>&1 | tee /tmp/release-create.log || true
-          if ! grep -qE "already_exists|already exists|Release.created" /tmp/release-create.log; then
-            : # neither success nor known-tolerable failure — fall through to verify
-          fi
-          gh release view "$tag" --repo "${{ github.repository }}" >/dev/null
+          for _ in $(seq 1 48); do
+            if gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+              echo "Release $tag exists — attaching RPMs."
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Release $tag not created yet (release.yml owns creation) — waiting…"
+            sleep 15
+          done
+          echo "::warning::Release $tag never appeared (REL-$tag marker tag not pushed?). Skipping RPM upload; RPMs remain as build-job artifacts."
+          echo "exists=false" >> "$GITHUB_OUTPUT"
 
       - name: Upload RPMs to release
+        if: steps.wait.outputs.exists == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Why

Three recurring problems on every release, all caused by multiple workflows racing on the same GitHub Release object when a tag is pushed:

1. **OBS Publish fails on every release.** It triggered the OBS rebuild and then tried to download the freshly-built RPMs *in the same run*. OBS builds asynchronously (~30–60 min), so the download always ran before the new version was published → `No RPMs were downloaded` → red ✗. The wait step also declared success on the *previous* build's stale `succeeded` state, so it "passed" in ~49s and then failed at download.
2. **The release shows as "edited" many times and its notes get rewritten.** OBS / RHEL / DEB each ran `gh release create --notes "Release artifacts…"`, so whichever workflow won the race stamped placeholder notes that `release.yml` then overwrote — plus every `--clobber` upload bumped the release.
3. **No contributors on the release page.** `release.yml` passed an explicit `body:` (the CHANGELOG section) without `generate_release_notes`, so GitHub's auto *What's Changed / New Contributors* block was never appended.

## What

- **Decouple OBS** (`obs-publish.yml`): split into a `trigger` job (tag push / dispatch — fire the OBS rebuild, exit green; never downloads) and an `attach` job (hourly `schedule` / dispatch — download + attach the RPMs once OBS has actually published the version, gated on the real download-index filename, not the stale `_result`). `attach` is a no-op when the RPMs aren't built yet (retries next hour) or are already attached (no churn). A release push can no longer go red here.
- **Single-writer release notes**: `release.yml` (REL- marker tag) is the sole creator of the release and the only writer of its title/notes. The packaging workflows (RHEL / DEB / OBS / AppImage) now **wait** for the release to exist, then only attach assets — they never `gh release create` a placeholder, so the notes aren't rewritten and the duplicate-release race is gone. AppImage moves off `action-gh-release` (which create-or-updates) to `gh release upload`.
- **Contributors**: `generate_release_notes: true` in `release.yml` appends GitHub's auto *New Contributors* / *Full Changelog* block under the hand-written CHANGELOG body.

## Notes

- 0.6.0 is already shipped; this is a follow-up to the release infra. The current `v0.6.0` release's OBS RPMs + contributors footer are being backfilled separately.
- Validated the OBS download/probe pipeline live against `download.opensuse.org` (it correctly finds `winpodx-0.6.0-*.rpm`).
- All five workflow files parse as valid YAML.