### PR TITLE
feat(pod): synthetic SMBIOS sensor blob for the disguise (#246 T1.5)

### DIFF
--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import platform
 import secrets
@@ -553,11 +554,44 @@ def _security_opt_block(cfg: Config) -> str:
     return "    security_opt:\n      - label=disable\n"
 
 
+def _write_disguise_smbios_blob(oem_dir: str) -> str | None:
+    """Write the synthetic SMBIOS sensor blob into the OEM dir (#246, T1.5).
+
+    Returns the in-container path for ``-smbios file=`` (``/oem/...``) on
+    success, or ``None`` on ANY failure — so a write/encode error never leaves
+    a dangling ``-smbios file=`` arg that would abort QEMU boot. The blob holds
+    only synthetic descriptor structures (no host serials / live readings); it
+    rides the existing ``/oem`` mount.
+    """
+    try:
+        from winpodx.core.pod.smbios import build_disguise_smbios_blob
+
+        blob = build_disguise_smbios_blob()
+        (Path(oem_dir) / "winpodx-smbios.bin").write_bytes(blob)
+        return "/oem/winpodx-smbios.bin"
+    except Exception:  # noqa: BLE001 — disguise must never break compose / boot
+        logging.getLogger(__name__).exception(
+            "disguise: failed to write SMBIOS blob; continuing without it"
+        )
+        return None
+
+
 def _build_compose_content(cfg: Config) -> str:
     """Build and return compose YAML content string for *cfg*."""
     password = cfg.rdp.password or generate_password()
     template = _build_compose_template(cfg.pod.backend)
     top_volumes, storage_mount = _render_storage_blocks(cfg)
+
+    # Bare-metal disguise (#246, T1.5): add the synthetic SMBIOS sensor blob
+    # (voltage/temp/fan/cache/slot/port descriptors) via `-smbios file=`. The
+    # blob write + the arg are kept together here so the arg is only added when
+    # the file actually landed (fail-safe — a missing file would abort boot).
+    oem_dir = _find_oem_dir()
+    qemu_args = _qemu_arguments_for_host(cfg)
+    if cfg.pod.disguise_active and platform.machine() != "aarch64":
+        blob_path = _write_disguise_smbios_blob(oem_dir)
+        if blob_path:
+            qemu_args = f"{qemu_args} -smbios file={blob_path}".strip()
     # All string fields that land inside a YAML double-quoted scalar
     # MUST pass through _yaml_escape — otherwise a hand-edited TOML
     # value (or a --win-version flag argument) containing ``"``, ``\n``,
@@ -581,12 +615,12 @@ def _build_compose_content(cfg: Config) -> str:
         timezone=_yaml_escape(_resolve_timezone_for_compose(cfg)),
         rdp_port=cfg.rdp.port,
         vnc_port=cfg.pod.vnc_port,
-        oem_dir=_find_oem_dir(),
+        oem_dir=oem_dir,
         top_volumes=top_volumes,
         storage_mount=storage_mount,
         cpu_flags=_cpu_flags_for_host(cfg),
         vmx=_vmx_env_for_host(cfg),
-        qemu_arguments=_qemu_arguments_for_host(cfg),
+        qemu_arguments=qemu_args,
         agent_port=AGENT_PORT,
         device_nodes=_device_nodes_block(cfg),
         extra_volumes=_extra_volumes_block(cfg),

--- a/src/winpodx/core/pod/smbios.py
+++ b/src/winpodx/core/pod/smbios.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: MIT
+"""Synthetic SMBIOS structure blob for the bare-metal disguise (#246, T1.5).
+
+al-khaser (and similar VM detectors) flag a guest as a VM when SMBIOS sensor /
+descriptor structures are *absent* — a physical board exposes voltage probes,
+temperature probes, a cooling device, cache, slots and port connectors, while
+QEMU's default SMBIOS omits them. These checks test for the *existence* of the
+corresponding ``Win32_*`` / ``CIM_*`` WMI classes, not live readings, so static
+descriptor structures with nominal/unknown values are enough to satisfy them.
+
+This module builds a small binary SMBIOS structure table (types 26 / 28 / 27 /
+7 / 9 / 8) with **synthetic** values — no host serials or live sensor data are
+read, so nothing machine-identifying is produced. The blob is written to the
+OEM dir (mounted into the container) and passed to QEMU via ``-smbios file=``.
+
+Format: each structure is ``type(1) length(1) handle(2 LE) <formatted> <strings>``
+where the string-set is the referenced 1-indexed null-terminated strings
+followed by a terminating null (or a double-null when there are no strings),
+per the DMTF SMBIOS spec. ``validate_blob`` walks the result back to catch an
+encoding slip before it ever reaches QEMU.
+"""
+
+from __future__ import annotations
+
+# Handles are arbitrary but must be unique within the table.
+_H_TEMP = 0x1C00
+_H_VOLT = 0x1A00
+_H_COOL = 0x1B00
+_H_CACHE = 0x0700
+_H_SLOT = 0x0900
+_H_PORT = 0x0800
+
+_UNKNOWN_W = 0x8000  # SMBIOS "unknown" sentinel for WORD probe values
+
+
+def _w(v: int) -> bytes:
+    return (v & 0xFFFF).to_bytes(2, "little")
+
+
+def _dw(v: int) -> bytes:
+    return (v & 0xFFFFFFFF).to_bytes(4, "little")
+
+
+def _structure(stype: int, handle: int, formatted: bytes, strings: list[str]) -> bytes:
+    """Encode one SMBIOS structure (header + formatted area + string-set)."""
+    length = 4 + len(formatted)
+    out = bytes([stype & 0xFF, length & 0xFF]) + _w(handle) + formatted
+    if strings:
+        for s in strings:
+            out += s.encode("ascii", "replace") + b"\x00"
+        out += b"\x00"
+    else:
+        out += b"\x00\x00"
+    return out
+
+
+def _probe(stype: int, handle: int, description: str) -> bytes:
+    """Voltage (26) / Temperature (28) probe — identical 22-byte layout."""
+    formatted = (
+        bytes([1, 0x03])  # description (string 1), location-and-status
+        + _w(_UNKNOWN_W)  # maximum value
+        + _w(_UNKNOWN_W)  # minimum value
+        + _w(_UNKNOWN_W)  # resolution
+        + _w(_UNKNOWN_W)  # tolerance
+        + _w(_UNKNOWN_W)  # accuracy
+        + _dw(0)  # OEM-defined
+        + _w(_UNKNOWN_W)  # nominal value
+    )
+    return _structure(stype, handle, formatted, [description])
+
+
+def build_disguise_smbios_blob() -> bytes:
+    """Build the synthetic SMBIOS structure blob (sensor/descriptor types)."""
+    parts: list[bytes] = []
+
+    # Type 28 — Temperature Probe
+    parts.append(_probe(28, _H_TEMP, "CPU Temperature"))
+
+    # Type 26 — Voltage Probe
+    parts.append(_probe(26, _H_VOLT, "CPU Voltage"))
+
+    # Type 27 — Cooling Device (references the temperature probe handle)
+    cool = (
+        _w(_H_TEMP)  # temperature probe handle
+        + bytes([0x67, 0x01])  # device type + status, cooling unit group
+        + _dw(0)  # OEM-defined
+        + _w(_UNKNOWN_W)  # nominal speed
+        + bytes([1])  # description (string 1)
+    )
+    parts.append(_structure(27, _H_COOL, cool, ["CPU Fan"]))
+
+    # Type 7 — Cache Information (L1)
+    cache = (
+        bytes([1])  # socket designation (string 1)
+        + _w(0x0180)  # cache configuration (enabled, WB, L1)
+        + _w(0x0040)  # maximum cache size (64 KB granularity unit)
+        + _w(0x0040)  # installed size
+        + _w(0x0002)  # supported SRAM type
+        + _w(0x0002)  # current SRAM type
+        + bytes([0x01, 0x06, 0x05, 0x07])  # speed, ECC, cache type, associativity
+    )
+    parts.append(_structure(7, _H_CACHE, cache, ["L1 Cache"]))
+
+    # Type 9 — System Slot (a PCIe slot)
+    slot = (
+        bytes([1, 0xB6, 0x0D, 0x03, 0x04])  # desig, type(PCIe), width, usage, length
+        + _w(1)  # slot ID
+        + bytes([0x04, 0x01])  # characteristics 1 + 2
+    )
+    parts.append(_structure(9, _H_SLOT, slot, ["PCIe Slot 1"]))
+
+    # Type 8 — Port Connector
+    port = bytes([1, 0xFF, 2, 0xFF, 0xFF])  # int-ref, int-type, ext-ref, ext-type, port-type
+    parts.append(_structure(8, _H_PORT, port, ["J1", "USB"]))
+
+    blob = b"".join(parts)
+    validate_blob(blob)  # raise on any encoding slip before it reaches QEMU
+    return blob
+
+
+def validate_blob(blob: bytes) -> None:
+    """Walk the blob structure-by-structure; raise ValueError on any slip.
+
+    A defensive parse-back so a future edit can't ship a malformed table that
+    QEMU would reject at boot. Checks each header length, that the formatted
+    area fits, that the string-set is double-null terminated, and that handles
+    are unique.
+    """
+    i = 0
+    handles: set[int] = set()
+    n = len(blob)
+    while i < n:
+        if i + 4 > n:
+            raise ValueError("smbios: truncated header")
+        length = blob[i + 1]
+        handle = int.from_bytes(blob[i + 2 : i + 4], "little")
+        if length < 4:
+            raise ValueError(f"smbios: bad structure length {length}")
+        if handle in handles:
+            raise ValueError(f"smbios: duplicate handle 0x{handle:04x}")
+        handles.add(handle)
+        j = i + length  # start of string-set
+        if j > n:
+            raise ValueError("smbios: formatted area overruns blob")
+        # Find the double-null that ends the string-set.
+        end = blob.find(b"\x00\x00", j)
+        if end == -1:
+            raise ValueError("smbios: unterminated string-set")
+        i = end + 2
+    if not handles:
+        raise ValueError("smbios: empty blob")

--- a/tests/test_compose_arch.py
+++ b/tests/test_compose_arch.py
@@ -18,10 +18,27 @@ The remaining x86 vs aarch64 split is in ``CPU_FLAGS``:
 
 from __future__ import annotations
 
+import pytest
+
 import winpodx.core.config as _config_module
 import winpodx.core.pod.compose as _compose_module
 from winpodx.core.config import Config
 from winpodx.core.pod.compose import _build_compose_content
+
+
+@pytest.fixture(autouse=True)
+def _stub_smbios_blob_write(monkeypatch):
+    """Keep these tests hermetic: don't write a real SMBIOS blob to the OEM dir.
+
+    The disguise (#246, T1.5) writes a synthetic SMBIOS blob during compose
+    generation; stub the writer so the `-smbios file=` arg is still added but no
+    file I/O happens. tests/test_smbios.py covers the real encode + write path.
+    """
+    monkeypatch.setattr(
+        _compose_module,
+        "_write_disguise_smbios_blob",
+        lambda oem_dir: "/oem/winpodx-smbios.bin",
+    )
 
 
 def _cfg() -> Config:

--- a/tests/test_smbios.py
+++ b/tests/test_smbios.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: MIT
+"""Synthetic SMBIOS disguise blob (#246, T1.5) — encode / validate / write."""
+
+from __future__ import annotations
+
+import pytest
+
+import winpodx.core.pod.compose as _compose_module
+from winpodx.core.pod.smbios import build_disguise_smbios_blob, validate_blob
+
+
+def _walk_types(blob: bytes) -> list[int]:
+    types: list[int] = []
+    i = 0
+    while i < len(blob):
+        types.append(blob[i])
+        length = blob[i + 1]
+        end = blob.find(b"\x00\x00", i + length)
+        i = end + 2
+    return types
+
+
+def test_blob_builds_and_validates():
+    blob = build_disguise_smbios_blob()
+    assert isinstance(blob, bytes) and len(blob) > 0
+    validate_blob(blob)  # raises on any encoding slip
+
+
+def test_blob_contains_sensor_descriptor_types():
+    # The types al-khaser checks for existence: voltage(26), temperature(28),
+    # cooling(27), cache(7), slot(9), port connector(8).
+    types = _walk_types(build_disguise_smbios_blob())
+    for t in (26, 28, 27, 7, 9, 8):
+        assert t in types, f"missing SMBIOS type {t}"
+
+
+def test_validate_rejects_truncated_header():
+    with pytest.raises(ValueError):
+        validate_blob(b"\x1c")  # too short for a 4-byte header
+
+
+def test_validate_rejects_unterminated_string_set():
+    # type 8 header (len 9) + 5 formatted bytes but no double-null terminator.
+    bad = bytes([8, 9, 0, 0]) + bytes([1, 0xFF, 2, 0xFF, 0xFF]) + b"J1"
+    with pytest.raises(ValueError):
+        validate_blob(bad)
+
+
+def test_write_blob_writes_and_returns_container_path(tmp_path):
+    path = _compose_module._write_disguise_smbios_blob(str(tmp_path))
+    assert path == "/oem/winpodx-smbios.bin"
+    written = tmp_path / "winpodx-smbios.bin"
+    assert written.exists()
+    validate_blob(written.read_bytes())  # what we wrote is valid
+
+
+def test_write_blob_failsafe_returns_none_on_bad_dir(tmp_path):
+    # A non-existent OEM dir → None, never a dangling `-smbios file=` arg.
+    bad = tmp_path / "does" / "not" / "exist"
+    assert _compose_module._write_disguise_smbios_blob(str(bad)) is None


### PR DESCRIPTION
Extends the default-on bare-metal disguise (#246) with the SMBIOS **sensor / descriptor** structures QEMU's CLI `-smbios type=` can't emit: voltage probe (26), temperature probe (28), cooling device (27), cache (7), system slot (9), port connector (8).

al-khaser & friends flag a VM when these `Win32_*` / `CIM_*` WMI classes return **no entries** — the checks test for *existence*, not live readings, so static descriptor structures with nominal / `unknown` values satisfy them. Flips ~10–13 of the remaining al-khaser BADs (VoltageProbe, PortConnector, CacheMemory, CIM_Sensor/NumericSensor/TemperatureSensor/VoltageSensor/Slot/PhysicalConnector, CPU fan, …).

## Privacy / git

The blob is **synthetic** — `core/pod/smbios.py` builds the structures with nominal/`unknown` values. **No host serials or live sensor data are read.** Nothing machine-identifying is produced or committed; the blob is generated at runtime into the OEM dir, never into git.

## Safety

- `validate_blob` walks the encoded table back (structure lengths, unique handles, string-set termination) to catch any encoding slip before it reaches QEMU.
- The blob write + the `-smbios file=` arg are kept together and **fail-safe**: any encode/write error emits **no** arg, so a missing file can't abort boot — it falls back to the CPU + vendor-DMI disguise (#508/#509).
- Default-on, x86 only; rides the existing `/oem` mount.

## ⚠️ Merge gate (important)

`-smbios file=` acceptance is **QEMU/dockur-version dependent** and I can't verify it without a real boot. A blob QEMU rejects would abort boot, and this is default-on → **boot-smoke this branch before merge**:

```bash
git checkout feature/disguise-smbios-sensors   # run winpodx from this branch
winpodx pod recreate
systeminfo | findstr hypervisor   # still gone
al-khaser_x64.exe                 # VoltageProbe / TemperatureProbe / CacheMemory / Slot / PortConnector / CPU fan → GOOD
```

- **Boots + checks flip** → merge.
- **Boot fails / QEMU rejects the table** → report; I fix-forward (trim/repair the structures) or we conclude `file=` isn't viable in dockur's QEMU.

## Validation (here)

- `ruff` clean; `tests/test_smbios.py` (encode/validate/walk/write/fail-safe) + `tests/test_compose_arch.py` (stubbed hermetic) — 21 passed.
- Integration: disguise default-on → `ARGUMENTS` gains `-smbios file=/oem/winpodx-smbios.bin` and the 170-byte blob is written + re-validates.