### PR TITLE
feat(discovery): checksum-gated periodic icon refresh

### DIFF
--- a/scripts/windows/discover_apps.ps1
+++ b/scripts/windows/discover_apps.ps1
@@ -147,6 +147,18 @@ function Read-IconBytesFromFile {
     } catch { return '' }
 }
 
+function Get-ExeHash {
+    # SHA256 of an app's executable, used host-side to detect when an app was
+    # updated (icon may have changed) vs unchanged (skip re-extraction). Returns
+    # '' for non-file paths (UWP InstallLocation dirs), missing or locked files.
+    param([string]$Path)
+    if (-not $Path) { return '' }
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return '' }
+    try {
+        return (Get-FileHash -LiteralPath $Path -Algorithm SHA256 -ErrorAction Stop).Hash.ToLower()
+    } catch { return '' }
+}
+
 # --- DryRun short-circuit for CI smoke tests -------------------------------
 
 if ($DryRun) {
@@ -264,6 +276,7 @@ function Add-Result {
         wm_class_hint = [string]$Entry.wm_class_hint
         launch_uri    = [string]$Entry.launch_uri
         icon_b64      = [string]$Entry.icon_b64
+        exe_hash      = Get-ExeHash $path
     }) | Out-Null
 }
 

--- a/src/winpodx/core/app.py
+++ b/src/winpodx/core/app.py
@@ -55,6 +55,10 @@ class AppInfo:
     # missed it, persist_discovered() synthesizes a stub so essentials
     # always appear. Users can still hide them.
     essential: bool = False
+    # SHA256 of the guest exe (discovery). The periodic icon-refresh compares
+    # this to re-extract only apps whose exe changed (an app update). "" for
+    # UWP / user entries.
+    exe_hash: str = ""
 
 
 def user_apps_dir() -> Path:
@@ -175,6 +179,7 @@ def load_app(app_dir: Path, default_source: str = "user") -> AppInfo | None:
         description=data.get("description", "") or "",
         hidden=bool(data.get("hidden", False)),
         essential=bool(data.get("essential", False)),
+        exe_hash=str(data.get("exe_hash", "") or ""),
     )
 
 

