### PR TITLE
fix(gui): stop discover crashing the window via heightForWidth recursion

### DIFF
--- a/src/winpodx/gui/_main_window_apps.py
+++ b/src/winpodx/gui/_main_window_apps.py
@@ -115,7 +115,13 @@ class AppCrudMixin:
     def _reload_apps(self) -> None:
         self.apps = list_available_apps()
         self._refresh_hidden_button()
+        # Clear any active search WITHOUT firing textChanged -> _filter_apps:
+        # _refresh_launcher_home() below already triggers the single rebuild.
+        # Two back-to-back rebuilds of app_list_layout raced Qt's heightForWidth
+        # pass and helped trigger the discover-time SIGSEGV.
+        self.search_box.blockSignals(True)
         self.search_box.clear()
+        self.search_box.blockSignals(False)
         self._refresh_launcher_home()
         visible = self._visible_apps()
         # "X of Y" mirrors the library toolbar format (Task 5); no search is

--- a/src/winpodx/gui/_main_window_library.py
+++ b/src/winpodx/gui/_main_window_library.py
@@ -859,16 +859,40 @@ class LibraryPageMixin:
         self._filter_apps(self.search_box.text())
 
     def _filter_apps(self, text: str) -> None:
-        q = text.lower()
-        self._refresh_commands(q)
-        base = self._visible_apps()
-        filtered = [a for a in base if q in a.full_name.lower() or q in a.name.lower()]
-        if self._active_category:
-            filtered = [a for a in filtered if self._active_category in a.categories]
-        self._refresh_launcher_sections(filtered)
-        self._populate_app_view(filtered)
-        # "X of Y" so the toolbar count reconciles with the info bar's total
-        # after a search/filter (Task 5).
-        self.app_count_label.setText(
-            tr("{shown} of {total} apps").format(shown=len(filtered), total=len(self.apps))
-        )
+        # Re-entrancy guard. Rebuilding app_list_layout below adds word-wrapped
+        # empty-state labels into a setWidgetResizable QScrollArea, which forces
+        # a synchronous heightForWidth layout pass. If that pass re-enters
+        # _filter_apps mid-rebuild -- via the window resizeEvent -> _reflow_library,
+        # or the pod-status -> _filter_apps refresh, or a discover reload that
+        # rebuilds twice -- Qt's QBoxLayout::heightForWidth recurses without bound
+        # and segfaults the whole GUI ("QObject::setParent: ... different thread"
+        # warnings then SIGSEGV, observed on Wayland after the discover button).
+        # Coalesce the nested call into one trailing rebuild instead.
+        if getattr(self, "_filtering", False):
+            self._filter_pending = text
+            return
+        self._filtering = True
+        try:
+            self._filter_pending = None
+            q = text.lower()
+            self._refresh_commands(q)
+            base = self._visible_apps()
+            filtered = [a for a in base if q in a.full_name.lower() or q in a.name.lower()]
+            if self._active_category:
+                filtered = [a for a in filtered if self._active_category in a.categories]
+            self._refresh_launcher_sections(filtered)
+            self._populate_app_view(filtered)
+            # "X of Y" so the toolbar count reconciles with the info bar's total
+            # after a search/filter (Task 5).
+            self.app_count_label.setText(
+                tr("{shown} of {total} apps").format(shown=len(filtered), total=len(self.apps))
+            )
+        finally:
+            self._filtering = False
+        # Honor the most recent text if a nested call arrived during the rebuild.
+        # This runs as a fresh top-level call (guard already released), so it
+        # cannot recurse into the layout pass that triggered it.
+        pending = self._filter_pending
+        if pending is not None and pending != text:
+            self._filter_pending = None
+            self._filter_apps(pending)

