### PR TITLE
fix(gui): don't force the window onto the leftmost monitor (#498)

### DIFF
--- a/src/winpodx/gui/main_window.py
+++ b/src/winpodx/gui/main_window.py
@@ -200,12 +200,19 @@ class WinpodxWindow(
     def _fit_to_screen(self) -> None:
         """Open at the preferred size, but never larger than the screen.
 
-        Clamps the window to the available screen area and centers it so the
-        right-hand content (Save button, Hardware column) can't fall off the
-        edge on smaller or fractionally-scaled displays.
+        Clamps the window to the available area of the *primary* screen so it
+        can't open bigger than the display on small or fractionally-scaled
+        setups. Placement (which monitor, where) is left to the window manager
+        / compositor on purpose: forcing a position here parked the window on
+        the leftmost monitor instead of the user's designated primary on
+        multi-monitor setups (#498), and a client ``move()`` is a no-op on
+        Wayland anyway. Clamping against the primary screen — not whatever
+        screen the not-yet-shown window happens to be associated with (usually
+        the leftmost) — also stops the window being squeezed to a narrow
+        portrait monitor's width.
         """
         pref_w, pref_h = getattr(self, "_preferred_size", (1100, 720))
-        screen = self.screen() or QApplication.primaryScreen()
+        screen = QApplication.primaryScreen() or self.screen()
         if screen is not None:
             avail = screen.availableGeometry()
             if avail.width() > 0 and avail.height() > 0:
@@ -216,10 +223,6 @@ class WinpodxWindow(
                 w = max(self.minimumWidth(), min(pref_w, avail.width() - 60))
                 h = max(self.minimumHeight(), min(pref_h, avail.height() - 80))
                 self.resize(w, h)
-                self.move(
-                    avail.x() + (avail.width() - w) // 2,
-                    avail.y() + (avail.height() - h) // 2,
-                )
                 return
         self.resize(pref_w, pref_h)
 


### PR DESCRIPTION
## Why (#498)

On a multi-monitor setup (reporter: 3 displays, left one rotated to portrait, **centre = designated primary**), the Dashboard opened on the **leftmost** monitor instead of the primary.

`_fit_to_screen` (added in #471) clamped the window size and then `move()`d it to the centre of `self.screen()`. For a not-yet-shown top-level, `self.screen()` is the screen at (0,0) — the **leftmost** monitor, not the user's primary. Two bugs from that:

1. **Placement** — forced onto the leftmost monitor.
2. **Sizing** — clamped against that screen too, so a narrow portrait monitor on the left squeezed the window width.

## What

Window placement is the WM/compositor's job (and a client `move()` is a no-op on Wayland anyway), so stop forcing a position:

- **Drop the `move()`** — let the WM place the window. KWin / GNOME / etc. then open it on the active/primary screen (where the tray that launched it lives). Works on native Wayland too, since we're no longer fighting the compositor.
- **Clamp the size against `QApplication.primaryScreen()`** (not `self.screen()`), so the window is sized for the intended display, not whatever the leftmost monitor happens to be.

The size clamp — the part #471 actually needed for small / fractionally-scaled displays — is preserved; only the buggy position override is removed.

## Validation

- `ruff check` + `format --check` clean.
- Offscreen smoke: `WinpodxWindow` builds, `_fit_to_screen()` runs and clamps, no forced position.
- (Real multi-monitor placement is WM-dependent; this stops winpodx from overriding the WM's correct choice.)