### PR TITLE
feat(disguise): extend synthetic SMBIOS + auto-recreate on compose change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ tmp-igbkp/
 # Never commit — carries a per-install secret.
 config/oem/agent_token.txt
 
+# Synthetic SMBIOS disguise blob, generated into the OEM bind mount at
+# compose time (#246). Runtime artefact — never commit.
+config/oem/winpodx-smbios.bin
+
 # Coverage / test artefacts.
 .coverage
 htmlcov/

--- a/src/winpodx/cli/migrate.py
+++ b/src/winpodx/cli/migrate.py
@@ -670,10 +670,16 @@ def _ensure_canonical_image_pin(non_interactive: bool) -> None:
 
     # Always regenerate compose.yaml on upgrade — NOT just when the image pin
     # changed. compose-template features that land in a release without a pin
-    # bump (e.g. the live-USB QMP/cgroup infra, #286) must reach an existing
-    # guest too. generate_compose is idempotent + atomic; the next `pod start`
-    # recreates the container only when the rendered compose actually differs
-    # (storage volume preserved — no ISO redownload, no Sysprep, ~30 s).
+    # bump (e.g. the live-USB infra #286, or the bare-metal disguise #246's
+    # CPU_FLAGS / -smbios) must reach an existing guest too. Snapshot the old
+    # rendering first so we can tell whether anything actually changed.
+    from winpodx.utils.paths import config_dir
+
+    compose_path = config_dir() / "compose.yaml"
+    try:
+        old_compose = compose_path.read_text(encoding="utf-8") if compose_path.exists() else ""
+    except OSError:
+        old_compose = ""
     try:
         from winpodx.core.compose import generate_compose
 
@@ -681,14 +687,40 @@ def _ensure_canonical_image_pin(non_interactive: bool) -> None:
     except Exception as e:  # noqa: BLE001
         print(f"  warning: compose.yaml regenerate failed ({e})")
         return
+    try:
+        new_compose = compose_path.read_text(encoding="utf-8") if compose_path.exists() else ""
+    except OSError:
+        new_compose = ""
 
-    if pin_changed:
+    if new_compose == old_compose:
+        return  # nothing changed — no recreate, no noise
+
+    # compose.yaml changed (image pin and/or a compose-template feature). A
+    # running container keeps its OLD QEMU command line until it is recreated,
+    # so deferring to "next pod start" would leave a default-on change (e.g.
+    # the #246 disguise) silently inactive until the user happened to restart.
+    # Apply it now when the pod is up; otherwise it lands on the next start.
+    # The storage volume is preserved — no ISO redownload, no Sysprep, ~30 s.
+    from winpodx.core.pod import PodState, pod_status, start_pod, stop_pod
+
+    try:
+        running = pod_status(cfg).state == PodState.RUNNING
+    except Exception:  # noqa: BLE001
+        running = False
+    if running:
         print(
-            "  cfg.pod.image + compose.yaml updated.\n"
-            "  Next `winpodx pod start` will recreate the container so the new\n"
-            "  image pin takes effect (~30 s, storage volume preserved — no ISO\n"
-            "  redownload, no Sysprep). Future dockur :latest pushes won't\n"
-            "  trigger automatic recreates."
+            "  compose.yaml changed — recreating the container to apply it now\n"
+            "  (~30 s, storage volume preserved — no ISO redownload, no Sysprep)..."
+        )
+        try:
+            stop_pod(cfg)
+            start_pod(cfg)
+        except Exception as e:  # noqa: BLE001 — never let this abort migrate
+            print(f"  warning: recreate failed ({e}); applies on next `winpodx pod start`.")
+    else:
+        print(
+            "  compose.yaml updated — applies on the next `winpodx pod start`\n"
+            "  (~30 s, storage volume preserved — no ISO redownload, no Sysprep)."
         )
 
 

--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -311,6 +311,7 @@ def _disguise_smbios_args() -> list[str]:
     board_vendor = _host_dmi_field("board_vendor")
     board = _host_dmi_field("board_name")
     bios_vendor = _host_dmi_field("bios_vendor")
+    bios_version = _host_dmi_field("bios_version")
     bios_date = _host_dmi_field("bios_date")
     chassis_vendor = _host_dmi_field("chassis_vendor")
 
