### PR TITLE
feat(disguise): opt-in patched-QEMU image for ACPI OEM + disk-model strings (#246)

### DIFF
--- a/docs/USAGE.ko.md
+++ b/docs/USAGE.ko.md
@@ -163,6 +163,8 @@ winpodx pod recreate --wipe-storage              # Windows 초기화 후 새 하
 
 GUI에서도 선택 가능: **Settings → Bare-metal compatibility**. 어느 쪽이든 `winpodx pod recreate` 후 적용됨 (QEMU `-cpu` 라인 + `HV` env + 디스크 크기를 바꾸므로; recreate는 Windows 디스크 유지).
 
+**고급 — 패치된 QEMU 이미지 (`cfg.pod.disguise_image`):** 일부 VM 마커(ACPI OEM `BOCHS`, 디스크 모델 `QEMU HARDDISK`)는 QEMU에 컴파일된 문자열이라 커맨드라인 인자로 못 바꿉니다. `packaging/qemu-disguise/`가 그 문자열을 패치한 커스텀 dockur 이미지를 빌드하며, `disguise_image`에 지정하면 `max`에서 사용됩니다. winpodx는 패치 레시피만 배포(패치된 바이너리 없음). PCI 벤더 ID는 일부러 안 건드림(스푸핑하면 dockur virtio-serial이 깨짐). 그 디렉터리 README 참고.
+
 **안티치트 우회 아님.** 캐주얼 탐지기와 VM 거부 앱(code 43, DRM/런치게이트)용 시그니처 레벨 숨김입니다. 커널 안티치트(EAC/BattlEye/Vanguard)는 **못 피합니다** — 하드웨어 attestation(TPM + Secure Boot)과 게스트가 위조 못 하는 VM-exit 타이밍에 의존하며, 온라인 게임 안티치트 우회는 게임 ToS 위반입니다.
 
 디스크 확대는 게이트됨: dockur 디스크는 sparse 라 광고 크기를 키워도 호스트 공간을 즉시 먹지 않지만, 호스트 여유 공간이 충분할 때만(10 GiB / 10 % 예약 유지) 올립니다. 작은 호스트에선 그대로 두고 경고만 출력. 구버전 `disguise_hypervisor = false` 키도 계속 작동 — `off` 로 매핑됩니다.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -164,6 +164,8 @@ winpodx pod recreate --wipe-storage              # WIPES Windows, reinstalls on 
 
 You can also pick the level in the GUI: **Settings → Bare-metal compatibility**. Either way it takes effect after a `winpodx pod recreate` (it edits the QEMU `-cpu` line, the `HV` env, and the disk size; recreate keeps your Windows disk).
 
+**Advanced — patched-QEMU image (`cfg.pod.disguise_image`):** a couple of VM markers live in QEMU's compiled-in strings (ACPI OEM `BOCHS`, disk model `QEMU HARDDISK`) that command-line args can't reach. `packaging/qemu-disguise/` builds a custom dockur image with those strings patched out; set `disguise_image` to it and it's used at `max`. winpodx ships only the patch recipe (no patched binary). PCI vendor IDs are deliberately left alone (spoofing them breaks dockur's virtio-serial). See that directory's README.
+
 **Not an anti-cheat bypass.** This is signature-level VM hiding for casual detectors and VM-hostile apps (code 43, DRM/launch gates). It does **not** defeat kernel-mode anti-cheat (EAC / BattlEye / Vanguard) — those anchor on hardware attestation (TPM + Secure Boot) and VM-exit timing the guest can't spoof — and bypassing online-game anti-cheat violates the game's ToS.
 
 The disk bump is gated: the dockur disk is sparse, so a larger advertised size costs ~0 host space up front, but winpodx only raises it when the host has enough free space (keeping a 10 GiB / 10 % reserve). On a small host it leaves the disk as-is and logs a warning. The pre-0.6.x `disguise_hypervisor = false` key still works — it maps to `off`.

