### PR TITLE
feat(disguise): tiered bare-metal levels (off/balanced/max) + auto-apply (#246)

### DIFF
--- a/data/winpodx.toml.example
+++ b/data/winpodx.toml.example
@@ -47,7 +47,7 @@ timezone = ""             # "" = follow the host timezone
 tuning_profile = "auto"   # auto | low | mid | high — host-adaptive Windows-on-KVM tuning
 usb_live = true           # bind the host USB bus so `device attach` hot-plugs live
 # devices = []            # passthrough device ids (managed by `winpodx device`)
-# disguise_hypervisor = false  # bare-metal mode (hide KVM/QEMU hypervisor) is ON by default; set false to opt out — Nvidia code-43 / VM-hostile apps; not an anti-cheat bypass (#246)
+# disguise_level = "balanced"  # bare-metal mode: off | balanced (default, free hiding) | max (Hyper-V off, slower). Nvidia code-43 / VM-hostile apps; not an anti-cheat bypass (#246)
 
 [reverse_open]
 enabled = true            # surface Linux apps in the Windows "Open with…" menu

--- a/docs/USAGE.ko.md
+++ b/docs/USAGE.ko.md
@@ -145,17 +145,26 @@ USB 장치는 live hot-plug (`cfg.pod.usb_live`, 기본 on) — 재시작 불필
 
 ## bare-metal 호환 모드 (하이퍼바이저 숨김)
 
-일부 소프트웨어는 하이퍼바이저가 감지되면 실행을 거부합니다 — 대표적으로 Nvidia 소비자 GPU 드라이버(KVM 감지 시 **code 43**, GPU 패스스루의 흔한 차단 원인)와 런치게이트 VM 체크가 있는 앱들. `cfg.pod.disguise_hypervisor` (#246) 가 KVM/QEMU 시그니처를 게스트에서 숨겨 물리 PC 처럼 보이게 합니다. **기본 활성화(on)** 입니다.
+일부 소프트웨어는 하이퍼바이저가 감지되면 실행을 거부합니다 — 대표적으로 Nvidia 소비자 GPU 드라이버(KVM 감지 시 **code 43**, GPU 패스스루의 흔한 차단 원인)와 런치게이트 VM 체크가 있는 앱들. `cfg.pod.disguise_level` (#246) 이 KVM/QEMU 시그니처를 게스트에서 숨겨 물리 PC 처럼 보이게 합니다. **3단계, 기본값 `balanced`**:
+
+| 레벨 | 동작 | 성능 |
+|------|------|------|
+| `off` | 숨김 없음 — 정직한 VM | 최고(호환성도) |
+| `balanced` (기본) | CPUID 하이퍼바이저 비트 + KVM 시그니처 제거, 호스트 SMBIOS/DMI 미러링, 합성 센서 디스크립터, 물리 PC 같은 디스크 크기 광고 | 손실 없음 |
+| `max` | `balanced` + Hyper-V enlightenment 비활성(`HV=N`)으로 al-khaser/Pafish Hyper-V 체크 통과 | 눈에 띄게 느려짐(Windows-on-KVM 타이머/스케줄러 튜닝 손실) |
 
 ```bash
-winpodx config set pod.disguise_hypervisor false   # 끄기 (opt out)
-winpodx pod recreate                               # compose 재생성 + 컨테이너만 재생성 (Windows 디스크 유지)
-winpodx config set pod.disguise_hypervisor true    # 다시 켜기
+winpodx config set pod.disguise_level off        # 정직한 VM
+winpodx config set pod.disguise_level balanced   # 기본 — 무손실 숨김
+winpodx config set pod.disguise_level max        # 최대 숨김, 느려짐
+winpodx pod recreate                             # compose 재생성 + 컨테이너만 재생성 (Windows 디스크 유지)
 ```
 
-GUI에서도 토글 가능: **Settings → Bare-metal compatibility**. 어느 쪽이든 `winpodx pod recreate` 후 적용됨 (QEMU `-cpu` 라인을 바꾸므로; recreate는 Windows 디스크 유지).
+GUI에서도 선택 가능: **Settings → Bare-metal compatibility**. 어느 쪽이든 `winpodx pod recreate` 후 적용됨 (QEMU `-cpu` 라인 + `HV` env + 디스크 크기를 바꾸므로; recreate는 Windows 디스크 유지).
 
-켜면 게스트 `-cpu` 라인이 CPUID 하이퍼바이저-존재 비트(leaf 1, ECX 31 — code-43/런치게이트의 주 트리거)를 지우고 `KVMKVMKVM` 시그니처 + KVM 파라버트 leaf 를 제거합니다. Hyper-V 성능 enlightenment 는 유지(Windows 가 다른 leaf 로 감지)되어 성능 손실 없음. tri-state: `false` = 끔, 키 없음 또는 `true` = 켬.
+**안티치트 우회 아님.** 캐주얼 탐지기와 VM 거부 앱(code 43, DRM/런치게이트)용 시그니처 레벨 숨김입니다. 커널 안티치트(EAC/BattlEye/Vanguard)는 **못 피합니다** — 하드웨어 attestation(TPM + Secure Boot)과 게스트가 위조 못 하는 VM-exit 타이밍에 의존하며, 온라인 게임 안티치트 우회는 게임 ToS 위반입니다.
+
+디스크 확대는 게이트됨: dockur 디스크는 sparse 라 광고 크기를 키워도 호스트 공간을 즉시 먹지 않지만, 호스트 여유 공간이 충분할 때만(10 GiB / 10 % 예약 유지) 올립니다. 작은 호스트에선 그대로 두고 경고만 출력. 구버전 `disguise_hypervisor = false` 키도 계속 작동 — `off` 로 매핑됩니다.
 
 > **안티치트 우회가 아닙니다.** 시그니처 레벨만이며 커널모드 안티치트(EAC / BattlEye / Vanguard)는 못 뚫습니다. 온라인 게임 안티치트 우회는 ToS 위반이고 밴 위험 — winpodx 는 그 용도를 지원하지 않습니다.
 
@@ -302,7 +311,7 @@ idle_timeout = 0                                 # 자동 suspend 까지 초 (0 
 boot_timeout = 300                               # 첫 부팅 unattended 설치 대기 초
 image = "docker.io/dockurr/windows:latest"       # 컨테이너 이미지 (에어갭 미러용 override)
 usb_live = true                                  # attach 된 USB 장치를 실행 중 게스트에 hot-plug (재시작 없이) — `winpodx device` 참고
-# disguise_hypervisor = false                    # bare-metal 모드(KVM/QEMU 하이퍼바이저 숨김) 기본 ON; 끄려면 false — Nvidia code-43 / VM 거부 앱; 안티치트 우회 아님 (#246)
+# disguise_level = "balanced"                    # bare-metal 모드: off | balanced(기본, 무손실 숨김) | max(Hyper-V 끔, 느려짐) — Nvidia code-43 / VM 거부 앱; 안티치트 우회 아님 (#246)
 disk_size = "64G"                                # dockur 에 전달하는 가상 디스크 크기 (`install grow-disk` 로 확장)
 disk_autogrow = true                             # C: 가 임계 넘으면 자동 확장 (idle 일 때만)
 disk_autogrow_threshold_pct = 80                 # 자동 확장 트리거 사용% (50-99)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -145,17 +145,26 @@ USB devices hot-plug live (`cfg.pod.usb_live`, default on) — no restart needed
 
 ## Bare-metal compatibility mode (hide the hypervisor)
 
-Some software refuses to run under a detected hypervisor — most notably Nvidia's consumer GPU drivers (they fault with **code 43** when they see KVM, the common GPU-passthrough blocker) and apps with launch-gate VM checks. `cfg.pod.disguise_hypervisor` (#246) hides the KVM/QEMU signature from the guest so it presents as a physical PC. **It is on by default.**
+Some software refuses to run under a detected hypervisor — most notably Nvidia's consumer GPU drivers (they fault with **code 43** when they see KVM, the common GPU-passthrough blocker) and apps with launch-gate VM checks. `cfg.pod.disguise_level` (#246) hides the KVM/QEMU signature from the guest so it presents as a physical PC. It has **three levels, default `balanced`**:
+
+| Level | What it does | Performance |
+|-------|--------------|-------------|
+| `off` | No disguise — an honest VM. | Best (and most compatible) |
+| `balanced` (default) | Clears the CPUID hypervisor bit + KVM signature, mirrors the host's SMBIOS/DMI, adds synthetic sensor descriptors, and advertises a bare-metal-looking disk size. | No measurable cost |
+| `max` | Everything in `balanced` **plus** disabling the Hyper-V enlightenments (`HV=N`) so the al-khaser / Pafish Hyper-V checks pass. | Noticeably slower (loses the Windows-on-KVM timer/scheduler tuning) |
 
 ```bash
-winpodx config set pod.disguise_hypervisor false   # opt out
-winpodx pod recreate                               # regenerate compose + recreate the container (keeps your Windows disk)
-winpodx config set pod.disguise_hypervisor true    # turn it back on
+winpodx config set pod.disguise_level off        # honest VM
+winpodx config set pod.disguise_level balanced   # default — free hiding
+winpodx config set pod.disguise_level max        # maximum hiding, slower
+winpodx pod recreate                             # regenerate compose + recreate the container (keeps your Windows disk)
 ```
 
-You can also toggle it in the GUI: **Settings → Bare-metal compatibility**. Either way it takes effect after a `winpodx pod recreate` (it edits the QEMU `-cpu` line; recreate keeps your Windows disk).
+You can also pick the level in the GUI: **Settings → Bare-metal compatibility**. Either way it takes effect after a `winpodx pod recreate` (it edits the QEMU `-cpu` line, the `HV` env, and the disk size; recreate keeps your Windows disk).
 
-When on, the guest's `-cpu` line clears the CPUID hypervisor-present bit (leaf 1, ECX bit 31 — the primary code-43 / launch-gate trigger) and drops the `KVMKVMKVM` signature + KVM paravirt leaves. Hyper-V performance enlightenments stay on (Windows keys those off a different leaf), so there is no measurable perf cost. The setting is tri-state — `false` opts out; absent or `true` is on.
+**Not an anti-cheat bypass.** This is signature-level VM hiding for casual detectors and VM-hostile apps (code 43, DRM/launch gates). It does **not** defeat kernel-mode anti-cheat (EAC / BattlEye / Vanguard) — those anchor on hardware attestation (TPM + Secure Boot) and VM-exit timing the guest can't spoof — and bypassing online-game anti-cheat violates the game's ToS.
+
+The disk bump is gated: the dockur disk is sparse, so a larger advertised size costs ~0 host space up front, but winpodx only raises it when the host has enough free space (keeping a 10 GiB / 10 % reserve). On a small host it leaves the disk as-is and logs a warning. The pre-0.6.x `disguise_hypervisor = false` key still works — it maps to `off`.
 
 > **This is not an anti-cheat bypass.** It is signature-level only and does **not** defeat kernel-mode anti-cheat (EAC / BattlEye / Vanguard). Bypassing anti-cheat in online games violates their terms of service and risks a ban — winpodx does not support that use.
 
@@ -302,7 +311,7 @@ idle_timeout = 0                                 # Seconds before auto-suspend (
 boot_timeout = 300                               # Seconds to wait for first-boot unattended install
 image = "docker.io/dockurr/windows:latest"       # Container image (override for air-gapped mirror)
 usb_live = true                                  # Hot-plug attached USB devices into the running guest (no restart) — see `winpodx device`
-# disguise_hypervisor = false                    # Bare-metal mode (hide KVM/QEMU hypervisor) is ON by default; set false to opt out — Nvidia code-43 / VM-hostile apps; not an anti-cheat bypass (#246)
+# disguise_level = "balanced"                    # Bare-metal mode: off | balanced (default, free hiding) | max (Hyper-V off, slower) — Nvidia code-43 / VM-hostile apps; not an anti-cheat bypass (#246)
 disk_size = "64G"                                # Virtual disk size passed to dockur (grows via `install grow-disk`)
 disk_autogrow = true                             # Auto-grow C: when it fills past the threshold (idle only)
 disk_autogrow_threshold_pct = 80                 # Used-% that triggers an auto-grow (50-99)

--- a/src/winpodx/cli/config_cmd.py
+++ b/src/winpodx/cli/config_cmd.py
@@ -5,8 +5,64 @@ from __future__ import annotations
 
 import argparse
 import sys
+from typing import Any
 
 from winpodx.core.i18n import tr
+
+# pod.* keys baked into compose.yaml that a plain recreate (container rm+create,
+# Windows disk preserved) is enough to apply — we do it automatically.
+_RECREATE_ON_CHANGE = frozenset(
+    {
+        "disguise_level",
+        "tuning_profile",
+        "cpu_cores",
+        "ram_gb",
+        "disk_size",
+        "vnc_port",
+        "image",
+    }
+)
+# Keys that only take effect on a *fresh* Windows install (first-boot unattend),
+# so a plain recreate won't reach the guest — needs --wipe-storage. We never
+# auto-wipe (destructive); just point the user at it.
+_WIPE_ON_CHANGE = frozenset({"win_version"})
+
+
+def _apply_compose_change(cfg: Any) -> None:
+    """Regenerate compose for *cfg* and apply it to the pod right away (#246).
+
+    Mirrors the GUI's Save behaviour and the migrate auto-recreate: regenerate
+    compose.yaml, and if the pod is running, recreate it now (stop+start;
+    container rm+create, Windows storage volume preserved, ~30s). If it's
+    stopped, the regenerated compose lands on the next ``pod start``. Best-effort
+    — never raises, so a failed apply can't lose the saved config value.
+    """
+    if cfg.pod.backend not in ("podman", "docker"):
+        return
+    try:
+        from winpodx.core.compose import generate_compose
+
+        generate_compose(cfg)
+    except Exception as e:  # noqa: BLE001
+        print(tr("  warning: could not regenerate compose ({error})").format(error=e))
+        return
+    try:
+        from winpodx.core.pod import PodState, pod_status, start_pod, stop_pod
+
+        running = pod_status(cfg).state == PodState.RUNNING
+    except Exception:  # noqa: BLE001
+        running = False
+    if not running:
+        print(tr("Saved — applies on the next 'winpodx pod start'."))
+        return
+    print(tr("Applying to the running container (recreate ~30s, storage preserved)..."))
+    try:
+        stop_pod(cfg)
+        start_pod(cfg)
+    except Exception as e:  # noqa: BLE001
+        print(
+            tr("  recreate failed ({error}); run 'winpodx pod recreate' to apply.").format(error=e)
+        )
 
 
 def handle_config(args: argparse.Namespace) -> None:
@@ -114,6 +170,18 @@ def _set(key: str, value: str | None, *, auto: bool = False) -> None:
         warning = check_session_budget(cfg)
         if warning:
             print(tr("WARNING: {warning}").format(warning=warning), file=sys.stderr)
+
+    # Apply compose-affecting changes immediately (no manual recreate needed),
+    # matching the GUI's Save behaviour.
+    if not auto and section == "pod" and field in _RECREATE_ON_CHANGE:
+        _apply_compose_change(cfg)
+    elif not auto and section == "pod" and field in _WIPE_ON_CHANGE:
+        print(
+            tr(
+                "Note: the Windows edition only changes on a fresh install — run "
+                "'winpodx pod recreate --wipe-storage' to apply (this wipes the guest)."
+            )
+        )
 
 
 def _resolve_auto_value(section: str, field: str) -> str | None:

--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -386,28 +386,36 @@ class PodConfig:
     # a plain ``/dev/bus/usb`` bind avoids that. Set False to keep the USB bus
     # out of the container (smaller surface; USB then only via the drive share).
     usb_live: bool = True
-    # Bare-metal compatibility mode (#246), tri-state, DEFAULT ON. Hides the
-    # KVM/QEMU hypervisor signature from the guest so software that refuses to
-    # run under a detected hypervisor works — primarily Nvidia GPU-passthrough
-    # "code 43" and apps with launch-gate VM checks. Clears the CPUID
-    # hypervisor-present bit + the KVM signature/paravirt leaves (see
-    # core/pod/compose.py). NOT for defeating kernel-mode anti-cheat (it can't,
-    # and bypassing online-game anti-cheat violates the game's ToS).
+    # Bare-metal compatibility mode (#246), 3 levels, DEFAULT "balanced". Hides
+    # the KVM/QEMU hypervisor from the guest so software that refuses to run
+    # under a detected hypervisor works — Nvidia GPU-passthrough "code 43",
+    # launch-gate VM checks, VM-hostile DRM. NOT for defeating kernel-mode
+    # anti-cheat (it can't, and bypassing online-game anti-cheat violates ToS).
     #
-    #   None  — key absent: use the default (ON). `disguise_active` resolves it.
-    #   True  — explicitly on.
-    #   False — explicitly off (opt out).
+    #   "off"      — no disguise (honest VM). Best performance + compatibility.
+    #   "balanced" — zero-perf-cost hiding: CPU flags + SMBIOS host mirror +
+    #                synthetic sensor blob + a real-looking disk size. DEFAULT.
+    #   "max"      — balanced + Hyper-V enlightenments off (HV=N) so the
+    #                al-khaser/Pafish Hyper-V checks pass, at a real perf cost.
+    #
+    # ``disguise_level`` is None when absent so __post_init__ can migrate the
+    # pre-0.6.x ``disguise_hypervisor`` bool (False -> off, True/None -> balanced).
+    disguise_level: str | None = None
+    # Legacy (pre-tier) toggle; kept only so an old config still maps. Coerced
+    # into ``disguise_level`` by __post_init__; new saves write disguise_level.
     disguise_hypervisor: bool | None = None
+
+    _DISGUISE_LEVELS = ("off", "balanced", "max")
 
     @property
     def disguise_active(self) -> bool:
-        """Resolve the tri-state ``disguise_hypervisor`` to on/off (#246).
+        """True when any disguise is on (balanced or max). #246."""
+        return self.disguise_level != "off"
 
-        Default ON: ``None`` (absent) and ``True`` enable the disguise; only an
-        explicit ``False`` opts out. Used by the compose generator and the GUI
-        toggle so both read the same rule.
-        """
-        return self.disguise_hypervisor is not False
+    @property
+    def disguise_max(self) -> bool:
+        """True only at the maximum-hide level (adds perf-costing knobs). #246."""
+        return self.disguise_level == "max"
 
     def __post_init__(self) -> None:
         if self.backend not in _VALID_BACKENDS:
@@ -423,10 +431,15 @@ class PodConfig:
         self.idle_timeout = max(0, int(self.idle_timeout))
         self.boot_timeout = max(30, min(3600, int(self.boot_timeout)))
         self.max_sessions = max(1, min(50, int(self.max_sessions)))
-        # disguise_hypervisor is tri-state (None = legacy/absent); coerce any
-        # hand-edited non-bool truthy/falsy value to a real bool, keep None.
-        if self.disguise_hypervisor is not None:
-            self.disguise_hypervisor = bool(self.disguise_hypervisor)
+        # Resolve disguise_level (#246, tiered). Prefer an explicit level; else
+        # migrate the legacy `disguise_hypervisor` bool (False->off,
+        # True/None->balanced); default "balanced". Keep the legacy bool mirrored
+        # so an older winpodx reading this config still behaves.
+        lvl = str(self.disguise_level).strip().lower() if self.disguise_level else ""
+        if lvl not in self._DISGUISE_LEVELS:
+            lvl = "off" if self.disguise_hypervisor is False else "balanced"
+        self.disguise_level = lvl
+        self.disguise_hypervisor = lvl != "off"
         if not isinstance(self.container_name, str) or not _CONTAINER_NAME_RE.match(
             self.container_name
         ):
@@ -841,6 +854,7 @@ class Config:
                 "initialized": self.pod.initialized,
                 "devices": list(self.pod.devices),
                 "usb_live": self.pod.usb_live,
+                "disguise_level": self.pod.disguise_level,
             },
             "reverse_open": {
                 "enabled": self.reverse_open.enabled,

--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -64,6 +64,7 @@ name: "winpodx"
       NETWORK: "user"
       CPU_FLAGS: "{cpu_flags}"
       VMX: "{vmx}"
+      HV: "{hv}"
       ARGUMENTS: "{qemu_arguments}"
       USER_PORTS: "{agent_port}"
     volumes:
@@ -579,6 +580,45 @@ def _write_disguise_smbios_blob(oem_dir: str) -> str | None:
         return None
 
 
+def _disguise_disk_size(cfg: Config) -> str:
+    """Effective ``DISK_SIZE`` for the compose, bumped to a bare-metal-looking
+    size when the disguise is active and the host can safely back it (#246).
+
+    al-khaser / Pafish flag a disk under ~128 GB as a VM tell. The dockur disk
+    is sparse, so a larger *ceiling* costs ~0 host space up front — but we still
+    gate on host headroom (via ``disk.effective_max_bytes``, which keeps the
+    10 GiB / 10 % reserve) so a runaway guest can never fill the host disk. When
+    the host can't reach the threshold, the size is left as-is and a warning is
+    logged (best-effort — the disk-size check then stays a VM tell).
+    """
+    cur = cfg.pod.disk_size
+    if not cfg.pod.disguise_active:
+        return cur
+    from winpodx.core.disk import DiskError, effective_max_bytes, format_size, parse_size
+
+    target = 128 * (1024**3)  # 128 GiB clears the al-khaser / Pafish thresholds
+    try:
+        cur_b = parse_size(cur)
+    except DiskError:
+        return cur
+    if cur_b >= target:
+        return cur  # already real-looking — never shrink the user's disk
+    cap = effective_max_bytes(cfg, cur_b)  # None = host-trusted / unbounded
+    want = target if cap is None else min(target, cap)
+    if want <= cur_b:
+        logging.getLogger(__name__).warning(
+            "disguise: not enough host free space to enlarge the %s disk to a "
+            "bare-metal-looking size; the disk-size VM check will not pass. Free "
+            "up host space or raise cfg.pod.disk_size to hide it.",
+            cur,
+        )
+        return cur
+    try:
+        return format_size(want)
+    except DiskError:
+        return cur
+
+
 def _build_compose_content(cfg: Config) -> str:
     """Build and return compose YAML content string for *cfg*."""
     password = cfg.rdp.password or generate_password()
@@ -602,12 +642,18 @@ def _build_compose_content(cfg: Config) -> str:
     # arbitrary env keys into the dockur service. Defense in depth:
     # PodConfig.__post_init__ also rejects these characters, but the
     # escape here is the last line of defence on the YAML boundary.
+    # Hyper-V enlightenments: dockur's default is HV=Y (the #215/#281 perf
+    # tuning). The "max" disguise level drops them (HV=N) so the al-khaser /
+    # Pafish Hyper-V checks pass, at a real Windows-on-KVM performance cost.
+    hv = "N" if cfg.pod.disguise_max else "Y"
+
     return template.format(
         ram=cfg.pod.ram_gb,
         cpu=cfg.pod.cpu_cores,
         container_name=_yaml_escape(cfg.pod.container_name),
         image=_yaml_escape(cfg.pod.image),
-        disk_size=_yaml_escape(cfg.pod.disk_size),
+        disk_size=_yaml_escape(_disguise_disk_size(cfg)),
+        hv=hv,
         user=_yaml_escape(cfg.rdp.user),
         password=_yaml_escape(password),
         home=str(Path.home()),

--- a/src/winpodx/core/pod/smbios.py
+++ b/src/winpodx/core/pod/smbios.py
@@ -9,8 +9,8 @@ corresponding ``Win32_*`` / ``CIM_*`` WMI classes, not live readings, so static
 descriptor structures with nominal/unknown values are enough to satisfy them.
 
 This module builds a small binary SMBIOS structure table (types 26 / 28 / 27 /
-7 / 9 / 8 / 16 / 17 / 11) with **synthetic** values — no host serials or live
-sensor data are read, so nothing machine-identifying is produced. The blob is
+7 / 9 / 8 / 16 / 17 / 6 / 11) with **synthetic** values — no host serials or
+live sensor data are read, so nothing machine-identifying is produced. The blob is
 written to the OEM dir (mounted into the container) and passed to QEMU via
 ``-smbios file=``. Types 16 / 17 add the physical-memory-array / memory-device
 descriptors (``Win32_PhysicalMemory`` existence); type 11 adds a benign OEM
@@ -34,6 +34,7 @@ _H_SLOT = 0x0900
 _H_PORT = 0x0800
 _H_MEMARRAY = 0x1000
 _H_MEMDEV = 0x1100
+_H_MEMMOD = 0x0600
 _H_OEMSTR = 0x0B00
 
 _UNKNOWN_W = 0x8000  # SMBIOS "unknown" sentinel for WORD probe values
@@ -160,6 +161,20 @@ def build_disguise_smbios_blob() -> bytes:
             ["DIMM 0", "BANK 0", "Generic", "00000000", "Not Specified", "Generic Module"],
         )
     )
+
+    # Type 6 — Memory Module Information (obsolete, pre-type-17). Best-effort
+    # for the Win32_MemoryDevice WMI existence check, which type 17 alone does
+    # not populate. Synthetic single module, 16 GB, socket "A0".
+    mem_mod = (
+        bytes([1])  # socket designation (string 1)
+        + bytes([0xFF])  # bank connections: none
+        + bytes([0x00])  # current speed: unknown
+        + _w(0x0080)  # current memory type: bit7 (DIMM)
+        + bytes([0x0E])  # installed size: 2^14 MB = 16 GB (bit7=0 single bank)
+        + bytes([0x0E])  # enabled size: 16 GB
+        + bytes([0x00])  # error status: none
+    )
+    parts.append(_structure(6, _H_MEMMOD, mem_mod, ["A0"]))
 
     # Type 11 — OEM Strings. Real boards expose a type-11 structure; QEMU often
     # omits it. A single benign "Default string" (what most retail boards ship)

--- a/src/winpodx/gui/_main_window_settings.py
+++ b/src/winpodx/gui/_main_window_settings.py
@@ -607,11 +607,9 @@ class SettingsPageMixin:
 
         # Bare-metal compatibility (#246) — hide the KVM/QEMU hypervisor so GPU
         # passthrough (Nvidia code 43) and apps that refuse to run in a VM work.
-        # Default ON. Save-Settings-scoped: it changes the QEMU `-cpu` line, so a
-        # pod recreate applies it (handled in _save_settings, like the tuning
-        # profile). The checkbox reads/writes the tri-state via disguise_active.
-        from PySide6.QtWidgets import QCheckBox as _QCheckBox
-
+        # 3 levels (off / balanced / max), default balanced. Save-Settings-scoped:
+        # it changes the QEMU `-cpu` line / HV env / disk size, so a pod recreate
+        # applies it (handled in _save_settings, like the tuning profile).
         disguise_card, disguise_layout = self._settings_card_shell(
             "hardware",
             tr("Bare-metal compatibility"),
@@ -620,12 +618,18 @@ class SettingsPageMixin:
                 "apps that refuse to run in a VM work. Not an anti-cheat bypass."
             ),
         )
