### PR TITLE
fix(reverse-open): Dashboard checkbox starts/stops the listener (#425)

### DIFF
--- a/src/winpodx/gui/_main_window_dashboard.py
+++ b/src/winpodx/gui/_main_window_dashboard.py
@@ -357,6 +357,28 @@ class DashboardMixin:
             self.cfg.save()
         except Exception as e:  # noqa: BLE001 -- never let a toggle crash the GUI
             log.warning("failed to persist reverse-open toggle: %s", e)
+            return
+        # Make the Dashboard checkbox live (#425): ticking it must actually
+        # start the listener now, not just flip the flag. The Settings-panel
+        # checkbox already did this, but the Dashboard home card only persisted
+        # the flag -- so a user who enabled it here saw the daemon stay down
+        # until the next pod bringup and had to start it by hand (0.6.0 report).
+        # Mirror the panel's _on_enable. Best-effort + quiet: starting needs the
+        # guest up, so a failure (guest down) just leaves the flag set for the
+        # next bringup instead of popping an error.
+        from types import SimpleNamespace
+
+        from winpodx.cli.host_open import _cmd_start_listener, _cmd_stop_listener
+
+        handler = _cmd_start_listener if checked else _cmd_stop_listener
+        try:
+            handler(SimpleNamespace(json=False))
+        except Exception:  # noqa: BLE001 -- status reflects the outcome
+            log.debug(
+                "reverse-open %s on dashboard toggle failed (guest may be down)",
+                "start" if checked else "stop",
+                exc_info=True,
+            )
 
     # -- live refresh ----------------------------------------------------- #
 

--- a/tests/test_dashboard_reverse_open_toggle.py
+++ b/tests/test_dashboard_reverse_open_toggle.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: MIT
+"""The Dashboard reverse-open checkbox must actually start/stop the listener.
+
+Regression for the 0.6.0 report on #425: the Settings-panel checkbox started
+the daemon on tick, but the Dashboard home card's checkbox only persisted
+cfg.reverse_open.enabled -- so a user who enabled it there saw "Enabled" yet
+the daemon stayed down and had to be started by hand. _on_reverse_open_toggled
+now mirrors the panel and drives _cmd_start_listener / _cmd_stop_listener.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+import winpodx.cli.host_open as ho  # noqa: E402
+from winpodx.core.config import Config  # noqa: E402
+from winpodx.gui._main_window_dashboard import DashboardMixin  # noqa: E402
+
+
+class _Harness(DashboardMixin):
+    """Bare host exposing only what _on_reverse_open_toggled reads."""
+
+    def __init__(self, cfg: Config) -> None:
+        self.cfg = cfg
+
+
+def _stub_handlers(monkeypatch):
+    calls: list[tuple[str, bool]] = []
+    monkeypatch.setattr(ho, "_cmd_start_listener", lambda a: calls.append(("start", a.json)) or 0)
+    monkeypatch.setattr(ho, "_cmd_stop_listener", lambda a: calls.append(("stop", a.json)) or 0)
+    return calls
+
+
+def test_toggle_on_persists_and_starts_listener(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    calls = _stub_handlers(monkeypatch)
+    cfg = Config()
+    _Harness(cfg)._on_reverse_open_toggled(True)
+    assert cfg.reverse_open.enabled is True
+    assert Config.load().reverse_open.enabled is True  # persisted
+    assert calls == [("start", False)]
+
+
+def test_toggle_off_persists_and_stops_listener(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    calls = _stub_handlers(monkeypatch)
+    cfg = Config()
+    cfg.reverse_open.enabled = True
+    _Harness(cfg)._on_reverse_open_toggled(False)
+    assert cfg.reverse_open.enabled is False
+    assert calls == [("stop", False)]
+
+
+def test_toggle_start_failure_is_quiet_and_keeps_flag(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    def _boom(_a):
+        raise RuntimeError("guest down")
+
+    monkeypatch.setattr(ho, "_cmd_start_listener", _boom)
+    cfg = Config()
+    # Must not raise even when the listener start fails (guest not up yet).
+    _Harness(cfg)._on_reverse_open_toggled(True)
+    # Flag stays persisted so the next pod bringup starts the listener.
+    assert cfg.reverse_open.enabled is True


### PR DESCRIPTION
Dashboard home-card reverse-open checkbox only persisted cfg.reverse_open.enabled; it never started the listener, so users saw Enabled but the daemon stayed down (0.6.0 report on #425). _on_reverse_open_toggled now mirrors the Settings panel: persist + _cmd_start_listener / _cmd_stop_listener (best-effort, quiet when guest down). Test: tests/test_dashboard_reverse_open_toggle.py. ruff + pytest green. Other #425 symptoms (open-with no-op, refresh hang, process_pending spam) trace to the listener loop already fixed on main in c1009b5.