--- a/packaging/qemu-disguise/Dockerfile
+++ b/packaging/qemu-disguise/Dockerfile
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: MIT
+#
+# winpodx bare-metal disguise (#246) — custom dockur image with an
+# anti-detection-patched QEMU.
+#
+# Builds QEMU from source with winpodx's identity-string patch (ACPI OEM + disk
+# model) applied, then layers it over the pinned dockur image so dockur runs
+# the patched qemu-system-x86_64. winpodx never ships this image — you build it
+# yourself and point cfg.pod.disguise_image at your local/registry tag.
+#
+# Build:
+#   docker build -t winpodx-windows-disguise \
+#     --build-arg DOCKUR_IMAGE=docker.io/dockurr/windows@sha256:<pin> \
+#     --build-arg QEMU_VERSION=<the version inside that image> \
+#     -f packaging/qemu-disguise/Dockerfile packaging/qemu-disguise
+#
+# Find the QEMU version inside your pinned image first:
+#   podman run --rm --entrypoint qemu-system-x86_64 <DOCKUR_IMAGE> --version
+#
+# Then:
+#   winpodx config set pod.disguise_level max
+#   winpodx config set pod.disguise_image winpodx-windows-disguise
+#   winpodx pod recreate --wipe-storage     # device + firmware change → reinstall
+#
+# NOTE: matching the build environment (Alpine version, configure flags, shared
+# libs) to the dockur base is the fiddly part — iterate until the patched
+# binary runs in the final image. This recipe targets dockur's Alpine base.
+
+ARG DOCKUR_IMAGE=docker.io/dockurr/windows:latest
+ARG QEMU_VERSION=10.0.8
+
+# --- stage 1: build patched QEMU in the same Alpine base dockur uses ---
+FROM ${DOCKUR_IMAGE} AS base
+
+FROM alpine:3.21 AS build
+ARG QEMU_VERSION
+RUN apk add --no-cache \
+        build-base ninja meson python3 bash pkgconf glib-dev pixman-dev \
+        zlib-dev curl tar xz linux-headers bzip2-dev \
+        libslirp-dev libusb-dev usbredir-dev spice-dev \
+        libcap-ng-dev attr-dev
+WORKDIR /build
+RUN curl -fsSL "https://download.qemu.org/qemu-${QEMU_VERSION}.tar.xz" -o qemu.tar.xz \
+    && tar xf qemu.tar.xz && mv "qemu-${QEMU_VERSION}" qemu
+COPY patch-strings.sh /build/patch-strings.sh
+RUN bash /build/patch-strings.sh /build/qemu
+WORKDIR /build/qemu
+# Build only the x86_64 system target. Add/trim --enable flags to match what
+# your dockur image's QEMU was built with (check its `qemu-system-x86_64
+# --version` / configure summary) so the binary links cleanly in stage 2.
+RUN ./configure --target-list=x86_64-softmmu --prefix=/usr \
+        --enable-slirp --enable-usb-redir --disable-docs --disable-gtk \
+    && make -j"$(nproc)" \
+    && strip build/qemu-system-x86_64
+
+# --- stage 2: drop the patched binary into the pinned dockur image ---
+FROM base
+COPY --from=build /build/qemu/build/qemu-system-x86_64 /usr/bin/qemu-system-x86_64
+# Sanity check at build time (fails the build if the binary won't run).
+RUN qemu-system-x86_64 --version