--- a/tests/test_library_filter_reentrancy.py
+++ b/tests/test_library_filter_reentrancy.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: MIT
+"""Regression: _filter_apps must not recurse when its own rebuild re-enters it.
+
+Discover -> _reload_apps -> _filter_apps rebuilds app_list_layout, which adds
+word-wrapped empty-state labels into a setWidgetResizable QScrollArea and forces
+a synchronous heightForWidth layout pass. On Wayland that pass re-entered
+_filter_apps mid-rebuild (window resizeEvent -> _reflow_library, and the
+pod-status -> _filter_apps refresh), and Qt's QBoxLayout::heightForWidth then
+recursed without bound -> SIGSEGV (the whole GUI window "just closed").
+
+The fix is a re-entrancy guard that coalesces a nested call into a single
+trailing rebuild. These tests pin that behavior without a live Qt event loop.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+from winpodx.gui._main_window_library import LibraryPageMixin  # noqa: E402
+
+
+class _Label:
+    def __init__(self) -> None:
+        self.text = ""
+
+    def setText(self, text: str) -> None:  # noqa: N802 - Qt signature
+        self.text = text
+
+
+class _Harness(LibraryPageMixin):
+    """Minimal host exposing only what _filter_apps reads, with a
+    _populate_app_view that re-enters _filter_apps once (the resize/pod-status
+    race) so the guard is exercised."""
+
+    def __init__(self) -> None:
+        self._active_category = ""
+        self.apps: list = []
+        self.app_count_label = _Label()
+        self.populate_calls: list[int] = []
+        self._reenter_with: str | None = None
+
+    # --- helpers _filter_apps calls; all no-ops except _populate_app_view ---
+    def _refresh_commands(self, q: str) -> None:
+        pass
+
+    def _visible_apps(self) -> list:
+        return []
+
+    def _refresh_launcher_sections(self, filtered: list) -> None:
+        pass
+
+    def _populate_app_view(self, apps: list) -> None:
+        self.populate_calls.append(len(apps))
+        # Simulate Qt's synchronous layout pass re-entering _filter_apps once,
+        # mid-rebuild, with a different query (e.g. a resize-driven reflow).
+        if self._reenter_with is not None:
+            text, self._reenter_with = self._reenter_with, None
+            self._filter_apps(text)
+
+
+def test_reentrant_filter_does_not_recurse_and_coalesces():
+    h = _Harness()
+    h._reenter_with = "zzz"
+    # Without the guard this recurses through the synchronous re-entry forever.
+    h._filter_apps("")
+    # Outer rebuild + exactly one coalesced trailing rebuild (text differed).
+    assert h.populate_calls == [0, 0]
+    # Guard is released so later top-level calls still work.
+    assert getattr(h, "_filtering", False) is False
+
+
+def test_reentrant_filter_with_same_text_skips_redundant_rebuild():
+    h = _Harness()
+    h._reenter_with = ""  # nested call carries the SAME query as the outer call
+    h._filter_apps("")
+    # Same text -> the trailing rebuild is skipped (no redundant work).
+    assert h.populate_calls == [0]
+    assert getattr(h, "_filtering", False) is False
+
+
+def test_non_reentrant_filter_runs_once():
+    h = _Harness()  # _reenter_with stays None -> no nested call
+    h._filter_apps("")
+    assert h.populate_calls == [0]
+    assert getattr(h, "_filtering", False) is False


### PR DESCRIPTION
## Problem

Clicking **discover / Refresh Apps** in the GUI closed the whole window. A coredump pinned it to a **SIGSEGV in the main thread's `QBoxLayout::heightForWidth`** (infinite recursion → stack overflow), preceded in the journal by repeated `QObject::setParent: ... different thread` warnings — collateral from Qt's state corrupting as the recursion ran away, not a separate worker-thread bug.

## Root cause

Refreshing rebuilds `app_list_layout`, which adds the word-wrapped empty-state labels (`make_empty_panel`) into a `setWidgetResizable(True)` `QScrollArea`. That forces a **synchronous `heightForWidth` layout pass**, and that pass **re-entered `_filter_apps` mid-rebuild** through several paths:

- the window `resizeEvent` → `_reflow_library` → `_filter_apps`,
- the pod-status refresh → `_filter_apps`,
- `_reload_apps` clearing the search box (firing `textChanged` → `_filter_apps`) *and then* calling `_refresh_launcher_home` → a second back-to-back rebuild.

Re-entering the rebuild while the in-flight layout pass was still running defeated Qt's `heightForWidth` recursion guard → unbounded recursion → segfault.

## Fix

- **Re-entrancy guard in `_filter_apps`**: a nested call during an active rebuild is coalesced into one trailing rebuild (latest query wins) instead of recursing into the in-flight layout pass. Covers every re-entry vector.
- **`_reload_apps`** clears the search box with signals blocked, so it no longer triggers a redundant second rebuild.

## Tests

- New `tests/test_library_filter_reentrancy.py` (re-entrant → coalesced, same-text → skipped, non-re-entrant → single rebuild).
- Full suite: **1854 passed, 1 skipped**. `ruff check` + `ruff format --check` clean.