-        self.checkbox_disguise = _QCheckBox(
-            tr("Present the guest as a bare-metal PC (hide the hypervisor)")
-        )
-        self.checkbox_disguise.setChecked(self.cfg.pod.disguise_active)
-        self.checkbox_disguise.setStyleSheet(CHECKBOX)
-        disguise_layout.addWidget(self.checkbox_disguise)
+        self.input_disguise_level = QComboBox()
+        for label, value in (
+            (tr("Standard VM — no hiding (best performance)"), "off"),
+            (tr("Balanced — hide the hypervisor, no performance cost (recommended)"), "balanced"),
+            (tr("Hardened — maximum hiding, slower (Hyper-V off)"), "max"),
+        ):
+            self.input_disguise_level.addItem(label, value)
+        _dl_idx = self.input_disguise_level.findData(self.cfg.pod.disguise_level)
+        if _dl_idx >= 0:
+            self.input_disguise_level.setCurrentIndex(_dl_idx)
+        self.input_disguise_level.setStyleSheet(COMBO)
+        disguise_layout.addWidget(self.input_disguise_level)
         layout.addWidget(disguise_card)
 
         # Reverse-open (#48) — Linux apps in the Windows guest's right-
@@ -1230,9 +1234,8 @@ class SettingsPageMixin:
         new_keyboard = self.input_keyboard.currentData() or ""
         new_timezone = self.input_timezone.currentData() or ""
         new_tuning_profile = self.input_tuning_profile.currentData() or "auto"
