### PR TITLE
fix(release): version-stamp drift + install.bat non-ASCII (0.7.0 CI) + prevention

### DIFF
--- a/config/oem/install.bat
+++ b/config/oem/install.bat
@@ -772,7 +772,7 @@ REM If shutdown fails for any reason, the marker is left behind --
 REM apply-fixes treats this as "still need second-pass reboot" and
 REM offers to retry. Failure mode is detectable, not silent.
 
-REM ── winpodx bare-metal disguise: prune unused virtio driver service keys ──
+REM -- winpodx bare-metal disguise: prune unused virtio driver service keys --
 REM al-khaser flags Services\{viostor,vioscsi,BalloonService} as VM tells. The
 REM virtio-win bundle installs them even with no matching device. The helper
 REM removes only the keys whose device is absent (guarded so a virtio-boot or

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+winpodx (0.7.0) unstable; urgency=medium
+
+  * Bare-metal disguise (VM-detection avoidance): an opt-in hardened level
+    that makes the Windows guest read as a physical machine to VM-detection
+    software (Nvidia GPU-passthrough "code 43", launch-gate VM checks).
+    Plus the symlinked-$HOME file-open fix (#547), the dockur v5.16
+    USB-monitor fix (#286), the Devices-panel flicker fix, and the dockur
+    v5.16 image pin. See CHANGELOG.md for the full list (#246).
+
+ -- Kim DaeHyun <kernalix7@kodenet.io>  Thu, 11 Jun 2026 12:00:00 +0000
+
 winpodx (0.6.0) unstable; urgency=medium
 
   * Consolidation + UX release. Host USB / PCI device passthrough (CLI +

--- a/packaging/rpm/winpodx.spec
+++ b/packaging/rpm/winpodx.spec
@@ -7,7 +7,7 @@ Name:           %{pypi_name}
 # bumping it per release is NOT required and has no effect on OBS output.
 # scripts/ci/verify_versions.py guards against drift between this literal and
 # pyproject.toml so a local-build version doesn't masquerade as a stale one.
-Version:        0.6.0
+Version:        0.7.0
 Release:        0
 Summary:        Windows app integration for Linux desktop
 # MIT covers winpodx + bundled rdprrap (same MIT terms).

--- a/scripts/ci/verify_versions.py
+++ b/scripts/ci/verify_versions.py
@@ -80,9 +80,73 @@ def installed_metadata_version() -> str | None:
         return None
 
 
+def _sync_spec(version: str) -> bool:
+    """Stamp ``Version: <version>`` into the RPM spec. True if it changed."""
+    path = ROOT / "packaging" / "rpm" / "winpodx.spec"
+    text = path.read_text()
+    new = re.sub(r"^(Version:\s+)\S+\s*$", rf"\g<1>{version}", text, count=1, flags=re.MULTILINE)
+    if new != text:
+        path.write_text(new)
+        return True
+    return False
+
+
+def _sync_debian(version: str) -> bool:
+    """Prepend a debian/changelog entry for ``version`` if the top entry differs.
+
+    Reuses the maintainer from the current top entry and stamps an RFC-2822
+    timestamp; the bullet is a generic pointer to CHANGELOG.md that the release
+    author can refine. True if an entry was added.
+    """
+    if debian_version() == version:
+        return False
+    path = ROOT / "debian" / "changelog"
+    text = path.read_text()
+    m = re.search(r"^ -- (.+?)  ", text, re.MULTILINE)
+    maintainer = m.group(1) if m else "Kim DaeHyun <kernalix7@kodenet.io>"
+    from datetime import datetime, timezone
+    from email.utils import format_datetime
+
+    stamp = format_datetime(datetime.now(timezone.utc))
+    entry = (
+        f"winpodx ({version}) unstable; urgency=medium\n\n"
+        f"  * Release {version}. See CHANGELOG.md for details.\n\n"
+        f" -- {maintainer}  {stamp}\n\n"
+    )
+    path.write_text(entry + text)
+    return True
+
+
 def main() -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Verify (or --write) version stamps.")
+    ap.add_argument(
+        "--write",
+        action="store_true",
+        help="stamp pyproject's version into debian/changelog + the RPM spec, "
+        "then verify -- run this during release prep so the stamps can't drift",
+    )
+    args = ap.parse_args()
+
+    pv = pyproject_version()
+    if args.write:
+        changed = [
+            name
+            for name, did in (
+                ("packaging/rpm/winpodx.spec", _sync_spec(pv)),
+                ("debian/changelog", _sync_debian(pv)),
+            )
+            if did
+        ]
+        print(
+            f"Stamped {pv} into: {', '.join(changed)} (refine the debian/changelog bullet)"
+            if changed
+            else f"Already at {pv}; nothing to stamp."
+        )
+
     versions = {
-        "pyproject.toml [project] version": pyproject_version(),
+        "pyproject.toml [project] version": pv,
         "debian/changelog (first entry)": debian_version(),
         "packaging/rpm/winpodx.spec Version:": spec_version(),
     }


### PR DESCRIPTION
Fix the 0.7.0 release CI failures **and prevent the recurrence**.

Two failures on the 0.7.0 tag:
- **lint "Verify version stamps agree"** — the release-prep bumped `pyproject.toml` to 0.7.0 but left `debian/changelog` and `packaging/rpm/winpodx.spec` at 0.6.0, so the `.deb` would build mis-versioned (the v0.5.2 incident again). Both stamped to 0.7.0.
- **test_oem_install_bat (non-ASCII)** — a box-drawing em-dash (`──`) slipped into a `REM` comment added to `config/oem/install.bat`; replaced with ASCII `--`.

**Prevention:** `scripts/ci/verify_versions.py` gains a `--write` mode that stamps `pyproject`'s version into `debian/changelog` (prepends an entry, reusing the maintainer + an RFC-2822 timestamp) and the RPM spec, then verifies. Release prep is now: bump `pyproject.toml`, run `python scripts/ci/verify_versions.py --write`, refine the changelog bullet — the stamps can no longer drift by hand.

`verify_versions.py` → "Version stamps consistent: 0.7.0"; `test_oem_install_bat` 11 passed; `ruff` clean.