--- a/src/winpodx/core/daemon.py
+++ b/src/winpodx/core/daemon.py
@@ -266,3 +266,78 @@ def run_idle_monitor(
                 idle_since = None  # Reset after suspend
 
         stop_event.wait(30)  # Check every 30 seconds, interruptible
+
+
+# App icons change rarely (only when a Windows app is updated), and a full
+# discovery sweep is non-trivial guest work, so check on a slow cadence.
+_ICON_REFRESH_INTERVAL_SECS = 6 * 3600  # 6 hours
+# Initial pass shortly after start to catch updates from a prior session.
+_ICON_REFRESH_FIRST_DELAY_SECS = 300  # 5 min
+
+
+def run_icon_refresh_monitor(
+    cfg: Config,
+    stop_event: threading.Event | None = None,
+) -> None:
+    """Periodically re-discover so an updated app's icon refreshes by itself.
+
+    A Windows app update can change its icon; winpodx only re-extracted icons on
+    a manual "Refresh Apps". This loop runs discovery on a slow cadence (every
+    6 h, plus once ~5 min after start). The checksum gate in
+    ``persist_discovered`` makes apps whose exe is unchanged a no-op, so an
+    idle sweep only rewrites apps that actually changed. Gated each cycle on the
+    pod being up + reachable; never wakes a paused/stopped pod. Runs on its own
+    thread; never raises out (a failure just retries next cycle).
+    """
+    if stop_event is None:
+        stop_event = threading.Event()
+    log.info("Icon-refresh monitor started (every %dh)", _ICON_REFRESH_INTERVAL_SECS // 3600)
+    next_run = time.monotonic() + _ICON_REFRESH_FIRST_DELAY_SECS
+    while not stop_event.is_set():
+        if time.monotonic() >= next_run:
+            next_run = time.monotonic() + _ICON_REFRESH_INTERVAL_SECS
+            try:
+                _icon_refresh_once(cfg)
+            except Exception as e:  # noqa: BLE001 -- never kill the monitor
+                log.debug("icon-refresh pass failed (will retry): %s", e)
+        stop_event.wait(60)  # interruptible; coarse enough for a 6 h cadence
+
+
+def _icon_refresh_once(cfg: Config) -> None:
+    """One checksum-gated discovery sweep. Skips when the pod isn't running."""
+    from winpodx.core.pod import PodState, pod_status
+
+    if is_pod_paused(cfg):
+        return
+    try:
+        if pod_status(cfg).state != PodState.RUNNING:
+            return
+    except Exception:  # noqa: BLE001 -- pod probe flaky -> skip this cycle
+        return
+
+    from winpodx.core import discovery
+
+    # discover_apps raises if the guest agent is unreachable -> caller retries.
+    apps = discovery.discover_apps(cfg)
+    written = discovery.persist_discovered(apps)  # checksum gate -> changed only
+    if not written:
+        return
+
+    # Re-sync the Linux desktop entries so any refreshed icon flows through, then
+    # rebuild the icon cache once. install_desktop_entry is idempotent, so the
+    # unchanged entries are cheap re-writes.
+    from winpodx.core.app import list_available_apps
+    from winpodx.desktop.entry import install_desktop_entry
+    from winpodx.desktop.icons import refresh_icon_cache
+
+    for info in list_available_apps():
+        if getattr(info, "hidden", False):
+            continue
+        try:
+            install_desktop_entry(info)
+        except Exception:  # noqa: BLE001 -- best-effort per app
+            log.debug("icon-refresh: install_desktop_entry failed for %s", info.name)
+    try:
+        refresh_icon_cache()
+    except Exception:  # noqa: BLE001 -- cache refresh is best-effort
+        log.debug("icon-refresh: icon cache refresh failed")

--- a/src/winpodx/core/discovery/__init__.py
+++ b/src/winpodx/core/discovery/__init__.py
@@ -254,6 +254,11 @@ class DiscoveredApp:
     source: str = "win32"  # uwp | win32 | steam
     wm_class_hint: str = ""
     launch_uri: str = ""  # UWP AUMID (shell:AppsFolder\<AUMID>) when source == "uwp"
+    # SHA256 of the guest executable (from discover_apps.ps1's Get-FileHash).
+    # Lets persist_discovered() skip re-extracting an app whose exe is unchanged,
+    # and the periodic icon-refresh re-extract only apps whose exe changed (an
+    # app update). Empty for UWP entries / when the guest couldn't hash it.
+    exe_hash: str = ""
     icon_bytes: bytes = field(default=b"", repr=False)
     # Filled by persist_discovered() after the on-disk layout is
     # materialised. Empty on freshly-parsed instances.
@@ -376,6 +381,27 @@ def _existing_hidden_override(app_dir: Path) -> bool | None:
         return None
     val = data.get("hidden")
     return bool(val) if isinstance(val, bool) else None
+
+
+def _unchanged_on_disk(app_dir: Path, exe_hash: str) -> bool:
+    """True if ``app_dir`` already holds this exe hash AND still has an icon.
+
+    The checksum gate for persist_discovered: an unchanged exe + a present icon
+    means there is nothing to re-extract, so the entry can be left as-is. A
+    missing icon forces a rewrite even on an unchanged hash so a previously
+    icon-less entry can pick one up.
+    """
+    toml_path = app_dir / "app.toml"
+    if not toml_path.exists():
+        return False
+    if not any((app_dir / f"icon.{ext}").exists() for ext in ("png", "svg")):
+        return False
+    try:
+        data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError, OSError):
+        return False
+    prior = data.get("exe_hash", "")
+    return isinstance(prior, str) and prior.lower() == exe_hash.lower()
 
 
 def _merge_essentials(scanned: list[DiscoveredApp]) -> list[DiscoveredApp]:
@@ -972,6 +998,14 @@ def _entry_to_discovered(entry: dict[str, Any]) -> DiscoveredApp | None:
     if not isinstance(launch_uri, str) or len(launch_uri) > _MAX_PATH_LEN:
         launch_uri = ""
 
+    # SHA256 hex (64 chars) of the guest exe; reject anything else so a hostile
+    # guest can't stuff junk into the persisted profile / change-detection key.
+    exe_hash = entry.get("exe_hash", "")
+    if not isinstance(exe_hash, str) or not re.fullmatch(r"[0-9a-fA-F]{64}", exe_hash):
+        exe_hash = ""
+    else:
+        exe_hash = exe_hash.lower()
+
     # UWP entries must have a launch_uri (AUMID); otherwise they are unlaunchable.
     if source == "uwp" and not launch_uri:
         return None
@@ -1006,6 +1040,7 @@ def _entry_to_discovered(entry: dict[str, Any]) -> DiscoveredApp | None:
         source=source,
         wm_class_hint=wm_class_hint,
         launch_uri=launch_uri,
+        exe_hash=exe_hash,
         icon_bytes=icon_bytes,
     )
 
