### PR TITLE
feat(pod): default-on bare-metal disguise + GUI/CLI toggle (#246)

### DIFF
--- a/data/winpodx.toml.example
+++ b/data/winpodx.toml.example
@@ -47,7 +47,7 @@ timezone = ""             # "" = follow the host timezone
 tuning_profile = "auto"   # auto | low | mid | high — host-adaptive Windows-on-KVM tuning
 usb_live = true           # bind the host USB bus so `device attach` hot-plugs live
 # devices = []            # passthrough device ids (managed by `winpodx device`)
-# disguise_hypervisor = true   # bare-metal mode: hide the KVM/QEMU hypervisor (Nvidia code-43 / VM-hostile apps); NOT an anti-cheat bypass (#246)
+# disguise_hypervisor = false  # bare-metal mode (hide KVM/QEMU hypervisor) is ON by default; set false to opt out — Nvidia code-43 / VM-hostile apps; not an anti-cheat bypass (#246)
 
 [reverse_open]
 enabled = true            # surface Linux apps in the Windows "Open with…" menu

--- a/docs/USAGE.ko.md
+++ b/docs/USAGE.ko.md
@@ -145,15 +145,17 @@ USB 장치는 live hot-plug (`cfg.pod.usb_live`, 기본 on) — 재시작 불필
 
 ## bare-metal 호환 모드 (하이퍼바이저 숨김)
 
-일부 소프트웨어는 하이퍼바이저가 감지되면 실행을 거부합니다 — 대표적으로 Nvidia 소비자 GPU 드라이버(KVM 감지 시 **code 43**, GPU 패스스루의 흔한 차단 원인)와 런치게이트 VM 체크가 있는 앱들. `cfg.pod.disguise_hypervisor` (#246) 가 KVM/QEMU 시그니처를 게스트에서 숨겨 물리 PC 처럼 보이게 합니다.
+일부 소프트웨어는 하이퍼바이저가 감지되면 실행을 거부합니다 — 대표적으로 Nvidia 소비자 GPU 드라이버(KVM 감지 시 **code 43**, GPU 패스스루의 흔한 차단 원인)와 런치게이트 VM 체크가 있는 앱들. `cfg.pod.disguise_hypervisor` (#246) 가 KVM/QEMU 시그니처를 게스트에서 숨겨 물리 PC 처럼 보이게 합니다. **기본 활성화(on)** 입니다.
 
 ```bash
-winpodx config set pod.disguise_hypervisor true    # 활성화
+winpodx config set pod.disguise_hypervisor false   # 끄기 (opt out)
 winpodx pod recreate                               # compose 재생성 + 컨테이너만 재생성 (Windows 디스크 유지)
-winpodx config set pod.disguise_hypervisor false   # 비활성화 (후 `winpodx pod recreate` 다시)
+winpodx config set pod.disguise_hypervisor true    # 다시 켜기
 ```
 
-켜면 게스트 `-cpu` 라인이 CPUID 하이퍼바이저-존재 비트(leaf 1, ECX 31 — code-43/런치게이트의 주 트리거)를 지우고, `KVMKVMKVM` 시그니처 + KVM 파라버트 leaf 를 제거하며, leaf `0x40000000` 에 호스트 CPU 벤더 문자열을 보고합니다. Hyper-V 성능 enlightenment 는 유지(Windows 가 다른 leaf 로 감지)되어 성능 손실 없음. tri-state: 키 없음 = 레거시(시그니처 노출), 업그레이드 시 기존 설치는 건드리지 않음.
+GUI에서도 토글 가능: **Settings → Bare-metal compatibility**. 어느 쪽이든 `winpodx pod recreate` 후 적용됨 (QEMU `-cpu` 라인을 바꾸므로; recreate는 Windows 디스크 유지).
+
+켜면 게스트 `-cpu` 라인이 CPUID 하이퍼바이저-존재 비트(leaf 1, ECX 31 — code-43/런치게이트의 주 트리거)를 지우고 `KVMKVMKVM` 시그니처 + KVM 파라버트 leaf 를 제거합니다. Hyper-V 성능 enlightenment 는 유지(Windows 가 다른 leaf 로 감지)되어 성능 손실 없음. tri-state: `false` = 끔, 키 없음 또는 `true` = 켬.
 
 > **안티치트 우회가 아닙니다.** 시그니처 레벨만이며 커널모드 안티치트(EAC / BattlEye / Vanguard)는 못 뚫습니다. 온라인 게임 안티치트 우회는 ToS 위반이고 밴 위험 — winpodx 는 그 용도를 지원하지 않습니다.
 
@@ -300,7 +302,7 @@ idle_timeout = 0                                 # 자동 suspend 까지 초 (0 
 boot_timeout = 300                               # 첫 부팅 unattended 설치 대기 초
 image = "docker.io/dockurr/windows:latest"       # 컨테이너 이미지 (에어갭 미러용 override)
 usb_live = true                                  # attach 된 USB 장치를 실행 중 게스트에 hot-plug (재시작 없이) — `winpodx device` 참고
-# disguise_hypervisor = true                     # bare-metal 모드: KVM/QEMU 하이퍼바이저 숨김 (Nvidia code-43 / VM 거부 앱); 안티치트 우회 아님 (#246)
+# disguise_hypervisor = false                    # bare-metal 모드(KVM/QEMU 하이퍼바이저 숨김) 기본 ON; 끄려면 false — Nvidia code-43 / VM 거부 앱; 안티치트 우회 아님 (#246)
 disk_size = "64G"                                # dockur 에 전달하는 가상 디스크 크기 (`install grow-disk` 로 확장)
 disk_autogrow = true                             # C: 가 임계 넘으면 자동 확장 (idle 일 때만)
 disk_autogrow_threshold_pct = 80                 # 자동 확장 트리거 사용% (50-99)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -145,15 +145,17 @@ USB devices hot-plug live (`cfg.pod.usb_live`, default on) — no restart needed
 
 ## Bare-metal compatibility mode (hide the hypervisor)
 
-Some software refuses to run under a detected hypervisor — most notably Nvidia's consumer GPU drivers (they fault with **code 43** when they see KVM, the common GPU-passthrough blocker) and apps with launch-gate VM checks. `cfg.pod.disguise_hypervisor` (#246) hides the KVM/QEMU signature from the guest so it presents as a physical PC.
+Some software refuses to run under a detected hypervisor — most notably Nvidia's consumer GPU drivers (they fault with **code 43** when they see KVM, the common GPU-passthrough blocker) and apps with launch-gate VM checks. `cfg.pod.disguise_hypervisor` (#246) hides the KVM/QEMU signature from the guest so it presents as a physical PC. **It is on by default.**
 
 ```bash
-winpodx config set pod.disguise_hypervisor true    # enable
+winpodx config set pod.disguise_hypervisor false   # opt out
 winpodx pod recreate                               # regenerate compose + recreate the container (keeps your Windows disk)
-winpodx config set pod.disguise_hypervisor false   # disable (then `winpodx pod recreate` again)
+winpodx config set pod.disguise_hypervisor true    # turn it back on
 ```
 
-When on, the guest's `-cpu` line clears the CPUID hypervisor-present bit (leaf 1, ECX bit 31 — the primary code-43 / launch-gate trigger), drops the `KVMKVMKVM` signature + KVM paravirt leaves, and reports the host CPU's vendor string at leaf `0x40000000`. Hyper-V performance enlightenments stay on (Windows keys those off a different leaf), so there is no measurable perf cost. The setting is tri-state: absent = legacy (signatures exposed); existing installs are left untouched on upgrade.
+You can also toggle it in the GUI: **Settings → Bare-metal compatibility**. Either way it takes effect after a `winpodx pod recreate` (it edits the QEMU `-cpu` line; recreate keeps your Windows disk).
+
+When on, the guest's `-cpu` line clears the CPUID hypervisor-present bit (leaf 1, ECX bit 31 — the primary code-43 / launch-gate trigger) and drops the `KVMKVMKVM` signature + KVM paravirt leaves. Hyper-V performance enlightenments stay on (Windows keys those off a different leaf), so there is no measurable perf cost. The setting is tri-state — `false` opts out; absent or `true` is on.
 
 > **This is not an anti-cheat bypass.** It is signature-level only and does **not** defeat kernel-mode anti-cheat (EAC / BattlEye / Vanguard). Bypassing anti-cheat in online games violates their terms of service and risks a ban — winpodx does not support that use.
 
@@ -300,7 +302,7 @@ idle_timeout = 0                                 # Seconds before auto-suspend (
 boot_timeout = 300                               # Seconds to wait for first-boot unattended install
 image = "docker.io/dockurr/windows:latest"       # Container image (override for air-gapped mirror)
 usb_live = true                                  # Hot-plug attached USB devices into the running guest (no restart) — see `winpodx device`
-# disguise_hypervisor = true                     # Bare-metal mode: hide the KVM/QEMU hypervisor (Nvidia code-43 / VM-hostile apps); NOT an anti-cheat bypass (#246)
+# disguise_hypervisor = false                    # Bare-metal mode (hide KVM/QEMU hypervisor) is ON by default; set false to opt out — Nvidia code-43 / VM-hostile apps; not an anti-cheat bypass (#246)
 disk_size = "64G"                                # Virtual disk size passed to dockur (grows via `install grow-disk`)
 disk_autogrow = true                             # Auto-grow C: when it fills past the threshold (idle only)
 disk_autogrow_threshold_pct = 80                 # Used-% that triggers an auto-grow (50-99)

--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -386,19 +386,28 @@ class PodConfig:
     # a plain ``/dev/bus/usb`` bind avoids that. Set False to keep the USB bus
     # out of the container (smaller surface; USB then only via the drive share).
     usb_live: bool = True
-    # Bare-metal compatibility mode (#246), tri-state. Hides KVM/QEMU
-    # signatures from the guest so software that refuses to run under a
-    # detected hypervisor works — primarily Nvidia GPU-passthrough "code 43"
-    # and apps with launch-gate VM checks. Phase 1 clears the CPUID
-    # hypervisor bit + vendor leaf + KVM paravirt leaves and sets a
-    # real-vendor NIC MAC OUI (see core/pod/compose.py). NOT for defeating
-    # kernel-mode anti-cheat (it can't, and bypassing online-game anti-cheat
-    # violates the game's ToS).
+    # Bare-metal compatibility mode (#246), tri-state, DEFAULT ON. Hides the
+    # KVM/QEMU hypervisor signature from the guest so software that refuses to
+    # run under a detected hypervisor works — primarily Nvidia GPU-passthrough
+    # "code 43" and apps with launch-gate VM checks. Clears the CPUID
+    # hypervisor-present bit + the KVM signature/paravirt leaves (see
+    # core/pod/compose.py). NOT for defeating kernel-mode anti-cheat (it can't,
+    # and bypassing online-game anti-cheat violates the game's ToS).
     #
-    #   None  — key absent: legacy, signatures exposed (existing installs).
-    #   True  — disguise on.
-    #   False — disguise off (explicit; suppresses the migration notice).
+    #   None  — key absent: use the default (ON). `disguise_active` resolves it.
+    #   True  — explicitly on.
+    #   False — explicitly off (opt out).
     disguise_hypervisor: bool | None = None
+
+    @property
+    def disguise_active(self) -> bool:
+        """Resolve the tri-state ``disguise_hypervisor`` to on/off (#246).
+
+        Default ON: ``None`` (absent) and ``True`` enable the disguise; only an
+        explicit ``False`` opts out. Used by the compose generator and the GUI
+        toggle so both read the same rule.
+        """
+        return self.disguise_hypervisor is not False
 
     def __post_init__(self) -> None:
         if self.backend not in _VALID_BACKENDS:

--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -157,28 +157,16 @@ def _cpu_flags_for_host(cfg: Config | None = None) -> str:
     if profile.apply_invtsc:
         sub_flags.append("+invtsc")
 
-    # Bare-metal compatibility mode (#246, Phase 1): hide the KVM/QEMU
-    # hypervisor signature from the guest so software that refuses to run
-    # under a detected hypervisor works (Nvidia GPU-passthrough "code 43",
-    # launch-gate VM checks). Independent of the tuning profile.
-    if cfg.pod.disguise_hypervisor:
+    # Bare-metal compatibility mode (#246): hide the KVM/QEMU hypervisor
+    # signature from the guest so software that refuses to run under a detected
+    # hypervisor works (Nvidia GPU-passthrough "code 43", launch-gate VM
+    # checks). Default ON — only an explicit `disguise_hypervisor = false`
+    # turns it off (cfg.pod.disguise_active resolves the tri-state). Independent
+    # of the tuning profile.
+    if cfg.pod.disguise_active:
         sub_flags.extend(_disguise_cpu_flags())
 
     return ",".join(sub_flags)
-
-
-def _host_cpu_vendor() -> str:
-    """Host CPU vendor string for ``hv-vendor-id`` (GenuineIntel / AuthenticAMD)."""
-    try:
-        with open("/proc/cpuinfo", encoding="utf-8") as fh:
-            for line in fh:
-                if line.startswith("vendor_id"):
-                    vendor = line.split(":", 1)[1].strip()
-                    if vendor:
-                        return vendor
-    except OSError:
-        pass
-    return "GenuineIntel"
 
 
 def _disguise_cpu_flags() -> list[str]:
@@ -188,13 +176,16 @@ def _disguise_cpu_flags() -> list[str]:
       bit): the primary trigger for Nvidia code 43 and launch-gate VM checks.
     * ``kvm=off`` — drop the ``KVMKVMKVM`` signature + KVM paravirt CPUID leaves.
     * ``-kvm-pv-*`` — explicitly mask the individual KVM paravirt features.
-    * ``hv-vendor-id=<host vendor>`` — present the host CPU's vendor string at
-      leaf ``0x40000000`` so a guest that still reads it sees a plausible value.
 
-    Hyper-V enlightenments (dockur ``HV=Y``) stay on: modern Windows keys those
-    off the ``0x40000001 = "Hv#1"`` interface leaf, not the vendor string, so
-    the perf flags survive the disguise. Does NOT defeat kernel-mode anti-cheat
-    (out of scope, #246) — this is signature-level only.
+    All five are plain, well-established ``-cpu`` properties that don't touch
+    dockur's Hyper-V enlightenment set (``HV=Y``), so they're safe to apply by
+    default. ``hv-vendor-id`` was deliberately dropped: the ``0x40000000``
+    vendor leaf already reads clean once the present bit is cleared (al-khaser
+    flags it GOOD), and stamping the hv vendor string is the one knob that
+    risks colliding with dockur's hv flags (QEMU's "Ambiguous CPU model"). The
+    Hyper-V perf enlightenments stay on (Windows keys those off the
+    ``0x40000001 = "Hv#1"`` interface leaf). Does NOT defeat kernel-mode
+    anti-cheat (out of scope, #246) — signature-level only.
     """
     return [
         "-hypervisor",
@@ -203,7 +194,6 @@ def _disguise_cpu_flags() -> list[str]:
         "-kvm-pv-unhalt",
         "-kvm-pv-tlb-flush",
         "-kvm-asyncpf",
-        f"hv-vendor-id={_host_cpu_vendor()}",
     ]
 
 

--- a/src/winpodx/gui/_main_window_settings.py
+++ b/src/winpodx/gui/_main_window_settings.py
@@ -605,6 +605,29 @@ class SettingsPageMixin:
         tuning_card = self._build_tuning_card(self.input_tuning_profile, tuning_summary)
         layout.addWidget(tuning_card)
 
+        # Bare-metal compatibility (#246) — hide the KVM/QEMU hypervisor so GPU
+        # passthrough (Nvidia code 43) and apps that refuse to run in a VM work.
+        # Default ON. Save-Settings-scoped: it changes the QEMU `-cpu` line, so a
+        # pod recreate applies it (handled in _save_settings, like the tuning
+        # profile). The checkbox reads/writes the tri-state via disguise_active.
+        from PySide6.QtWidgets import QCheckBox as _QCheckBox
+
+        disguise_card, disguise_layout = self._settings_card_shell(
+            "hardware",
+            tr("Bare-metal compatibility"),
+            tr(
+                "Hide the KVM/QEMU hypervisor so GPU passthrough (Nvidia code 43) and "
+                "apps that refuse to run in a VM work. Not an anti-cheat bypass."
+            ),
+        )
+        self.checkbox_disguise = _QCheckBox(
+            tr("Present the guest as a bare-metal PC (hide the hypervisor)")
+        )
+        self.checkbox_disguise.setChecked(self.cfg.pod.disguise_active)
+        self.checkbox_disguise.setStyleSheet(CHECKBOX)
+        disguise_layout.addWidget(self.checkbox_disguise)
+        layout.addWidget(disguise_card)
+
         # Reverse-open (#48) — Linux apps in the Windows guest's right-
         # click "Open with…" menu. The panel is self-contained — its
         # button handlers call into the host_open CLI handlers
@@ -1207,6 +1230,9 @@ class SettingsPageMixin:
         new_keyboard = self.input_keyboard.currentData() or ""
         new_timezone = self.input_timezone.currentData() or ""
         new_tuning_profile = self.input_tuning_profile.currentData() or "auto"
+        # Bare-metal disguise (#246) — the 2-state checkbox collapses the
+        # tri-state to an explicit bool on save (checked = on, unchecked = off).
+        new_disguise = bool(self.checkbox_disguise.isChecked())
 
         old_cfg = Config.load()
         # ``needs_container`` is true when any first-boot env knob is
@@ -1229,6 +1255,10 @@ class SettingsPageMixin:
             # the new -cpu sub-options (+vmx/+svm, hv-*, +invtsc) and
             # -device args (virtio-rng-pci).
             or new_tuning_profile != old_cfg.pod.tuning_profile
+            # #246: the hypervisor disguise toggles `-cpu` sub-flags
+            # (-hypervisor / kvm=off / -kvm-pv-*) in CPU_FLAGS, so a container
+            # recreate is required to pick up the change.
+            or new_disguise != old_cfg.pod.disguise_active
         )
         needs_wipe = (
             new_win_version != old_cfg.pod.win_version
@@ -1257,6 +1287,7 @@ class SettingsPageMixin:
         self.cfg.pod.keyboard = new_keyboard
         self.cfg.pod.timezone = new_timezone
         self.cfg.pod.tuning_profile = new_tuning_profile
+        self.cfg.pod.disguise_hypervisor = new_disguise
         # Let __post_init__ clamp max_sessions to [1, 50] before save.
         self.cfg.pod.__post_init__()
         self.cfg.save()

--- a/src/winpodx/locale/de.json
+++ b/src/winpodx/locale/de.json
@@ -1,4 +1,7 @@
 {
+  "Bare-metal compatibility": "Bare-Metal-Kompatibilität",
+  "Hide the KVM/QEMU hypervisor so GPU passthrough (Nvidia code 43) and apps that refuse to run in a VM work. Not an anti-cheat bypass.": "Versteckt den KVM/QEMU-Hypervisor, damit GPU-Passthrough (Nvidia-Code 43) und Apps funktionieren, die in einer VM nicht laufen. Kein Anti-Cheat-Bypass.",
+  "Present the guest as a bare-metal PC (hide the hypervisor)": "Den Gast als Bare-Metal-PC darstellen (Hypervisor verstecken)",
   "\n  Could not start pod: {error}": "\n  Pod konnte nicht gestartet werden: {error}",
   "\n  Discovery failed: {error}": "\n  Erkennung fehlgeschlagen: {error}",
   "\n  Discovery unavailable in this build. Skipping.": "\n  Erkennung in diesem Build nicht verfügbar. Wird übersprungen.",

--- a/src/winpodx/locale/fr.json
+++ b/src/winpodx/locale/fr.json
@@ -1,4 +1,7 @@
 {
+  "Bare-metal compatibility": "Compatibilité bare-metal",
+  "Hide the KVM/QEMU hypervisor so GPU passthrough (Nvidia code 43) and apps that refuse to run in a VM work. Not an anti-cheat bypass.": "Masque l'hyperviseur KVM/QEMU pour que le passthrough GPU (code 43 Nvidia) et les applis qui refusent de tourner dans une VM fonctionnent. Pas un contournement d'anti-triche.",
+  "Present the guest as a bare-metal PC (hide the hypervisor)": "Présenter l'invité comme un PC bare-metal (masquer l'hyperviseur)",
   "\n  Could not start pod: {error}": "\n  Impossible de démarrer le pod : {error}",
   "\n  Discovery failed: {error}": "\n  Échec de la découverte : {error}",
   "\n  Discovery unavailable in this build. Skipping.": "\n  Découverte indisponible dans cette version. Ignorée.",

--- a/src/winpodx/locale/it.json
+++ b/src/winpodx/locale/it.json
@@ -1,4 +1,7 @@
 {
+  "Bare-metal compatibility": "Compatibilità bare-metal",
+  "Hide the KVM/QEMU hypervisor so GPU passthrough (Nvidia code 43) and apps that refuse to run in a VM work. Not an anti-cheat bypass.": "Nasconde l'hypervisor KVM/QEMU così funzionano il passthrough GPU (codice 43 Nvidia) e le app che rifiutano di girare in una VM. Non è un bypass anti-cheat.",
+  "Present the guest as a bare-metal PC (hide the hypervisor)": "Presenta il guest come un PC bare-metal (nascondi l'hypervisor)",
   "\n  Could not start pod: {error}": "\n  Impossibile avviare il pod: {error}",
   "\n  Discovery failed: {error}": "\n  Rilevamento non riuscito: {error}",
   "\n  Discovery unavailable in this build. Skipping.": "\n  Rilevamento non disponibile in questa build. Ignorato.",

--- a/src/winpodx/locale/ja.json
+++ b/src/winpodx/locale/ja.json
@@ -1,4 +1,7 @@
 {
+  "Bare-metal compatibility": "ベアメタル互換モード",
+  "Hide the KVM/QEMU hypervisor so GPU passthrough (Nvidia code 43) and apps that refuse to run in a VM work. Not an anti-cheat bypass.": "KVM/QEMU ハイパーバイザーを隠して、GPU パススルー（Nvidia コード43）や VM での実行を拒否するアプリを動作させます。アンチチート回避ではありません。",
+  "Present the guest as a bare-metal PC (hide the hypervisor)": "ゲストをベアメタル PC として見せる（ハイパーバイザーを隠す）",
   "\n  Could not start pod: {error}": "\n  pod を起動できませんでした: {error}",
   "\n  Discovery failed: {error}": "\n  検出に失敗しました: {error}",
   "\n  Discovery unavailable in this build. Skipping.": "\n  このビルドでは検出を利用できません。スキップします。",

--- a/src/winpodx/locale/ko.json
+++ b/src/winpodx/locale/ko.json
@@ -1,4 +1,7 @@
 {
+  "Bare-metal compatibility": "베어메탈 호환",
+  "Hide the KVM/QEMU hypervisor so GPU passthrough (Nvidia code 43) and apps that refuse to run in a VM work. Not an anti-cheat bypass.": "KVM/QEMU 하이퍼바이저를 숨겨 GPU 패스스루(Nvidia 코드 43)와 VM 실행을 거부하는 앱이 동작하게 합니다. 안티치트 우회가 아닙니다.",
+  "Present the guest as a bare-metal PC (hide the hypervisor)": "게스트를 베어메탈 PC로 표시 (하이퍼바이저 숨김)",
   "\n  Could not start pod: {error}": "\n  pod을 시작할 수 없습니다: {error}",
   "\n  Discovery failed: {error}": "\n  탐색에 실패했습니다: {error}",
   "\n  Discovery unavailable in this build. Skipping.": "\n  이 빌드에서는 탐색을 사용할 수 없습니다. 건너뜁니다.",

--- a/src/winpodx/locale/zh.json
+++ b/src/winpodx/locale/zh.json
@@ -1,4 +1,7 @@
 {
+  "Bare-metal compatibility": "裸机兼容模式",
+  "Hide the KVM/QEMU hypervisor so GPU passthrough (Nvidia code 43) and apps that refuse to run in a VM work. Not an anti-cheat bypass.": "隐藏 KVM/QEMU 虚拟机管理程序，使 GPU 直通（Nvidia 代码 43）和拒绝在虚拟机中运行的应用可用。这不是反作弊绕过。",
+  "Present the guest as a bare-metal PC (hide the hypervisor)": "将客户机呈现为裸机 PC（隐藏虚拟机管理程序）",
   "\n  Could not start pod: {error}": "\n  无法启动 pod：{error}",
   "\n  Discovery failed: {error}": "\n  发现失败：{error}",
   "\n  Discovery unavailable in this build. Skipping.": "\n  此版本不支持应用发现。已跳过。",

--- a/tests/test_compose_arch.py
+++ b/tests/test_compose_arch.py
@@ -36,6 +36,10 @@ def _cfg() -> Config:
     # detection (#215). Turn off the auto tuner so the CPU_FLAGS reflects
     # only the architecture branch under test.
     cfg.pod.tuning_profile = "off"
+    # Likewise isolate from the default-ON hypervisor disguise (#246) — the
+    # arch/tuning tests assert an exact CPU_FLAGS string. The disguise tests
+    # below set it explicitly.
+    cfg.pod.disguise_hypervisor = False
     return cfg
 
 
@@ -99,49 +103,54 @@ def test_compose_cpu_flags_invtsc_off_profile_does_not_append(monkeypatch):
     assert 'CPU_FLAGS: "arch_capabilities=off"' in content
 
 
-# --- Bare-metal compatibility / hypervisor disguise (#246, Phase 1) ------
+# --- Bare-metal compatibility / hypervisor disguise (#246, default ON) ---
+
+_DISGUISE_FLAGS = (
+    "-hypervisor",
+    "kvm=off",
+    "-kvm-pv-eoi",
+    "-kvm-pv-unhalt",
+    "-kvm-pv-tlb-flush",
+    "-kvm-asyncpf",
+)
 
 
-def test_compose_disguise_off_by_default(monkeypatch):
-    """disguise_hypervisor=None (legacy/absent) emits no disguise flags."""
+def test_compose_disguise_on_by_default(monkeypatch):
+    """disguise_hypervisor=None (absent) defaults ON — emits the disguise flags."""
     monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
     cfg = _cfg()
-    assert cfg.pod.disguise_hypervisor is None
+    cfg.pod.disguise_hypervisor = None  # the real default (absent key)
+    assert cfg.pod.disguise_active is True
     content = _build_compose_content(cfg)
-    assert "-hypervisor" not in content
-    assert "kvm=off" not in content
+    for flag in _DISGUISE_FLAGS:
+        assert flag in content, f"disguise flag {flag!r} missing (default ON)"
+    # hv-vendor-id was deliberately dropped (collides with dockur hv flags).
+    assert "hv-vendor-id" not in content
 
 
-def test_compose_disguise_on_emits_signature_flags(monkeypatch):
-    """disguise_hypervisor=True clears the hypervisor bit + KVM signature."""
+def test_compose_disguise_explicit_true(monkeypatch):
+    """disguise_hypervisor=True emits the same flags as the default."""
     monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
-    monkeypatch.setattr(_compose_module, "_host_cpu_vendor", lambda: "GenuineIntel")
     cfg = _cfg()
     cfg.pod.disguise_hypervisor = True
     content = _build_compose_content(cfg)
-    for flag in (
-        "-hypervisor",
-        "kvm=off",
-        "-kvm-pv-eoi",
-        "-kvm-pv-unhalt",
-        "-kvm-pv-tlb-flush",
-        "-kvm-asyncpf",
-        "hv-vendor-id=GenuineIntel",
-    ):
+    for flag in _DISGUISE_FLAGS:
         assert flag in content, f"disguise flag {flag!r} missing from compose"
+    assert "hv-vendor-id" not in content
 
 
-def test_compose_disguise_explicit_false_emits_nothing(monkeypatch):
-    """disguise_hypervisor=False (explicit off) emits no disguise flags."""
+def test_compose_disguise_explicit_false_opts_out(monkeypatch):
+    """disguise_hypervisor=False (explicit opt-out) emits no disguise flags."""
     monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
     cfg = _cfg()
     cfg.pod.disguise_hypervisor = False
+    assert cfg.pod.disguise_active is False
     content = _build_compose_content(cfg)
     assert "-hypervisor" not in content
-    assert "+invtsc" not in content
+    assert "kvm=off" not in content
 
 
 def test_compose_cpu_flags_invtsc_auto_profile_appends_when_supported(monkeypatch):


### PR DESCRIPTION
Follow-up to #507 — per the maintainer decision, the hypervisor disguise is now **ON by default** with an opt-out, settable from both the **CLI and the GUI**.

## Changes

- **Default ON.** `cfg.pod.disguise_active` resolves the tri-state: `None` (absent) and `True` enable; only an explicit `False` opts out. The compose generator gates on `disguise_active`.
- **Dropped `hv-vendor-id`.** al-khaser confirms the `0x40000000` vendor leaf already reads clean once the present bit is cleared, and `hv-vendor-id` is the one flag that risks colliding with dockur's `hv-*` enlightenments (QEMU "Ambiguous CPU model"). Keeping only the plain, safe `-cpu` properties (`-hypervisor` / `kvm=off` / `-kvm-pv-*`) de-risks shipping this on by default — and code-43 / launch-gate checks only need the present bit + KVM signature cleared.
- **GUI:** a "Bare-metal compatibility" toggle on the Settings page (Save-scoped; a change triggers the same pod-recreate path as the tuning profile). New strings translated across all 6 locale catalogs (869 keys each, at parity).
- **CLI:** `winpodx config set pod.disguise_hypervisor true|false` (generic setter — already worked).
- **Docs:** `USAGE.md` / `USAGE.ko.md` + the annotated config example reframed to default-ON / opt-out.

## Validation

- Full suite **1804 passed, 1 skipped**; `ruff check` + `format --check` clean.
- Compose tri-state tests flipped to default-ON (None → disguise flags present; `False` → none).
- GUI offscreen smoke: `WinpodxWindow` builds, the Settings checkbox reflects `disguise_active` (checked by default).
- al-khaser baseline (disguise off) captured by the maintainer: `cpuid(0x1) hypervisor field = BAD`; this flips it `GOOD` while SMBIOS/disk/ACPI stay flagged (Phase 2/3 / out of scope, as documented in #246).

## ⚠️ Merge gate

This is a **default-ON** change to the QEMU `-cpu` line, so it affects every guest's next `pod recreate`. Per the agent-first lesson, please **boot-smoke before merge**: `winpodx pod recreate` with the default on → confirm Windows boots and `systeminfo` no longer reports a hypervisor. (Risk is low now that `hv-vendor-id` is dropped, but confirm.) If a host/dockur combo fails to boot, fix-forward by trimming the flag set.