### PR TITLE
feat(pod): mirror host SMBIOS vendor/model into the guest (#246 T1)

### DIFF
--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -265,7 +265,79 @@ def _qemu_arguments_for_host(cfg: Config | None = None) -> str:
     if pci:
         extra_args += qemu_device_args(pci)
 
+    # Bare-metal disguise (#246, T1): mirror the host's real SMBIOS/DMI into
+    # the guest so Win32_ComputerSystem / the SMBIOS tables report a genuine
+    # bare-metal identity instead of QEMU / SeaBIOS. x86 only (dockur owns the
+    # aarch64 firmware).
+    if cfg.pod.disguise_active and platform.machine() != "aarch64":
+        extra_args += _disguise_smbios_args()
+
     return " ".join(extra_args)
+
+
+def _host_dmi_field(name: str) -> str | None:
+    """Read one ``/sys/class/dmi/id/<name>`` field if it is safe to embed.
+
+    Returns ``None`` when the field is unreadable (e.g. inside a container with
+    no DMI) or when its value contains a character that would break dockur's
+    space-split ``ARGUMENTS`` env or the comma-delimited ``-smbios`` arg — a
+    space, comma, ``=`` or quote. A product string with spaces (e.g. a
+    marketing name like ``Some Laptop 9000``) is skipped rather than mangled;
+    the space-free vendor / model codes are what carry the disguise. Serial /
+    UUID / asset-tag fields are never read (root-only, and reading them would
+    leak the host serial and perturb the digital-licence hash).
+    """
+    try:
+        val = (Path("/sys/class/dmi/id") / name).read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not val or not all(c.isalnum() or c in "._/+-" for c in val):
+        return None
+    return val
+
+
+def _disguise_smbios_args() -> list[str]:
+    """`-smbios` args mirroring the host's real (shell-safe) DMI fields (#246).
+
+    Overrides QEMU's default SMBIOS (which leaks ``QEMU`` / ``SeaBIOS``) with
+    the host's actual vendor + model strings, so the guest presents the real
+    machine's identity. Best-effort: any field that's unreadable or has unsafe
+    characters is omitted, and an empty result (no DMI on this host) leaves
+    QEMU's defaults untouched.
+    """
+    sys_vendor = _host_dmi_field("sys_vendor")
+    product = _host_dmi_field("product_name")
+    board_vendor = _host_dmi_field("board_vendor")
+    board = _host_dmi_field("board_name")
+    bios_vendor = _host_dmi_field("bios_vendor")
+    bios_date = _host_dmi_field("bios_date")
+    chassis_vendor = _host_dmi_field("chassis_vendor")
+
+    args: list[str] = []
+    t0 = []
+    if bios_vendor:
+        t0.append(f"vendor={bios_vendor}")
+    if bios_date:
+        t0.append(f"date={bios_date}")
+    if t0:
+        args += ["-smbios", "type=0," + ",".join(t0)]
+    t1 = []
+    if sys_vendor:
+        t1.append(f"manufacturer={sys_vendor}")
+    if product:
+        t1.append(f"product={product}")
+    if t1:
+        args += ["-smbios", "type=1," + ",".join(t1)]
+    t2 = []
+    if board_vendor:
+        t2.append(f"manufacturer={board_vendor}")
+    if board:
+        t2.append(f"product={board}")
+    if t2:
+        args += ["-smbios", "type=2," + ",".join(t2)]
+    if chassis_vendor:
+        args += ["-smbios", f"type=3,manufacturer={chassis_vendor}"]
+    return args
 
 
 def _yaml_escape(val: str) -> str:

--- a/tests/test_compose_arch.py
+++ b/tests/test_compose_arch.py
@@ -153,6 +153,59 @@ def test_compose_disguise_explicit_false_opts_out(monkeypatch):
     assert "kvm=off" not in content
 
 
+def test_compose_disguise_smbios_mirrors_host_dmi(monkeypatch):
+    """T1 (#246): the host's real, shell-safe DMI fields land in `-smbios`."""
+    monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
+    # Synthetic fixture values (not any real machine's DMI).
+    dmi = {
+        "sys_vendor": "ACME",
+        "product_name": "MDL-9000",
+        "board_vendor": "ACME",
+        "board_name": "BRD-42",
+        "bios_vendor": "ACME",
+        "bios_date": "01/01/2020",
+        "chassis_vendor": "ACME",
+    }
+    monkeypatch.setattr(_compose_module, "_host_dmi_field", lambda n: dmi.get(n))
+    cfg = _cfg()
+    cfg.pod.disguise_hypervisor = None  # default ON
+    content = _build_compose_content(cfg)
+    assert "type=1,manufacturer=ACME,product=MDL-9000" in content
+    assert "type=0,vendor=ACME,date=01/01/2020" in content
+    assert "type=3,manufacturer=ACME" in content
+
+
+def test_compose_disguise_smbios_skips_unsafe_dmi(monkeypatch):
+    """Fields with spaces / unsafe chars are dropped, not mangled into ARGUMENTS."""
+    monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
+    # Only product_name is unsafe (space); the vendor is safe. Emulate the
+    # real _host_dmi_field safety filter (drop values with unsafe chars).
+    dmi = {"sys_vendor": "ACME", "product_name": "Generic Model 9000"}
+
+    def fake(n):
+        v = dmi.get(n)
+        return v if (v and all(c.isalnum() or c in "._/+-" for c in v)) else None
+
+    monkeypatch.setattr(_compose_module, "_host_dmi_field", fake)
+    cfg = _cfg()
+    cfg.pod.disguise_hypervisor = True
+    content = _build_compose_content(cfg)
+    assert "manufacturer=ACME" in content  # safe vendor kept
+    assert "Generic Model 9000" not in content  # spaced product dropped
+
+
+def test_compose_disguise_off_emits_no_smbios(monkeypatch):
+    """disguise off (explicit) → no host-DMI `-smbios` override."""
+    monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(_compose_module, "_host_dmi_field", lambda n: "ACME")
+    cfg = _cfg()  # _cfg() sets disguise_hypervisor = False
+    content = _build_compose_content(cfg)
+    assert "-smbios" not in content
+
+
 def test_compose_cpu_flags_invtsc_auto_profile_appends_when_supported(monkeypatch):
     """``tuning_profile = "auto"`` + invtsc-capable host appends
     ``+invtsc`` to CPU_FLAGS (#215). hv-* enlightenments are NOT


### PR DESCRIPTION
Extends the default-on bare-metal disguise (#246): when active, override QEMU's default SMBIOS (which leaks `QEMU` / `SeaBIOS`) with the **host's real DMI** vendor + model strings, read from `/sys/class/dmi/id` at compose time.

Flips `Manufacturer from ComputerSystem` + the `SMBIOS tables` / `SMBIOS firmware` al-khaser checks `BAD → GOOD`.

## Safety (privacy / git)

- **Per-host + dynamic** — each install mirrors its **own** hardware at compose time; nothing is hardcoded or committed (test fixtures use synthetic `ACME` values).
- **No secrets read** — only the world-readable, non-secret fields: `sys_vendor`, `product_name`, `board_vendor`, `board_name`, `bios_vendor`, `bios_date`, `chassis_vendor`. **Serial / UUID / asset-tag are never read** (root-only; touching the UUID would perturb the digital-licence hash and leak the host serial into the guest).
- **Shell/arg-safe** — dockur passes `ARGUMENTS` through an unquoted shell expansion, so any DMI value containing a space / comma / `=` / quote is **skipped**, not mangled. The space-free vendor + model codes carry the disguise.
- x86 only (dockur owns aarch64 firmware); no DMI on the host (e.g. nested container) → QEMU defaults left untouched.

## Scope

This is the CLI-settable SMBIOS half (types 0/1/2/3). The **sensor-descriptor types** (voltage 26 / temperature 28 / cooling 27 / cache 7 / slot 9) are NOT settable via QEMU's `-smbios` CLI and need a hand-built `-smbios file=` binary blob — that lands in a follow-up PR (default-on too), iterated against a real boot + al-khaser run.

## Validation

- `ruff` clean; `tests/test_compose_arch.py` 15 passed (host-DMI mirror, unsafe-field skip, disguise-off → no `-smbios`).
- Live smoke on the dev host: `disguise` on → `ARGUMENTS` gains `-smbios type=0..3` with the host's real vendor/model; off → none.

## Merge gate

Default-on touches the QEMU command line → boot-smoke before merge: `winpodx pod recreate` with disguise on, confirm Windows boots and `al-khaser` shows `Manufacturer` / `SMBIOS tables` flipped. (Low risk — these `-smbios type=` args are standard; the riskier `file=` blob is the separate follow-up.)