### PR TITLE
fix(disguise): disk gate skipped roomy hosts; retry discovery on transient bring-up hiccup

### DIFF
--- a/docs/USAGE.ko.md
+++ b/docs/USAGE.ko.md
@@ -151,7 +151,7 @@ USB 장치는 live hot-plug (`cfg.pod.usb_live`, 기본 on) — 재시작 불필
 |------|------|------|
 | `off` | 숨김 없음 — 정직한 VM | 최고(호환성도) |
 | `balanced` (기본) | CPUID 하이퍼바이저 비트 + KVM 시그니처 제거, 호스트 SMBIOS/DMI 미러링, 합성 센서 디스크립터, 물리 PC 같은 디스크 크기 광고 | 손실 없음 |
-| `max` | `balanced` + Hyper-V enlightenment 비활성(`HV=N`)으로 al-khaser/Pafish Hyper-V 체크 통과 | 눈에 띄게 느려짐(Windows-on-KVM 타이머/스케줄러 튜닝 손실) |
+| `max` | `balanced` + Hyper-V CPUID enlightenment 비활성(`HV=N`)으로 CPUID 표면 축소. (참고: al-khaser의 Hyper-V *드라이버/오브젝트* 체크는 vmgenid 디바이스 + 게스트 통합 드라이버를 보는데, 기존 설치된 게스트에선 `HV=N`만으로 안 지워짐 — 새 `max` 설치에서만 정리됨) | 눈에 띄게 느려짐(Windows-on-KVM 타이머/스케줄러 튜닝 손실) |
 
 ```bash
 winpodx config set pod.disguise_level off        # 정직한 VM

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -151,7 +151,7 @@ Some software refuses to run under a detected hypervisor — most notably Nvidia
 |-------|--------------|-------------|
 | `off` | No disguise — an honest VM. | Best (and most compatible) |
 | `balanced` (default) | Clears the CPUID hypervisor bit + KVM signature, mirrors the host's SMBIOS/DMI, adds synthetic sensor descriptors, and advertises a bare-metal-looking disk size. | No measurable cost |
-| `max` | Everything in `balanced` **plus** disabling the Hyper-V enlightenments (`HV=N`) so the al-khaser / Pafish Hyper-V checks pass. | Noticeably slower (loses the Windows-on-KVM timer/scheduler tuning) |
+| `max` | Everything in `balanced` **plus** dropping the Hyper-V CPUID enlightenments (`HV=N`) to shrink the VM's CPUID surface. (Note: al-khaser's Hyper-V *driver/object* checks key off the VM-generation-id device + guest integration drivers, which `HV=N` alone doesn't remove on an already-installed guest — those clear only on a fresh `max` install.) | Noticeably slower (loses the Windows-on-KVM timer/scheduler tuning) |
 
 ```bash
 winpodx config set pod.disguise_level off        # honest VM

