### PR TITLE
fix(apps): delete works on discovered profiles + stays deleted (#514)

### DIFF
--- a/src/winpodx/core/app.py
+++ b/src/winpodx/core/app.py
@@ -67,6 +67,60 @@ def discovered_apps_dir() -> Path:
     return data_dir() / "discovered"
 
 
+def _suppressed_file() -> Path:
+    """Tombstone list of discovered slugs the user deleted (#514).
+
+    Deleting a discovered profile only removes its directory — the next
+    discovery sweep would re-create it. Recording the slug here lets
+    ``persist_discovered`` skip it so a deleted auto-discovered app (the
+    "garbage" entries) stays gone across rescans.
+    """
+    return data_dir() / "discovered_suppressed.txt"
+
+
+def suppressed_app_slugs() -> set[str]:
+    """Slugs the user has deleted from discovery (skipped on rediscovery)."""
+    try:
+        text = _suppressed_file().read_text(encoding="utf-8")
+    except OSError:
+        return set()
+    return {
+        ln.strip() for ln in text.splitlines() if ln.strip() and _SAFE_NAME_RE.match(ln.strip())
+    }
+
+
+def suppress_app_slug(slug: str) -> None:
+    """Add *slug* to the discovery suppress list (idempotent)."""
+    if not _SAFE_NAME_RE.match(slug):
+        return
+    current = suppressed_app_slugs()
+    if slug in current:
+        return
+    current.add(slug)
+    path = _suppressed_file()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("\n".join(sorted(current)) + "\n", encoding="utf-8")
+    except OSError as e:  # noqa: BLE001
+        log.warning("could not record suppressed app %r: %s", slug, e)
+
+
+def unsuppress_app_slug(slug: str) -> None:
+    """Remove *slug* from the suppress list so discovery can re-add it."""
+    current = suppressed_app_slugs()
+    if slug not in current:
+        return
+    current.discard(slug)
+    path = _suppressed_file()
+    try:
+        if current:
+            path.write_text("\n".join(sorted(current)) + "\n", encoding="utf-8")
+        else:
+            path.unlink(missing_ok=True)
+    except OSError:  # noqa: BLE001
+        pass
+
+
 _VALID_APP_SOURCES = frozenset({"discovered", "user"})
 
 

--- a/src/winpodx/core/discovery/__init__.py
+++ b/src/winpodx/core/discovery/__init__.py
@@ -1063,12 +1063,18 @@ def persist_discovered(
         apps = _merge_essentials(apps)
 
     written: list[Path] = []
+    from winpodx.core.app import suppressed_app_slugs
+
+    suppressed = suppressed_app_slugs()  # user-deleted discovered apps (#514)
+
     seen: set[str] = set()
     for app in apps:
         if app.name in seen:
             continue
         if not _SAFE_NAME_RE.match(app.name):
             continue
+        if app.name in suppressed:
+            continue  # deleted from discovery — don't resurrect it
         seen.add(app.name)
 
         app_dir = root / app.name

--- a/src/winpodx/gui/_main_window_apps.py
+++ b/src/winpodx/gui/_main_window_apps.py
@@ -84,6 +84,12 @@ class AppCrudMixin:
 
         delete_app_profile(app.name)
         remove_desktop_entry(app.name)
+        # A discovered profile would be re-created by the next discovery sweep;
+        # record a tombstone so a deleted auto-discovered app stays gone (#514).
+        if getattr(app, "source", "user") == "discovered":
+            from winpodx.core.app import suppress_app_slug
+
+            suppress_app_slug(app.name)
         self._reload_apps()
         self.info_label.setText(tr("Removed: {name}").format(name=app.full_name))
 

--- a/src/winpodx/gui/app_dialog.py
+++ b/src/winpodx/gui/app_dialog.py
@@ -337,18 +337,27 @@ def save_app_profile(data: dict) -> Path:
 
 
 def delete_app_profile(name: str) -> bool:
-    """Delete an app profile directory."""
+    """Delete an app profile directory (user OR discovered) (#514).
+
+    Profiles live in two places: user-authored under ``apps/`` and
+    auto-discovered under ``discovered/``. The old version only looked in
+    ``apps/``, so deleting a discovered app silently did nothing. Remove the
+    directory from whichever root holds it (path-traversal guarded per root).
+    """
     import shutil
 
     if not _validate_app_name(name):
         return False
 
-    app_dir = data_dir() / "apps" / name
-    apps_root = data_dir() / "apps"
-    if not app_dir.resolve().is_relative_to(apps_root.resolve()):
-        return False
-
-    if app_dir.exists():
-        shutil.rmtree(app_dir)
-        return True
-    return False
+    deleted = False
+    for root in (data_dir() / "apps", data_dir() / "discovered"):
+        app_dir = root / name
+        try:
+            if not app_dir.resolve().is_relative_to(root.resolve()):
+                continue
+        except OSError:
+            continue
+        if app_dir.exists():
+            shutil.rmtree(app_dir, ignore_errors=True)
+            deleted = True
+    return deleted

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -160,3 +160,60 @@ def test_cli_app_hide_dispatch(monkeypatch):
     app_cli.handle_app(argparse.Namespace(app_command="hide", name="myapp"))
     app_cli.handle_app(argparse.Namespace(app_command="show", name="myapp"))
     assert calls == [("myapp", True), ("myapp", False)]
+
+
+# --- #514: deleting a discovered profile (delete worked only on user/) -------
+
+
+def test_suppress_slug_roundtrip(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from winpodx.core.app import (
+        suppress_app_slug,
+        suppressed_app_slugs,
+        unsuppress_app_slug,
+    )
+
+    assert suppressed_app_slugs() == set()
+    suppress_app_slug("notepad")
+    suppress_app_slug("notepad")  # idempotent
+    suppress_app_slug("calc")
+    assert suppressed_app_slugs() == {"notepad", "calc"}
+    # path-traversal / junk slugs are ignored
+    suppress_app_slug("../evil")
+    assert "../evil" not in suppressed_app_slugs()
+    unsuppress_app_slug("notepad")
+    assert suppressed_app_slugs() == {"calc"}
+
+
+def test_delete_app_profile_removes_discovered(monkeypatch, tmp_path):
+    import pytest
+
+    pytest.importorskip("PySide6")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from winpodx.core.app import data_dir
+    from winpodx.gui.app_dialog import delete_app_profile
+
+    disc = data_dir() / "discovered" / "ghostapp"
+    disc.mkdir(parents=True)
+    (disc / "app.toml").write_text('name = "ghostapp"\n', encoding="utf-8")
+
+    assert delete_app_profile("ghostapp") is True  # found in discovered/
+    assert not disc.exists()
+
+
+def test_persist_discovered_skips_suppressed(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from winpodx.core import discovery as disc_mod
+    from winpodx.core.app import suppress_app_slug
+
+    root = tmp_path / "discovered"  # passed explicitly via target_dir
+    suppress_app_slug("junkapp")
+
+    apps = [
+        disc_mod.DiscoveredApp(name="realapp", full_name="Real App", executable="C:\\r.exe"),
+        disc_mod.DiscoveredApp(name="junkapp", full_name="Junk", executable="C:\\j.exe"),
+    ]
+    disc_mod.persist_discovered(apps, target_dir=root)
+
+    assert (root / "realapp" / "app.toml").exists()
+    assert not (root / "junkapp").exists()  # suppressed → not re-created


### PR DESCRIPTION
Right-click Delete no-op'd for discovered apps: delete_app_profile only touched apps/<name>, but discovered apps live under discovered/<name>. Now deletes from both roots + records a suppress tombstone so a deleted auto-discovered app isn't re-created on the next discovery sweep. 149 affected-module tests pass.