@@ -1078,6 +1113,16 @@ def persist_discovered(
         seen.add(app.name)
 
         app_dir = root / app.name
+
+        # Checksum gate: if the guest reported an exe hash and it matches the
+        # one already on disk, AND that entry still has its icon, the app is
+        # unchanged -- leave it untouched. This is what makes a periodic refresh
+        # cheap (re-extract only apps whose exe changed = an app update) and
+        # keeps an unchanged app's icon stable. Skipped for UWP / hashless
+        # entries (exe_hash ""), which always re-write as before.
+        if replace and app.exe_hash and _unchanged_on_disk(app_dir, app.exe_hash):
+            written.append(app_dir / "app.toml")
+            continue
 
         # Read the user's prior hidden override BEFORE the rmtree below
         # nukes it; the override (None / True / False) decides what gets
@@ -1156,6 +1201,8 @@ def _render_app_toml(app: DiscoveredApp) -> str:
         data["wm_class_hint"] = app.wm_class_hint
     if app.launch_uri:
         data["launch_uri"] = app.launch_uri
+    if app.exe_hash:
+        data["exe_hash"] = app.exe_hash
     # Always emit hidden / essential when set so AppInfo.load_app picks
     # them up. Keep the keys absent on the default-False side to keep
     # toml diffs minimal for the common case (visible, non-essential).

--- a/src/winpodx/desktop/tray.py
+++ b/src/winpodx/desktop/tray.py
@@ -781,6 +781,16 @@ def run_tray() -> None:
             daemon=True,
         ).start()
 
+    # Periodic checksum-gated icon refresh (runs regardless of idle timeout):
+    # picks up a Windows app update's new icon without a manual Refresh.
+    from winpodx.core.daemon import run_icon_refresh_monitor
+
+    threading.Thread(
+        target=run_icon_refresh_monitor,
+        args=(cfg, idle_stop),
+        daemon=True,
+    ).start()
+
     def on_tray_activate(reason: int) -> None:
         # Qt slot: any uncaught exception here aborts the event loop and kills
         # the tray, so catch broadly (not just RuntimeError).

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -303,3 +303,78 @@ def test_preserve_app_icon_skips_when_discovered_twin(monkeypatch, tmp_path):
     # NOT copied -- the loader inherits the (fresh) discovered icon instead of
     # freezing a stale copy that a guest-side app update couldn't refresh.
     assert not (data_dir() / "apps" / "word" / "icon.svg").exists()
