### PR TITLE
fix(gui): phase-1 bring-up shows pod progress, not the poll-attempt counter

### DIFF
--- a/src/winpodx/gui/_main_window_bringup.py
+++ b/src/winpodx/gui/_main_window_bringup.py
@@ -936,12 +936,10 @@ class BringUpMixin:
         import time
 
         started = time.monotonic()
-        attempt = 0
         err_streak = 0
         while True:
             if self._is_cancelled():
                 return self._emit_cancelled()
-            attempt += 1
             try:
                 state = pod_status(self.cfg).state
             except Exception:  # noqa: BLE001
@@ -965,12 +963,20 @@ class BringUpMixin:
                 except Exception:  # noqa: BLE001
                     rdp_ok = False
                 if rdp_ok:
-                    self._emit_phase("phase_1_pod", f"Attempt {attempt} - RDP ready")
+                    self._emit_phase("phase_1_pod", "Remote Desktop is up")
                     return True
 
-            state_name = state.value if state is not None else "unknown"
-            detail = progress or f"pod state: {state_name}"
-            self._emit_phase("phase_1_pod", f"Attempt {attempt} - {detail}")
+            # Surface what the pod is actually DOING (dockur install progress),
+            # not the internal poll counter — that's the user-meaningful state.
+            if progress:
+                detail = progress
+            elif state == PodState.RUNNING:
+                detail = "Windows is starting — waiting for Remote Desktop..."
+            elif state is not None:
+                detail = f"Pod {state.value}..."
+            else:
+                detail = "Checking pod..."
+            self._emit_phase("phase_1_pod", detail)
 
             # Generous budget while a fresh install is in flight; the normal
             # pod-ready budget otherwise.

--- a/tests/test_main_window_bringup.py
+++ b/tests/test_main_window_bringup.py
@@ -410,17 +410,16 @@ def test_polling_phases_emit_attempt_counters(
     harness._run_full_bring_up()
     _wait_for_done(harness, timeout=10.0)
 
-    # Find phase_1_pod emissions that include "Attempt N -" prefix.
-    phase1_attempts = [
-        detail
-        for pid, detail in harness.bringup_phase.emissions
-        if pid == "phase_1_pod" and detail.startswith("Attempt ")
+    # phase_1_pod surfaces the pod's own state/progress (not an internal poll
+    # counter) — e.g. "Pod starting..." while the container comes up.
+    phase1_details = [
+        detail for pid, detail in harness.bringup_phase.emissions if pid == "phase_1_pod"
     ]
-    assert phase1_attempts, (
-        "phase_1_pod never emitted an Attempt-counter sub_detail; "
-        f"all emissions: {harness.bringup_phase.emissions}"
-    )
-    # At least one phase_2_agent attempt detail too.
+    assert any(
+        ("starting" in d.lower() or "windows" in d.lower() or "pod " in d.lower())
+        for d in phase1_details
+    ), f"phase_1_pod never emitted a pod-progress detail; all: {harness.bringup_phase.emissions}"
+    # phase_2_agent still streams its Attempt-counter detail.
     phase2_attempts = [
         detail
         for pid, detail in harness.bringup_phase.emissions


### PR DESCRIPTION
phase-1 detail now surfaces the pod's actual progress (dockur 'Downloading NN%' / 'Installing...', or 'Windows is starting — waiting for Remote Desktop...') instead of 'Attempt N - pod state: starting', which read like a stuck loop.