### PR TITLE
chore(release): 0.7.0 — bare-metal disguise (VM-detection avoidance) (#246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-06-11
+
+### Added
+
+- **Bare-metal disguise — make the Windows guest read like a physical machine to VM-detection software (#246).** Opt-in, off by default. Software that refuses to run under a *detected* hypervisor — Nvidia GPU-passthrough "code 43", launch-gate VM checks, VM-hostile installers — sees a genuine-looking bare-metal box instead of QEMU/KVM. It works in two layers, picked by the **bare-metal level** (`winpodx config set pod.disguise_level off | balanced | max`, or the GUI Settings selector):
+  - **Per-VM, no rebuild (`balanced`+):** clears the CPUID hypervisor-present bit and the KVM signature (`-cpu -hypervisor,kvm=off,-kvm-pv-*`), mirrors the host's real SMBIOS/DMI (system / board / BIOS vendor + product, CPU vendor + model) into the guest, and injects a synthetic SMBIOS sensor/descriptor blob (voltage / temperature probe, cooling device, cache, memory array + DIMMs, 40+ structures) so the `Win32_*` / `CIM_*` WMI sensor classes report like real hardware.
+  - **Patched-QEMU image (`max` / "Hardened"):** `winpodx disguise build-image` compiles QEMU **locally** (~20–40 min; no binary is ever shipped) with the VM-identifying *strings* QEMU can't reach via the command line rewritten to the host's real values — ACPI OEM IDs (`BOCHS`/`BXPC` → host), the FADT hypervisor-vendor + PM-profile byte, device `_HID`s, the `WAET` table signature, disk / optical model **and INQUIRY vendor** — plus an injected thermal-zone SSDT and a WSMT table. At `max`, winpodx also presents a SATA system disk, an e1000 NIC, std VGA, and a `nec-usb-xhci` USB-3 controller (keeps USB3 while dropping the Red Hat `VEN_1B36` tell), removes the virtio-rng device (`VEN_1AF4`), and prunes the unused virtio driver service keys in the guest. Selecting Hardened in the GUI builds + wires the image automatically.
+  - **Privacy:** the host-derived strings are *non-identifying* (vendor / model codes, like the disk model) and flow via Docker build-args into the **local image layer only — never committed to git, never pushed**. Serial / UUID / asset-tag are never read. The source ships generic fallbacks (`ALASKA` / `Samsung SSD` / `ATA`).
+  - Verified against **al-khaser 0.82** on real Windows: the disk, sensor, SMBIOS, ACPI, CPUID, virtio-service and username detection families read clean. Remaining tells are the container-QEMU structural floor (RDTSC timing, the legacy `Win32_MemoryDevice` class that is empty on real hardware too, and the Windows-inherent Hyper-V integration objects that share the RDP display driver).
+- **Default Windows guest username is now `WPX-User`** (was `User`), which avoids al-khaser's exact-match sandbox-username list. Change it with `winpodx config set rdp.user <name>` before first install.
+
+### Fixed
+
+- **Opening a file under a symlinked subdirectory of `$HOME`** — e.g. `~/Documents` symlinked to `/mnt/store/Documents` — no longer fails with "Path is outside shared locations" (#547). The host→guest path is normalised lexically instead of resolved, so a symlinked subdir is traversed like a folder (FreeRDP follows it); `..` is still blocked, and the Fedora Atomic `/home → /var/home` handling is kept (#418).
+- **USB hot-plug works again on the new dockur image.** dockur v5.16 moved the QEMU monitor from `telnet:7100` to a unix socket, which broke the live USB attach path with "QEMU monitor unreachable"; winpodx now talks to the socket (and still falls back to telnet for older dockur) (#286).
+- **The GUI Devices panel no longer flickers** when a host USB device is unplugged while the tab is open, and a device yanked mid-enumeration no longer raises into the Qt slot.
+
+### Changed
+
+- **Pinned dockur/windows bumped to v5.16** (x86_64) and the dockur/windows-arm `:latest` security rebuild (aarch64) (#554, #555).
+
 ## [0.6.0] - 2026-06-05
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Or just click an app icon in your application menu. See [docs/USAGE.md](docs/USA
 - Windows debloat: telemetry, ads, Cortana, search indexing disabled by default
 - FreeRDP `extra_flags` allowlist (regex-validated) as the user-input safety boundary
 - Time sync: force Windows clock resync after host sleep/wake
+- **Bare-metal disguise** (0.7.0, opt-in): `pod.disguise_level balanced|max` makes the Windows guest read as a physical machine to VM-hostile software (Nvidia GPU code 43, launch-gate checks, VM-hostile installers) — balanced hides CPUID/KVM signatures and mirrors host SMBIOS; max adds a locally-built patched-QEMU image (`winpodx disguise build-image`); al-khaser-verified; off by default
 
 </td><td width="50%">
 

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -7,6 +7,27 @@
 형식은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)를 기반으로 하며,
 버전 정책은 [Semantic Versioning](https://semver.org/lang/ko/)을 지향합니다.
 
+## [0.7.0] - 2026-06-11
+
+### Added
+
+- **베어메탈 위장 — VM 탐지 소프트웨어에게 Windows 게스트를 물리 머신처럼 보이게 (#246).** Opt-in, 기본 꺼짐. 하이퍼바이저 *감지* 시 실행을 거부하는 소프트웨어 — Nvidia GPU 패스스루 "code 43", launch-gate VM 체크, VM 비적합 설치 프로그램 — 가 QEMU/KVM 대신 실물 베어메탈 머신으로 인식. **베어메탈 레벨** 로 동작 계층을 선택합니다 (`winpodx config set pod.disguise_level off | balanced | max`, 또는 GUI Settings 셀렉터):
+  - **재빌드 불필요, VM 별 적용 (`balanced`+):** CPUID 하이퍼바이저 present 비트와 KVM 시그니처 제거 (`-cpu -hypervisor,kvm=off,-kvm-pv-*`), 호스트의 실제 SMBIOS/DMI (시스템 / 보드 / BIOS 벤더 + 제품, CPU 벤더 + 모델) 를 게스트에 미러링, 합성 SMBIOS 센서/디스크립터 blob (전압 / 온도 프로브, 냉각 장치, 캐시, 메모리 어레이 + DIMM, 40+ 구조체) 을 주입하여 `Win32_*` / `CIM_*` WMI 센서 클래스가 실제 하드웨어처럼 보고하도록.
+  - **패치된 QEMU 이미지 (`max` / "Hardened"):** `winpodx disguise build-image` 가 QEMU 를 **로컬에서** 컴파일 (~20–40 분; 바이너리는 절대 shipped 안 됨) 하되, 커맨드 라인으로 건드릴 수 없는 VM 식별 *문자열* 을 호스트 실제 값으로 재작성 — ACPI OEM ID (`BOCHS`/`BXPC` → 호스트), FADT 하이퍼바이저 벤더 + PM-profile 바이트, 디바이스 `_HID`, `WAET` 테이블 시그니처, 디스크 / 광학 모델 **및 INQUIRY 벤더** — 에 더해 thermal-zone SSDT 와 WSMT 테이블 주입. `max` 에서 winpodx 는 SATA 시스템 디스크, e1000 NIC, std VGA, `nec-usb-xhci` USB-3 컨트롤러 (USB3 유지하면서 Red Hat `VEN_1B36` 특징 제거) 를 사용하고, virtio-rng 디바이스 (`VEN_1AF4`) 를 제거하며, 게스트에서 미사용 virtio 드라이버 서비스 키를 정리. GUI 에서 Hardened 선택 시 이미지 빌드 + 연결이 자동으로 이루어짐.
+  - **개인정보:** 호스트에서 파생된 문자열은 *비식별* (벤더 / 모델 코드 등 디스크 모델) 이며 Docker build-arg 를 거쳐 **로컬 이미지 레이어에만 — git 에 절대 커밋되지 않고 push 도 없음**. 시리얼 / UUID / 자산 태그는 읽지 않습니다. 소스는 제네릭 폴백 (`ALASKA` / `Samsung SSD` / `ATA`) 을 ship.
+  - 실제 Windows 에서 **al-khaser 0.82** 검증 완료: 디스크, 센서, SMBIOS, ACPI, CPUID, virtio 서비스, 사용자명 탐지 계열 clean. 남은 특징들은 컨테이너-QEMU 구조적 바닥 (RDTSC 타이밍, 실제 하드웨어에서도 비어있는 레거시 `Win32_MemoryDevice` 클래스, RDP 디스플레이 드라이버를 공유하는 Windows 내재 Hyper-V 통합 객체).
+- **기본 Windows 게스트 사용자명이 이제 `WPX-User`** (기존 `User`) — al-khaser 의 정확한 일치 샌드박스 사용자명 목록을 회피합니다. 첫 설치 전에 `winpodx config set rdp.user <name>` 으로 변경하세요.
+
+### Fixed
+
+- **`$HOME` 의 심볼릭 링크 서브디렉토리 하위 파일 열기** — 예: `~/Documents` 가 `/mnt/store/Documents` 로 심링크된 경우 — 가 "Path is outside shared locations" 오류 없이 동작 (#547). 호스트→게스트 경로가 resolve 대신 lexical 정규화되어, 심링크 서브디렉토리를 폴더처럼 traverse (FreeRDP 가 따라가도록); `..` 는 여전히 차단되며 Fedora Atomic `/home → /var/home` 처리는 유지 (#418).
+- **새 dockur 이미지에서 USB 핫플러그 복구.** dockur v5.16 이 QEMU 모니터를 `telnet:7100` 에서 unix socket 으로 이전하면서 라이브 USB 연결 경로가 "QEMU monitor unreachable" 로 깨졌습니다; winpodx 가 이제 소켓과 통신하며 (구 dockur 는 telnet 폴백 유지) (#286).
+- **GUI Devices 패널이 USB 디바이스가 탭 열린 상태에서 뽑힐 때 더 이상 깜빡이지 않음**, 그리고 열거 도중 뽑힌 디바이스가 Qt 슬롯에서 예외를 올리지 않음.
+
+### Changed
+
+- **dockur/windows 핀을 v5.16** (x86_64) 과 dockur/windows-arm `:latest` 보안 재빌드 (aarch64) 로 업 (#554, #555).
+
 ## [0.6.0] - 2026-06-05
 
 ### Removed

--- a/docs/FEATURES.ko.md
+++ b/docs/FEATURES.ko.md
@@ -138,6 +138,47 @@ winpodx device detach <id>     # 다시 분리
 - 시간 동기화: 호스트 sleep/wake 후 Windows 시계 강제 resync
 - FreeRDP `extra_flags` allowlist (regex 검증) 가 사용자 input 안전 경계
 
+## 베어메탈 위장 (VM 탐지 회피)
+
+v0.7.0 에 탑재. Opt-in, 기본 꺼짐. 하이퍼바이저 감지 시 실행을 거부하는 소프트웨어 — Nvidia GPU 패스스루 "code 43", launch-gate VM 체크, VM 비적합 설치 프로그램 — 가 QEMU/KVM 대신 실물 베어메탈 머신으로 인식합니다. 레벨 선택:
+
+```bash
+winpodx config set pod.disguise_level off      # 기본 — 위장 없음
+winpodx config set pod.disguise_level balanced # VM 별 args 만, 재빌드 없음
+winpodx config set pod.disguise_level max      # 패치된 QEMU 이미지 (Hardened)
+```
+
+또는 GUI Settings 페이지 → "Bare-metal level" 셀렉터 사용 (Hardened 선택 시 이미지 빌드가 자동으로 시작).
+
+### 레벨
+
+**`balanced`** (VM 별, 재빌드 불필요):
+- CPUID 하이퍼바이저 present 비트와 KVM 시그니처 제거 (`-cpu -hypervisor,kvm=off,-kvm-pv-*`)
+- 호스트의 실제 SMBIOS/DMI (시스템 / 보드 / BIOS 벤더 + 제품, CPU 벤더 + 모델) 를 게스트에 미러링
+- 합성 SMBIOS 센서/디스크립터 blob (전압 / 온도 프로브, 냉각 장치, 캐시, 메모리 어레이 + DIMM, 40+ 구조체) 주입하여 `Win32_*` / `CIM_*` WMI 센서 클래스가 실제 하드웨어처럼 보고하도록
+
+**`max` ("Hardened")** (`balanced` 의 모든 것 + 추가):
+- `winpodx disguise build-image` 가 QEMU 를 **로컬에서** 컴파일 (~20–40 분), 커맨드 라인으로 override 불가한 VM 식별 문자열을 호스트 실제 값으로 재작성: ACPI OEM ID (`BOCHS`/`BXPC` → 호스트), FADT 하이퍼바이저 벤더 + PM-profile 바이트, 디바이스 `_HID`, `WAET` 테이블 시그니처, 디스크 / 광학 모델 **및 INQUIRY 벤더**; thermal-zone SSDT + WSMT 테이블도 주입
+- SATA 시스템 디스크, e1000 NIC, std VGA, `nec-usb-xhci` USB-3 컨트롤러 (USB3 유지하면서 Red Hat `VEN_1B36` 특징 제거); virtio-rng 디바이스 (`VEN_1AF4`) 제거 + 게스트 미사용 virtio 드라이버 서비스 키 정리
+
+바이너리는 절대 shipped 되지 않습니다 — 이미지는 표준 QEMU 소스로 본인 머신에서 빌드됩니다.
+
+### 패치된 이미지 빌드
+
+```bash
+winpodx disguise build-image    # 첫 빌드 ~20–40 분; 이후 캐시됨
+```
+
+또는 GUI Settings → Bare-metal level 에서 "Hardened" 선택 시 빌드가 자동으로 시작.
+
+### 개인정보
+
+호스트에서 파생된 문자열은 *비식별* (벤더 / 모델 코드 등 디스크 모델) 이며 Docker build-arg 를 거쳐 **로컬 이미지 레이어에만 — git 에 절대 커밋되지 않고 push 도 없음**. 시리얼 / UUID / 자산 태그는 읽지 않습니다. 소스는 제네릭 폴백 (`ALASKA` / `Samsung SSD` / `ATA`) 을 ship.
+
+### 검증
+
+실제 Windows 에서 **al-khaser 0.82** 검증 완료: 디스크, 센서, SMBIOS, ACPI, CPUID, virtio 서비스, 사용자명 탐지 계열 clean. 남은 특징들은 컨테이너-QEMU 구조적 바닥 (RDTSC 타이밍, 실제 하드웨어에서도 비어있는 레거시 `Win32_MemoryDevice` 클래스, RDP 디스플레이 드라이버를 공유하는 Windows 내재 Hyper-V 통합 객체).
+
 ## Windows 디스크 자동 확장
 
 Windows `C:` 드라이브가 채워질수록 스스로 커짐 — 거대한 가상 디스크를 미리 잡아둘 필요도, 설치 도중 공간이 떨어질 일도 없음.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -138,6 +138,47 @@ winpodx device detach <id>     # detach it again
 - Time sync: force Windows clock resync after host sleep/wake
 - FreeRDP `extra_flags` allowlist (regex-validated) as the user-input safety boundary
 
+## Bare-metal disguise (VM-detection avoidance)
+
+Shipped in v0.7.0. Opt-in, off by default. Software that refuses to run when a hypervisor is detected — Nvidia GPU-passthrough "code 43", launch-gate VM checks, VM-hostile installers — sees a genuine-looking bare-metal box instead of QEMU/KVM. Select the level with:
+
+```bash
+winpodx config set pod.disguise_level off      # default — no disguise
+winpodx config set pod.disguise_level balanced # per-VM args only, no rebuild
+winpodx config set pod.disguise_level max      # patched-QEMU image (Hardened)
+```
+
+Or use the GUI Settings page → "Bare-metal level" selector (choosing Hardened triggers the image build automatically).
+
+### Levels
+
+**`balanced`** (per-VM, no rebuild):
+- Clears the CPUID hypervisor-present bit and the KVM signature (`-cpu -hypervisor,kvm=off,-kvm-pv-*`)
+- Mirrors the host's real SMBIOS/DMI (system / board / BIOS vendor + product, CPU vendor + model) into the guest
+- Injects a synthetic SMBIOS sensor/descriptor blob (voltage / temperature probes, cooling device, cache, memory array + DIMMs, 40+ structures) so `Win32_*` / `CIM_*` WMI sensor classes report like real hardware
+
+**`max` ("Hardened")** (includes everything in `balanced`, plus):
+- `winpodx disguise build-image` compiles QEMU **locally** (~20–40 min) with the VM-identifying strings that can't be overridden via command line rewritten to the host's real values: ACPI OEM IDs (`BOCHS`/`BXPC` → host), FADT hypervisor-vendor + PM-profile byte, device `_HID`s, `WAET` table signature, disk / optical model **and INQUIRY vendor**; also injects a thermal-zone SSDT and a WSMT table
+- Presents a SATA system disk, e1000 NIC, std VGA, and `nec-usb-xhci` USB-3 controller (keeps USB3 while dropping the Red Hat `VEN_1B36` tell); removes the virtio-rng device (`VEN_1AF4`) and prunes unused virtio driver service keys in the guest
+
+No binary is ever shipped — the image is built on your machine from the standard QEMU source.
+
+### Building the patched image
+
+```bash
+winpodx disguise build-image    # ~20–40 min on first build; cached after that
+```
+
+Or select "Hardened" in GUI Settings → Bare-metal level, which starts the build automatically.
+
+### Privacy
+
+The host-derived strings are *non-identifying* (vendor / model codes, like the disk model) and flow via Docker build-args into the **local image layer only — never committed to git, never pushed**. Serial / UUID / asset-tag are never read. The source ships generic fallbacks (`ALASKA` / `Samsung SSD` / `ATA`) so a build without host data is still valid.
+
+### Verification
+
+Verified against **al-khaser 0.82** on real Windows: the disk, sensor, SMBIOS, ACPI, CPUID, virtio-service, and username detection families read clean. Remaining tells are the container-QEMU structural floor (RDTSC timing, the legacy `Win32_MemoryDevice` class that is empty on real hardware too, and the Windows-inherent Hyper-V integration objects that share the RDP display driver).
+
 ## Windows disk auto-grow
 
 The Windows `C:` drive grows itself as it fills, so you don't have to pre-provision a huge virtual disk or run out of space mid-install.

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -205,6 +205,7 @@ winpodx app run desktop           # 전체 Windows 데스크톱
 - Windows debloat: 텔레메트리, 광고, Cortana, 검색 인덱싱 기본 비활성
 - FreeRDP `extra_flags` allowlist (regex 검증) 가 사용자 input 안전 경계
 - 시간 동기화: 호스트 sleep/wake 후 Windows 시계 강제 resync
+- **베어메탈 위장** (0.7.0, opt-in): `pod.disguise_level balanced|max` 로 Windows 게스트가 VM 비적합 소프트웨어에게 물리 머신처럼 보임 (Nvidia GPU code 43, launch-gate 체크, VM 비적합 설치 프로그램) — balanced 는 CPUID/KVM 시그니처 은폐 + 호스트 SMBIOS 미러링; max 는 로컬 빌드 패치된 QEMU 이미지 추가 (`winpodx disguise build-image`); al-khaser 검증 완료; 기본 꺼짐
 
 </td><td width="50%">
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "winpodx"
-version = "0.6.0"
+version = "0.7.0"
 description = "Windows app integration for Linux desktop"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
0.7.0 release prep — version bump + changelog + docs for the headline **bare-metal disguise (VM-detection avoidance)** feature (#246), plus this cycle's fixes.

- `pyproject.toml` → 0.7.0
- `CHANGELOG.md` + `docs/CHANGELOG.ko.md`: the [0.7.0] entry — disguise (#246), `WPX-User` default, the symlinked-`$HOME` file-open fix (#547), the dockur-v5.16 USB-monitor fix (#286), the Devices-panel flicker fix, and the dockur v5.16 pin (#554/#555).
- `README.md` / `docs/README.ko.md`: a Key-features bullet for the disguise.
- `docs/FEATURES.md` / `docs/FEATURES.ko.md`: a "Bare-metal disguise (VM-detection avoidance)" section (off / balanced / max, how to build the patched image, the privacy note, al-khaser 0.82 verification).

All disguise/USB/symlink code already merged this cycle (#540, #547/#552, #556, #557, #558, #559, #562, #563, #564). `ruff` clean, 92 version/config/taxonomy tests pass.