--- a/packaging/qemu-disguise/README.md
+++ b/packaging/qemu-disguise/README.md
@@ -1,0 +1,67 @@
+# Bare-metal disguise — patched-QEMU image (advanced, opt-in) (#246)
+
+`balanced`/`max` hide most VM signatures through QEMU **command-line args**
+(no recompile): the hypervisor CPUID bit, the KVM signature, the SMBIOS
+vendor/model (mirrored from your real host), synthetic sensors, and — at `max`
+— emulated SATA/std-VGA devices.
+
+A few VM markers live in QEMU's compiled-in **strings**, which args can't reach:
+
+| al-khaser check | string | where |
+|-----------------|--------|-------|
+| ACPI table strings / "QEMU ACPI tables" | ACPI OEM ID `BOCHS` / `BXPC` | `include/hw/acpi/aml-build.h` |
+| SetupDi / Disk\Enum / Enum\IDE·SCSI | disk model `QEMU HARDDISK` | `hw/ide/core.c`, `hw/scsi/scsi-disk.c` |
+
+To clear those you need a QEMU built with those strings changed. This directory
+builds a custom dockur image that does exactly that, and winpodx uses it when
+you opt in.
+
+## What this does NOT do
+
+- **PCI vendor IDs (`0x1AF4` / `0x1B36`) are left untouched.** Spoofing them to
+  Intel breaks the Windows virtio driver binding — including dockur's own
+  **virtio-serial** channel — so the guest and dockur fail to boot. So
+  `VEN_1AF4` / `VEN_1B36` stay visible. This is a hard dockur constraint.
+- It is **not an anti-cheat bypass.** Kernel anti-cheat (EAC/BattlEye/Vanguard)
+  anchors on TPM attestation + RDTSC VM-exit timing, neither of which this
+  touches. Bypassing online-game anti-cheat also violates game ToS. This is
+  signature-level hiding for VM-hostile apps and malware-analysis sandboxes.
+- winpodx **never ships a patched binary** — you build the image locally, so
+  there's no GPL-binary redistribution and nothing for AV to flag in winpodx's
+  own packages.
+
+## Build
+
+```bash
+# 1. find the QEMU version inside your pinned dockur image
+podman run --rm --entrypoint qemu-system-x86_64 \
+  docker.io/dockurr/windows:latest --version
+
+# 2. build the patched image (match QEMU_VERSION to step 1)
+podman build -t winpodx-windows-disguise \
+  --build-arg DOCKUR_IMAGE=docker.io/dockurr/windows:latest \
+  --build-arg QEMU_VERSION=10.0.8 \
+  -f packaging/qemu-disguise/Dockerfile packaging/qemu-disguise
+```
+
+Matching the build flags to your dockur image is the fiddly part — if
+`qemu-system-x86_64 --version` fails in stage 2, adjust the `./configure`
+`--enable-*` flags to match what the image's QEMU was built with, and rebuild.
+
+## Use
+
+```bash
+winpodx config set pod.disguise_level max
+winpodx config set pod.disguise_image winpodx-windows-disguise
+winpodx pod recreate --wipe-storage   # device + firmware change → reinstall
+```
+
+`disguise_image` is only honoured at `disguise_level = max`. Leave it empty to
+use the normal pinned image. Re-build the image whenever you bump the dockur
+pin (the QEMU version changes).
+
+## The patch
+
+`patch-strings.sh` is plain `sed` string-replacement (robust across QEMU minor
+versions). Read it — it's short. Tweak the replacement model/OEM strings to
+taste (keep ACPI OEM lengths at 6 and 8 bytes).

--- a/packaging/qemu-disguise/patch-strings.sh
+++ b/packaging/qemu-disguise/patch-strings.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+#
+# winpodx bare-metal disguise (#246) — QEMU source string patch.
+#
+# Rewrites the VM-identifying *strings* that winpodx CANNOT reach via QEMU
+# command-line args, so the guest's ACPI OEM IDs and disk model stop reporting
+# "BOCHS" / "QEMU HARDDISK". Run against an unpacked QEMU source tree before
+# `configure && make`. It is string-replacement only (sed), so it is robust
+# across QEMU minor versions — no fragile context-diff to re-port.
+#
+# DELIBERATELY NOT INCLUDED:
+#   * PCI vendor IDs (0x1AF4 / 0x1B36 -> 0x8086). Spoofing these breaks the
+#     Windows virtio driver binding — including dockur's own virtio-serial
+#     channel — so the guest (and dockur) fail to boot. Leave them alone.
+#   * SMBIOS / CPUID. winpodx already handles those via `-smbios` args and
+#     `-cpu ...,kvm=off`, per-VM, no recompile.
+#
+# This is signature-level VM hiding for VM-hostile apps / malware-analysis
+# sandboxes. It does NOT defeat kernel anti-cheat (TPM attestation + RDTSC
+# timing are untouched) and is not intended to.
+set -euo pipefail
+
+SRC="${1:-.}"
+cd "$SRC"
+
+echo "winpodx: patching QEMU identity strings in $(pwd)"
+
+# --- ACPI OEM ID (6 bytes) + OEM Table ID (8 bytes) ---
+# QEMU defaults: ACPI_BUILD_APPNAME6 "BOCHS ", ACPI_BUILD_APPNAME8 "BXPC    ".
+# al-khaser flags "BOCHS". Replace with a common real BIOS OEM (AMI). Lengths
+# MUST stay 6 and 8 bytes respectively.
+sed -i 's/"BOCHS "/"ALASKA"/g' include/hw/acpi/aml-build.h
+sed -i 's/"BXPC    "/"A M I   "/g' include/hw/acpi/aml-build.h
+
+# --- Disk / optical model strings ---
+# ATA (ide-hd, used by DISK_TYPE=sata) + SCSI defaults report "QEMU HARDDISK"
+# / "QEMU DVD-ROM"; al-khaser scans Disk\Enum + IDE/SCSI for "QEMU".
+sed -i 's/"QEMU HARDDISK"/"Samsung SSD 860"/g' hw/ide/core.c hw/scsi/scsi-disk.c
+sed -i 's/"QEMU DVD-ROM"/"ASUS  DRW-24"/g' hw/ide/core.c hw/ide/atapi.c
+sed -i 's/"QEMU CD-ROM"/"ASUS  DRW-24"/g' hw/scsi/scsi-disk.c
+
+echo "winpodx: identity-string patch applied (ACPI OEM + disk model)."

