### PR TITLE
fix(gui): recreate runs through bring-up worker; wake agent on headless boot (#525)

### DIFF
--- a/src/winpodx/gui/_main_window_bringup.py
+++ b/src/winpodx/gui/_main_window_bringup.py
@@ -125,6 +125,13 @@ class _ChecklistIconLabel(QLabel):
 # transport during the long-tail Sysprep wait.
 _POLL_CADENCE_SECS = 2.0
 
+# #525: on a recreate/post-install boot the guest agent's autostart only fires
+# inside an interactive session, which a headless recreate boot lacks until an
+# RDP logon. If the agent hasn't settled this many seconds into phase 2 (and the
+# pod is already initialized, so we're not mid-Sysprep on a fresh install), open
+# a desktop session to force that logon and wake the agent.
+_AGENT_KICK_GRACE_SECS = 45.0
+
 # Discovery (phase 4) retry: on a fresh install the agent's /health can flicker
 # (TermService / rdprrap reactivation restarts it), so the discovery /exec POST
 # can land on a momentarily-closed socket ("Remote end closed connection without
@@ -692,17 +699,28 @@ class BringUpMixin:
 
     # ----- public entry point --------------------------------------------
 
-    def _run_full_bring_up(self) -> None:
+    def _run_full_bring_up(self, *, recreate: bool = False, wipe_storage: bool = False) -> None:
         """Kick off the bring-up worker thread.
 
         Returns immediately. Phase progress is emitted via
         ``bringup_phase`` / ``bringup_done``. The dialog is opened on
         the GUI thread via ``bringup_started`` (so the caller can be
         on any thread).
+
+        When ``recreate`` is True the worker runs a container recreate
+        (stop -> optional wipe -> regenerate compose -> recreate) as its
+        first step, BEFORE waiting for the pod. The settings save used to
+        do this inline and only opened the progress dialog afterwards, so
+        the dialog appeared tens of seconds late (after the slow podman
+        recreate) -- reading as "nothing happened" then a sudden popup.
+        Folding it in lets ``bringup_started`` open the dialog FIRST and
+        surface the recreate as live progress (#525 confusion).
         """
         # Lazy-allocate the cancel event. New event per run so a stale
         # "cancelled" flag from a prior bring-up can't trip the next.
         self._bringup_cancel = threading.Event()
+        self._bringup_recreate = recreate
+        self._bringup_wipe = wipe_storage
 
         # Signal back to the GUI thread that a dialog should open. The
         # caller (``_save_settings`` worker thread) cannot construct
@@ -843,6 +861,9 @@ class BringUpMixin:
         phase methods below.
         """
         try:
+            if getattr(self, "_bringup_recreate", False):
+                if not self._phase0_recreate():
+                    return
             if not self._phase1_wait_pod_ready():
                 return
             if not self._phase2_wait_agent_settle():
@@ -857,6 +878,48 @@ class BringUpMixin:
         except Exception as exc:  # noqa: BLE001
             log.exception("bring-up worker crashed")
             self._emit_done(False, f"{exc.__class__.__name__}: {exc}")
+
+    # ----- phase 0: recreate container (settings-driven) -----------------
+
+    def _phase0_recreate(self) -> bool:
+        """Recreate the container before the wait -> settle -> ... chain.
+
+        Driven by a settings save that changed a compose-affecting knob.
+        Runs on the worker thread so the (already-open) dialog shows the
+        recreate as live progress, instead of the user staring at a frozen
+        window while a slow ``podman recreate`` ran inline before the dialog
+        even appeared. Emits under the ``phase_1_pod`` row -- recreate is
+        pod-lifecycle, and reusing that slug keeps the 5-row checklist intact
+        (no renumbering). Returns False + emits ``bringup_done`` on failure.
+        """
+        if self._is_cancelled():
+            return self._emit_cancelled()
+        wipe = getattr(self, "_bringup_wipe", False)
+        try:
+            from winpodx.cli.pod import _wipe_pod_storage
+            from winpodx.cli.setup_cmd import _generate_compose, _recreate_container
+            from winpodx.core.pod import stop_pod
+
+            if wipe:
+                # Stop before wipe -- can't remove a volume still attached to a
+                # running container, and bind-mount contents under a live
+                # container risk EBUSY on rmtree.
+                self._emit_phase("phase_1_pod", "Stopping container + wiping Windows disk...")
+                stop_pod(self.cfg)
+                _wipe_pod_storage(self.cfg)
+            self._emit_phase("phase_1_pod", "Regenerating compose...")
+            _generate_compose(self.cfg)
+            self._emit_phase(
+                "phase_1_pod",
+                "Recreating container (Windows reinstalling)..."
+                if wipe
+                else "Recreating container...",
+            )
+            _recreate_container(self.cfg)
+        except Exception as exc:  # noqa: BLE001
+            self._emit_done(False, f"Recreate failed: {exc}")
+            return False
+        return True
 
     # ----- phase 1: wait pod ready ---------------------------------------
 
@@ -1005,6 +1068,7 @@ class BringUpMixin:
         client = AgentClient(self.cfg)
         started = time.monotonic()
         attempt = 0
+        kicked = False
         while True:
             if self._is_cancelled():
                 return self._emit_cancelled()
@@ -1040,11 +1104,52 @@ class BringUpMixin:
                 )
                 return True
 
+            # #525 agent-kick: a headless recreate boot has no interactive
+            # session, so the agent's autostart never fires and we'd burn the
+            # whole budget. Open a desktop session once to force the logon ->
+            # autostart -> agent. Gated to initialized pods so we never connect
+            # mid-Sysprep on a fresh install (an early RDP login can kill
+            # install.bat's autologon session). Best-effort + non-fatal.
+            if (
+                not kicked
+                and elapsed >= _AGENT_KICK_GRACE_SECS
+                and getattr(self.cfg.pod, "initialized", False)
+            ):
+                kicked = True
+                self._kick_interactive_session()
+
             self._emit_phase(
                 "phase_2_agent",
                 f"Attempt {attempt} - {health_detail}; {token_detail or 'awaiting /health'}",
             )
             self._sleep_cancellable(_POLL_CADENCE_SECS)
+
+    def _kick_interactive_session(self) -> None:
+        """Open a desktop RDP session to force an interactive logon (#525).
+
+        The guest agent only autostarts inside an interactive session; a
+        headless recreate boot has none, so this connects a plain desktop
+        session to create one (firing HKCU\\Run + the keep-alive task). This
+        is the "start a Windows app and the agent activates" workaround,
+        automated. Left OPEN intentionally -- closing it could tear the
+        session (and the agent) back down before the agent is confirmed up;
+        the user's later app launches reuse the single RDP session. Best-
+        effort; never raises.
+
+        NOTE: this path's effect (does a desktop connect reliably wake the
+        agent, and should the kick session be closed afterwards?) needs a
+        real-Windows smoke check -- it can't be verified from host code.
+        """
+        self._emit_phase(
+            "phase_2_agent",
+            "Agent not responding -- opening a desktop session to wake it (#525)...",
+        )
+        try:
+            from winpodx.core.rdp import launch_desktop
+
+            launch_desktop(self.cfg)
+        except Exception as exc:  # noqa: BLE001
+            log.debug("agent-kick desktop launch failed: %s", exc, exc_info=True)
 
     # ----- phase 3: apply windows-side fixes -----------------------------
 

--- a/src/winpodx/gui/_main_window_settings.py
+++ b/src/winpodx/gui/_main_window_settings.py
@@ -19,11 +19,9 @@ Host-class contract (only listed for readers; not enforced):
 from __future__ import annotations
 
 import logging
-import threading
 
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
-    QApplication,
     QBoxLayout,
     QComboBox,
     QFrame,
@@ -1358,50 +1356,15 @@ class SettingsPageMixin:
                     if needs_wipe
                     else tr("Recreating container...")
                 )
-                QApplication.processEvents()
-                wipe_storage = needs_wipe
-
-                def _recreate() -> None:
-                    try:
-                        from winpodx.cli.pod import _wipe_pod_storage
-                        from winpodx.cli.setup_cmd import (
-                            _generate_compose,
-                            _recreate_container,
-                        )
-                        from winpodx.core.pod import stop_pod
-
-                        if wipe_storage:
-                            # Stop before wipe -- can't remove a volume
-                            # that's still attached to a running container,
-                            # and bind-mount contents under an active
-                            # container risk EBUSY on rmtree.
-                            stop_pod(self.cfg)
-                            _wipe_pod_storage(self.cfg)
-
-                        _generate_compose(self.cfg)
-                        _recreate_container(self.cfg)
-                        self.app_launched.emit(
-                            tr("Container recreated; Windows reinstalling")
-                            if wipe_storage
-                            else tr("Container restarted")
-                        )
-                    except Exception as e:  # noqa: BLE001
-                        self.app_launch_failed.emit(tr("Restart failed: {e}").format(e=e))
-                        return
-                    # v0.5.1: the freshly-recreated guest has no booted
-                    # Windows / no agent / no rdprrap / no apps yet. Run
-                    # the full bring-up chain (wait pod -> wait agent ->
-                    # apply Windows fixes -> discover apps -> reverse-
-                    # open sync) on its own worker thread. The call
-                    # returns immediately; the user sees progress in
-                    # ``BringUpProgressDialog`` (opened on the GUI thread
-                    # via the ``bringup_started`` signal).
-                    try:
-                        self._run_full_bring_up()
-                    except Exception as e:  # noqa: BLE001
-                        self.app_launch_failed.emit(tr("Bring-up kickoff failed: {e}").format(e=e))
-
-                threading.Thread(target=_recreate, daemon=True).start()
+                # Open the bring-up dialog FIRST, then do the (slow) recreate as
+                # its phase 0 on the worker thread. Previously the recreate ran
+                # inline here and the dialog only appeared after the slow podman
+                # recreate finished -- so for tens of seconds it looked like the
+                # save did nothing, then a dialog popped out of nowhere (#525
+                # confusion). _run_full_bring_up emits ``bringup_started`` before
+                # any slow work, so the dialog is up immediately and the
+                # stop/wipe/compose/recreate steps stream as live progress.
+                self._run_full_bring_up(recreate=True, wipe_storage=needs_wipe)
                 return
 
             # Declined. A device-changing disguise switch must NOT be left

--- a/tests/test_main_window_bringup.py
+++ b/tests/test_main_window_bringup.py
@@ -768,3 +768,203 @@ def test_phase4_does_not_retry_real_script_failure(monkeypatch: pytest.MonkeyPat
     success, msg = harness.bringup_done.emissions[0]
     assert success is False
     assert "Discovery script failed" in msg
+
+
+# ----- phase 0: settings-driven recreate (#525) --------------------------
+
+
+def _mock_happy_chain(monkeypatch: pytest.MonkeyPatch, cfg: Config) -> None:
+    """Mock phases 1-5 so they all succeed, leaving the test free to focus on
+    the recreate phase 0 + agent-kick behavior."""
+    monkeypatch.setattr(
+        "winpodx.core.pod.pod_status",
+        lambda _cfg: PodStatus(state=PodState.RUNNING, ip="127.0.0.1"),
+    )
+    monkeypatch.setattr("winpodx.core.pod.check_rdp_port", lambda _ip, _port, timeout=3.0: True)
+
+    class FakeClient:
+        def __init__(self, _cfg: Config) -> None:
+            pass
+
+        def health(self) -> dict:
+            return {"ok": True}
+
+        def auth_ready(self) -> tuple[bool, str]:
+            return True, ""
+
+    monkeypatch.setattr("winpodx.core.agent.AgentClient", FakeClient)
+    monkeypatch.setattr(
+        "winpodx.core.provisioner.apply_windows_runtime_fixes",
+        lambda _cfg: {"max_sessions": "ok", "multi_session": "ok"},
+    )
+    monkeypatch.setattr("winpodx.core.discovery.scan", lambda _cfg: ["app1"])
+    monkeypatch.setattr("winpodx.core.discovery.persist_discovered", lambda _apps: ["/tmp/a.toml"])
+    monkeypatch.setattr("winpodx.cli.host_open._cmd_refresh", lambda _args: 0)
+    cfg.reverse_open.enabled = True
+
+
+def test_recreate_runs_phase0_no_wipe_before_pod(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _make_cfg()
+    _mock_happy_chain(monkeypatch, cfg)
+    calls: list[str] = []
+    monkeypatch.setattr("winpodx.core.pod.stop_pod", lambda _cfg: calls.append("stop"))
+    monkeypatch.setattr("winpodx.cli.pod._wipe_pod_storage", lambda _cfg: calls.append("wipe"))
+    monkeypatch.setattr(
+        "winpodx.cli.setup_cmd._generate_compose", lambda _cfg: calls.append("compose")
+    )
+    monkeypatch.setattr(
+        "winpodx.cli.setup_cmd._recreate_container", lambda _cfg: calls.append("recreate")
+    )
+
+    harness = Harness(cfg)
+    harness._run_full_bring_up(recreate=True, wipe_storage=False)
+    _wait_for_done(harness)
+
+    assert harness.bringup_done.emissions == [(True, "")]
+    # No-wipe recreate: regenerate compose + recreate, NO stop/wipe.
+    assert calls == ["compose", "recreate"]
+    # Dialog kick fired before any slow work (immediate dialog).
+    assert harness.bringup_started.emissions == [()]
+    # The recreate progress lands BEFORE the agent phase.
+    raws = harness.bringup_phase.emissions
+    recreate_idx = next(i for i, (_p, d) in enumerate(raws) if "Recreating container" in d)
+    agent_idx = next(i for i, (p, _d) in enumerate(raws) if p == "phase_2_agent")
+    assert recreate_idx < agent_idx
+
+
+def test_recreate_wipe_stops_and_wipes_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _make_cfg()
+    _mock_happy_chain(monkeypatch, cfg)
+    calls: list[str] = []
+    monkeypatch.setattr("winpodx.core.pod.stop_pod", lambda _cfg: calls.append("stop"))
+    monkeypatch.setattr("winpodx.cli.pod._wipe_pod_storage", lambda _cfg: calls.append("wipe"))
+    monkeypatch.setattr(
+        "winpodx.cli.setup_cmd._generate_compose", lambda _cfg: calls.append("compose")
+    )
+    monkeypatch.setattr(
+        "winpodx.cli.setup_cmd._recreate_container", lambda _cfg: calls.append("recreate")
+    )
+
+    harness = Harness(cfg)
+    harness._run_full_bring_up(recreate=True, wipe_storage=True)
+    _wait_for_done(harness)
+
+    assert harness.bringup_done.emissions == [(True, "")]
+    assert calls == ["stop", "wipe", "compose", "recreate"]
+
+
+def test_recreate_failure_stops_chain(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _make_cfg()
+    _mock_happy_chain(monkeypatch, cfg)
+    monkeypatch.setattr("winpodx.core.pod.stop_pod", lambda _cfg: None)
+    monkeypatch.setattr("winpodx.cli.pod._wipe_pod_storage", lambda _cfg: None)
+    monkeypatch.setattr("winpodx.cli.setup_cmd._generate_compose", lambda _cfg: None)
+
+    def _boom(_cfg: Config) -> None:
+        raise RuntimeError("podman recreate busted")
+
+    monkeypatch.setattr("winpodx.cli.setup_cmd._recreate_container", _boom)
+
+    harness = Harness(cfg)
+    harness._run_full_bring_up(recreate=True, wipe_storage=False)
+    _wait_for_done(harness)
+
+    assert len(harness.bringup_done.emissions) == 1
+    success, msg = harness.bringup_done.emissions[0]
+    assert success is False
+    assert "Recreate failed" in msg and "podman recreate busted" in msg
+    # The wait/settle chain must NOT run after a failed recreate.
+    assert "phase_2_agent" not in _phase_labels(harness.bringup_phase.emissions)
+
+
+def test_non_recreate_run_skips_phase0(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _make_cfg()
+    _mock_happy_chain(monkeypatch, cfg)
+    monkeypatch.setattr(
+        "winpodx.cli.setup_cmd._recreate_container",
+        lambda _cfg: pytest.fail("recreate must not run when recreate=False"),
+    )
+
+    harness = Harness(cfg)
+    harness._run_full_bring_up()  # default recreate=False
+    _wait_for_done(harness)
+
+    assert harness.bringup_done.emissions == [(True, "")]
+
+
+# ----- phase 2: agent-kick on a headless recreate boot (#525) ------------
+
+
+class _DeadAgent:
+    def __init__(self, _cfg: Config) -> None:
+        pass
+
+    def health(self) -> dict:
+        raise RuntimeError("agent down (no interactive session)")
+
+    def auth_ready(self) -> tuple[bool, str]:
+        return False, "no agent"
+
+
+def _short_kick_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    import winpodx.gui._main_window_bringup as b
+
+    monkeypatch.setattr(b, "_AGENT_KICK_GRACE_SECS", 0.0)
+    monkeypatch.setattr(b, "_POLL_CADENCE_SECS", 0.01)
+
+
+def test_phase2_kicks_session_when_initialized(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _make_cfg()
+    cfg.install.wait_ready_stage3_secs = 0.3
+    cfg.pod.initialized = True
+    monkeypatch.setattr("winpodx.core.agent.AgentClient", _DeadAgent)
+    _short_kick_window(monkeypatch)
+    kicks: list[int] = []
+    monkeypatch.setattr(Harness, "_kick_interactive_session", lambda self: kicks.append(1))
+
+    harness = Harness(cfg)
+    harness._bringup_cancel = threading.Event()
+    result = harness._phase2_wait_agent_settle()
+
+    assert result is False  # agent never settled
+    assert kicks == [1]  # kicked exactly once (not re-kicked every poll)
+
+
+def test_phase2_no_kick_when_not_initialized(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _make_cfg()
+    cfg.install.wait_ready_stage3_secs = 0.2
+    cfg.pod.initialized = False  # fresh install mid-Sysprep -- never RDP early
+    monkeypatch.setattr("winpodx.core.agent.AgentClient", _DeadAgent)
+    _short_kick_window(monkeypatch)
+    kicks: list[int] = []
+    monkeypatch.setattr(Harness, "_kick_interactive_session", lambda self: kicks.append(1))
+
+    harness = Harness(cfg)
+    harness._bringup_cancel = threading.Event()
+    harness._phase2_wait_agent_settle()
+
+    assert kicks == []
+
+
+def test_kick_interactive_session_launches_desktop(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _make_cfg()
+    called: list[int] = []
+    monkeypatch.setattr("winpodx.core.rdp.launch_desktop", lambda _cfg, **_kw: called.append(1))
+
+    harness = Harness(cfg)
+    harness._kick_interactive_session()
+
+    assert called == [1]
+    assert any(p == "phase_2_agent" for p, _d in harness.bringup_phase.emissions)
+
+
+def test_kick_interactive_session_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _make_cfg()
+
+    def _boom(_cfg: Config, **_kw: object) -> None:
+        raise RuntimeError("no freerdp")
+
+    monkeypatch.setattr("winpodx.core.rdp.launch_desktop", _boom)
+
+    harness = Harness(cfg)
+    harness._kick_interactive_session()  # must not raise


### PR DESCRIPTION
## Problem (0.6.0, #525)

A settings save that changes a compose-affecting knob recreates the container. Two issues:

1. **The progress dialog appeared tens of seconds late.** `_save_settings` ran stop → wipe → compose → recreate **inline** and only opened the bring-up dialog *after* that slow `podman recreate` finished — so for tens of seconds it looked like the save did nothing, then a dialog popped out of nowhere.
2. **"Waiting for Agent" hung forever on a recreate boot.** The guest agent autostarts only inside an interactive session (HKCU\\Run + the keep-alive task, both `LogonType Interactive`); a headless recreate boot has none until an RDP logon — so the agent never settled and the only workaround was to start a Windows app by hand.

## Fix

1. **Recreate is now bring-up phase 0.** `_run_full_bring_up(recreate=True, wipe_storage=...)` emits `bringup_started` (opens the dialog) **before** any slow work; the stop/wipe/compose/recreate steps stream as live progress under the "Pod ready" row. This also folds recreate into the single bring-up sequence instead of a parallel inline path.
2. **Agent-kick.** Phase 2, after a grace period and **only on an already-initialized pod** (never mid-Sysprep on a fresh install, where an early RDP connect can kill install.bat's autologon session), opens a desktop session via `launch_desktop` to force the logon → autostart → agent. Best-effort and non-fatal — if it fails, phase 2 keeps polling as before.

## Tests

- Phase-0 recreate: no-wipe ordering (compose→recreate, dialog first, before agent), wipe ordering (stop→wipe→compose→recreate), failure stops the chain, non-recreate skips phase 0.
- Agent-kick: kicks once when initialized, never when not, `launch_desktop` wiring + never-raises.
- Full suite: **1865 passed, 1 skipped**. `ruff check` + `ruff format --check` clean.

## Needs smoke

The agent-kick's guest-session effect — does a desktop connect reliably wake the agent, and should the kick session be closed afterwards — needs a real-Windows check. It degrades gracefully (non-fatal) if it doesn't help.