@@ -318,6 +319,8 @@ def _disguise_smbios_args() -> list[str]:
     t0 = []
     if bios_vendor:
         t0.append(f"vendor={bios_vendor}")
+    if bios_version:
+        t0.append(f"version={bios_version}")
     if bios_date:
         t0.append(f"date={bios_date}")
     if t0:

--- a/src/winpodx/core/pod/smbios.py
+++ b/src/winpodx/core/pod/smbios.py
@@ -9,9 +9,12 @@ corresponding ``Win32_*`` / ``CIM_*`` WMI classes, not live readings, so static
 descriptor structures with nominal/unknown values are enough to satisfy them.
 
 This module builds a small binary SMBIOS structure table (types 26 / 28 / 27 /
-7 / 9 / 8) with **synthetic** values — no host serials or live sensor data are
-read, so nothing machine-identifying is produced. The blob is written to the
-OEM dir (mounted into the container) and passed to QEMU via ``-smbios file=``.
+7 / 9 / 8 / 16 / 17 / 11) with **synthetic** values — no host serials or live
+sensor data are read, so nothing machine-identifying is produced. The blob is
+written to the OEM dir (mounted into the container) and passed to QEMU via
+``-smbios file=``. Types 16 / 17 add the physical-memory-array / memory-device
+descriptors (``Win32_PhysicalMemory`` existence); type 11 adds a benign OEM
+string so a raw SMBIOS string scan finds no ``QEMU`` / ``winpodx`` marker.
 
 Format: each structure is ``type(1) length(1) handle(2 LE) <formatted> <strings>``
 where the string-set is the referenced 1-indexed null-terminated strings
@@ -29,6 +32,9 @@ _H_COOL = 0x1B00
 _H_CACHE = 0x0700
 _H_SLOT = 0x0900
 _H_PORT = 0x0800
+_H_MEMARRAY = 0x1000
+_H_MEMDEV = 0x1100
+_H_OEMSTR = 0x0B00
 
 _UNKNOWN_W = 0x8000  # SMBIOS "unknown" sentinel for WORD probe values
 
@@ -112,6 +118,53 @@ def build_disguise_smbios_blob() -> bytes:
     # Type 8 — Port Connector
     port = bytes([1, 0xFF, 2, 0xFF, 0xFF])  # int-ref, int-type, ext-ref, ext-type, port-type
     parts.append(_structure(8, _H_PORT, port, ["J1", "USB"]))
+
+    # Type 16 — Physical Memory Array (parent of the memory devices). Satisfies
+    # the Win32_PhysicalMemoryArray existence check; QEMU's default SMBIOS omits
+    # it, which al-khaser flags as a VM tell.
+    mem_array = (
+        bytes([0x03, 0x03, 0x03])  # location: system board, use: system memory, ecc: none
+        + _dw(0x04000000)  # maximum capacity = 64 GB (in KB)
+        + _w(0xFFFE)  # memory error info handle: not provided
+        + _w(1)  # number of memory devices
+    )
+    parts.append(_structure(16, _H_MEMARRAY, mem_array, []))
+
+    # Type 17 — Memory Device (one synthetic DIMM under the array). Satisfies the
+    # Win32_PhysicalMemory / CIM_PhysicalMemory existence checks. All strings are
+    # synthetic (no host serial / part is read); the serial is a static
+    # placeholder, never a real module serial.
+    mem_dev = (
+        _w(_H_MEMARRAY)  # physical memory array handle
+        + _w(0xFFFE)  # memory error info handle: not provided
+        + _w(0x0040)  # total width: 64 bits
+        + _w(0x0040)  # data width: 64 bits
+        + _w(0x4000)  # size: 16384 MB (16 GB)
+        + bytes([0x09])  # form factor: DIMM
+        + bytes([0x00])  # device set: none
+        + bytes([1])  # device locator (string 1)
+        + bytes([2])  # bank locator (string 2)
+        + bytes([0x1A])  # memory type: DDR4
+        + _w(0x0080)  # type detail: synchronous
+        + _w(0x0C80)  # speed: 3200 MT/s
+        + bytes([3])  # manufacturer (string 3)
+        + bytes([4])  # serial number (string 4)
+        + bytes([5])  # asset tag (string 5)
+        + bytes([6])  # part number (string 6)
+    )
+    parts.append(
+        _structure(
+            17,
+            _H_MEMDEV,
+            mem_dev,
+            ["DIMM 0", "BANK 0", "Generic", "00000000", "Not Specified", "Generic Module"],
+        )
+    )
+
+    # Type 11 — OEM Strings. Real boards expose a type-11 structure; QEMU often
+    # omits it. A single benign "Default string" (what most retail boards ship)
+    # avoids leaking "QEMU" / "winpodx" into a raw SMBIOS string scan.
+    parts.append(_structure(11, _H_OEMSTR, bytes([1]), ["Default string"]))
 
     blob = b"".join(parts)
     validate_blob(blob)  # raise on any encoding slip before it reaches QEMU

