### PR TITLE
feat(gui): auto-build the patched-QEMU image when switching to Hardened (#246)

### DIFF
--- a/src/winpodx/cli/disguise.py
+++ b/src/winpodx/cli/disguise.py
@@ -83,36 +83,62 @@ def _qemu_version(backend: str, image: str) -> str:
     return m.group(1) if m else ""
 
 
-def _build_image(args: argparse.Namespace) -> None:
-    from winpodx.core.config import DOCKUR_IMAGE_PIN, Config
+def disguise_image_present(cfg) -> bool:  # type: ignore[no-untyped-def]
+    """True if the patched-QEMU disguise image already exists locally.
+
+    Lets callers (e.g. the GUI switching to hardened mode) decide whether a
+    build is needed without rebuilding the ~20-40 min image every time.
+    """
+    backend = cfg.pod.backend if cfg.pod.backend in ("podman", "docker") else "podman"
+    try:
+        return (
+            subprocess.run(
+                [backend, "image", "inspect", _DISGUISE_TAG],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            ).returncode
+            == 0
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def build_disguise_image(cfg, *, on_line=None, should_cancel=None) -> bool:  # type: ignore[no-untyped-def]
+    """Build the patched-QEMU disguise image locally. Returns True on success.
+
+    Compiles QEMU with the ACPI OEM + disk-model strings patched to the HOST's
+    real values (~20-40 min). Streams build output line-by-line to ``on_line``
+    (a callable taking one str) and aborts if ``should_cancel`` returns True.
+    On success sets ``cfg.pod.disguise_image`` + saves. Never raises -- returns
+    False on any failure so callers can fall back.
+
+    LOCAL-ONLY: winpodx ships the recipe (packaging/qemu-disguise/), never a
+    patched binary, and the host values are read into the local image, never
+    committed -- so there is no GPL-binary redistribution and no host identity
+    in git.
+    """
+    from winpodx.core.config import DOCKUR_IMAGE_PIN
+
+    def _emit(line: str) -> None:
+        if on_line is not None:
+            try:
+                on_line(line)
+            except Exception:  # noqa: BLE001
+                pass
 
     recipe = _recipe_dir()
     if recipe is None:
-        print(tr("Build recipe not found (packaging/qemu-disguise). Use a source checkout."))
-        sys.exit(1)
+        _emit("disguise build: recipe not found (packaging/qemu-disguise); need a source checkout")
+        return False
 
-    cfg = Config.load()
     backend = cfg.pod.backend if cfg.pod.backend in ("podman", "docker") else "podman"
     pin = cfg.pod.image or DOCKUR_IMAGE_PIN
-
-    qver = _qemu_version(backend, pin)
-    if not qver:
-        print(
-            tr("Could not detect the QEMU version in {image}; defaulting to 10.0.8.").format(
-                image=pin
-            )
-        )
-        qver = "10.0.8"
-
+    qver = _qemu_version(backend, pin) or "10.0.8"
     vendor = _host_dmi("sys_vendor") or _host_dmi("bios_vendor")
     disk = _host_disk_model()
 
-    build_args = [
-        "--build-arg",
-        f"DOCKUR_IMAGE={pin}",
-        "--build-arg",
-        f"QEMU_VERSION={qver}",
-    ]
+    build_args = ["--build-arg", f"DOCKUR_IMAGE={pin}", "--build-arg", f"QEMU_VERSION={qver}"]
     if vendor:
         build_args += ["--build-arg", f"ACPI_OEM6={vendor}", "--build-arg", f"ACPI_OEM8={vendor}"]
     if disk:
@@ -128,25 +154,43 @@ def _build_image(args: argparse.Namespace) -> None:
         str(recipe / "Dockerfile"),
         str(recipe),
     ]
-    print(
-        tr(
-            "Building {tag} from {image} (QEMU {ver}) — this compiles QEMU and can "
-            "take 20-40 minutes.\n  ACPI OEM / disk model: {vendor} / {disk}"
-        ).format(
-            tag=_DISGUISE_TAG,
-            image=pin,
-            ver=qver,
-            vendor=vendor or "(default)",
-            disk=disk or "(default)",
-        )
+    _emit(
+        f"Building {_DISGUISE_TAG} from {pin} (QEMU {qver}); "
+        f"ACPI/disk = {vendor or '(default)'} / {disk or '(default)'}; compiling, ~20-40 min..."
     )
-    rc = subprocess.call(cmd)
+    try:
+        proc = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        _emit(f"disguise build: failed to start ({exc})")
+        return False
+
+    if proc.stdout is not None:
+        for line in proc.stdout:
+            _emit(line.rstrip())
+            if should_cancel is not None and should_cancel():
+                proc.terminate()
+                _emit("disguise build: cancelled")
+                return False
+    rc = proc.wait()
     if rc != 0:
-        print(tr("Build failed (exit {rc}). See the output above.").format(rc=rc))
-        sys.exit(1)
+        _emit(f"disguise build: FAILED (exit {rc})")
+        return False
 
     cfg.pod.disguise_image = _DISGUISE_TAG
     cfg.save()
+    _emit(f"disguise build: done -> {_DISGUISE_TAG}")
+    return True
+
+
+def _build_image(args: argparse.Namespace) -> None:
+    from winpodx.core.config import Config
+
+    cfg = Config.load()
+    if not build_disguise_image(cfg, on_line=print):
+        print(tr("Build failed. See the output above."))
+        sys.exit(1)
     print(
         tr(
             "Built {tag} and set pod.disguise_image. To use it:\n"

--- a/src/winpodx/gui/_main_window_bringup.py
+++ b/src/winpodx/gui/_main_window_bringup.py
@@ -163,7 +163,12 @@ def _is_transient_discovery_error(exc: Exception) -> bool:
 #     phases (3-5) that can't honour the cancel event mid-call -- the
 #     dialog disables Cancel while those run.
 _PHASE_DEFS: tuple[tuple[str, str, str, bool], ...] = (
-    ("phase_1_pod", "Pod ready", "usually ~1-2 min", True),
+    (
+        "phase_1_pod",
+        "Pod ready",
+        "usually ~1-2 min; 20-40 min on a fresh install (Windows download + setup)",
+        True,
+    ),
     (
         "phase_2_agent",
         "Agent ready",
@@ -699,7 +704,13 @@ class BringUpMixin:
 
     # ----- public entry point --------------------------------------------
 
-    def _run_full_bring_up(self, *, recreate: bool = False, wipe_storage: bool = False) -> None:
+    def _run_full_bring_up(
+        self,
+        *,
+        recreate: bool = False,
+        wipe_storage: bool = False,
+        build_disguise: bool = False,
+    ) -> None:
         """Kick off the bring-up worker thread.
 
         Returns immediately. Phase progress is emitted via
@@ -721,6 +732,7 @@ class BringUpMixin:
         self._bringup_cancel = threading.Event()
         self._bringup_recreate = recreate
         self._bringup_wipe = wipe_storage
+        self._bringup_build_disguise = build_disguise
 
         # Signal back to the GUI thread that a dialog should open. The
         # caller (``_save_settings`` worker thread) cannot construct
@@ -861,6 +873,9 @@ class BringUpMixin:
         phase methods below.
         """
         try:
+            if getattr(self, "_bringup_build_disguise", False):
+                if not self._phase_build_disguise():
+                    return
             if getattr(self, "_bringup_recreate", False):
                 if not self._phase0_recreate():
                     return
@@ -878,6 +893,51 @@ class BringUpMixin:
         except Exception as exc:  # noqa: BLE001
             log.exception("bring-up worker crashed")
             self._emit_done(False, f"{exc.__class__.__name__}: {exc}")
+
+    # ----- phase 0-pre: build patched-QEMU disguise image (hardened) ------
+
+    def _phase_build_disguise(self) -> bool:
+        """Build the patched-QEMU disguise image before recreate (hardened mode).
+
+        Triggered when the user switches ``disguise_level`` to ``max`` and the
+        local image isn't built yet -- so picking "Hardened" delivers the full
+        disguise (ACPI OEM + disk-model patched to the host's values) without a
+        separate manual ``winpodx disguise build-image`` step. ~20-40 min QEMU
+        compile, streamed under the "Pod ready" row. The build is LOCAL only:
+        no patched binary is distributed, host values stay in the local image.
+
+        NON-FATAL: a build failure falls back to hardened WITHOUT the patched
+        image (the emulated SATA/e1000/std devices still apply), so the chain
+        still proceeds. Returns False only on cancel (to stop the chain).
+        """
+        if self._is_cancelled():
+            return self._emit_cancelled()
+        from winpodx.cli.disguise import build_disguise_image
+
+        self._emit_phase(
+            "phase_1_pod",
+            "Hardened mode: building patched-QEMU image (one-time, ~20-40 min)...",
+        )
+
+        def _on_line(line: str) -> None:
+            if line.strip():
+                self._emit_phase("phase_1_pod", f"build: {line[-80:]}")
+
+        try:
+            ok = build_disguise_image(self.cfg, on_line=_on_line, should_cancel=self._is_cancelled)
+        except Exception as exc:  # noqa: BLE001
+            ok = False
+            log.debug("disguise build raised: %s", exc, exc_info=True)
+
+        if self._is_cancelled():
+            return self._emit_cancelled()
+        if not ok:
+            # Fall back to hardened-without-patched-image rather than aborting.
+            self._emit_phase(
+                "phase_1_pod",
+                "patched-QEMU build failed -- continuing hardened without it",
+            )
+        return True
 
     # ----- phase 0: recreate container (settings-driven) -----------------
 

--- a/src/winpodx/gui/_main_window_settings.py
+++ b/src/winpodx/gui/_main_window_settings.py
@@ -1335,6 +1335,20 @@ class SettingsPageMixin:
                     "Container must be recreated to apply (Windows disk "
                     "preserved).\n\nRestart now?"
                 )
+            # Hardened (max) delivers its full disguise only with the patched-QEMU
+            # image (ACPI OEM + disk model). Build it locally + automatically when
+            # switching to max and it isn't built yet -- no manual
+            # `winpodx disguise build-image` step. The build is local-only (no
+            # binary shipped, host values stay local), so there's no GPL/privacy
+            # cost. Warn about the one-time ~20-40 min compile up front.
+            from winpodx.cli.disguise import disguise_image_present
+
+            build_disguise = new_disguise_level == "max" and not disguise_image_present(self.cfg)
+            if build_disguise:
+                prompt += tr(
+                    "\n\nHardened mode will also build a patched-QEMU image locally "
+                    "first (one-time, ~20-40 min). Progress shows in the setup window."
+                )
             if needs_wipe:
                 # Destructive — default to No so a stray Enter can't wipe Windows.
                 reply = QMessageBox.question(
@@ -1364,7 +1378,9 @@ class SettingsPageMixin:
                 # confusion). _run_full_bring_up emits ``bringup_started`` before
                 # any slow work, so the dialog is up immediately and the
                 # stop/wipe/compose/recreate steps stream as live progress.
-                self._run_full_bring_up(recreate=True, wipe_storage=needs_wipe)
+                self._run_full_bring_up(
+                    recreate=True, wipe_storage=needs_wipe, build_disguise=build_disguise
+                )
                 return
 
             # Declined. A device-changing disguise switch must NOT be left

--- a/tests/test_disguise_cli.py
+++ b/tests/test_disguise_cli.py
@@ -1,9 +1,40 @@
 # SPDX-License-Identifier: MIT
-"""`winpodx disguise build-image` — host-derived patched-QEMU image (#246)."""
+"""`winpodx disguise build-image` + the reusable build helpers (#246).
+
+The build now streams via ``subprocess.Popen`` (so the GUI can surface
+progress + cancel a long compile), and the GUI auto-builds the image when
+the user switches to hardened mode.
+"""
 
 from __future__ import annotations
 
 import argparse
+
+import pytest
+
+
+class _FakeProc:
+    """Minimal Popen stand-in: records the cmd, streams a couple of lines."""
+
+    def __init__(self, cmd, rc: int = 0, lines: list[str] | None = None) -> None:
+        self.cmd = cmd
+        self._rc = rc
+        self.stdout = iter(lines if lines is not None else ["Step 1/5\n", "Step 5/5\n"])
+        self.terminated = False
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def wait(self) -> int:
+        return self._rc
+
+
+def _seed_host_values(monkeypatch, d) -> None:
+    """Synthetic host values (NOT any real machine's) -- proves the command
+    passes whatever the host reports without baking a real vendor into git."""
+    monkeypatch.setattr(d, "_host_dmi", lambda n: "ACME" if n == "sys_vendor" else "")
+    monkeypatch.setattr(d, "_host_disk_model", lambda: "ACME SSD 1TB")
+    monkeypatch.setattr(d, "_qemu_version", lambda backend, image: "10.0.8")
 
 
 def test_build_image_uses_host_values_and_sets_config(monkeypatch, tmp_path):
@@ -16,24 +47,22 @@ def test_build_image_uses_host_values_and_sets_config(monkeypatch, tmp_path):
     recipe = tmp_path / "qemu-disguise"
     recipe.mkdir()
     (recipe / "Dockerfile").write_text("x", encoding="utf-8")
-
     monkeypatch.setattr(d, "_recipe_dir", lambda: recipe)
-    # Synthetic host values (NOT any real machine's) — proves the command passes
-    # whatever the host reports, without baking a real vendor into the repo.
-    monkeypatch.setattr(d, "_host_dmi", lambda n: "ACME" if n == "sys_vendor" else "")
-    monkeypatch.setattr(d, "_host_disk_model", lambda: "ACME SSD 1TB")
-    monkeypatch.setattr(d, "_qemu_version", lambda backend, image: "10.0.8")
+    _seed_host_values(monkeypatch, d)
 
     captured: dict = {}
-    monkeypatch.setattr(
-        d.subprocess, "call", lambda cmd: captured.setdefault("cmd", cmd) and 0 or 0
-    )
+
+    def _fake_popen(cmd, **_kw):
+        captured["cmd"] = cmd
+        return _FakeProc(cmd)
+
+    monkeypatch.setattr(d.subprocess, "Popen", _fake_popen)
 
     d.handle_disguise(argparse.Namespace(disguise_command="build-image"))
 
     joined = " ".join(captured["cmd"])
     assert "build" in captured["cmd"]
-    assert "ACPI_OEM6=ACME" in joined  # host vendor, not a fixed ASUS
+    assert "ACPI_OEM6=ACME" in joined  # host vendor, not a fixed brand
     assert "DISK_MODEL=ACME SSD 1TB" in joined  # host disk, not a fixed model
     assert "QEMU_VERSION=10.0.8" in joined
     assert Config.load().pod.disguise_image == "winpodx-windows-disguise"
@@ -41,16 +70,97 @@ def test_build_image_uses_host_values_and_sets_config(monkeypatch, tmp_path):
 
 def test_build_image_aborts_without_recipe(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    import pytest
-
     from winpodx.cli import disguise as d
     from winpodx.core.config import Config
 
     Config().save()
     monkeypatch.setattr(d, "_recipe_dir", lambda: None)
-    called = {"n": 0}
-    monkeypatch.setattr(d.subprocess, "call", lambda cmd: called.__setitem__("n", 1) or 0)
+    started = {"n": 0}
+    monkeypatch.setattr(
+        d.subprocess, "Popen", lambda *a, **k: started.__setitem__("n", 1) or _FakeProc([])
+    )
 
     with pytest.raises(SystemExit):
         d.handle_disguise(argparse.Namespace(disguise_command="build-image"))
-    assert called["n"] == 0  # never shelled out to a build
+    assert started["n"] == 0  # never shelled out to a build
+
+
+def test_build_disguise_image_streams_and_returns_true(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    from winpodx.cli import disguise as d
+    from winpodx.core.config import Config
+
+    cfg = Config()
+    recipe = tmp_path / "qemu-disguise"
+    recipe.mkdir()
+    (recipe / "Dockerfile").write_text("x", encoding="utf-8")
+    monkeypatch.setattr(d, "_recipe_dir", lambda: recipe)
+    _seed_host_values(monkeypatch, d)
+    monkeypatch.setattr(
+        d.subprocess, "Popen", lambda cmd, **_k: _FakeProc(cmd, lines=["a\n", "b\n"])
+    )
+
+    seen: list[str] = []
+    ok = d.build_disguise_image(cfg, on_line=seen.append)
+
+    assert ok is True
+    assert cfg.pod.disguise_image == "winpodx-windows-disguise"
+    assert "a" in seen and "b" in seen  # streamed each build line
+
+
+def test_build_disguise_image_returns_false_on_nonzero(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    from winpodx.cli import disguise as d
+    from winpodx.core.config import Config
+
+    cfg = Config()
+    recipe = tmp_path / "qemu-disguise"
+    recipe.mkdir()
+    (recipe / "Dockerfile").write_text("x", encoding="utf-8")
+    monkeypatch.setattr(d, "_recipe_dir", lambda: recipe)
+    _seed_host_values(monkeypatch, d)
+    monkeypatch.setattr(d.subprocess, "Popen", lambda cmd, **_k: _FakeProc(cmd, rc=1))
+
+    ok = d.build_disguise_image(cfg)
+
+    assert ok is False
+    assert cfg.pod.disguise_image == ""  # not set on failure
+
+
+def test_build_disguise_image_cancel_terminates(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    from winpodx.cli import disguise as d
+    from winpodx.core.config import Config
+
+    cfg = Config()
+    recipe = tmp_path / "qemu-disguise"
+    recipe.mkdir()
+    (recipe / "Dockerfile").write_text("x", encoding="utf-8")
+    monkeypatch.setattr(d, "_recipe_dir", lambda: recipe)
+    _seed_host_values(monkeypatch, d)
+    proc = _FakeProc([], lines=["x\n", "y\n", "z\n"])
+    monkeypatch.setattr(d.subprocess, "Popen", lambda *a, **k: proc)
+
+    ok = d.build_disguise_image(cfg, should_cancel=lambda: True)
+
+    assert ok is False
+    assert proc.terminated is True
+    assert cfg.pod.disguise_image == ""
+
+
+def test_disguise_image_present(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    from winpodx.cli import disguise as d
+    from winpodx.core.config import Config
+
+    cfg = Config()
+
+    class _R:
+        def __init__(self, rc):
+            self.returncode = rc
+
+    monkeypatch.setattr(d.subprocess, "run", lambda *a, **k: _R(0))
+    assert d.disguise_image_present(cfg) is True
+
+    monkeypatch.setattr(d.subprocess, "run", lambda *a, **k: _R(1))
+    assert d.disguise_image_present(cfg) is False

--- a/tests/test_main_window_bringup.py
+++ b/tests/test_main_window_bringup.py
@@ -968,3 +968,64 @@ def test_kick_interactive_session_never_raises(monkeypatch: pytest.MonkeyPatch) 
 
     harness = Harness(cfg)
     harness._kick_interactive_session()  # must not raise
+
+
+# ----- hardened mode: auto-build the patched-QEMU image (#246) ------------
+
+
+def test_build_disguise_phase_runs_before_recreate(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _make_cfg()
+    _mock_happy_chain(monkeypatch, cfg)
+    order: list[str] = []
+    monkeypatch.setattr(
+        "winpodx.cli.disguise.build_disguise_image",
+        lambda _cfg, **_kw: order.append("build") or True,
+    )
+    monkeypatch.setattr("winpodx.core.pod.stop_pod", lambda _cfg: None)
+    monkeypatch.setattr("winpodx.cli.pod._wipe_pod_storage", lambda _cfg: None)
+    monkeypatch.setattr("winpodx.cli.setup_cmd._generate_compose", lambda _cfg: None)
+    monkeypatch.setattr(
+        "winpodx.cli.setup_cmd._recreate_container", lambda _cfg: order.append("recreate")
+    )
+
+    harness = Harness(cfg)
+    harness._run_full_bring_up(recreate=True, wipe_storage=True, build_disguise=True)
+    _wait_for_done(harness)
+
+    assert harness.bringup_done.emissions == [(True, "")]
+    assert order == ["build", "recreate"]  # image built BEFORE the recreate
+
+
+def test_build_disguise_failure_is_nonfatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _make_cfg()
+    _mock_happy_chain(monkeypatch, cfg)
+    # Build fails -> chain must still recreate + complete (hardened w/o image).
+    monkeypatch.setattr("winpodx.cli.disguise.build_disguise_image", lambda _cfg, **_kw: False)
+    recreated = {"n": 0}
+    monkeypatch.setattr("winpodx.cli.setup_cmd._generate_compose", lambda _cfg: None)
+    monkeypatch.setattr(
+        "winpodx.cli.setup_cmd._recreate_container",
+        lambda _cfg: recreated.__setitem__("n", recreated["n"] + 1),
+    )
+
+    harness = Harness(cfg)
+    harness._run_full_bring_up(recreate=True, wipe_storage=False, build_disguise=True)
+    _wait_for_done(harness)
+
+    assert harness.bringup_done.emissions == [(True, "")]
+    assert recreated["n"] == 1  # recreate still happened despite build failure
+
+
+def test_no_build_disguise_when_flag_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _make_cfg()
+    _mock_happy_chain(monkeypatch, cfg)
+    monkeypatch.setattr(
+        "winpodx.cli.disguise.build_disguise_image",
+        lambda _cfg, **_kw: pytest.fail("must not build when build_disguise=False"),
+    )
+
+    harness = Harness(cfg)
+    harness._run_full_bring_up()  # defaults: no recreate, no build
+    _wait_for_done(harness)
+
+    assert harness.bringup_done.emissions == [(True, "")]


### PR DESCRIPTION
## Why

Hardened (max) only fully hides the VM with the **patched-QEMU image** (ACPI OEM + disk-model strings → the host's real values). That image was opt-in behind a manual `winpodx disguise build-image`, so picking Hardened in the GUI left the ACPI / disk al-khaser checks still reading `BOCHS` / `QEMU HARDDISK`. The build is **local-only** (winpodx ships the recipe, never a binary; host values stay in the local image), so there's no GPL-redistribution or git-privacy cost to making it automatic.

## What

- Switching `disguise_level` to **max** now **auto-builds** the image (when not already built) as a bring-up step **before** the recreate. `_save_settings` detects the need via `disguise_image_present()` and warns about the one-time **~20-40 min** compile in the recreate prompt.
- New reusable helpers in `cli/disguise`: `build_disguise_image(cfg, on_line=, should_cancel=)` streams the build + is cancellable; `disguise_image_present(cfg)` checks the local backend. The CLI `winpodx disguise build-image` now uses them.
- **Non-fatal:** a build failure falls back to hardened **without** the patched image (emulated SATA/e1000/std still apply) and the chain proceeds.
- Fix the phase-1 ("Pod ready") ETA hint: it read "usually ~1-2 min" but a fresh install does the Windows download + setup in that phase (20-40 min). The hint now says so.

## Tests

- Build streaming / success / non-zero / cancel + presence check; bring-up build phase ordering (before recreate), non-fatal fallback, skip when not flagged.
- Full suite: **1872 passed, 1 skipped**. `ruff check` + `ruff format --check` clean.

## Needs smoke

The ~20-40 min patched-QEMU build, and that the patched binary boots dockur and actually flips the ACPI/disk al-khaser checks, needs a real-Windows run. Degrades gracefully (non-fatal) if the build fails.