### PR TITLE
chore(deps): bump dockur pin to windows v5.16 + arm security rebuild (#554, #555)

### DIFF
--- a/config/oem/VERSIONS.txt
+++ b/config/oem/VERSIONS.txt
@@ -18,7 +18,7 @@
 # describes what winpodx deliberately uses.
 #
 # Format: <key>=<value>
-dockur=v5.15
-dockur-digest=sha256:32abe0836aeeb744b8ff8af25688fcd348cc66016a1378fe1bd0768c8c67022c
+dockur=v5.16
+dockur-digest=sha256:3633f055f31aadf76bb650b1ca86897ab45b76ad8eb2cf81e86389ace5eb45ac
 dockur-arm=v5.15
-dockur-arm-digest=sha256:5775bcfd335bad14fe35001460dd6640e131eb660601c2f3c90af43005a9532a
+dockur-arm-digest=sha256:7c28ddbbe69eb02900bef3b7ab3ad60fbd5fb409524a307a60a3c934f80a9dd5

--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -158,10 +158,10 @@ def _validate_device_entry(entry: object) -> str | None:
 # current ``:latest`` digest, paste below. See ``winpodx setup --update
 # -image`` for the runtime equivalent users invoke explicitly.
 #
-# As of 2026-05-21 (dockur/windows v5.15):
+# As of 2026-06-10 (dockur/windows v5.16):
 DOCKUR_IMAGE_PIN = (
     "docker.io/dockurr/windows@sha256:"
-    "32abe0836aeeb744b8ff8af25688fcd348cc66016a1378fe1bd0768c8c67022c"
+    "3633f055f31aadf76bb650b1ca86897ab45b76ad8eb2cf81e86389ace5eb45ac"
 )
 
 # Pinned dockur/windows-arm image — used as the default ``cfg.pod.image``
@@ -171,10 +171,10 @@ DOCKUR_IMAGE_PIN = (
 # OCI index, so container runtimes pick the right platform manifest
 # (amd64 or arm64) automatically.
 #
-# As of 2026-05-21 (dockur/windows-arm v5.15):
+# As of 2026-06-10 (dockur/windows-arm v5.15, :latest security rebuild):
 DOCKUR_IMAGE_ARM_PIN = (
     "docker.io/dockurr/windows-arm@sha256:"
-    "5775bcfd335bad14fe35001460dd6640e131eb660601c2f3c90af43005a9532a"
+    "7c28ddbbe69eb02900bef3b7ab3ad60fbd5fb409524a307a60a3c934f80a9dd5"
 )
 
 


### PR DESCRIPTION
Resolves the weekly upstream-drift chores #554 and #555.

- **#554** dockur/windows v5.15 → **v5.16**: `DOCKUR_IMAGE_PIN` + `VERSIONS.txt` (`dockur`, `dockur-digest`) rolled forward to `sha256:3633f055…`.
- **#555** dockur/windows-arm `:latest` security rebuild (release tag stays v5.15): `DOCKUR_IMAGE_ARM_PIN` + `dockur-arm-digest` rolled forward to `sha256:7c28ddbb…`.

The disguise image (#246) auto-detects the QEMU version from the pinned image at build time (`disguise.py:_qemu_version`), so the bump needs no `patch-strings.sh` change. `TargetReleaseVersionInfo` (Windows 25H2) is independent of the dockur version and is left unchanged.

`config` loads, `ruff` clean, `test_config` 74 passed.
