### PR TITLE
fix: open files under symlinked $HOME subdirs (#547)

### DIFF
--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -1165,39 +1165,48 @@ def launch_desktop(cfg: Config, *, extra_args: str = "") -> RDPSession:
 
 def linux_to_unc(path: str) -> str:
     """Convert a Linux file path to a Windows UNC path via tsclient."""
-    p = Path(path).resolve()
+    # Normalise lexically (expanduser + absolutise + collapse '.' / '..') but do
+    # NOT resolve() the file: following its own symlinks turns a file the user
+    # deliberately placed under $HOME via a symlinked subdir (e.g.
+    # ~/Documents -> /mnt/store) into an out-of-home path and wrongly rejects it
+    # (#547). FreeRDP serves $HOME and traverses symlinks within it, so the
+    # guest reaches \\tsclient\home\<link>\file whatever the link points at.
+    # '..' is still collapsed lexically, so ../../etc/passwd cannot escape $HOME.
+    p = Path(path).expanduser()
+    if not p.is_absolute():
+        p = Path.cwd() / p
+    p = Path(os.path.normpath(p))
     posix_str = str(p)
     if _INVALID_WIN_CHARS & set(posix_str):
         raise ValueError(f"Path contains characters invalid for Windows: {posix_str}")
 
-    # Resolve $HOME (and the media base) too, not just the file (#418). On
-    # Fedora Atomic / Silverblue / Kinoite, /home is a symlink to /var/home, so
-    # `Path(path).resolve()` yields /var/home/me/... while a bare `Path.home()`
-    # stays /home/me — the prefix check then wrongly reports the file as
-    # "outside shared locations". Resolving both sides makes the comparison
-    # symlink-agnostic (and is a no-op on normal layouts).
-    home = Path.home().resolve()
     sep = "\\"
-    try:
-        relative = p.relative_to(home)
-        win_path = str(relative).replace("/", sep)
-        return f"\\\\tsclient\\home\\{win_path}"
-    except ValueError:
-        pass
+    # Compare against $HOME both as-is and resolved: on Fedora Atomic /home is a
+    # symlink to /var/home, so the file may arrive as /var/home/me/... while
+    # Path.home() stays /home/me (#418). Resolving only the home *prefix* (not
+    # the file) keeps that fix without re-introducing the #547 content-symlink
+    # rejection.
+    for home in {Path.home(), Path.home().resolve()}:
+        try:
+            relative = p.relative_to(home)
+            win_path = str(relative).replace("/", sep)
+            return f"\\\\tsclient\\home\\{win_path}"
+        except ValueError:
+            continue
 
-    # Media share mounted as \\tsclient\media.
+    # Media share mounted as \\tsclient\media (same dual-prefix handling).
     media_base = _find_media_base()
     if media_base is not None:
-        media_base = media_base.resolve()
-        try:
-            relative = p.relative_to(media_base)
-            win_path = str(relative).replace("/", sep)
-            return f"\\\\tsclient\\media\\{win_path}"
-        except ValueError:
-            pass
+        for mb in {media_base, media_base.resolve()}:
+            try:
+                relative = p.relative_to(mb)
+                win_path = str(relative).replace("/", sep)
+                return f"\\\\tsclient\\media\\{win_path}"
+            except ValueError:
+                continue
 
     raise ValueError(
-        f"Path is outside shared locations (home={home}"
+        f"Path is outside shared locations (home={Path.home()}"
         f"{', media=' + str(media_base) if media_base else ''}): {posix_str}. "
         "Move the file under your home directory or a mounted media volume."
     )

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -646,6 +646,39 @@ def test_linux_to_unc_home_symlink_atomic(monkeypatch, tmp_path):
     assert result == "\\\\tsclient\\home\\Desktop\\temp.doc"
 
 
+def test_linux_to_unc_symlinked_subdir_under_home(monkeypatch, tmp_path):
+    # #547: a subdir under $HOME is itself a symlink pointing out of home
+    # (~/Documents -> /mnt/store/Documents). The file is still reachable as
+    # \\tsclient\home\Documents\... because FreeRDP serves $HOME and follows
+    # symlinks within it; resolving the file path would wrongly reject it.
+    home = tmp_path / "home" / "me"
+    home.mkdir(parents=True)
+    external = tmp_path / "mnt" / "store" / "Documents"
+    external.mkdir(parents=True)
+    (home / "Documents").symlink_to(external)
+    doc = external / "book.xlsx"
+    doc.touch()
+
+    monkeypatch.setattr("winpodx.core.rdp.Path.home", staticmethod(lambda: home))
+    monkeypatch.setattr("winpodx.core.rdp._find_media_base", lambda: None)
+
+    result = linux_to_unc(str(home / "Documents" / "book.xlsx"))
+    assert result == "\\\\tsclient\\home\\Documents\\book.xlsx"
+
+
+def test_linux_to_unc_dotdot_traversal_still_blocked(monkeypatch, tmp_path):
+    # '..' is collapsed lexically, so a crafted path can't escape $HOME even
+    # though the file itself is no longer resolve()'d (#547 fix must not weaken
+    # the containment check).
+    home = tmp_path / "home" / "me"
+    home.mkdir(parents=True)
+    monkeypatch.setattr("winpodx.core.rdp.Path.home", staticmethod(lambda: home))
+    monkeypatch.setattr("winpodx.core.rdp._find_media_base", lambda: None)
+
+    with pytest.raises(ValueError, match="outside shared locations"):
+        linux_to_unc(str(home / ".." / ".." / "etc" / "passwd"))
+
+
 class TestResolveWmClass:
     """resolve_wm_class() is the single source of truth shared by FreeRDP's
     /wm-class and the .desktop StartupWMClass (taskbar window matching)."""


### PR DESCRIPTION
## Problem
Opening a file that lives under a symlinked subdirectory of `$HOME` — e.g. `~/Documents` symlinked to `/mnt/store/Documents`, common when data is kept off the home partition — fails with `Path is outside shared locations`. Reported in #547 (Fedora 44, KDE Plasma 6.6, FreeRDP 3.25).

## Cause
`linux_to_unc()` called `Path.resolve()`, which follows the file's own symlinks. The resolved path then sits outside `$HOME`, so the home-containment check rejects it — even though FreeRDP serves `$HOME` and transparently traverses symlinks within it, so the guest can open `\\tsclient\home\Documents\file` regardless of the link target.

## Fix
Normalise the path lexically (`expanduser` + `os.path.normpath`) instead of resolving it, so symlinked subdirs under `$HOME` are traversed like folders. `..` is still collapsed lexically, so a crafted `../../etc/passwd` cannot escape `$HOME`. `$HOME` is compared both as-is and resolved, retaining the Fedora Atomic `/home → /var/home` fix (#418).

## Tests
- `test_linux_to_unc_symlinked_subdir_under_home` — a symlinked subdir now maps correctly.
- `test_linux_to_unc_dotdot_traversal_still_blocked` — `..` escape is still refused.
- Existing #418 atomic-home + security (invalid-char) tests pass.

`20 passed`, `ruff check` / `ruff format` clean.