-        # Bare-metal disguise (#246) — the 2-state checkbox collapses the
-        # tri-state to an explicit bool on save (checked = on, unchecked = off).
-        new_disguise = bool(self.checkbox_disguise.isChecked())
+        # Bare-metal disguise (#246) — 3-level selector (off / balanced / max).
+        new_disguise_level = self.input_disguise_level.currentData() or "balanced"
 
         old_cfg = Config.load()
         # ``needs_container`` is true when any first-boot env knob is
@@ -1255,10 +1258,10 @@ class SettingsPageMixin:
             # the new -cpu sub-options (+vmx/+svm, hv-*, +invtsc) and
             # -device args (virtio-rng-pci).
             or new_tuning_profile != old_cfg.pod.tuning_profile
-            # #246: the hypervisor disguise toggles `-cpu` sub-flags
-            # (-hypervisor / kvm=off / -kvm-pv-*) in CPU_FLAGS, so a container
-            # recreate is required to pick up the change.
-            or new_disguise != old_cfg.pod.disguise_active
+            # #246: the disguise level changes CPU_FLAGS (-hypervisor / kvm=off),
+            # the SMBIOS args, the HV env, and the disk size in compose.yaml, so
+            # a container recreate is required to pick up the change.
+            or new_disguise_level != old_cfg.pod.disguise_level
         )
         needs_wipe = (
             new_win_version != old_cfg.pod.win_version
@@ -1287,7 +1290,7 @@ class SettingsPageMixin:
         self.cfg.pod.keyboard = new_keyboard
         self.cfg.pod.timezone = new_timezone
         self.cfg.pod.tuning_profile = new_tuning_profile
-        self.cfg.pod.disguise_hypervisor = new_disguise
+        self.cfg.pod.disguise_level = new_disguise_level
         # Let __post_init__ clamp max_sessions to [1, 50] before save.
         self.cfg.pod.__post_init__()
         self.cfg.save()

--- a/src/winpodx/locale/de.json
+++ b/src/winpodx/locale/de.json
@@ -1,7 +1,6 @@
 {
   "Bare-metal compatibility": "Bare-Metal-Kompatibilität",
   "Hide the KVM/QEMU hypervisor so GPU passthrough (Nvidia code 43) and apps that refuse to run in a VM work. Not an anti-cheat bypass.": "Versteckt den KVM/QEMU-Hypervisor, damit GPU-Passthrough (Nvidia-Code 43) und Apps funktionieren, die in einer VM nicht laufen. Kein Anti-Cheat-Bypass.",
-  "Present the guest as a bare-metal PC (hide the hypervisor)": "Den Gast als Bare-Metal-PC darstellen (Hypervisor verstecken)",
   "\n  Could not start pod: {error}": "\n  Pod konnte nicht gestartet werden: {error}",
   "\n  Discovery failed: {error}": "\n  Erkennung fehlgeschlagen: {error}",
   "\n  Discovery unavailable in this build. Skipping.": "\n  Erkennung in diesem Build nicht verfügbar. Wird übersprungen.",
@@ -873,5 +872,13 @@
   "Distro package:": "Distributionspaket:",
   "(Your distro may not package PySide6 for apt — use the AppImage above.)": "(Ihre Distribution stellt PySide6 möglicherweise nicht für apt bereit – verwenden Sie das AppImage oben.)",
   "Setting up Windows (first run)…": "Windows wird eingerichtet (erster Start)…",
-  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "Windows wird heruntergeladen und installiert — das kann 20–40 Minuten dauern. Den Fortschritt können Sie unter http://127.0.0.1:8006 verfolgen"
+  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "Windows wird heruntergeladen und installiert — das kann 20–40 Minuten dauern. Den Fortschritt können Sie unter http://127.0.0.1:8006 verfolgen",
+  "Standard VM — no hiding (best performance)": "Standard-VM — keine Tarnung (beste Leistung)",
+  "Balanced — hide the hypervisor, no performance cost (recommended)": "Ausgewogen — Hypervisor verbergen, ohne Leistungseinbußen (empfohlen)",
+  "Hardened — maximum hiding, slower (Hyper-V off)": "Gehärtet — maximale Tarnung, langsamer (Hyper-V aus)",
+  "Saved — applies on the next 'winpodx pod start'.": "Gespeichert — wird beim nächsten 'winpodx pod start' angewendet.",
+  "Applying to the running container (recreate ~30s, storage preserved)...": "Wird auf den laufenden Container angewendet (Recreate ~30s, Speicher bleibt erhalten)...",
+  "  warning: could not regenerate compose ({error})": "  Warnung: compose konnte nicht neu erzeugt werden ({error})",
+  "  recreate failed ({error}); run 'winpodx pod recreate' to apply.": "  Recreate fehlgeschlagen ({error}); führen Sie 'winpodx pod recreate' aus, um anzuwenden.",
+  "Note: the Windows edition only changes on a fresh install — run 'winpodx pod recreate --wipe-storage' to apply (this wipes the guest).": "Hinweis: Die Windows-Edition ändert sich nur bei einer Neuinstallation — führen Sie 'winpodx pod recreate --wipe-storage' aus (löscht den Gast)."
 }

--- a/src/winpodx/locale/fr.json
+++ b/src/winpodx/locale/fr.json
@@ -1,7 +1,6 @@
 {
   "Bare-metal compatibility": "Compatibilité bare-metal",
   "Hide the KVM/QEMU hypervisor so GPU passthrough (Nvidia code 43) and apps that refuse to run in a VM work. Not an anti-cheat bypass.": "Masque l'hyperviseur KVM/QEMU pour que le passthrough GPU (code 43 Nvidia) et les applis qui refusent de tourner dans une VM fonctionnent. Pas un contournement d'anti-triche.",
-  "Present the guest as a bare-metal PC (hide the hypervisor)": "Présenter l'invité comme un PC bare-metal (masquer l'hyperviseur)",
   "\n  Could not start pod: {error}": "\n  Impossible de démarrer le pod : {error}",
   "\n  Discovery failed: {error}": "\n  Échec de la découverte : {error}",
   "\n  Discovery unavailable in this build. Skipping.": "\n  Découverte indisponible dans cette version. Ignorée.",
@@ -873,5 +872,13 @@
   "Distro package:": "Paquet de la distribution :",
   "(Your distro may not package PySide6 for apt — use the AppImage above.)": "(Votre distribution ne fournit peut-être pas PySide6 pour apt — utilisez l'AppImage ci-dessus.)",
   "Setting up Windows (first run)…": "Configuration de Windows (premier lancement)…",
-  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "Téléchargement et installation de Windows — cela peut prendre 20 à 40 minutes. Vous pouvez suivre la progression sur http://127.0.0.1:8006"
+  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "Téléchargement et installation de Windows — cela peut prendre 20 à 40 minutes. Vous pouvez suivre la progression sur http://127.0.0.1:8006",
+  "Standard VM — no hiding (best performance)": "VM standard — aucune dissimulation (meilleures performances)",
+  "Balanced — hide the hypervisor, no performance cost (recommended)": "Équilibré — masquer l'hyperviseur, sans perte de performance (recommandé)",
+  "Hardened — maximum hiding, slower (Hyper-V off)": "Renforcé — dissimulation maximale, plus lent (Hyper-V désactivé)",
+  "Saved — applies on the next 'winpodx pod start'.": "Enregistré — sera appliqué au prochain 'winpodx pod start'.",
+  "Applying to the running container (recreate ~30s, storage preserved)...": "Application au conteneur en cours d'exécution (recreate ~30s, stockage conservé)...",
+  "  warning: could not regenerate compose ({error})": "  avertissement : impossible de régénérer compose ({error})",
+  "  recreate failed ({error}); run 'winpodx pod recreate' to apply.": "  échec du recreate ({error}) ; exécutez 'winpodx pod recreate' pour appliquer.",
+  "Note: the Windows edition only changes on a fresh install — run 'winpodx pod recreate --wipe-storage' to apply (this wipes the guest).": "Remarque : l'édition de Windows ne change que lors d'une nouvelle installation — exécutez 'winpodx pod recreate --wipe-storage' pour appliquer (cela efface l'invité)."
 }

--- a/src/winpodx/locale/it.json
+++ b/src/winpodx/locale/it.json
@@ -1,7 +1,6 @@
 {
   "Bare-metal compatibility": "Compatibilità bare-metal",
   "Hide the KVM/QEMU hypervisor so GPU passthrough (Nvidia code 43) and apps that refuse to run in a VM work. Not an anti-cheat bypass.": "Nasconde l'hypervisor KVM/QEMU così funzionano il passthrough GPU (codice 43 Nvidia) e le app che rifiutano di girare in una VM. Non è un bypass anti-cheat.",
-  "Present the guest as a bare-metal PC (hide the hypervisor)": "Presenta il guest come un PC bare-metal (nascondi l'hypervisor)",
   "\n  Could not start pod: {error}": "\n  Impossibile avviare il pod: {error}",
   "\n  Discovery failed: {error}": "\n  Rilevamento non riuscito: {error}",
   "\n  Discovery unavailable in this build. Skipping.": "\n  Rilevamento non disponibile in questa build. Ignorato.",
@@ -873,5 +872,13 @@
   "Distro package:": "Pacchetto della distribuzione:",
   "(Your distro may not package PySide6 for apt — use the AppImage above.)": "(La tua distribuzione potrebbe non fornire PySide6 per apt — usa l'AppImage sopra.)",
   "Setting up Windows (first run)…": "Configurazione di Windows (primo avvio)…",
-  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "Download e installazione di Windows — può richiedere 20–40 minuti. Puoi seguire l'avanzamento su http://127.0.0.1:8006"
+  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "Download e installazione di Windows — può richiedere 20–40 minuti. Puoi seguire l'avanzamento su http://127.0.0.1:8006",
+  "Standard VM — no hiding (best performance)": "VM standard — nessun occultamento (prestazioni migliori)",
+  "Balanced — hide the hypervisor, no performance cost (recommended)": "Bilanciato — nascondi l'hypervisor, senza perdita di prestazioni (consigliato)",
+  "Hardened — maximum hiding, slower (Hyper-V off)": "Rafforzato — occultamento massimo, più lento (Hyper-V disattivato)",
+  "Saved — applies on the next 'winpodx pod start'.": "Salvato — verrà applicato al prossimo 'winpodx pod start'.",
+  "Applying to the running container (recreate ~30s, storage preserved)...": "Applicazione al container in esecuzione (recreate ~30s, archiviazione conservata)...",
+  "  warning: could not regenerate compose ({error})": "  avviso: impossibile rigenerare compose ({error})",
+  "  recreate failed ({error}); run 'winpodx pod recreate' to apply.": "  recreate non riuscito ({error}); esegui 'winpodx pod recreate' per applicare.",
+  "Note: the Windows edition only changes on a fresh install — run 'winpodx pod recreate --wipe-storage' to apply (this wipes the guest).": "Nota: l'edizione di Windows cambia solo con un'installazione pulita — esegui 'winpodx pod recreate --wipe-storage' per applicare (cancella il guest)."
 }

--- a/src/winpodx/locale/ja.json
+++ b/src/winpodx/locale/ja.json
@@ -1,7 +1,6 @@
 {
   "Bare-metal compatibility": "ベアメタル互換モード",
   "Hide the KVM/QEMU hypervisor so GPU passthrough (Nvidia code 43) and apps that refuse to run in a VM work. Not an anti-cheat bypass.": "KVM/QEMU ハイパーバイザーを隠して、GPU パススルー（Nvidia コード43）や VM での実行を拒否するアプリを動作させます。アンチチート回避ではありません。",
-  "Present the guest as a bare-metal PC (hide the hypervisor)": "ゲストをベアメタル PC として見せる（ハイパーバイザーを隠す）",
   "\n  Could not start pod: {error}": "\n  pod を起動できませんでした: {error}",
   "\n  Discovery failed: {error}": "\n  検出に失敗しました: {error}",
   "\n  Discovery unavailable in this build. Skipping.": "\n  このビルドでは検出を利用できません。スキップします。",
@@ -873,5 +872,13 @@
   "Distro package:": "ディストリのパッケージ:",
   "(Your distro may not package PySide6 for apt — use the AppImage above.)": "(お使いのディストリでは apt 用の PySide6 が提供されていない場合があります — 上記の AppImage を使用してください。)",
   "Setting up Windows (first run)…": "Windows をセットアップ中 (初回)…",
-  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "Windows をダウンロードしてインストールしています — 20〜40分ほどかかる場合があります。http://127.0.0.1:8006 で進行状況を確認できます"
+  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "Windows をダウンロードしてインストールしています — 20〜40分ほどかかる場合があります。http://127.0.0.1:8006 で進行状況を確認できます",
+  "Standard VM — no hiding (best performance)": "標準 VM — 隠蔽なし (最高性能)",
+  "Balanced — hide the hypervisor, no performance cost (recommended)": "バランス — ハイパーバイザーを隠蔽、性能低下なし (推奨)",
+  "Hardened — maximum hiding, slower (Hyper-V off)": "強化 — 最大限の隠蔽、低速 (Hyper-V オフ)",
+  "Saved — applies on the next 'winpodx pod start'.": "保存しました — 次回の 'winpodx pod start' で適用されます。",
+  "Applying to the running container (recreate ~30s, storage preserved)...": "実行中のコンテナに適用しています (recreate 約30秒、ストレージは保持)...",
+  "  warning: could not regenerate compose ({error})": "  警告: compose の再生成に失敗しました ({error})",
+  "  recreate failed ({error}); run 'winpodx pod recreate' to apply.": "  recreate に失敗しました ({error})。適用するには 'winpodx pod recreate' を実行してください。",
+  "Note: the Windows edition only changes on a fresh install — run 'winpodx pod recreate --wipe-storage' to apply (this wipes the guest).": "注意: Windows エディションは新規インストール時のみ変更されます — 適用するには 'winpodx pod recreate --wipe-storage' を実行してください (ゲストは消去されます)。"
 }

--- a/src/winpodx/locale/ko.json
+++ b/src/winpodx/locale/ko.json
@@ -1,7 +1,6 @@
 {
   "Bare-metal compatibility": "베어메탈 호환",
   "Hide the KVM/QEMU hypervisor so GPU passthrough (Nvidia code 43) and apps that refuse to run in a VM work. Not an anti-cheat bypass.": "KVM/QEMU 하이퍼바이저를 숨겨 GPU 패스스루(Nvidia 코드 43)와 VM 실행을 거부하는 앱이 동작하게 합니다. 안티치트 우회가 아닙니다.",
-  "Present the guest as a bare-metal PC (hide the hypervisor)": "게스트를 베어메탈 PC로 표시 (하이퍼바이저 숨김)",
   "\n  Could not start pod: {error}": "\n  pod을 시작할 수 없습니다: {error}",
   "\n  Discovery failed: {error}": "\n  탐색에 실패했습니다: {error}",
   "\n  Discovery unavailable in this build. Skipping.": "\n  이 빌드에서는 탐색을 사용할 수 없습니다. 건너뜁니다.",
@@ -873,5 +872,13 @@
   "Distro package:": "배포판 패키지:",
   "(Your distro may not package PySide6 for apt — use the AppImage above.)": "(사용 중인 배포판이 apt용 PySide6를 제공하지 않을 수 있습니다 — 위의 AppImage를 사용하세요.)",
   "Setting up Windows (first run)…": "Windows 설정 중 (첫 실행)…",
-  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "Windows를 다운로드하고 설치하는 중입니다 — 20~40분 정도 걸릴 수 있습니다. http://127.0.0.1:8006 에서 진행 상황을 볼 수 있습니다"
+  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "Windows를 다운로드하고 설치하는 중입니다 — 20~40분 정도 걸릴 수 있습니다. http://127.0.0.1:8006 에서 진행 상황을 볼 수 있습니다",
+  "Standard VM — no hiding (best performance)": "표준 VM — 숨김 없음 (최고 성능)",
+  "Balanced — hide the hypervisor, no performance cost (recommended)": "균형 — 하이퍼바이저 숨김, 성능 손실 없음 (권장)",
+  "Hardened — maximum hiding, slower (Hyper-V off)": "강화 — 최대 숨김, 느려짐 (Hyper-V 끔)",
+  "Saved — applies on the next 'winpodx pod start'.": "저장됨 — 다음 'winpodx pod start' 에서 적용됩니다.",
+  "Applying to the running container (recreate ~30s, storage preserved)...": "실행 중인 컨테이너에 적용 중 (recreate ~30초, 저장소 유지)...",
+  "  warning: could not regenerate compose ({error})": "  경고: compose 재생성 실패 ({error})",
+  "  recreate failed ({error}); run 'winpodx pod recreate' to apply.": "  recreate 실패 ({error}); 적용하려면 'winpodx pod recreate' 를 실행하세요.",
+  "Note: the Windows edition only changes on a fresh install — run 'winpodx pod recreate --wipe-storage' to apply (this wipes the guest).": "참고: Windows 에디션은 새 설치에서만 바뀝니다 — 적용하려면 'winpodx pod recreate --wipe-storage' 를 실행하세요 (게스트가 초기화됩니다)."
 }

--- a/src/winpodx/locale/zh.json
+++ b/src/winpodx/locale/zh.json
@@ -1,7 +1,6 @@
 {
   "Bare-metal compatibility": "裸机兼容模式",
   "Hide the KVM/QEMU hypervisor so GPU passthrough (Nvidia code 43) and apps that refuse to run in a VM work. Not an anti-cheat bypass.": "隐藏 KVM/QEMU 虚拟机管理程序，使 GPU 直通（Nvidia 代码 43）和拒绝在虚拟机中运行的应用可用。这不是反作弊绕过。",
-  "Present the guest as a bare-metal PC (hide the hypervisor)": "将客户机呈现为裸机 PC（隐藏虚拟机管理程序）",
   "\n  Could not start pod: {error}": "\n  无法启动 pod：{error}",
   "\n  Discovery failed: {error}": "\n  发现失败：{error}",
   "\n  Discovery unavailable in this build. Skipping.": "\n  此版本不支持应用发现。已跳过。",
@@ -873,5 +872,13 @@
   "Distro package:": "发行版软件包：",
   "(Your distro may not package PySide6 for apt — use the AppImage above.)": "（你的发行版可能没有为 apt 提供 PySide6 —— 请使用上面的 AppImage。）",
   "Setting up Windows (first run)…": "正在设置 Windows（首次运行）…",
-  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "正在下载并安装 Windows —— 这可能需要 20–40 分钟。你可以在 http://127.0.0.1:8006 查看进度"
+  "Downloading and installing Windows — this can take 20–40 minutes. You can watch progress at http://127.0.0.1:8006": "正在下载并安装 Windows —— 这可能需要 20–40 分钟。你可以在 http://127.0.0.1:8006 查看进度",
+  "Standard VM — no hiding (best performance)": "标准 VM — 不隐藏（性能最佳）",
+  "Balanced — hide the hypervisor, no performance cost (recommended)": "均衡 — 隐藏虚拟机监控程序，无性能损失（推荐）",
+  "Hardened — maximum hiding, slower (Hyper-V off)": "强化 — 最大程度隐藏，较慢（关闭 Hyper-V）",
+  "Saved — applies on the next 'winpodx pod start'.": "已保存 —— 将在下次 'winpodx pod start' 时应用。",
+  "Applying to the running container (recreate ~30s, storage preserved)...": "正在应用到运行中的容器（recreate 约 30 秒，存储保留）...",
+  "  warning: could not regenerate compose ({error})": "  警告：无法重新生成 compose（{error}）",
+  "  recreate failed ({error}); run 'winpodx pod recreate' to apply.": "  recreate 失败（{error}）；运行 'winpodx pod recreate' 以应用。",
+  "Note: the Windows edition only changes on a fresh install — run 'winpodx pod recreate --wipe-storage' to apply (this wipes the guest).": "注意：Windows 版本仅在全新安装时更改 —— 运行 'winpodx pod recreate --wipe-storage' 以应用（这会清除来宾系统）。"
 }

--- a/tests/test_compose_arch.py
+++ b/tests/test_compose_arch.py
@@ -55,8 +55,8 @@ def _cfg() -> Config:
     cfg.pod.tuning_profile = "off"
     # Likewise isolate from the default-ON hypervisor disguise (#246) — the
     # arch/tuning tests assert an exact CPU_FLAGS string. The disguise tests
-    # below set it explicitly.
-    cfg.pod.disguise_hypervisor = False
+    # below set the level explicitly.
+    cfg.pod.disguise_level = "off"
     return cfg
 
 
@@ -133,41 +133,87 @@ _DISGUISE_FLAGS = (
 
 
 def test_compose_disguise_on_by_default(monkeypatch):
-    """disguise_hypervisor=None (absent) defaults ON — emits the disguise flags."""
+    """disguise_level=None (absent) resolves to balanced — emits the flags."""
     monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
     cfg = _cfg()
-    cfg.pod.disguise_hypervisor = None  # the real default (absent key)
+    cfg.pod.disguise_level = None  # the real default (absent key)
+    cfg.pod.__post_init__()  # re-resolve: None -> "balanced"
+    cfg.pod.storage_path = ""  # named-volume mode → host-trusted disk bump
+    assert cfg.pod.disguise_level == "balanced"
     assert cfg.pod.disguise_active is True
     content = _build_compose_content(cfg)
     for flag in _DISGUISE_FLAGS:
         assert flag in content, f"disguise flag {flag!r} missing (default ON)"
     # hv-vendor-id was deliberately dropped (collides with dockur hv flags).
     assert "hv-vendor-id" not in content
+    # balanced keeps Hyper-V on (perf); the disk is bumped to a real size.
+    assert 'HV: "Y"' in content
+    assert 'DISK_SIZE: "128G"' in content
 
 
-def test_compose_disguise_explicit_true(monkeypatch):
-    """disguise_hypervisor=True emits the same flags as the default."""
+def test_compose_disguise_legacy_bool_false_maps_to_off(monkeypatch):
+    """A pre-tier config (disguise_hypervisor=False) migrates to level off."""
+    monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
+    cfg = _cfg()
+    cfg.pod.disguise_level = None
+    cfg.pod.disguise_hypervisor = False
+    cfg.pod.__post_init__()
+    assert cfg.pod.disguise_level == "off"
+
+
+def test_compose_disguise_balanced(monkeypatch):
+    """level=balanced emits the disguise flags, keeps HV=Y."""
     monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
     cfg = _cfg()
-    cfg.pod.disguise_hypervisor = True
+    cfg.pod.disguise_level = "balanced"
     content = _build_compose_content(cfg)
     for flag in _DISGUISE_FLAGS:
         assert flag in content, f"disguise flag {flag!r} missing from compose"
     assert "hv-vendor-id" not in content
+    assert 'HV: "Y"' in content
 
 
-def test_compose_disguise_explicit_false_opts_out(monkeypatch):
-    """disguise_hypervisor=False (explicit opt-out) emits no disguise flags."""
+def test_compose_disguise_max_disables_hyperv(monkeypatch):
+    """level=max emits the disguise flags AND drops Hyper-V (HV=N)."""
     monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
     cfg = _cfg()
-    cfg.pod.disguise_hypervisor = False
+    cfg.pod.disguise_level = "max"
+    content = _build_compose_content(cfg)
+    for flag in _DISGUISE_FLAGS:
+        assert flag in content
+    assert 'HV: "N"' in content  # the max-only Hyper-V opt-out
+
+
+def test_compose_disguise_disk_not_bumped_when_host_small(monkeypatch):
+    """A host with no headroom leaves the disk as-is (warn, no bump) — #246."""
+    monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
+    import winpodx.core.disk as _disk
+
+    # effective_max_bytes == current bytes → no headroom → must not bump.
+    monkeypatch.setattr(_disk, "effective_max_bytes", lambda cfg, cur: cur)
+    cfg = _cfg()
+    cfg.pod.disguise_level = "balanced"
+    cfg.pod.disk_size = "64G"
+    cfg.pod.storage_path = "/some/path"  # non-empty → effective_max_bytes consulted
+    content = _build_compose_content(cfg)
+    assert 'DISK_SIZE: "64G"' in content  # left as-is, not enlarged
+
+
+def test_compose_disguise_off_opts_out(monkeypatch):
+    """level=off emits no disguise flags, keeps HV=Y and the user's disk."""
+    monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
+    cfg = _cfg()  # _cfg() sets disguise_level = "off"
     assert cfg.pod.disguise_active is False
     content = _build_compose_content(cfg)
     assert "-hypervisor" not in content
     assert "kvm=off" not in content
+    assert 'HV: "Y"' in content
+    assert 'DISK_SIZE: "64G"' in content  # off never bumps the disk
 
 
 def test_compose_disguise_smbios_mirrors_host_dmi(monkeypatch):
@@ -187,7 +233,7 @@ def test_compose_disguise_smbios_mirrors_host_dmi(monkeypatch):
     }
     monkeypatch.setattr(_compose_module, "_host_dmi_field", lambda n: dmi.get(n))
     cfg = _cfg()
-    cfg.pod.disguise_hypervisor = None  # default ON
+    cfg.pod.disguise_level = "balanced"
     content = _build_compose_content(cfg)
     assert "type=1,manufacturer=ACME,product=MDL-9000" in content
     assert "type=0,vendor=ACME,version=BIOS-1.0,date=01/01/2020" in content
@@ -208,7 +254,7 @@ def test_compose_disguise_smbios_skips_unsafe_dmi(monkeypatch):
 
     monkeypatch.setattr(_compose_module, "_host_dmi_field", fake)
     cfg = _cfg()
-    cfg.pod.disguise_hypervisor = True
+    cfg.pod.disguise_level = "balanced"
     content = _build_compose_content(cfg)
     assert "manufacturer=ACME" in content  # safe vendor kept
     assert "Generic Model 9000" not in content  # spaced product dropped
@@ -219,7 +265,7 @@ def test_compose_disguise_off_emits_no_smbios(monkeypatch):
     monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(_compose_module, "_host_dmi_field", lambda n: "ACME")
-    cfg = _cfg()  # _cfg() sets disguise_hypervisor = False
+    cfg = _cfg()  # _cfg() sets disguise_level = "off"
     content = _build_compose_content(cfg)
     assert "-smbios" not in content
 

--- a/tests/test_config_set_auto.py
+++ b/tests/test_config_set_auto.py
@@ -69,3 +69,53 @@ class TestSetAuto:
             _set("pod.timezone", value=None, auto=False)
         assert exc.value.code == 1
         assert "Either pass a positional value or --auto" in capsys.readouterr().out
+
+
+class TestApplyComposeChange:
+    """`config set` of a compose-affecting key auto-applies it (#246)."""
+
+    def _seed(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        cfg = Config()
+        cfg.pod.backend = "podman"
+        cfg.save()
+
+    def _stub_pod(self, monkeypatch, *, running: bool):
+        import winpodx.core.compose as _compose
+        import winpodx.core.pod as _pod
+
+        monkeypatch.setattr(_compose, "generate_compose", lambda c: None)
+        state = _pod.PodState.RUNNING if running else _pod.PodState.STOPPED
+        monkeypatch.setattr(_pod, "pod_status", lambda c: type("S", (), {"state": state})())
+        calls = {"stop": 0, "start": 0}
+        monkeypatch.setattr(
+            _pod, "stop_pod", lambda c: calls.__setitem__("stop", calls["stop"] + 1)
+        )
+        monkeypatch.setattr(
+            _pod, "start_pod", lambda c: calls.__setitem__("start", calls["start"] + 1)
+        )
+        return calls
+
+    def test_disguise_level_recreates_when_running(self, tmp_path, monkeypatch, capsys):
+        self._seed(tmp_path, monkeypatch)
+        calls = self._stub_pod(monkeypatch, running=True)
+        _set("pod.disguise_level", value="max", auto=False)
+        out = capsys.readouterr().out
+        assert "Set pod.disguise_level = max" in out
+        assert calls == {"stop": 1, "start": 1}  # recreated now
+        assert Config.load().pod.disguise_level == "max"
+
+    def test_disguise_level_defers_when_stopped(self, tmp_path, monkeypatch, capsys):
+        self._seed(tmp_path, monkeypatch)
+        calls = self._stub_pod(monkeypatch, running=False)
+        _set("pod.disguise_level", value="off", auto=False)
+        out = capsys.readouterr().out
+        assert "applies on the next" in out
+        assert calls == {"stop": 0, "start": 0}  # not running → no recreate
+        assert Config.load().pod.disguise_level == "off"
+
+    def test_non_compose_key_does_not_recreate(self, tmp_path, monkeypatch, capsys):
+        self._seed(tmp_path, monkeypatch)
+        calls = self._stub_pod(monkeypatch, running=True)
+        _set("pod.auto_start", value="true", auto=False)
+        assert calls == {"stop": 0, "start": 0}  # not a compose key

--- a/tests/test_smbios.py
+++ b/tests/test_smbios.py
@@ -29,9 +29,9 @@ def test_blob_builds_and_validates():
 def test_blob_contains_sensor_descriptor_types():
     # The types al-khaser checks for existence: voltage(26), temperature(28),
     # cooling(27), cache(7), slot(9), port connector(8), physical memory
-    # array(16), memory device(17), OEM strings(11).
+    # array(16), memory device(17), memory module(6), OEM strings(11).
     types = _walk_types(build_disguise_smbios_blob())
-    for t in (26, 28, 27, 7, 9, 8, 16, 17, 11):
+    for t in (26, 28, 27, 7, 9, 8, 16, 17, 6, 11):
         assert t in types, f"missing SMBIOS type {t}"
 
 


### PR DESCRIPTION
Turn the bare-metal disguise (#246) into a 3-level setting and make every change auto-apply.

## Levels (`cfg.pod.disguise_level`, default `balanced`)
| Level | Does | Performance |
|-------|------|-------------|
| `off` | No disguise — honest VM. | Best / most compatible |
| `balanced` (default) | CPU flags + SMBIOS host mirror + synthetic sensor blob + **SMBIOS type 6 (Win32_MemoryDevice)** + **bare-metal-looking disk size**. | No measurable cost |
| `max` | balanced + **Hyper-V enlightenments off (`HV=N`)** so the al-khaser / Pafish Hyper-V checks pass. | Slower (loses Windows-on-KVM timer/scheduler tuning) |

Supersedes the on/off `disguise_hypervisor` bool, which migrates (`False`→`off`, `True`/absent→`balanced`). The level is now persisted in `Config.save()` — the old bool was never serialised, so an opt-out was silently lost on reload; fixed.

## Auto-apply (no more manual recreate)
- **GUI** Settings → Bare-metal compatibility is a 3-way selector; Save recreates the container when the level changes.
- **CLI** `winpodx config set pod.disguise_level <off|balanced|max>` regenerates compose and, if the pod is running, recreates it (stop+start, storage preserved). Same auto-apply for the other compose-affecting pod keys.
- **Update** path already auto-recreates on compose change (#511).

## Disk size
Gated on host headroom via `disk.effective_max_bytes` (keeps the 10 GiB / 10 % reserve). The dockur disk is sparse, so a larger advertised ceiling costs ~0 host space; on a small host it stays as-is and logs a warning.

## Privacy
No host serial / UUID / asset is read — only the existing non-identifying DMI fields (vendor/model/bios) + host free space (a quantity). The SMBIOS blob is fully synthetic. Nothing host-identifying is committed.

## Not an anti-cheat bypass
Signature-level VM hiding for casual detectors and VM-hostile apps (code 43, DRM/launch gates). Does not defeat kernel anti-cheat (TPM/Secure-Boot attestation + VM-exit timing).

## Testing
- `pytest tests/` — **1833 passed, 1 skipped**
- ruff clean; 6 locale catalogs synced (882 keys, parity)
