### PR TITLE
feat(disguise): clear VEN_1AF4 + VEN_1B36 PCI tells while keeping USB3 (#246)

### DIFF
--- a/packaging/qemu-disguise/Dockerfile
+++ b/packaging/qemu-disguise/Dockerfile
@@ -111,5 +111,11 @@ COPY --from=build /build/qemu/pc-bios/ /usr/share/qemu/
 # Synthetic-sensor SSDT, injected by winpodx via -acpitable at disguise max.
 COPY --from=build /build/ssdt-sensors.aml /usr/share/qemu/winpodx-ssdt-sensors.aml
 COPY --from=build /build/wsmt.aml /usr/share/qemu/winpodx-wsmt.aml
+# Drop dockur's unconditional virtio-rng-pci device. It is the only VEN_1AF4
+# (Red Hat virtio) device on the bus here -- dockur uses no virtio-serial -- and
+# al-khaser flags any VEN_1AF4* PCI device. Windows keeps its own CNG entropy,
+# so removing the paravirtual RNG is safe. config.sh is dockur's qemu-arg
+# assembler; the sed is a harmless no-op if a future dockur drops the line.
+RUN sed -i '/virtio-rng-pci/d' /run/config.sh
 # Sanity check at build time (fails the build if the binary won't run).
 RUN qemu-system-x86_64 --version

--- a/packaging/qemu-disguise/patch-strings.sh
+++ b/packaging/qemu-disguise/patch-strings.sh
@@ -85,6 +85,14 @@ sed -i "s/aml_string(\"QEMU0002\")/aml_string(\"${HID4}0002\")/" \
 sed -i "s/aml_string(\"QEMU0001\")/aml_string(\"${HID4}0001\")/" hw/misc/pvpanic-isa.c
 sed -i "s/aml_string(\"QEMUVGID\")/aml_string(\"${HID4}VGID\")/" hw/acpi/vmgenid.c
 
+# --- fw_cfg ACPI device name ("FWCF") ---
+# The fw_cfg ACPI device is named "FWCF" (aml_device("FWCF")) -- the one QEMU
+# token still present in the DSDT after the _HID scrub above. Some al-khaser
+# 0.82 builds scan the DSDT for it, so rename the AML device node. Windows has
+# no fw_cfg driver and the firmware reaches fw_cfg through its I/O ports (not
+# the ACPI node), so the rename is cosmetic; the node has no by-name references.
+sed -i "s/aml_device(\"FWCF\")/aml_device(\"FWCG\")/" hw/nvram/fw_cfg-acpi.c hw/i386/fw_cfg.c
+
 # --- WAET table signature ---
 # QEMU emits a WAET ("Windows ACPI Emulated devices Table") -- a table only
 # present under emulation, which al-khaser's ACPI check enumerates as a VM tell.

--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -65,7 +65,7 @@ name: "winpodx"
       NETWORK: "user"
       ADAPTER: "{adapter}"
       MTU: "{mtu}"
-      VGA: "{vga}"
+{usb_env}      VGA: "{vga}"
       CPU_FLAGS: "{cpu_flags}"
       VMX: "{vmx}"
       HV: "{hv}"
@@ -789,8 +789,14 @@ def _build_compose_content(cfg: Config) -> str:
     # dockur's virtio auto-MTU.
     if cfg.pod.disguise_max:
         disk_type, adapter, vga, mtu = "sata", "e1000", "std", "1500"
+        # Swap dockur's default qemu-xhci (VEN_1B36, Red Hat) for nec-usb-xhci
+        # (VEN_1033, NEC/Renesas) -- still a real USB3 xHCI controller, so USB3 +
+        # passthrough keep working, but al-khaser's VEN_1B36* PCI check no longer
+        # matches. dockur takes the controller from the USB env (run/config.sh).
+        usb_env = '      USB: "nec-usb-xhci,id=xhci"\n'
     else:
         disk_type, adapter, vga, mtu = "", "", "", ""
+        usb_env = ""
 
     return template.format(
         ram=cfg.pod.ram_gb,
@@ -801,6 +807,7 @@ def _build_compose_content(cfg: Config) -> str:
         disk_type=disk_type,
         adapter=adapter,
         mtu=mtu,
+        usb_env=usb_env,
         vga=vga,
         hv=hv,
         user=_yaml_escape(cfg.rdp.user),


### PR DESCRIPTION
Round 2 of the bare-metal disguise (#246), clearing the last two structural PCI tells **while keeping USB3**:

- **VEN_1AF4** (al-khaser KVM section): dockur's only virtio device in this config is virtio-rng (no virtio-serial). The disguise image now drops it (`sed '/virtio-rng-pci/d' /run/config.sh`) — Windows keeps its own CNG entropy, so the paravirtual RNG is safe to remove. → VEN_1AF4 GOOD.
- **VEN_1B36** (al-khaser QEMU section): swap dockur's default `qemu-xhci` (Red Hat 1B36) for `nec-usb-xhci` (NEC/Renesas 1033) via the `USB` compose env at max. Still a real USB3 xHCI controller, so USB3 + passthrough keep working, but the `VEN_1B36*` PCI check no longer matches. → VEN_1B36 GOOD.
- fw_cfg ACPI device `FWCF` → `FWCG` in `patch-strings.sh` (best-effort for "ACPI table strings" — it did not flip on al-khaser 0.82, but it removes the last QEMU token from the DSDT).

Verified on al-khaser 0.82 (real Windows, max + patched image): **VEN_1AF4 + VEN_1B36 now GOOD**. The remaining BADs are the documented floor — NtYield (RDTSC timing / host kernel), Win32_MemoryDevice (legacy WMI, empty on real HW too), ACPI table strings (0.82 structural quirk), Hyper-V driver/global (the RDP IndirectKmd display trade-off).

`ruff` clean, `test_compose_arch` 23 passed, patch-strings.sh sed verified against qemu-10.0.8.