+
+
+# -- checksum-gated re-extraction (periodic icon refresh) ------------------
+
+_H1 = "a" * 64
+_H2 = "b" * 64
+
+
+def _persist_one(root, *, exe_hash):
+    from winpodx.core import discovery as d
+
+    app = d.DiscoveredApp(
+        name="word",
+        full_name="Word",
+        executable="C:\\w.exe",
+        exe_hash=exe_hash,
+        icon_bytes=b"<svg/>",
+    )
+    d.persist_discovered([app], target_dir=root, add_essentials=False)
+
+
+def test_persist_skips_unchanged_exe_hash(tmp_path):
+    root = tmp_path / "discovered"
+    _persist_one(root, exe_hash=_H1)
+    sentinel = root / "word" / "SENTINEL"
+    sentinel.write_text("x", encoding="utf-8")
+
+    _persist_one(root, exe_hash=_H1)  # same hash -> unchanged -> left as-is
+    assert sentinel.exists()  # dir not rmtree'd = re-extraction skipped
+
+
+def test_persist_reextracts_on_changed_exe_hash(tmp_path):
+    root = tmp_path / "discovered"
+    _persist_one(root, exe_hash=_H1)
+    sentinel = root / "word" / "SENTINEL"
+    sentinel.write_text("x", encoding="utf-8")
+
+    _persist_one(root, exe_hash=_H2)  # changed hash -> re-extract
+    assert not sentinel.exists()  # dir rmtree'd = rewritten
+
+
+def test_persist_always_rewrites_when_no_hash(tmp_path):
+    root = tmp_path / "discovered"
+    _persist_one(root, exe_hash="")  # UWP / hashless -> no gating
+    sentinel = root / "word" / "SENTINEL"
+    sentinel.write_text("x", encoding="utf-8")
+
+    _persist_one(root, exe_hash="")
+    assert not sentinel.exists()  # always rewritten (gate disabled without a hash)
+
+
+def test_persist_rewrites_unchanged_hash_if_icon_missing(tmp_path):
+    root = tmp_path / "discovered"
+    _persist_one(root, exe_hash=_H1)
+    # Drop the icon: an icon-less entry must rewrite even on an unchanged hash.
+    for ext in ("svg", "png"):
+        (root / "word" / f"icon.{ext}").unlink(missing_ok=True)
+    sentinel = root / "word" / "SENTINEL"
+    sentinel.write_text("x", encoding="utf-8")
+
+    _persist_one(root, exe_hash=_H1)
+    assert not sentinel.exists()  # rewritten to recover the missing icon
+
+
+def test_exe_hash_roundtrips_through_toml(tmp_path):
+    from winpodx.core.app import load_app
+    from winpodx.core.discovery import DiscoveredApp, _render_app_toml
+
+    app = DiscoveredApp(name="word", full_name="Word", executable="C:\\w.exe", exe_hash=_H1)
+    d = tmp_path / "word"
+    d.mkdir()
+    (d / "app.toml").write_text(_render_app_toml(app), encoding="utf-8")
+    loaded = load_app(d)
+    assert loaded is not None
+    assert loaded.exe_hash == _H1

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -137,3 +137,85 @@ def test_cleanup_ignores_symlinks(tmp_path):
     assert len(removed) == 0
     assert target.exists()
     assert symlink.is_symlink()
