### PR TITLE
fix(disguise): auto-resolve patched image at max when pointer is empty (#246)

### DIFF
--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -742,8 +742,21 @@ def _build_compose_content(cfg: Config) -> str:
     # disk-model ("QEMU HARDDISK"->real) strings patched out — the bits winpodx
     # can't reach via QEMU args. Only honoured at max + on a real image string.
     image = cfg.pod.image
-    if cfg.pod.disguise_max and cfg.pod.disguise_image.strip():
-        image = cfg.pod.disguise_image.strip()
+    if cfg.pod.disguise_max:
+        disguise_img = cfg.pod.disguise_image.strip()
+        if not disguise_img and platform.machine() != "aarch64":
+            # disguise_image not wired -- e.g. a GUI balanced<->max toggle that
+            # cleared the pointer, or max set via `config set` (which doesn't
+            # build/wire). Auto-resolve to the canonical patched-image tag if
+            # it's actually built locally, so Hardened never silently falls back
+            # to the stock dockur image. (The GUI/build paths still persist the
+            # pointer; this is the belt-and-suspenders for the paths that don't.)
+            from winpodx.cli.disguise import _DISGUISE_TAG, disguise_image_present
+
+            if disguise_image_present(cfg):
+                disguise_img = _DISGUISE_TAG
+        if disguise_img:
+            image = disguise_img
     if cfg.pod.disguise_active and platform.machine() != "aarch64":
         blob_path = _write_disguise_smbios_blob(oem_dir)
         if blob_path:


### PR DESCRIPTION
Hardened (max) only uses the patched-QEMU image when `cfg.pod.disguise_image` is non-empty. Several paths reach max without that pointer set:

- `winpodx config set pod.disguise_level max` (sets the level, not the image)
- a GUI `balanced → max` toggle where the image was built earlier but the pointer got cleared
- an older GUI build still running pre-#558 code

In all of these, compose silently fell back to the **stock** dockur image, so Hardened did nothing (disk model / ACPI / FADT / sensors all still read as QEMU) with no error.

**Fix:** when `disguise_max` and `disguise_image` is empty, auto-resolve to the canonical patched-image tag *if it actually exists locally* (`disguise_image_present`). The GUI/build paths still persist the pointer (#558); this is the belt-and-suspenders so any path that reaches max uses the patched image as long as it's built. If the image isn't built, compose still uses the stock image (and the GUI's build phase handles building it).

`ruff` clean, `test_compose_arch` 23 passed.