--- a/tests/test_compose_arch.py
+++ b/tests/test_compose_arch.py
@@ -181,6 +181,7 @@ def test_compose_disguise_smbios_mirrors_host_dmi(monkeypatch):
         "board_vendor": "ACME",
         "board_name": "BRD-42",
         "bios_vendor": "ACME",
+        "bios_version": "BIOS-1.0",
         "bios_date": "01/01/2020",
         "chassis_vendor": "ACME",
     }
@@ -189,7 +190,7 @@ def test_compose_disguise_smbios_mirrors_host_dmi(monkeypatch):
     cfg.pod.disguise_hypervisor = None  # default ON
     content = _build_compose_content(cfg)
     assert "type=1,manufacturer=ACME,product=MDL-9000" in content
-    assert "type=0,vendor=ACME,date=01/01/2020" in content
+    assert "type=0,vendor=ACME,version=BIOS-1.0,date=01/01/2020" in content
     assert "type=3,manufacturer=ACME" in content
 
 

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -884,3 +884,59 @@ class TestMaybeAutoMigrateStorage:
         assert "FAIL" in out
         assert "rsync interrupted" in out
         assert "winpodx setup --migrate-storage" in out
+
+
+# --- _ensure_canonical_image_pin: recreate on compose change ---
+
+
+def _pin_cfg():
+    from winpodx.core.config import DOCKUR_IMAGE_PIN
+
+    cfg = MagicMock()
+    cfg.pod.backend = "podman"
+    cfg.pod.image = DOCKUR_IMAGE_PIN  # already pinned → isolate the compose-diff path
+    return cfg
+
+
+def test_canonical_pin_recreates_when_compose_changed_and_running(tmp_path):
+    from winpodx.cli.migrate import _ensure_canonical_image_pin
+    from winpodx.core.pod import PodState
+
+    compose = tmp_path / "compose.yaml"
+    compose.write_text("OLD", encoding="utf-8")
+    with (
+        patch("winpodx.core.config.Config.load", return_value=_pin_cfg()),
+        patch("winpodx.utils.paths.config_dir", return_value=tmp_path),
+        patch(
+            "winpodx.core.compose.generate_compose",
+            side_effect=lambda c: compose.write_text("NEW", encoding="utf-8"),
+        ),
+        patch("winpodx.core.pod.pod_status", return_value=MagicMock(state=PodState.RUNNING)),
+        patch("winpodx.core.pod.stop_pod") as stop,
+        patch("winpodx.core.pod.start_pod") as start,
+    ):
+        _ensure_canonical_image_pin(non_interactive=True)
+    stop.assert_called_once()
+    start.assert_called_once()
+
+
+def test_canonical_pin_no_recreate_when_compose_unchanged(tmp_path):
+    from winpodx.cli.migrate import _ensure_canonical_image_pin
+    from winpodx.core.pod import PodState
+
+    compose = tmp_path / "compose.yaml"
+    compose.write_text("SAME", encoding="utf-8")
+    with (
+        patch("winpodx.core.config.Config.load", return_value=_pin_cfg()),
+        patch("winpodx.utils.paths.config_dir", return_value=tmp_path),
+        patch(
+            "winpodx.core.compose.generate_compose",
+            side_effect=lambda c: compose.write_text("SAME", encoding="utf-8"),
+        ),
+        patch("winpodx.core.pod.pod_status", return_value=MagicMock(state=PodState.RUNNING)),
+        patch("winpodx.core.pod.stop_pod") as stop,
+        patch("winpodx.core.pod.start_pod") as start,
+    ):
+        _ensure_canonical_image_pin(non_interactive=True)
+    stop.assert_not_called()
+    start.assert_not_called()