+
+
+# -- periodic checksum-gated icon refresh ---------------------------------
+
+
+def test_icon_refresh_once_skips_when_paused(monkeypatch):
+    from winpodx.core import daemon
+
+    monkeypatch.setattr(daemon, "is_pod_paused", lambda cfg: True)
+    hit = {"n": 0}
+    monkeypatch.setattr(
+        "winpodx.core.discovery.discover_apps", lambda cfg: hit.__setitem__("n", 1) or []
+    )
+    daemon._icon_refresh_once(Config())
+    assert hit["n"] == 0  # never discovered while paused
+
+
+def test_icon_refresh_once_skips_when_not_running(monkeypatch):
+    from winpodx.core import daemon
+    from winpodx.core.pod import PodState, PodStatus
+
+    monkeypatch.setattr(daemon, "is_pod_paused", lambda cfg: False)
+    monkeypatch.setattr(
+        "winpodx.core.pod.pod_status", lambda cfg: PodStatus(state=PodState.STOPPED)
+    )
+    hit = {"n": 0}
+    monkeypatch.setattr(
+        "winpodx.core.discovery.discover_apps", lambda cfg: hit.__setitem__("n", 1) or []
+    )
+    daemon._icon_refresh_once(Config())
+    assert hit["n"] == 0  # pod not running -> skip
+
+
+def test_icon_refresh_once_no_sync_when_nothing_changed(monkeypatch):
+    from winpodx.core import daemon
+    from winpodx.core.pod import PodState, PodStatus
+
+    monkeypatch.setattr(daemon, "is_pod_paused", lambda cfg: False)
+    monkeypatch.setattr(
+        "winpodx.core.pod.pod_status", lambda cfg: PodStatus(state=PodState.RUNNING)
+    )
+    seq = []
+    monkeypatch.setattr(
+        "winpodx.core.discovery.discover_apps", lambda cfg: seq.append("disc") or ["app"]
+    )
+    monkeypatch.setattr(
+        "winpodx.core.discovery.persist_discovered", lambda apps: seq.append("persist") or []
+    )
+    monkeypatch.setattr(
+        "winpodx.desktop.entry.install_desktop_entry",
+        lambda info: seq.append("install"),  # must NOT be called
+    )
+    daemon._icon_refresh_once(Config())
+    assert seq == ["disc", "persist"]  # checksum gate left nothing changed -> no resync
+
+
+def test_icon_refresh_once_syncs_when_changed(monkeypatch):
+    from winpodx.core import daemon
+    from winpodx.core.pod import PodState, PodStatus
+
+    monkeypatch.setattr(daemon, "is_pod_paused", lambda cfg: False)
+    monkeypatch.setattr(
+        "winpodx.core.pod.pod_status", lambda cfg: PodStatus(state=PodState.RUNNING)
+    )
+    monkeypatch.setattr("winpodx.core.discovery.discover_apps", lambda cfg: ["app"])
+    monkeypatch.setattr("winpodx.core.discovery.persist_discovered", lambda apps: ["/p/app.toml"])
+    monkeypatch.setattr(
+        "winpodx.core.app.list_available_apps",
+        lambda: [
+            type("A", (), {"name": "word", "hidden": False})(),
+            type("A", (), {"name": "hiddenapp", "hidden": True})(),
+        ],
+    )
+    installed = []
+    monkeypatch.setattr(
+        "winpodx.desktop.entry.install_desktop_entry", lambda info: installed.append(info.name)
+    )
+    monkeypatch.setattr(
+        "winpodx.desktop.icons.refresh_icon_cache", lambda: installed.append("cache")
+    )
+    daemon._icon_refresh_once(Config())
+    assert installed == ["word", "cache"]  # visible app installed, hidden skipped, cache refreshed


### PR DESCRIPTION
## Why

A Windows app update can change its icon, but winpodx only re-extracted icons on a manual **Refresh Apps** — so an updated app kept its stale icon (the follow-up to #530). Now icons refresh **automatically**, and **cheaply**: the exe is hashed so unchanged apps are skipped.

## What

- `discover_apps.ps1` emits each app's exe **SHA256** (`Get-FileHash`, best-effort; "" for UWP InstallLocation dirs / locked files).
- `DiscoveredApp` / `AppInfo` carry `exe_hash`; it round-trips through `app.toml`.
- **`persist_discovered` checksum gate**: an entry whose on-disk `exe_hash` matches the freshly-scanned one **and still has its icon** is left untouched (unchanged → no-op); a **changed** hash re-extracts; a **missing icon** forces a rewrite even on an unchanged hash. UWP / hashless entries are never gated.
- **`run_icon_refresh_monitor`** (core/daemon): a discovery sweep ~5 min after start and **every 6 h**, gated on the pod being up + reachable (never wakes a paused/stopped pod), non-fatal. The tray starts it regardless of the idle timeout. The checksum gate makes an idle sweep rewrite only apps that actually changed.

## Interval

6 h (+ one pass ~5 min after start). App icons change rarely (only on app updates) and a sweep is non-trivial guest work, so a slow cadence balances freshness vs cost.

## Tests

- Persist gate: skip-unchanged / re-extract-changed / no-hash-always-rewrite / missing-icon-rewrite / toml round-trip.
- Monitor gating: paused / not-running / no-change-no-resync / changed-resyncs.
- Full suite: **1887 passed, 1 skipped**. `ruff check` + `ruff format --check` clean.

## Needs smoke

The guest `exe_hash` emission + the periodic loop end-to-end (a real app update flipping the icon) need a real-Windows run. Degrades gracefully — an empty `exe_hash` just disables the gate (always re-extract, as before).

## Follow-up (not in this PR)

A two-phase hash-only guest call (enumerate + hash without extracting icon bytes) would let the *guest* skip work for unchanged apps too, enabling a much shorter interval. Not needed at a 6 h cadence.