--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -585,16 +585,26 @@ def _disguise_disk_size(cfg: Config) -> str:
     size when the disguise is active and the host can safely back it (#246).
 
     al-khaser / Pafish flag a disk under ~128 GB as a VM tell. The dockur disk
-    is sparse, so a larger *ceiling* costs ~0 host space up front — but we still
-    gate on host headroom (via ``disk.effective_max_bytes``, which keeps the
-    10 GiB / 10 % reserve) so a runaway guest can never fill the host disk. When
-    the host can't reach the threshold, the size is left as-is and a warning is
-    logged (best-effort — the disk-size check then stays a VM tell).
+    is **sparse**, so a larger *ceiling* costs ~0 host space up front — it only
+    consumes what Windows actually writes. So the gate just needs to guarantee
+    that even a fully-written guest can't overfill the host: require the target
+    size free, plus a flat 10 GiB floor. (We deliberately do NOT reuse
+    ``disk.effective_max_bytes`` here — its reserve is 10 % of the *total*
+    filesystem, sized for repeated auto-grows; on a multi-TB host that demanded
+    hundreds of GB free just to advertise a 128 GB sparse ceiling, so a host
+    with plenty free was wrongly skipped.) Respects an explicit ``disk_max_size``
+    cap. When the host can't back it, the size is left as-is + a warning logged.
     """
     cur = cfg.pod.disk_size
     if not cfg.pod.disguise_active:
         return cur
-    from winpodx.core.disk import DiskError, effective_max_bytes, format_size, parse_size
+    from winpodx.core.disk import (
+        _HOST_RESERVE_FLOOR,
+        DiskError,
+        _host_free_and_total,
+        format_size,
+        parse_size,
+    )
 
     target = 128 * (1024**3)  # 128 GiB clears the al-khaser / Pafish thresholds
     try:
@@ -603,16 +613,30 @@ def _disguise_disk_size(cfg: Config) -> str:
         return cur
     if cur_b >= target:
         return cur  # already real-looking — never shrink the user's disk
-    cap = effective_max_bytes(cfg, cur_b)  # None = host-trusted / unbounded
-    want = target if cap is None else min(target, cap)
+
+    want = target
+    if cfg.pod.disk_max_size:  # honour an explicit user cap
+        try:
+            want = min(target, parse_size(cfg.pod.disk_max_size))
+        except DiskError:
+            want = target
     if want <= cur_b:
-        logging.getLogger(__name__).warning(
-            "disguise: not enough host free space to enlarge the %s disk to a "
-            "bare-metal-looking size; the disk-size VM check will not pass. Free "
-            "up host space or raise cfg.pod.disk_size to hide it.",
-            cur,
-        )
-        return cur
+        return cur  # user cap below the threshold — nothing to do
+
+    ht = _host_free_and_total(cfg)
+    if ht is not None:
+        free, _total = ht
+        if free - _HOST_RESERVE_FLOOR < want:
+            logging.getLogger(__name__).warning(
+                "disguise: host has %.0f GiB free, need ~%.0f GiB to safely "
+                "advertise a bare-metal disk; leaving %s (disk-size VM check "
+                "stays). Free up host space or raise cfg.pod.disk_size to hide it.",
+                free / (1024**3),
+                (want + _HOST_RESERVE_FLOOR) / (1024**3),
+                cur,
+            )
+            return cur
+    # ht is None → named-volume / unknown root → host-trusted, bump.
     try:
         return format_size(want)
     except DiskError:

--- a/src/winpodx/gui/_main_window_bringup.py
+++ b/src/winpodx/gui/_main_window_bringup.py
@@ -125,6 +125,23 @@ class _ChecklistIconLabel(QLabel):
 # transport during the long-tail Sysprep wait.
 _POLL_CADENCE_SECS = 2.0
 
+# Discovery (phase 4) retry: on a fresh install the agent's /health can flicker
+# (TermService / rdprrap reactivation restarts it), so the discovery /exec POST
+# can land on a momentarily-closed socket ("Remote end closed connection without
+# response"). That's transient — retry a few times before failing the bring-up,
+# matching the agent_keepalive + apply-burst transient retries.
+_DISCOVERY_MAX_ATTEMPTS = 3
+_DISCOVERY_RETRY_SECS = 4.0
+
+
+def _is_transient_discovery_error(exc: Exception) -> bool:
+    """True when a discovery failure is a transient channel hiccup worth a retry.
+
+    Only a genuine guest-side script failure (the script ran and exited non-zero)
+    is non-transient — every channel / socket / agent-flicker error is retried.
+    """
+    return "Discovery script failed (rc=" not in str(exc)
+
 
 # Stable phase identifiers + their display label / ETA hint / cancellable
 # flag. The phase ID is the wire contract between BringUpMixin and
@@ -990,11 +1007,30 @@ class BringUpMixin:
             return self._emit_cancelled()
 
         self._emit_phase("phase_4_discovery", "Scanning guest Start Menu + AppX...")
-        try:
-            apps = discovery_mod.scan(self.cfg)
-        except Exception as exc:  # noqa: BLE001
-            self._emit_done(False, f"discovery.scan raised: {exc}")
-            return False
+        apps = None
+        for attempt in range(1, _DISCOVERY_MAX_ATTEMPTS + 1):
+            if self._is_cancelled():
+                return self._emit_cancelled()
+            try:
+                apps = discovery_mod.scan(self.cfg)
+                break
+            except Exception as exc:  # noqa: BLE001
+                fatal = (
+                    not _is_transient_discovery_error(exc)
+                    or attempt == _DISCOVERY_MAX_ATTEMPTS
+                )
+                if fatal:
+                    self._emit_done(False, f"discovery.scan raised: {exc}")
+                    return False
+                # Transient agent-channel hiccup (e.g. /health flickered mid-scan)
+                # — wait for the agent to re-settle and try again.
+                self._emit_phase(
+                    "phase_4_discovery",
+                    f"Attempt {attempt} - agent channel closed mid-scan; retrying...",
+                )
+                self._sleep_cancellable(_DISCOVERY_RETRY_SECS)
+        if apps is None:  # cancelled inside the loop
+            return self._emit_cancelled()
 
         try:
             persisted = discovery_mod.persist_discovered(apps)

--- a/tests/test_compose_arch.py
+++ b/tests/test_compose_arch.py
@@ -188,19 +188,44 @@ def test_compose_disguise_max_disables_hyperv(monkeypatch):
 
 
 def test_compose_disguise_disk_not_bumped_when_host_small(monkeypatch):
-    """A host with no headroom leaves the disk as-is (warn, no bump) — #246."""
+    """A host without room for the target leaves the disk as-is (warn) — #246."""
     monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
     import winpodx.core.disk as _disk
 
-    # effective_max_bytes == current bytes → no headroom → must not bump.
-    monkeypatch.setattr(_disk, "effective_max_bytes", lambda cfg, cur: cur)
+    # 50 GiB free − 10 GiB floor = 40 GiB < 128 GiB target → must not bump.
+    monkeypatch.setattr(
+        _disk, "_host_free_and_total", lambda cfg: (50 * 1024**3, 100 * 1024**3)
+    )
     cfg = _cfg()
     cfg.pod.disguise_level = "balanced"
     cfg.pod.disk_size = "64G"
-    cfg.pod.storage_path = "/some/path"  # non-empty → effective_max_bytes consulted
+    cfg.pod.storage_path = "/some/path"  # non-empty → host free space consulted
     content = _build_compose_content(cfg)
     assert 'DISK_SIZE: "64G"' in content  # left as-is, not enlarged
+
+
+def test_compose_disguise_disk_bumped_when_host_has_room(monkeypatch):
+    """Plenty of host free space → disk advertised at 128G (sparse) — #246.
+
+    Regression: the old gate reused effective_max_bytes (reserve = 10 % of the
+    *total* filesystem), so a multi-TB host with hundreds of GB free was still
+    skipped. The flat-floor gate bumps whenever the target fits.
+    """
+    monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
+    import winpodx.core.disk as _disk
+
+    # 300 GiB free on a 4 TB disk → must bump despite the 10 %-of-total being huge.
+    monkeypatch.setattr(
+        _disk, "_host_free_and_total", lambda cfg: (300 * 1024**3, 4000 * 1024**3)
+    )
+    cfg = _cfg()
+    cfg.pod.disguise_level = "balanced"
+    cfg.pod.disk_size = "64G"
+    cfg.pod.storage_path = "/some/path"
+    content = _build_compose_content(cfg)
+    assert 'DISK_SIZE: "128G"' in content
 
 
 def test_compose_disguise_off_opts_out(monkeypatch):

--- a/tests/test_main_window_bringup.py
+++ b/tests/test_main_window_bringup.py
@@ -579,3 +579,98 @@ def test_dialog_done_freezes_active_phase_elapsed() -> None:
             assert elapsed_label.text(), f"row {i} elapsed empty"
     finally:
         dlg.reject()
+
+
+# ----- phase 4 discovery retry (transient agent-channel hiccup) -----------
+
+
+def _pass_phases_123(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub phases 1-3 so a test can focus on phase 4 (discovery)."""
+    monkeypatch.setattr(
+        "winpodx.core.pod.pod_status",
+        lambda _cfg: PodStatus(state=PodState.RUNNING, ip="127.0.0.1"),
+    )
+    monkeypatch.setattr("winpodx.core.pod.check_rdp_port", lambda _ip, _port, timeout=3.0: True)
+
+    class _FakeClient:
+        def __init__(self, _cfg: Config) -> None:
+            pass
+
+        def health(self) -> dict:
+            return {"ok": True}
+
+        def auth_ready(self) -> tuple[bool, str]:
+            return True, ""
+
+    monkeypatch.setattr("winpodx.core.agent.AgentClient", _FakeClient)
+    monkeypatch.setattr(
+        "winpodx.core.provisioner.apply_windows_runtime_fixes",
+        lambda _cfg: {
+            "max_sessions": "ok",
+            "rdp_timeouts": "ok",
+            "oem_runtime_fixes": "ok",
+            "vbs_launchers": "ok",
+            "multi_session": "ok",
+        },
+    )
+
+
+def test_phase4_retries_transient_channel_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from winpodx.core.discovery import DiscoveryError
+
+    cfg = _make_cfg()
+    cfg.reverse_open.enabled = True
+    _pass_phases_123(monkeypatch)
+    monkeypatch.setattr("winpodx.gui._main_window_bringup._DISCOVERY_RETRY_SECS", 0.01)
+
+    calls = {"n": 0}
+
+    def _flaky(_cfg: Config) -> list[str]:
+        calls["n"] += 1
+        if calls["n"] < 3:  # the agent /health flickered mid-scan twice
+            raise DiscoveryError(
+                "Discovery channel failure: /exec socket error: "
+                "Remote end closed connection without response",
+                kind="pod_not_running",
+            )
+        return ["app1"]
+
+    monkeypatch.setattr("winpodx.core.discovery.scan", _flaky)
+    monkeypatch.setattr("winpodx.core.discovery.persist_discovered", lambda _a: ["/tmp/app1.toml"])
+    monkeypatch.setattr("winpodx.cli.host_open._cmd_refresh", lambda _args: 0)
+
+    harness = Harness(cfg)
+    harness._run_full_bring_up()
+    _wait_for_done(harness, timeout=5.0)
+
+    assert calls["n"] == 3  # 2 transient retries + 1 success
+    assert harness.bringup_done.emissions == [(True, "")]
+
+
+def test_phase4_does_not_retry_real_script_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    from winpodx.core.discovery import DiscoveryError
+
+    cfg = _make_cfg()
+    _pass_phases_123(monkeypatch)
+    monkeypatch.setattr("winpodx.gui._main_window_bringup._DISCOVERY_RETRY_SECS", 0.01)
+
+    calls = {"n": 0}
+
+    def _failing(_cfg: Config) -> list[str]:
+        calls["n"] += 1
+        raise DiscoveryError("Discovery script failed (rc=1): boom", kind="script_failed")
+
+    monkeypatch.setattr("winpodx.core.discovery.scan", _failing)
+    monkeypatch.setattr(
+        "winpodx.cli.host_open._cmd_refresh",
+        lambda _args: pytest.fail("phase 5 must not run when discovery fails"),
+    )
+
+    harness = Harness(cfg)
+    harness._run_full_bring_up()
+    _wait_for_done(harness, timeout=5.0)
+
+    assert calls["n"] == 1  # genuine script failure → no retry
+    success, msg = harness.bringup_done.emissions[0]
+    assert success is False
+    assert "Discovery script failed" in msg


### PR DESCRIPTION
Two post-#513 fixes found while smoke-testing the disguise levels.

## 1. Disk gate skipped hosts that had plenty of room
`_disguise_disk_size` reused `disk.effective_max_bytes`, whose reserve is **10 % of the total filesystem** (sized for repeated auto-grows). On a multi-TB host that demanded hundreds of GB free just to advertise a 128 GB **sparse** ceiling — e.g. 210 GiB free on a 3.7 TB disk → reserve 372 GiB → wrongly left at 64 GB, so the disk-size VM checks (WMI / DeviceIoControl / GetDiskFreeSpaceEx) kept failing.

The dockur disk is sparse (a bigger ceiling costs ~0 up front), so the gate only needs the target free plus a flat 10 GiB floor. Computed directly from host free space now. Verified on the affected host: 64G → 128G.

## 2. Bring-up false "did not complete" on a transient agent hiccup
On a fresh install the agent's `/health` can flicker (TermService / rdprrap reactivation restarts it), so the phase-4 discovery `/exec` POST can land on a momentarily-closed socket (`Remote end closed connection without response`) — and the whole bring-up was failed on the first try even though the pod + agent are up. Phase 4 now retries the scan up to 3× on a transient channel error (matching the agent_keepalive + apply-burst retries); a genuine guest-side script failure (rc != 0) is not retried.

Also corrects the docs: `HV=N` drops the Hyper-V CPUID enlightenments but does **not** clear al-khaser's vmgenid / integration-driver Hyper-V checks on an already-installed guest (only a fresh install would).

## Testing
- `pytest tests/` — **1836 passed, 1 skipped**
- ruff clean