--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -405,6 +405,14 @@ class PodConfig:
     # into ``disguise_level`` by __post_init__; new saves write disguise_level.
     disguise_hypervisor: bool | None = None
 
+    # Optional custom dockur image with an anti-detection-patched QEMU (#246,
+    # opt-in/advanced). When set AND disguise_level == "max", the compose uses
+    # this image instead of the pinned one, so the patched QEMU's ACPI OEM +
+    # disk-model strings replace the QEMU/BOCHS markers. Built by the user from
+    # packaging/qemu-disguise/ (winpodx never ships a patched binary). Empty =
+    # use the normal pinned image. NOT an anti-cheat bypass.
+    disguise_image: str = ""
+
     _DISGUISE_LEVELS = ("off", "balanced", "max")
 
     @property
@@ -855,6 +863,7 @@ class Config:
                 "devices": list(self.pod.devices),
                 "usb_live": self.pod.usb_live,
                 "disguise_level": self.pod.disguise_level,
+                "disguise_image": self.pod.disguise_image,
             },
             "reverse_open": {
                 "enabled": self.reverse_open.enabled,

--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -661,6 +661,15 @@ def _build_compose_content(cfg: Config) -> str:
     # the file actually landed (fail-safe — a missing file would abort boot).
     oem_dir = _find_oem_dir()
     qemu_args = _qemu_arguments_for_host(cfg)
+
+    # Anti-detection-patched QEMU image (#246, opt-in): at the max level, if the
+    # user built + configured a custom image (packaging/qemu-disguise/), use it
+    # instead of the pinned one. Its QEMU has the ACPI OEM ("BOCHS"->real) and
+    # disk-model ("QEMU HARDDISK"->real) strings patched out — the bits winpodx
+    # can't reach via QEMU args. Only honoured at max + on a real image string.
+    image = cfg.pod.image
+    if cfg.pod.disguise_max and cfg.pod.disguise_image.strip():
+        image = cfg.pod.disguise_image.strip()
     if cfg.pod.disguise_active and platform.machine() != "aarch64":
         blob_path = _write_disguise_smbios_blob(oem_dir)
         if blob_path:
@@ -700,7 +709,7 @@ def _build_compose_content(cfg: Config) -> str:
         ram=cfg.pod.ram_gb,
         cpu=cfg.pod.cpu_cores,
         container_name=_yaml_escape(cfg.pod.container_name),
-        image=_yaml_escape(cfg.pod.image),
+        image=_yaml_escape(image),
         disk_size=_yaml_escape(_disguise_disk_size(cfg)),
         disk_type=disk_type,
         adapter=adapter,

--- a/tests/test_compose_arch.py
+++ b/tests/test_compose_arch.py
@@ -192,6 +192,27 @@ def test_compose_disguise_max_uses_emulated_devices(monkeypatch):
     assert "virtio-rng-pci" not in content  # the rng would re-add VEN_1AF4
 
 
+def test_compose_disguise_image_used_only_at_max(monkeypatch):
+    """cfg.pod.disguise_image overrides the image only at level=max (#246)."""
+    monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
+
+    cfg = _cfg()
+    cfg.pod.image = "docker.io/dockurr/windows:pinned"
+    cfg.pod.disguise_image = "winpodx-windows-disguise"
+
+    # balanced → ignore disguise_image, use the pinned image.
+    cfg.pod.disguise_level = "balanced"
+    content = _build_compose_content(cfg)
+    assert "image: docker.io/dockurr/windows:pinned" in content
+    assert "winpodx-windows-disguise" not in content
+
+    # max → use the custom patched image.
+    cfg.pod.disguise_level = "max"
+    content = _build_compose_content(cfg)
+    assert "image: winpodx-windows-disguise" in content
+
+
 def test_disguise_changes_devices_only_at_max_boundary():
     """Only crossing the max boundary changes virtual hardware (needs a wipe)."""
     from winpodx.core.config import disguise_changes_devices


### PR DESCRIPTION
Adds packaging/qemu-disguise/ (sed string-patch for ACPI OEM 'BOCHS' + disk model 'QEMU HARDDISK' + Dockerfile + README) and cfg.pod.disguise_image (used at level=max). winpodx ships only the recipe — the user builds the image locally (no GPL-binary redistribution / AV exposure). PCI vendor IDs excluded (breaks dockur's virtio-serial). Not an anti-cheat bypass. 1845 passed.