### PR TITLE
fix(gui): correct PySide6 install hint + first-run setup progress (#502)

### DIFF
--- a/src/winpodx/gui/_main_window_library.py
+++ b/src/winpodx/gui/_main_window_library.py
@@ -607,16 +607,32 @@ class LibraryPageMixin:
         """
         query = self.search_box.text().strip()
         category = self._active_category
-        pod_running = getattr(self, "_pod_state", "checking") == "running"
+        pod_state = getattr(self, "_pod_state", "checking")
+        pod_running = pod_state == "running"
+        cfg = getattr(self, "cfg", None)
+        initialized = bool(cfg and getattr(cfg.pod, "initialized", False))
+        # First-ever install: setup hasn't completed yet, but the pod is coming
+        # up (dockur downloads + installs Windows inside the running container,
+        # so the state is "starting" or even "running" for the whole ~20-40 min
+        # install). Without this the grid showed "Windows isn't running" + a
+        # Start button the entire time, reading as broken (#502 reporter).
+        installing = (not initialized) and pod_state in ("starting", "running")
         any_apps = bool(self.apps)
         all_hidden = any_apps and all(a.hidden for a in self.apps)
 
         action_label = ""
         action_cb = None
 
+        # (a0) First-time setup is in progress — show progress, no Start button.
+        if not any_apps and installing:
+            title = tr("Setting up Windows (first run)…")
+            body = tr(
+                "Downloading and installing Windows — this can take 20–40 minutes. "
+                "You can watch progress at http://127.0.0.1:8006"
+            )
         # (a) Nothing discovered yet AND Windows isn't up — the most likely
         # cause of an empty library on a fresh/stopped install.
-        if not any_apps and not pod_running:
+        elif not any_apps and not pod_running:
             title = tr("Windows isn't running")
             body = tr("Start it to scan for your installed apps.")
             action_label = tr("Start Windows")

--- a/src/winpodx/gui/_main_window_pod.py
+++ b/src/winpodx/gui/_main_window_pod.py
@@ -266,6 +266,15 @@ class PodStatusMixin:
             QTimer.singleShot(2000, self._on_refresh_apps)
 
         self._pod_state = state
+        # While the library is empty, repaint its empty-state so a first-run
+        # install reads as "Setting up Windows…" the moment the pod starts
+        # coming up, instead of a stale "Windows isn't running" (#502).
+        if not getattr(self, "apps", None) and hasattr(self, "_filter_apps"):
+            search = getattr(self, "search_box", None)
+            try:
+                self._filter_apps(search.text() if search is not None else "")
+            except Exception:  # noqa: BLE001 — cosmetic refresh, never break status
+                pass
         colors = {
             "running": C.GREEN,
             "stopped": C.RED,

--- a/src/winpodx/locale/de.json
+++ b/src/winpodx/locale/de.json
@@ -540,8 +540,6 @@
   "Pulling {tag}...": "{tag} wird abgerufen...",
   "Push host updates (agent, fixes, rdprrap) into the guest -- no reinstall": "Host-Updates (Agent, Korrekturen, rdprrap) in den Gast übertragen -- keine Neuinstallation",
   "Push this host's updated guest files (agent, urlacl, rdprrap, registry fixes) into the running Windows guest? The agent restarts briefly at the end. Windows data is untouched.\n\nProceed?": "Die aktualisierten Gast-Dateien dieses Hosts (Agent, urlacl, rdprrap, Registry-Korrekturen) in den laufenden Windows-Gast übertragen? Der Agent startet am Ende kurz neu. Windows-Daten bleiben unangetastet.\n\nFortfahren?",
-  "PySide6 (Qt6) is required to launch the GUI. Install it one of these ways:": "PySide6 (Qt6) wird zum Starten der GUI benötigt. Installieren Sie es auf eine dieser Arten:",
-  "Or use the AppImage or the install.sh installer — both bundle the GUI.": "Oder verwenden Sie das AppImage oder den install.sh-Installer — beide enthalten die GUI.",
   "QEMU + Windows-on-KVM knob preset": "QEMU + Windows-on-KVM-Optionsvoreinstellung",
   "Querying multi-session status...": "Multi-Session-Status wird abgefragt...",
   "Queuing multi-session activation (detached)...": "Multi-Session-Aktivierung wird in Warteschlange gestellt (abgekoppelt)...",
@@ -867,5 +865,13 @@
   "Checking pod health…": "Pod-Zustand wird geprüft…",
   "Pod is stopped": "Pod ist gestoppt",
   "Status unknown": "Status unbekannt",
-  "Devices": "Geräte"
+  "Devices": "Geräte",
+  "PySide6 (Qt6) is required to launch the GUI. Easiest path: use the AppImage.": "PySide6 (Qt6) wird zum Starten der GUI benötigt. Einfachster Weg: Verwenden Sie das AppImage.",
+  "AppImage (bundles the GUI, no Python setup): download winpodx-x86_64.AppImage from the Releases page, then run `chmod +x winpodx-x86_64.AppImage && ./winpodx-x86_64.AppImage gui`.": "AppImage (enthält die GUI, keine Python-Einrichtung): Laden Sie winpodx-x86_64.AppImage von der Releases-Seite herunter und führen Sie `chmod +x winpodx-x86_64.AppImage && ./winpodx-x86_64.AppImage gui` aus.",
+  "install.sh installer: sets up a private venv with the GUI (no PEP 668 issue).": "install.sh-Installer: richtet eine private venv mit der GUI ein (kein PEP-668-Problem).",
+  "If you installed winpodx with pip:": "Wenn Sie winpodx mit pip installiert haben:",
+  "Distro package:": "Distributionspaket:",
+  "(Your distro may not package PySide6 for apt — use the AppImage above.)": "(Ihre Distribution stellt PySide6 möglicherweise nicht für apt bereit – verwenden Sie das AppImage oben.)",
+  "Setting up Windows (first run)…": "Windows wird eingerichtet (erster Start)…",
+  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "Windows wird heruntergeladen und installiert — das kann 20–40 Minuten dauern. Den Fortschritt können Sie unter http://127.0.0.1:8006 verfolgen"
 }

--- a/src/winpodx/locale/fr.json
+++ b/src/winpodx/locale/fr.json
@@ -540,8 +540,6 @@
   "Pulling {tag}...": "Récupération de {tag}...",
   "Push host updates (agent, fixes, rdprrap) into the guest -- no reinstall": "Pousser les mises à jour de l'hôte (agent, correctifs, rdprrap) vers l'invité -- sans réinstallation",
   "Push this host's updated guest files (agent, urlacl, rdprrap, registry fixes) into the running Windows guest? The agent restarts briefly at the end. Windows data is untouched.\n\nProceed?": "Pousser les fichiers invité mis à jour de cet hôte (agent, urlacl, rdprrap, correctifs du registre) vers l'invité Windows en cours d'exécution ? L'agent redémarre brièvement à la fin. Les données Windows ne sont pas touchées.\n\nContinuer ?",
-  "PySide6 (Qt6) is required to launch the GUI. Install it one of these ways:": "PySide6 (Qt6) est requis pour lancer l'interface graphique. Installez-le de l'une de ces façons :",
-  "Or use the AppImage or the install.sh installer — both bundle the GUI.": "Ou utilisez l'AppImage ou l'installateur install.sh — les deux incluent l'interface graphique.",
   "QEMU + Windows-on-KVM knob preset": "Préréglage d'options QEMU + Windows-on-KVM",
   "Querying multi-session status...": "Interrogation de l'état multi-session...",
   "Queuing multi-session activation (detached)...": "Mise en file d'attente de l'activation multi-session (détachée)...",
@@ -867,5 +865,13 @@
   "Checking pod health…": "Vérification de l'état du pod…",
   "Pod is stopped": "Le pod est arrêté",
   "Status unknown": "État inconnu",
-  "Devices": "Appareils"
+  "Devices": "Appareils",
+  "PySide6 (Qt6) is required to launch the GUI. Easiest path: use the AppImage.": "PySide6 (Qt6) est requis pour lancer l'interface graphique. Le plus simple : utilisez l'AppImage.",
+  "AppImage (bundles the GUI, no Python setup): download winpodx-x86_64.AppImage from the Releases page, then run `chmod +x winpodx-x86_64.AppImage && ./winpodx-x86_64.AppImage gui`.": "AppImage (intègre l'interface graphique, sans configuration Python) : téléchargez winpodx-x86_64.AppImage depuis la page Releases, puis exécutez `chmod +x winpodx-x86_64.AppImage && ./winpodx-x86_64.AppImage gui`.",
+  "install.sh installer: sets up a private venv with the GUI (no PEP 668 issue).": "Installateur install.sh : configure un venv privé avec l'interface graphique (pas de problème PEP 668).",
+  "If you installed winpodx with pip:": "Si vous avez installé winpodx avec pip :",
+  "Distro package:": "Paquet de la distribution :",
+  "(Your distro may not package PySide6 for apt — use the AppImage above.)": "(Votre distribution ne fournit peut-être pas PySide6 pour apt — utilisez l'AppImage ci-dessus.)",
+  "Setting up Windows (first run)…": "Configuration de Windows (premier lancement)…",
+  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "Téléchargement et installation de Windows — cela peut prendre 20 à 40 minutes. Vous pouvez suivre la progression sur http://127.0.0.1:8006"
 }

--- a/src/winpodx/locale/it.json
+++ b/src/winpodx/locale/it.json
@@ -540,8 +540,6 @@
   "Pulling {tag}...": "Download di {tag}...",
   "Push host updates (agent, fixes, rdprrap) into the guest -- no reinstall": "Invia gli aggiornamenti dell'host (agent, correzioni, rdprrap) nel guest -- nessuna reinstallazione",
   "Push this host's updated guest files (agent, urlacl, rdprrap, registry fixes) into the running Windows guest? The agent restarts briefly at the end. Windows data is untouched.\n\nProceed?": "Inviare i file del guest aggiornati di questo host (agent, urlacl, rdprrap, correzioni del registro) nel guest Windows in esecuzione? L'agent si riavvia brevemente alla fine. I dati Windows non vengono toccati.\n\nProcedere?",
-  "PySide6 (Qt6) is required to launch the GUI. Install it one of these ways:": "PySide6 (Qt6) è necessario per avviare la GUI. Installalo in uno di questi modi:",
-  "Or use the AppImage or the install.sh installer — both bundle the GUI.": "Oppure usa l'AppImage o l'installer install.sh — entrambi includono la GUI.",
   "QEMU + Windows-on-KVM knob preset": "Preset dei parametri QEMU + Windows-on-KVM",
   "Querying multi-session status...": "Interrogazione dello stato multi-sessione...",
   "Queuing multi-session activation (detached)...": "Accodamento dell'attivazione multi-sessione (distaccato)...",
@@ -867,5 +865,13 @@
   "Checking pod health…": "Verifica dello stato del pod…",
   "Pod is stopped": "Il pod è arrestato",
   "Status unknown": "Stato sconosciuto",
-  "Devices": "Dispositivi"
+  "Devices": "Dispositivi",
+  "PySide6 (Qt6) is required to launch the GUI. Easiest path: use the AppImage.": "PySide6 (Qt6) è necessario per avviare la GUI. Metodo più semplice: usa l'AppImage.",
+  "AppImage (bundles the GUI, no Python setup): download winpodx-x86_64.AppImage from the Releases page, then run `chmod +x winpodx-x86_64.AppImage && ./winpodx-x86_64.AppImage gui`.": "AppImage (include la GUI, nessuna configurazione Python): scarica winpodx-x86_64.AppImage dalla pagina Releases, quindi esegui `chmod +x winpodx-x86_64.AppImage && ./winpodx-x86_64.AppImage gui`.",
+  "install.sh installer: sets up a private venv with the GUI (no PEP 668 issue).": "Installer install.sh: configura un venv privato con la GUI (nessun problema PEP 668).",
+  "If you installed winpodx with pip:": "Se hai installato winpodx con pip:",
+  "Distro package:": "Pacchetto della distribuzione:",
+  "(Your distro may not package PySide6 for apt — use the AppImage above.)": "(La tua distribuzione potrebbe non fornire PySide6 per apt — usa l'AppImage sopra.)",
+  "Setting up Windows (first run)…": "Configurazione di Windows (primo avvio)…",
+  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "Download e installazione di Windows — può richiedere 20–40 minuti. Puoi seguire l'avanzamento su http://127.0.0.1:8006"
 }

--- a/src/winpodx/locale/ja.json
+++ b/src/winpodx/locale/ja.json
@@ -540,8 +540,6 @@
   "Pulling {tag}...": "{tag} を pull しています...",
   "Push host updates (agent, fixes, rdprrap) into the guest -- no reinstall": "ホストの更新 (エージェント、修正、rdprrap) をゲストにプッシュ -- 再インストール不要",
   "Push this host's updated guest files (agent, urlacl, rdprrap, registry fixes) into the running Windows guest? The agent restarts briefly at the end. Windows data is untouched.\n\nProceed?": "このホストの更新されたゲストファイル (エージェント、urlacl、rdprrap、レジストリ修正) を実行中の Windows ゲストにプッシュしますか? 最後にエージェントが短時間再起動します。Windows データには手を加えません。\n\n続行しますか?",
-  "PySide6 (Qt6) is required to launch the GUI. Install it one of these ways:": "GUI の起動には PySide6 (Qt6) が必要です。次のいずれかの方法でインストールしてください:",
-  "Or use the AppImage or the install.sh installer — both bundle the GUI.": "または AppImage か install.sh インストーラーを使用してください — どちらも GUI を同梱しています。",
   "QEMU + Windows-on-KVM knob preset": "QEMU + Windows-on-KVM の項目プリセット",
   "Querying multi-session status...": "マルチセッションの状態を照会しています...",
   "Queuing multi-session activation (detached)...": "マルチセッションのアクティベーションをキューに追加しています (デタッチ)...",
@@ -867,5 +865,13 @@
   "Checking pod health…": "ポッドの状態を確認中…",
   "Pod is stopped": "ポッドは停止しています",
   "Status unknown": "状態不明",
-  "Devices": "デバイス"
+  "Devices": "デバイス",
+  "PySide6 (Qt6) is required to launch the GUI. Easiest path: use the AppImage.": "GUI の起動には PySide6 (Qt6) が必要です。最も簡単な方法: AppImage を使用してください。",
+  "AppImage (bundles the GUI, no Python setup): download winpodx-x86_64.AppImage from the Releases page, then run `chmod +x winpodx-x86_64.AppImage && ./winpodx-x86_64.AppImage gui`.": "AppImage (GUI 同梱、Python の設定不要): Releases ページから winpodx-x86_64.AppImage をダウンロードし、`chmod +x winpodx-x86_64.AppImage && ./winpodx-x86_64.AppImage gui` を実行してください。",
+  "install.sh installer: sets up a private venv with the GUI (no PEP 668 issue).": "install.sh インストーラー: GUI を含む専用の venv をセットアップします (PEP 668 の問題なし)。",
+  "If you installed winpodx with pip:": "winpodx を pip でインストールした場合:",
+  "Distro package:": "ディストリのパッケージ:",
+  "(Your distro may not package PySide6 for apt — use the AppImage above.)": "(お使いのディストリでは apt 用の PySide6 が提供されていない場合があります — 上記の AppImage を使用してください。)",
+  "Setting up Windows (first run)…": "Windows をセットアップ中 (初回)…",
+  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "Windows をダウンロードしてインストールしています — 20〜40分ほどかかる場合があります。http://127.0.0.1:8006 で進行状況を確認できます"
 }

--- a/src/winpodx/locale/ko.json
+++ b/src/winpodx/locale/ko.json
@@ -540,8 +540,6 @@
   "Pulling {tag}...": "{tag}을(를) 가져오는 중...",
   "Push host updates (agent, fixes, rdprrap) into the guest -- no reinstall": "호스트 업데이트(에이전트, 수정 사항, rdprrap)를 게스트에 전송 -- 재설치 없음",
   "Push this host's updated guest files (agent, urlacl, rdprrap, registry fixes) into the running Windows guest? The agent restarts briefly at the end. Windows data is untouched.\n\nProceed?": "이 호스트의 업데이트된 게스트 파일(에이전트, urlacl, rdprrap, 레지스트리 수정)을 실행 중인 Windows 게스트에 전송할까요? 끝에 에이전트가 잠시 재시작됩니다. Windows 데이터는 그대로 유지됩니다.\n\n진행할까요?",
-  "PySide6 (Qt6) is required to launch the GUI. Install it one of these ways:": "GUI 실행에 PySide6 (Qt6) 가 필요합니다. 다음 방법 중 하나로 설치하세요:",
-  "Or use the AppImage or the install.sh installer — both bundle the GUI.": "또는 AppImage 나 install.sh 설치 프로그램을 사용하세요 — 둘 다 GUI 를 포함합니다.",
   "QEMU + Windows-on-KVM knob preset": "QEMU + Windows-on-KVM 옵션 프리셋",
   "Querying multi-session status...": "다중 세션 상태를 조회하는 중...",
   "Queuing multi-session activation (detached)...": "다중 세션 활성화를 대기열에 추가하는 중 (분리됨)...",
@@ -867,5 +865,13 @@
   "Checking pod health…": "팟 상태 확인 중…",
   "Pod is stopped": "팟이 중지됨",
   "Status unknown": "상태 알 수 없음",
-  "Devices": "장치"
+  "Devices": "장치",
+  "PySide6 (Qt6) is required to launch the GUI. Easiest path: use the AppImage.": "GUI 실행에는 PySide6 (Qt6)가 필요합니다. 가장 쉬운 방법: AppImage를 사용하세요.",
+  "AppImage (bundles the GUI, no Python setup): download winpodx-x86_64.AppImage from the Releases page, then run `chmod +x winpodx-x86_64.AppImage && ./winpodx-x86_64.AppImage gui`.": "AppImage (GUI 내장, Python 설정 불필요): Releases 페이지에서 winpodx-x86_64.AppImage를 받은 뒤 `chmod +x winpodx-x86_64.AppImage && ./winpodx-x86_64.AppImage gui` 를 실행하세요.",
+  "install.sh installer: sets up a private venv with the GUI (no PEP 668 issue).": "install.sh 설치 프로그램: GUI가 포함된 전용 venv를 구성합니다 (PEP 668 문제 없음).",
+  "If you installed winpodx with pip:": "winpodx를 pip로 설치한 경우:",
+  "Distro package:": "배포판 패키지:",
+  "(Your distro may not package PySide6 for apt — use the AppImage above.)": "(사용 중인 배포판이 apt용 PySide6를 제공하지 않을 수 있습니다 — 위의 AppImage를 사용하세요.)",
+  "Setting up Windows (first run)…": "Windows 설정 중 (첫 실행)…",
+  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "Windows를 다운로드하고 설치하는 중입니다 — 20~40분 정도 걸릴 수 있습니다. http://127.0.0.1:8006 에서 진행 상황을 볼 수 있습니다"
 }

--- a/src/winpodx/locale/zh.json
+++ b/src/winpodx/locale/zh.json
@@ -540,8 +540,6 @@
   "Pulling {tag}...": "正在拉取 {tag}...",
   "Push host updates (agent, fixes, rdprrap) into the guest -- no reinstall": "将主机更新（agent、fixes、rdprrap）推送到客户机 -- 无需重新安装",
   "Push this host's updated guest files (agent, urlacl, rdprrap, registry fixes) into the running Windows guest? The agent restarts briefly at the end. Windows data is untouched.\n\nProceed?": "将此主机更新后的客户机文件（agent、urlacl、rdprrap、注册表修复）推送到正在运行的 Windows 客户机吗？代理会在结束时短暂重启。Windows 数据不受影响。\n\n继续吗？",
-  "PySide6 (Qt6) is required to launch the GUI. Install it one of these ways:": "启动 GUI 需要 PySide6 (Qt6)。可通过以下任一方式安装：",
-  "Or use the AppImage or the install.sh installer — both bundle the GUI.": "或使用 AppImage 或 install.sh 安装程序——两者都已内置 GUI。",
   "QEMU + Windows-on-KVM knob preset": "QEMU + Windows-on-KVM 设置预设",
   "Querying multi-session status...": "正在查询多会话状态...",
   "Queuing multi-session activation (detached)...": "正在将多会话激活加入队列（分离模式）...",
@@ -867,5 +865,13 @@
   "Checking pod health…": "正在检查 Pod 健康状况…",
   "Pod is stopped": "Pod 已停止",
   "Status unknown": "状态未知",
-  "Devices": "设备"
+  "Devices": "设备",
+  "PySide6 (Qt6) is required to launch the GUI. Easiest path: use the AppImage.": "启动 GUI 需要 PySide6 (Qt6)。最简单的方法：使用 AppImage。",
+  "AppImage (bundles the GUI, no Python setup): download winpodx-x86_64.AppImage from the Releases page, then run `chmod +x winpodx-x86_64.AppImage && ./winpodx-x86_64.AppImage gui`.": "AppImage（内置 GUI，无需配置 Python）：从 Releases 页面下载 winpodx-x86_64.AppImage，然后运行 `chmod +x winpodx-x86_64.AppImage && ./winpodx-x86_64.AppImage gui`。",
+  "install.sh installer: sets up a private venv with the GUI (no PEP 668 issue).": "install.sh 安装程序：创建包含 GUI 的独立 venv（无 PEP 668 问题）。",
+  "If you installed winpodx with pip:": "如果你用 pip 安装了 winpodx：",
+  "Distro package:": "发行版软件包：",
+  "(Your distro may not package PySide6 for apt — use the AppImage above.)": "（你的发行版可能没有为 apt 提供 PySide6 —— 请使用上面的 AppImage。）",
+  "Setting up Windows (first run)…": "正在设置 Windows（首次运行）…",
+  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "正在下载并安装 Windows —— 这可能需要 20–40 分钟。你可以在 http://127.0.0.1:8006 查看进度"
 }

--- a/src/winpodx/utils/install_source.py
+++ b/src/winpodx/utils/install_source.py
@@ -240,43 +240,100 @@ def _distro_id_like() -> str:
     return ""
 
 
-def _pyside6_pkg_command() -> str:
-    """The distro package-manager command that installs PySide6 (Qt6).
+def _apt_has_candidate(pkg: str) -> bool:
+    """True when ``apt-cache policy <pkg>`` reports an installable candidate.
 
-    Falls back to a PEP 668-safe suggestion (pipx / venv) for an unrecognised
-    distro -- never a bare ``pip install``, which fails with
+    Guards against suggesting a package that doesn't exist in the user's apt
+    archive -- e.g. ``python3-pyside6.qtwidgets`` has *no installation
+    candidate* on Ubuntu 24.04 LTS (PySide6 only entered the archive in later
+    releases), the exact failure reported in #502.
+    """
+    try:
+        out = subprocess.run(
+            ["apt-cache", "policy", pkg],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return False
+    for line in out.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Candidate:"):
+            cand = stripped.split(":", 1)[1].strip()
+            return bool(cand) and cand != "(none)"
+    return False
+
+
+def _apt_pyside6_command() -> str | None:
+    """An ``apt install`` line using only PySide6 package names that actually
+    have a candidate on this system, or ``None`` when apt packages none of
+    them (the Ubuntu 24.04 LTS case -- there the AppImage is the only path).
+
+    Package naming varies across releases, so probe in preference order: the
+    split Qt-module packages (Debian / Ubuntu >= 24.10), then a metapackage.
+    """
+    if not shutil.which("apt-cache"):
+        return None
+    split = ["python3-pyside6.qtwidgets", "python3-pyside6.qtsvg"]
+    if all(_apt_has_candidate(p) for p in split):
+        return "sudo apt install " + " ".join(split)
+    for meta in ("python3-pyside6", "python3-qtpy-pyside6"):
+        if _apt_has_candidate(meta):
+            return f"sudo apt install {meta}"
+    return None
+
+
+def _pyside6_pkg_command() -> str | None:
+    """The distro package-manager command that installs PySide6 (Qt6), or
+    ``None`` when no distro package is available (caller falls back to the
+    AppImage). Never a bare ``pip install`` -- that fails with
     ``externally-managed-environment`` on modern Debian/Ubuntu/Fedora (#502).
+
+    Debian/Ubuntu is probed at runtime (``apt-cache``) because the package
+    name + availability differ per release; the other families ship a stable
+    package name so they stay static.
     """
     family = f"{_distro_id()} {_distro_id_like()}".lower()
     if any(d in family for d in ("debian", "ubuntu", "mint", "pop", "raspbian")):
-        return (
-            "sudo apt install python3-pyside6.qtwidgets python3-pyside6.qtsvg"
-            "   # Ubuntu: enable the 'universe' repo first"
-        )
+        return _apt_pyside6_command()
     if any(d in family for d in ("fedora", "rhel", "centos", "almalinux", "rocky", "nobara")):
         return "sudo dnf install python3-pyside6"
     if any(d in family for d in ("arch", "manjaro", "endeavouros", "cachyos")):
         return "sudo pacman -S pyside6"
     if any(d in family for d in ("opensuse", "suse", "sles")):
         return "sudo zypper install python3-PySide6"
-    return "pipx install PySide6   # or install into a venv (avoids the PEP 668 error)"
+    return None
 
 
 def pyside6_install_hint() -> str:
     """Actionable, distro-aware message for the GUI's missing-PySide6 case.
 
     The old hint (``pip install PySide6``) fails on PEP 668 externally-managed
-    Pythons and never named the actual package (#502). Give the correct distro
-    package command, the pip path for source installs, and the AppImage /
-    install.sh, which bundle the GUI outright.
+    Pythons, and #502's reporter then found the apt package we named doesn't
+    even exist on Ubuntu 24.04 LTS. So lead with the AppImage (works on every
+    distro, no Python setup), then install.sh / pip, and only show a distro
+    package command when one is actually available (see _pyside6_pkg_command).
     """
     from winpodx.core.i18n import tr  # lazy import: avoid an import cycle
 
-    return "\n".join(
-        [
-            tr("PySide6 (Qt6) is required to launch the GUI. Install it one of these ways:"),
-            f"  - Distro package:  {_pyside6_pkg_command()}",
-            "  - If you installed winpodx with pip:  pip install 'winpodx[gui]'",
-            "  - " + tr("Or use the AppImage or the install.sh installer — both bundle the GUI."),
-        ]
-    )
+    lines = [
+        tr("PySide6 (Qt6) is required to launch the GUI. Easiest path: use the AppImage."),
+        "  - "
+        + tr(
+            "AppImage (bundles the GUI, no Python setup): download "
+            "winpodx-x86_64.AppImage from the Releases page, then run "
+            "`chmod +x winpodx-x86_64.AppImage && ./winpodx-x86_64.AppImage gui`."
+        ),
+        "  - "
+        + tr("install.sh installer: sets up a private venv with the GUI (no PEP 668 issue)."),
+        "  - " + tr("If you installed winpodx with pip:") + "  pip install 'winpodx[gui]'",
+    ]
+    pkg = _pyside6_pkg_command()
+    if pkg:
+        lines.append("  - " + tr("Distro package:") + f"  {pkg}")
+    else:
+        lines.append(
+            "  - " + tr("(Your distro may not package PySide6 for apt — use the AppImage above.)")
+        )
+    return "\n".join(lines)

--- a/tests/test_pyside6_hint.py
+++ b/tests/test_pyside6_hint.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: MIT
+"""GUI missing-PySide6 install hint (#502): distro-aware, apt-candidate-probed."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from winpodx.utils import install_source as src
+
+
+class _Proc:
+    def __init__(self, stdout: str):
+        self.stdout = stdout
+
+
+def _apt_policy(candidate: str | None) -> str:
+    """Render an `apt-cache policy` stdout with the given Candidate value."""
+    cand = candidate if candidate is not None else "(none)"
+    return f"python3-pyside6.qtwidgets:\n  Installed: (none)\n  Candidate: {cand}\n"
+
+
+def test_apt_has_candidate_true_and_false():
+    with patch.object(src.subprocess, "run", return_value=_Proc(_apt_policy("6.6.0-1"))):
+        assert src._apt_has_candidate("python3-pyside6.qtwidgets") is True
+    with patch.object(src.subprocess, "run", return_value=_Proc(_apt_policy(None))):
+        assert src._apt_has_candidate("python3-pyside6.qtwidgets") is False
+    # Unknown package — apt-cache prints nothing for it.
+    with patch.object(src.subprocess, "run", return_value=_Proc("")):
+        assert src._apt_has_candidate("nope") is False
+
+
+def test_apt_has_candidate_survives_subprocess_error():
+    with patch.object(src.subprocess, "run", side_effect=OSError):
+        assert src._apt_has_candidate("python3-pyside6.qtwidgets") is False
+
+
+def test_apt_command_split_packages_when_available():
+    with (
+        patch.object(src.shutil, "which", return_value="/usr/bin/apt-cache"),
+        patch.object(src, "_apt_has_candidate", return_value=True),
+    ):
+        cmd = src._apt_pyside6_command()
+    assert cmd == "sudo apt install python3-pyside6.qtwidgets python3-pyside6.qtsvg"
+
+
+def test_apt_command_falls_back_to_metapackage():
+    def has(pkg: str) -> bool:
+        return pkg == "python3-pyside6"  # only the metapackage exists
+
+    with (
+        patch.object(src.shutil, "which", return_value="/usr/bin/apt-cache"),
+        patch.object(src, "_apt_has_candidate", side_effect=has),
+    ):
+        assert src._apt_pyside6_command() == "sudo apt install python3-pyside6"
+
+
+def test_apt_command_none_when_archive_lacks_pyside6():
+    # The Ubuntu 24.04 LTS case: no candidate for any name.
+    with (
+        patch.object(src.shutil, "which", return_value="/usr/bin/apt-cache"),
+        patch.object(src, "_apt_has_candidate", return_value=False),
+    ):
+        assert src._apt_pyside6_command() is None
+
+
+def test_apt_command_none_without_apt_cache():
+    with patch.object(src.shutil, "which", return_value=None):
+        assert src._apt_pyside6_command() is None
+
+
+def test_pkg_command_static_families():
+    with (
+        patch.object(src, "_distro_id", return_value="fedora"),
+        patch.object(src, "_distro_id_like", return_value=""),
+    ):
+        assert src._pyside6_pkg_command() == "sudo dnf install python3-pyside6"
+    with (
+        patch.object(src, "_distro_id", return_value="arch"),
+        patch.object(src, "_distro_id_like", return_value=""),
+    ):
+        assert src._pyside6_pkg_command() == "sudo pacman -S pyside6"
+
+
+def test_pkg_command_unknown_distro_is_none():
+    with (
+        patch.object(src, "_distro_id", return_value="weirdos"),
+        patch.object(src, "_distro_id_like", return_value=""),
+    ):
+        assert src._pyside6_pkg_command() is None
+
+
+def test_hint_leads_with_appimage_and_never_bare_pip():
+    with patch.object(src, "_pyside6_pkg_command", return_value=None):
+        hint = src.pyside6_install_hint()
+    first = hint.splitlines()[0]
+    assert "AppImage" in first
+    # The old failing advice must be gone.
+    assert "pip install PySide6" not in hint
+    # When no distro package, the explicit fallback note is shown.
+    assert "may not package PySide6" in hint
+
+
+def test_hint_shows_distro_package_when_available():
+    with patch.object(src, "_pyside6_pkg_command", return_value="sudo apt install python3-pyside6"):
+        hint = src.pyside6_install_hint()
+    assert "sudo apt install python3-pyside6" in hint
+    assert "may not package PySide6" not in hint


### PR DESCRIPTION
Two fixes from #502.

## 1. PySide6 install hint (the actual #502 bug)
#505's hint named `python3-pyside6.qtwidgets` / `.qtsvg`, which have **no
installation candidate on Ubuntu 24.04 LTS** (PySide6 only entered the archive
in later releases) → the reporter's apt command still failed. Now:
- Lead with the **AppImage** (bundles its own PySide6 — works on every distro,
  no PEP 668 / apt-name problem), then install.sh / pip.
- Probe `apt-cache policy` at render time and only suggest a Debian/Ubuntu
  package that actually has a candidate; when apt packages none, say so and
  point at the AppImage. Other families (dnf/pacman/zypper) stay static.

## 2. First-run setup progress
On a first launch dockur installs Windows inside the running pod (~20-40 min);
the library grid showed "Windows isn't running" + a Start button the whole
time, reading as broken. Now shows **"Setting up Windows (first run)…"** with
the ~20-40 min note + the VNC progress URL while installing, repainted as the
pod comes up.

## Testing
- `pytest tests/test_pyside6_hint.py tests/test_i18n.py` + GUI bringup — pass
- ruff clean; 6 locale catalogs synced (875 keys, parity)
