### PR TITLE
fix(gui): keep the app icon when editing a profile (#530)

### DIFF
--- a/src/winpodx/core/app.py
+++ b/src/winpodx/core/app.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 try:
@@ -227,6 +227,17 @@ def list_available_apps() -> list[AppInfo]:
             app = load_app(app_dir, default_source=provenance)
             if app is None:
                 continue
+            prev = by_name.get(app.name)
+            if provenance == "user" and not app.icon_path and prev is not None and prev.icon_path:
+                # A user override only carries metadata -- the GUI editor can't
+                # set an icon -- so an override created by editing name/MIME has
+                # no icon file and would otherwise fall back to the generic
+                # letter glyph (#530). Inherit the discovered profile's icon.
+                # This also keeps it FRESH: a later discovery re-extract updates
+                # discovered/<name>/icon.*, which flows through here (vs freezing
+                # a copy in the override that a guest-side app update can't
+                # refresh).
+                app = replace(app, icon_path=prev.icon_path)
             if app.name not in by_name:
                 order.append(app.name)
             by_name[app.name] = app

--- a/src/winpodx/gui/_main_window_apps.py
+++ b/src/winpodx/gui/_main_window_apps.py
@@ -51,7 +51,7 @@ class AppCrudMixin:
             self.info_label.setText(tr("Added: {name}").format(name=data["full_name"]))
 
     def _on_edit_app(self, app: AppInfo) -> None:
-        from winpodx.gui.app_dialog import AppProfileDialog, save_app_profile
+        from winpodx.gui.app_dialog import AppProfileDialog, preserve_app_icon, save_app_profile
 
         dlg = AppProfileDialog(
             self,
@@ -65,6 +65,10 @@ class AppCrudMixin:
         if dlg.exec():
             data = dlg.get_result()
             save_app_profile(data)
+            # Keep the existing icon across the edit (rename / MIME change /
+            # discovered->user override) so it doesn't reset to the generic
+            # letter glyph (#530).
+            preserve_app_icon(app.icon_path, str(data["name"]))
             self._reload_apps()
             self.info_label.setText(tr("Updated: {name}").format(name=data["full_name"]))
 

--- a/src/winpodx/gui/app_dialog.py
+++ b/src/winpodx/gui/app_dialog.py
@@ -336,6 +336,48 @@ def save_app_profile(data: dict) -> Path:
     return toml_path
 
 
+def preserve_app_icon(src_icon_path: str, dest_name: str) -> None:
+    """Copy an existing app icon into the saved (user) profile dir (#530).
+
+    ``AppInfo.icon_path`` is the ``icon.{svg,png}`` FILE in the app's dir, not a
+    TOML field -- so editing a profile (rename, MIME-association change, or
+    promoting a discovered app to a user override under ``apps/``) writes a new
+    ``app.toml`` whose dir has NO icon file, and desktop-entry regeneration then
+    falls back to the generic letter glyph. Copying the prior icon across keeps
+    it. Best-effort; never raises. (For a genuinely new/changed Windows icon,
+    re-running discovery re-extracts it from the guest exe.)
+    """
+    import shutil
+
+    if not src_icon_path or not _validate_app_name(dest_name):
+        return
+    src = Path(src_icon_path)
+    suffix = src.suffix.lower()
+    if suffix not in (".svg", ".png") or not src.exists():
+        return
+    # If a discovered profile of this name exists, DON'T copy: list_available_apps
+    # makes the user override inherit the discovered icon, which stays fresh when
+    # discovery re-extracts after a guest-side app update. Copying here would
+    # freeze a stale icon. Only copy for a rename (new slug, no discovered twin).
+    if any((data_dir() / "discovered" / dest_name / f"icon.{e}").exists() for e in ("svg", "png")):
+        return
+    apps_root = data_dir() / "apps"
+    dest_dir = apps_root / dest_name
+    try:
+        if not dest_dir.resolve().is_relative_to(apps_root.resolve()):
+            return
+    except OSError:
+        return
+    # Don't clobber an icon the saved dir already carries.
+    if any((dest_dir / f"icon.{e}").exists() for e in ("svg", "png")):
+        return
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        shutil.copy2(src, dest_dir / f"icon{suffix}")
+    except OSError:
+        pass
+
+
 def delete_app_profile(name: str) -> bool:
     """Delete an app profile directory (user OR discovered) (#514).
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -217,3 +217,89 @@ def test_persist_discovered_skips_suppressed(monkeypatch, tmp_path):
 
     assert (root / "realapp" / "app.toml").exists()
     assert not (root / "junkapp").exists()  # suppressed → not re-created
+
+
+# -- icon preservation across edits (#530) --------------------------------
+
+
+def test_user_override_inherits_discovered_icon(monkeypatch, tmp_path):
+    """A user override with no icon file inherits the discovered profile's icon
+    (so editing name/MIME doesn't reset it to the fallback letter glyph) (#530)."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from winpodx.core.app import data_dir, list_available_apps
+
+    disc = data_dir() / "discovered" / "word"
+    disc.mkdir(parents=True)
+    (disc / "app.toml").write_text(
+        'name = "word"\nfull_name = "Word"\nexecutable = "C:\\\\w.exe"\n', encoding="utf-8"
+    )
+    (disc / "icon.svg").write_text("<svg/>", encoding="utf-8")
+
+    user = data_dir() / "apps" / "word"
+    user.mkdir(parents=True)
+    (user / "app.toml").write_text(
+        'name = "word"\nfull_name = "Word (edited)"\nexecutable = "C:\\\\w.exe"\n', encoding="utf-8"
+    )  # NO icon file in the override
+
+    apps = list_available_apps()
+    assert len(apps) == 1
+    assert apps[0].full_name == "Word (edited)"  # user metadata wins
+    assert apps[0].icon_path == str(disc / "icon.svg")  # inherited the discovered icon
+
+
+def test_user_override_keeps_its_own_icon(monkeypatch, tmp_path):
+    """An override that DOES carry its own icon keeps it (no inherit)."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from winpodx.core.app import data_dir, list_available_apps
+
+    disc = data_dir() / "discovered" / "word"
+    disc.mkdir(parents=True)
+    (disc / "app.toml").write_text(
+        'name = "word"\nfull_name = "Word"\nexecutable = "C:\\\\w.exe"\n', encoding="utf-8"
+    )
+    (disc / "icon.svg").write_text("<svg/>", encoding="utf-8")
+    user = data_dir() / "apps" / "word"
+    user.mkdir(parents=True)
+    (user / "app.toml").write_text(
+        'name = "word"\nfull_name = "Word"\nexecutable = "C:\\\\w.exe"\n', encoding="utf-8"
+    )
+    (user / "icon.png").write_text("png", encoding="utf-8")
+
+    apps = list_available_apps()
+    assert apps[0].icon_path == str(user / "icon.png")  # its own icon, not the discovered one
+
+
+def test_preserve_app_icon_copies_on_rename(monkeypatch, tmp_path):
+    import pytest
+
+    pytest.importorskip("PySide6")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from winpodx.core.app import data_dir
+    from winpodx.gui.app_dialog import preserve_app_icon
+
+    old = data_dir() / "apps" / "oldname"
+    old.mkdir(parents=True)
+    (old / "icon.svg").write_text("<svg/>", encoding="utf-8")
+    (data_dir() / "apps" / "newname").mkdir(parents=True)  # save_app_profile made this
+
+    preserve_app_icon(str(old / "icon.svg"), "newname")
+    assert (data_dir() / "apps" / "newname" / "icon.svg").exists()  # carried across the rename
+
+
+def test_preserve_app_icon_skips_when_discovered_twin(monkeypatch, tmp_path):
+    import pytest
+
+    pytest.importorskip("PySide6")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from winpodx.core.app import data_dir
+    from winpodx.gui.app_dialog import preserve_app_icon
+
+    disc = data_dir() / "discovered" / "word"
+    disc.mkdir(parents=True)
+    (disc / "icon.svg").write_text("<svg/>", encoding="utf-8")
+    (data_dir() / "apps" / "word").mkdir(parents=True)
+
+    preserve_app_icon(str(disc / "icon.svg"), "word")
+    # NOT copied -- the loader inherits the (fresh) discovered icon instead of
+    # freezing a stale copy that a guest-side app update couldn't refresh.
+    assert not (data_dir() / "apps" / "word" / "icon.svg").exists()


### PR DESCRIPTION
## Problem

Editing a Windows app's **name** or **MIME associations** in the GUI reset its icon to the generic letter glyph ("W").

## Root cause

`AppInfo.icon_path` is the `icon.{svg,png}` **file** in the app's dir, not a TOML field. Editing a discovered app writes a **user override** under `apps/<name>` that shadows the discovered profile **entirely — including its icon** — but the GUI editor can't set an icon, so the override has no icon file and desktop-entry regeneration falls back to the glyph.

## Fix

- `list_available_apps` now makes an iconless user override **inherit the discovered profile's icon**. This fixes the reset AND keeps the icon **fresh**: a later discovery re-extract updates `discovered/<name>/icon.*`, which flows straight through — instead of freezing a stale copy that a guest-side app update couldn't refresh.
- `preserve_app_icon` copies the prior icon across a genuine **rename** (new slug, no discovered twin to inherit from) so a renamed profile isn't left iconless. It deliberately **skips when a discovered twin exists**, to avoid freezing.

## Why not re-extract from the exe on every edit?

The exe lives in the guest, so re-extraction is a guest round-trip (pod must be up) — the GUI edit path is host-only and must work pod-down. Discovery already does the extraction; inheriting from it keeps the icon current without coupling the editor to the guest. (A checksum-gated icon refresh in discovery — re-extract only when the exe hash changes — is a reasonable separate optimization.)

## Tests

- Override inherits discovered icon; override keeps its own icon when present; rename copies; copy skipped when a discovered twin exists.
- Full suite: **1878 passed, 1 skipped**. `ruff check` + `ruff format --check` clean.