### PR TITLE
fix(reverse-open): listener no longer infinite-loops on a missing-target request (#425)

### DIFF
--- a/src/winpodx/reverse_open/listener.py
+++ b/src/winpodx/reverse_open/listener.py
@@ -302,6 +302,15 @@ class Listener:
             log.warning("listener: path rejected for %s: %s", path.name, exc)
             _safe_unlink(path)
             return
+        except Exception as exc:  # noqa: BLE001
+            # Belt-and-braces: ANY unexpected dispatch error must still drop the
+            # request file. Otherwise process_pending re-reads it every loop and
+            # the listener spins forever on one bad entry (#425), starving real
+            # reverse-open requests and wedging the refresh dialog.
+            self._stats.spawn_errors += 1
+            log.warning("listener: dispatch failed for %s: %s", path.name, exc)
+            _safe_unlink(path)
+            return
 
         # Only record the UUID after the spawn actually fired -- a
         # spawn-error path above leaves the UUID unrecorded so the

--- a/src/winpodx/reverse_open/paths.py
+++ b/src/winpodx/reverse_open/paths.py
@@ -419,7 +419,14 @@ def safe_open_unc(
     # caught by the readlink validation below: the kernel's
     # /proc/self/fd/N readlink returns the *real* path to the inode,
     # and if that path isn't under the share root we reject.
-    fd = os.open(str(candidate), _O_PATH | os.O_NOFOLLOW)
+    try:
+        fd = os.open(str(candidate), _O_PATH | os.O_NOFOLLOW)
+    except OSError as exc:
+        # The file is gone / unreadable / a symlink (ELOOP). Surface it as a
+        # ReversePathError so the listener drops the request instead of letting
+        # a raw FileNotFoundError escape _handle_request and re-loop forever on
+        # the same stale entry (#425: continuous 'process_pending raised').
+        raise ReversePathError(f"cannot open {candidate}: {exc}") from exc
 
     try:
         # With ``O_PATH | O_NOFOLLOW``, the kernel opens the symlink

--- a/tests/test_reverse_open_listener.py
+++ b/tests/test_reverse_open_listener.py
@@ -274,6 +274,32 @@ def test_process_pending_spawns_on_happy_path(
     assert not (inc / f"{uid}.json").exists()
 
 
+def test_process_pending_drops_request_for_missing_target(
+    tmp_path: Path, home_under_tmp: Path, spawn_capture: tuple
+) -> None:
+    # #425: a request whose target file is gone must be DROPPED, not re-looped
+    # forever. safe_open_unc raises ReversePathError on the missing file, the
+    # listener catches it and unlinks the request. A second sweep finds nothing.
+    captured, spawn = spawn_capture
+    inc = _incoming(tmp_path)
+    inc.chmod(0o700)
+    missing = home_under_tmp / "gone.txt"  # deliberately NOT created
+    uid = _write_request(inc, _valid_request(missing))
+
+    cfg = ListenerConfig(incoming_dir=inc, share_roots={"home": home_under_tmp})
+    apps_db = _apps_db_with("kate", ["/usr/bin/kate", "%f"])
+    listener = Listener(cfg, apps_db, _seen(tmp_path), spawn=spawn)
+
+    listener.process_pending()
+    assert not (inc / f"{uid}.json").exists()  # dropped on the first sweep
+    listener.process_pending()  # nothing left → no re-loop
+
+    stats = listener.stats_snapshot()
+    assert stats.rejected_path == 1
+    assert stats.accepted == 0
+    assert captured == []
+
+
 def test_process_pending_rejects_replay(
     tmp_path: Path, home_under_tmp: Path, spawn_capture: tuple
 ) -> None:

--- a/tests/test_reverse_open_paths.py
+++ b/tests/test_reverse_open_paths.py
@@ -304,17 +304,17 @@ def test_safe_open_unc_yields_safefile_with_proc_path(tmp_path):
 def test_safe_open_unc_nonexistent_raises_oserror(tmp_path):
     """Opening a path that doesn't exist surfaces OSError.
 
-    The listener catches and logs INFO "target file does not exist"
-    instead of WARNING -- distinct from a translation failure, which
-    is a security event.
+    A missing target raises ``ReversePathError`` (not a raw
+    ``FileNotFoundError``) so the listener's ``except ReversePathError`` drops
+    the request instead of letting the error escape ``_handle_request`` and
+    re-loop on the stale entry forever (#425).
     """
     share_roots = {"home": tmp_path}
     before = _fd_count()
-    with pytest.raises(OSError):
+    with pytest.raises(ReversePathError):
         with safe_open_unc(r"\\tsclient\home\does_not_exist", share_roots):
             pass
-    # OSError on os.open() means the FD was never allocated, so the
-    # count is unchanged.
+    # The open failed, so the FD was never allocated -- count is unchanged.
     assert _fd_count() == before
 
 


### PR DESCRIPTION
A request for a gone file made safe_open_unc raise raw FileNotFoundError; _handle_request only caught ReversePathError → error escaped, request never deleted → process_pending re-looped forever, starving real reverse-open + wedging refresh. Now safe_open_unc raises ReversePathError on os.open failure + _handle_request has a catch-all that always unlinks the request. 65 reverse-open tests pass.