--- a/tests/test_smbios.py
+++ b/tests/test_smbios.py
@@ -28,10 +28,41 @@ def test_blob_builds_and_validates():
 
 def test_blob_contains_sensor_descriptor_types():
     # The types al-khaser checks for existence: voltage(26), temperature(28),
-    # cooling(27), cache(7), slot(9), port connector(8).
+    # cooling(27), cache(7), slot(9), port connector(8), physical memory
+    # array(16), memory device(17), OEM strings(11).
     types = _walk_types(build_disguise_smbios_blob())
-    for t in (26, 28, 27, 7, 9, 8):
+    for t in (26, 28, 27, 7, 9, 8, 16, 17, 11):
         assert t in types, f"missing SMBIOS type {t}"
+
+
+def test_memory_device_references_array_handle():
+    # Type 17's first formatted field is the parent type-16 array handle; a
+    # dangling reference would make the WMI memory tree look synthetic.
+    from winpodx.core.pod.smbios import _H_MEMARRAY, _H_MEMDEV
+
+    blob = build_disguise_smbios_blob()
+    i = 0
+    handles_seen = set()
+    array_ref = None
+    while i < len(blob):
+        stype = blob[i]
+        length = blob[i + 1]
+        handle = int.from_bytes(blob[i + 2 : i + 4], "little")
+        handles_seen.add(handle)
+        if stype == 17:
+            array_ref = int.from_bytes(blob[i + 4 : i + 6], "little")
+        i = blob.find(b"\x00\x00", i + length) + 2
+    assert _H_MEMARRAY in handles_seen
+    assert _H_MEMDEV in handles_seen
+    assert array_ref == _H_MEMARRAY
+
+
+def test_blob_has_no_vm_marker_strings():
+    # A raw SMBIOS string scan must not surface a VM / project marker.
+    blob = build_disguise_smbios_blob()
+    lowered = blob.lower()
+    for marker in (b"qemu", b"bochs", b"seabios", b"winpodx", b"virtual"):
+        assert marker not in lowered, f"leaked marker {marker!r} into SMBIOS blob"
 
 
 def test_validate_rejects_truncated_header():


### PR DESCRIPTION
## Summary

Two independent improvements on top of the #246 bare-metal disguise:

### 1. Extend the synthetic SMBIOS disguise
Push more al-khaser / Pafish detector checks GOOD at **zero runtime cost**, all
through the existing `-smbios` injection path (no boot risk, no perf impact):

- **Type 16 + 17** (physical memory array + memory device) — the guest now
  satisfies the `Win32_PhysicalMemory` / `CIM_PhysicalMemory` existence checks
  that QEMU's default SMBIOS omits. One synthetic 16 GB DIMM with a static
  placeholder serial; **no host module serial is read**.
- **Type 11** OEM strings (a single benign `Default string`) so a raw SMBIOS
  string scan surfaces no `QEMU` / `winpodx` marker.
- Mirror the host **`bios_version`** into type 0 (non-identifying firmware
  version string).

Privacy unchanged: only non-identifying DMI fields are read at runtime
(vendor / product / board / bios names + version + date); **serial / UUID /
asset are never read**, and the generated blob is git-ignored.

### 2. Auto-recreate the container on compose change during migrate
A migration that regenerates `compose.yaml` (image pin, disguise args, tuning)
previously deferred the actual container recreate to the next manual
`pod start`, leaving the running container on stale config. Now: snapshot
compose before/after regeneration; if it changed and the pod is running,
`stop` + `start` to apply immediately; if stopped, note it applies next start;
unchanged compose stays a silent no-op.

## Testing
- `pytest tests/` — **1817 passed, 1 skipped**
- `ruff check` + `ruff format --check` — clean
- SMBIOS blob validates: 296 bytes / 9 structures
