### PR TITLE
feat(gui): restore deleted apps + visible checkbox/Reset (#530 follow-up)

### DIFF
--- a/src/winpodx/core/app.py
+++ b/src/winpodx/core/app.py
@@ -125,6 +125,25 @@ def unsuppress_app_slug(slug: str) -> None:
         pass
 
 
+def clear_suppressed_slugs() -> int:
+    """Drop every deletion tombstone so the next discovery re-adds them (#530).
+
+    Powers the GUI's "Re-detect all" — undeletes every app the user previously
+    removed in one shot. Returns the number of tombstones cleared. The apps
+    themselves reappear on the next discovery sweep (their ``discovered/<slug>``
+    dirs were removed on delete), so callers should trigger a refresh after.
+    """
+    current = suppressed_app_slugs()
+    if not current:
+        return 0
+    try:
+        _suppressed_file().unlink(missing_ok=True)
+    except OSError as e:  # noqa: BLE001
+        log.warning("could not clear suppressed-app list: %s", e)
+        return 0
+    return len(current)
+
+
 _VALID_APP_SOURCES = frozenset({"discovered", "user"})
 
 

--- a/src/winpodx/gui/_main_window_apps.py
+++ b/src/winpodx/gui/_main_window_apps.py
@@ -159,6 +159,7 @@ class AppCrudMixin:
     def _reload_apps(self) -> None:
         self.apps = list_available_apps()
         self._refresh_hidden_button()
+        self._refresh_deleted_button()
         # Clear any active search WITHOUT firing textChanged -> _filter_apps:
         # _refresh_launcher_home() below already triggers the single rebuild.
         # Two back-to-back rebuilds of app_list_layout raced Qt's heightForWidth

--- a/src/winpodx/gui/_main_window_library.py
+++ b/src/winpodx/gui/_main_window_library.py
@@ -61,6 +61,7 @@ from winpodx.gui.theme import (
     BTN_GHOST,
     BTN_PRIMARY,
     BTN_SECONDARY,
+    CHECKBOX,
     FILTER_CHIP,
     SCROLL_AREA,
     SEARCH_BAR,
@@ -786,7 +787,10 @@ class LibraryPageMixin:
         if getattr(self, "_select_mode", False):
             cb = QCheckBox()
             cb.setChecked(app.name in self._selected_names)
-            cb.setStyleSheet("margin-left: 12px;")
+            # Use the themed indicator (bordered box, blue when checked); the
+            # old bare "margin-left" stylesheet wiped the indicator style so the
+            # box was invisible against the dark tile (#530 follow-up).
+            cb.setStyleSheet(CHECKBOX + "QCheckBox { margin-left: 12px; }")
             cb.toggled.connect(lambda checked, n=app.name: self._on_tile_checked(n, checked))
             layout.addWidget(cb)
             layout.addSpacing(SPACE_S)

--- a/src/winpodx/gui/_main_window_library.py
+++ b/src/winpodx/gui/_main_window_library.py
@@ -221,6 +221,16 @@ class LibraryPageMixin:
         self.btn_show_hidden.clicked.connect(self._on_toggle_hidden)
         right_group.addWidget(self.btn_show_hidden)
 
+        # Restore-deleted entry point (#530). Deleting an app tombstones its
+        # slug so discovery won't re-add it; this opens the un-delete list.
+        # Hidden when there's nothing to restore.
+        self.btn_deleted = QPushButton(tr("Deleted"))
+        self.btn_deleted.setStyleSheet(BTN_GHOST)
+        self.btn_deleted.setToolTip(tr("Restore apps you previously deleted"))
+        self.btn_deleted.clicked.connect(self._on_open_deleted_apps)
+        self.btn_deleted.setVisible(False)
+        right_group.addWidget(self.btn_deleted)
+
         # Multi-select bulk-remove (#530). Toggling drops to list view (the only
         # tile with room for a checkbox -- the grid card is a minimal external
         # widget) and reveals the batch action bar below the toolbar.
@@ -849,6 +859,20 @@ class LibraryPageMixin:
         layout.addWidget(edit_btn)
         layout.addSpacing(6)
 
+        # Surface "Reset" as a visible button (not just the right-click menu)
+        # when this app is an edited override with a detected twin to fall back
+        # to — the context-menu-only action was too hard to find (#530).
+        if getattr(app, "source", "user") == "user":
+            from winpodx.core.app import discovered_profile_exists
+
+            if discovered_profile_exists(app.name):
+                reset_btn = QPushButton(tr("Reset"))
+                reset_btn.setStyleSheet(BTN_SECONDARY)
+                reset_btn.setToolTip(tr("Restore the auto-detected profile + icon"))
+                reset_btn.clicked.connect(lambda: self._on_reset_app(app))
+                layout.addWidget(reset_btn)
+                layout.addSpacing(6)
+
         hide_btn = QPushButton(tr("Show") if app.hidden else tr("Hide"))
         hide_btn.setStyleSheet(BTN_SECONDARY)
         hide_btn.clicked.connect(lambda: self._on_toggle_app_hidden(app))
@@ -895,6 +919,49 @@ class LibraryPageMixin:
         self._show_hidden = self.btn_show_hidden.isChecked()
         self._refresh_hidden_button()
         self._filter_apps(self.search_box.text())
+
+    # -- restore deleted apps (#530) --------------------------------------
+
+    def _refresh_deleted_button(self) -> None:
+        """Show the "Deleted (N)" button only when there are tombstones."""
+        if not hasattr(self, "btn_deleted"):
+            return
+        from winpodx.core.app import suppressed_app_slugs
+
+        n = len(suppressed_app_slugs())
+        self.btn_deleted.setVisible(n > 0)
+        self.btn_deleted.setText(tr("Deleted ({n})").format(n=n) if n else tr("Deleted"))
+
+    def _on_open_deleted_apps(self) -> None:
+        from winpodx.core.app import suppressed_app_slugs
+        from winpodx.gui.deleted_apps_dialog import DeletedAppsDialog
+
+        slugs = sorted(suppressed_app_slugs())
+        if not slugs:
+            self._refresh_deleted_button()
+            return
+        dlg = DeletedAppsDialog(self, slugs=slugs, on_restore=self._restore_deleted_slugs)
+        dlg.exec()
+        self._refresh_deleted_button()
+
+    def _restore_deleted_slugs(self, slugs: list[str]) -> None:
+        """Un-tombstone the given slugs and re-scan so they reappear (#530)."""
+        from winpodx.core.app import (
+            clear_suppressed_slugs,
+            suppressed_app_slugs,
+            unsuppress_app_slug,
+        )
+
+        # Restore-all wipes the whole tombstone file; a partial set unsuppresses each.
+        if set(slugs) >= suppressed_app_slugs():
+            clear_suppressed_slugs()
+        else:
+            for s in slugs:
+                unsuppress_app_slug(s)
+        self.info_label.setText(tr("Restoring {n} app(s) — re-scanning…").format(n=len(slugs)))
+        # The discovered/<slug> dirs were removed on delete, so only a fresh
+        # discovery sweep actually brings the apps back.
+        self._on_refresh_apps()
 
     # -- multi-select bulk remove (#530) ----------------------------------
 

--- a/src/winpodx/gui/deleted_apps_dialog.py
+++ b/src/winpodx/gui/deleted_apps_dialog.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: MIT
+"""Restore-deleted-apps dialog (#530).
+
+Deleting an app tombstones its slug (see ``core.app.suppress_app_slug``) so the
+next discovery sweep won't resurrect it. This dialog is the un-delete UI: it
+lists the tombstoned slugs and lets the user restore one or all of them. The
+actual un-suppress + re-discovery is done by the caller via ``on_restore``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from winpodx.core.i18n import tr
+from winpodx.gui.theme import (
+    BTN_PRIMARY,
+    BTN_SECONDARY,
+    DIALOG,
+    SPACE_M,
+    SPACE_S,
+    C,
+)
+
+
+class DeletedAppsDialog(QDialog):
+    """List tombstoned (deleted) app slugs with per-row + bulk restore."""
+
+    def __init__(
+        self,
+        parent=None,
+        *,
+        slugs: list[str],
+        on_restore: Callable[[list[str]], None],
+    ) -> None:
+        super().__init__(parent)
+        self._on_restore = on_restore
+        self._rows: dict[str, QFrame] = {}
+        self.setWindowTitle(tr("Deleted Apps"))
+        self.setMinimumSize(440, 420)
+        self.setStyleSheet(DIALOG + f"QLabel {{ color: {C.TEXT}; }}")
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 20, 24, 20)
+        layout.setSpacing(SPACE_M)
+
+        title = QLabel(tr("Restore deleted apps"))
+        title.setStyleSheet(f"color: {C.TEXT}; font-size: 16px; font-weight: 600;")
+        layout.addWidget(title)
+        sub = QLabel(
+            tr(
+                "Apps you removed are tombstoned so discovery won't re-add them. "
+                "Restore brings one back on the next scan."
+            )
+        )
+        sub.setStyleSheet(f"color: {C.OVERLAY0}; font-size: 12px;")
+        sub.setWordWrap(True)
+        layout.addWidget(sub)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        scroll.setStyleSheet("QScrollArea { border: none; background: transparent; }")
+        self._list_host = QWidget()
+        self._list_host.setStyleSheet("background: transparent;")
+        self._list_layout = QVBoxLayout(self._list_host)
+        self._list_layout.setContentsMargins(0, 0, 0, 0)
+        self._list_layout.setSpacing(SPACE_S)
+        scroll.setWidget(self._list_host)
+        layout.addWidget(scroll, 1)
+
+        self._empty_lbl = QLabel(tr("No deleted apps."))
+        self._empty_lbl.setStyleSheet(f"color: {C.OVERLAY0}; font-size: 12px;")
+        self._empty_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self._empty_lbl)
+        self._empty_lbl.setVisible(False)
+
+        for slug in sorted(slugs):
+            self._add_row(slug)
+
+        btn_row = QHBoxLayout()
+        self._restore_all_btn = QPushButton(tr("Restore all"))
+        self._restore_all_btn.setStyleSheet(BTN_PRIMARY)
+        self._restore_all_btn.clicked.connect(self._on_restore_all)
+        btn_row.addWidget(self._restore_all_btn)
+        btn_row.addStretch()
+        close = QPushButton(tr("Close"))
+        close.setStyleSheet(BTN_SECONDARY)
+        close.clicked.connect(self.accept)
+        btn_row.addWidget(close)
+        layout.addLayout(btn_row)
+
+        self._refresh_empty_state()
+
+    def _add_row(self, slug: str) -> None:
+        row = QFrame()
+        row.setStyleSheet(
+            f"QFrame {{ background: {C.SURFACE0}; border-radius: 8px; }}"
+            f"QFrame:hover {{ background: {C.SURFACE1}; }}"
+        )
+        rl = QHBoxLayout(row)
+        rl.setContentsMargins(SPACE_M, SPACE_S, SPACE_M, SPACE_S)
+        name = QLabel(slug)
+        name.setStyleSheet(f"background: transparent; color: {C.TEXT}; font-size: 13px;")
+        rl.addWidget(name)
+        rl.addStretch()
+        restore = QPushButton(tr("Restore"))
+        restore.setStyleSheet(BTN_SECONDARY)
+        restore.clicked.connect(lambda _=False, s=slug: self._on_restore_one(s))
+        rl.addWidget(restore)
+        self._list_layout.addWidget(row)
+        self._rows[slug] = row
+
+    def _on_restore_one(self, slug: str) -> None:
+        self._on_restore([slug])
+        row = self._rows.pop(slug, None)
+        if row is not None:
+            row.setParent(None)
+            row.deleteLater()
+        self._refresh_empty_state()
+
+    def _on_restore_all(self) -> None:
+        if not self._rows:
+            return
+        self._on_restore(list(self._rows))
+        self.accept()
+
+    def _refresh_empty_state(self) -> None:
+        has_rows = bool(self._rows)
+        self._empty_lbl.setVisible(not has_rows)
+        self._restore_all_btn.setEnabled(has_rows)

--- a/src/winpodx/locale/de.json
+++ b/src/winpodx/locale/de.json
@@ -902,5 +902,17 @@
   "Remove selected": "Auswahl entfernen",
   "Remove Apps": "Apps entfernen",
   "Remove {n} selected app profiles?\nThis only removes the profiles, not the Windows apps.": "{n} ausgewählte App-Profile entfernen?\nDies entfernt nur die Profile, nicht die Windows-Apps.",
-  "Removed {n} apps": "{n} Apps entfernt"
+  "Removed {n} apps": "{n} Apps entfernt",
+  "Deleted": "Gelöscht",
+  "Restore apps you previously deleted": "Zuvor gelöschte Apps wiederherstellen",
+  "Deleted ({n})": "Gelöscht ({n})",
+  "Restoring {n} app(s) — re-scanning…": "{n} App(s) werden wiederhergestellt — erneut suchen…",
+  "Reset": "Zurücksetzen",
+  "Restore the auto-detected profile + icon": "Automatisch erkanntes Profil + Symbol wiederherstellen",
+  "Deleted Apps": "Gelöschte Apps",
+  "Restore deleted apps": "Gelöschte Apps wiederherstellen",
+  "Apps you removed are tombstoned so discovery won't re-add them. Restore brings one back on the next scan.": "Entfernte Apps werden markiert, damit die Erkennung sie nicht erneut hinzufügt. Wiederherstellen bringt sie beim nächsten Scan zurück.",
+  "No deleted apps.": "Keine gelöschten Apps.",
+  "Restore all": "Alle wiederherstellen",
+  "Restore": "Wiederherstellen"
 }

--- a/src/winpodx/locale/fr.json
+++ b/src/winpodx/locale/fr.json
@@ -902,5 +902,17 @@
   "Remove selected": "Supprimer la sélection",
   "Remove Apps": "Supprimer les applications",
   "Remove {n} selected app profiles?\nThis only removes the profiles, not the Windows apps.": "Supprimer {n} profils d'application sélectionnés ?\nCela supprime uniquement les profils, pas les applications Windows.",
-  "Removed {n} apps": "{n} applications supprimées"
+  "Removed {n} apps": "{n} applications supprimées",
+  "Deleted": "Supprimés",
+  "Restore apps you previously deleted": "Restaurer les applications précédemment supprimées",
+  "Deleted ({n})": "Supprimés ({n})",
+  "Restoring {n} app(s) — re-scanning…": "Restauration de {n} application(s) — nouvelle analyse…",
+  "Reset": "Réinitialiser",
+  "Restore the auto-detected profile + icon": "Restaurer le profil détecté automatiquement + l'icône",
+  "Deleted Apps": "Applications supprimées",
+  "Restore deleted apps": "Restaurer les applications supprimées",
+  "Apps you removed are tombstoned so discovery won't re-add them. Restore brings one back on the next scan.": "Les applications supprimées sont marquées pour que la détection ne les rajoute pas. La restauration les fait réapparaître au prochain scan.",
+  "No deleted apps.": "Aucune application supprimée.",
+  "Restore all": "Tout restaurer",
+  "Restore": "Restaurer"
 }

--- a/src/winpodx/locale/it.json
+++ b/src/winpodx/locale/it.json
@@ -902,5 +902,17 @@
   "Remove selected": "Rimuovi selezionati",
   "Remove Apps": "Rimuovi app",
   "Remove {n} selected app profiles?\nThis only removes the profiles, not the Windows apps.": "Rimuovere {n} profili di app selezionati?\nVengono rimossi solo i profili, non le app di Windows.",
-  "Removed {n} apps": "{n} app rimosse"
+  "Removed {n} apps": "{n} app rimosse",
+  "Deleted": "Eliminate",
+  "Restore apps you previously deleted": "Ripristina le app eliminate in precedenza",
+  "Deleted ({n})": "Eliminate ({n})",
+  "Restoring {n} app(s) — re-scanning…": "Ripristino di {n} app — nuova scansione…",
+  "Reset": "Reimposta",
+  "Restore the auto-detected profile + icon": "Ripristina il profilo rilevato automaticamente + icona",
+  "Deleted Apps": "App eliminate",
+  "Restore deleted apps": "Ripristina le app eliminate",
+  "Apps you removed are tombstoned so discovery won't re-add them. Restore brings one back on the next scan.": "Le app rimosse vengono contrassegnate così la rilevazione non le riaggiunge. Il ripristino le riporta alla scansione successiva.",
+  "No deleted apps.": "Nessuna app eliminata.",
+  "Restore all": "Ripristina tutto",
+  "Restore": "Ripristina"
 }

--- a/src/winpodx/locale/ja.json
+++ b/src/winpodx/locale/ja.json
@@ -902,5 +902,17 @@
   "Remove selected": "選択項目を削除",
   "Remove Apps": "アプリを削除",
   "Remove {n} selected app profiles?\nThis only removes the profiles, not the Windows apps.": "選択した {n} 個のアプリプロファイルを削除しますか?\nプロファイルのみが削除され、Windows アプリは削除されません。",
-  "Removed {n} apps": "{n} 個のアプリを削除しました"
+  "Removed {n} apps": "{n} 個のアプリを削除しました",
+  "Deleted": "削除済み",
+  "Restore apps you previously deleted": "以前に削除したアプリを復元",
+  "Deleted ({n})": "削除済み ({n})",
+  "Restoring {n} app(s) — re-scanning…": "{n} 個のアプリを復元中 — 再スキャン…",
+  "Reset": "リセット",
+  "Restore the auto-detected profile + icon": "自動検出されたプロファイル + アイコンを復元",
+  "Deleted Apps": "削除されたアプリ",
+  "Restore deleted apps": "削除されたアプリを復元",
+  "Apps you removed are tombstoned so discovery won't re-add them. Restore brings one back on the next scan.": "削除したアプリは再検出で再追加されないようマークされます。復元すると次のスキャンで再び表示されます。",
+  "No deleted apps.": "削除されたアプリはありません。",
+  "Restore all": "すべて復元",
+  "Restore": "復元"
 }

--- a/src/winpodx/locale/ko.json
+++ b/src/winpodx/locale/ko.json
@@ -902,5 +902,17 @@
   "Remove selected": "선택 항목 제거",
   "Remove Apps": "앱 제거",
   "Remove {n} selected app profiles?\nThis only removes the profiles, not the Windows apps.": "선택한 앱 프로필 {n}개를 제거할까요?\n프로필만 제거되며 Windows 앱은 삭제되지 않습니다.",
-  "Removed {n} apps": "앱 {n}개 제거됨"
+  "Removed {n} apps": "앱 {n}개 제거됨",
+  "Deleted": "삭제됨",
+  "Restore apps you previously deleted": "이전에 삭제한 앱 복원",
+  "Deleted ({n})": "삭제됨 ({n})",
+  "Restoring {n} app(s) — re-scanning…": "앱 {n}개 복원 중 — 다시 검색…",
+  "Reset": "초기화",
+  "Restore the auto-detected profile + icon": "자동 감지된 프로필 + 아이콘 복원",
+  "Deleted Apps": "삭제된 앱",
+  "Restore deleted apps": "삭제된 앱 복원",
+  "Apps you removed are tombstoned so discovery won't re-add them. Restore brings one back on the next scan.": "제거한 앱은 재검색에서 다시 추가되지 않도록 표시됩니다. 복원하면 다음 검색 때 다시 나타납니다.",
+  "No deleted apps.": "삭제된 앱 없음.",
+  "Restore all": "모두 복원",
+  "Restore": "복원"
 }

--- a/src/winpodx/locale/zh.json
+++ b/src/winpodx/locale/zh.json
@@ -902,5 +902,17 @@
   "Remove selected": "删除所选",
   "Remove Apps": "删除应用",
   "Remove {n} selected app profiles?\nThis only removes the profiles, not the Windows apps.": "删除选中的 {n} 个应用配置？\n仅删除配置，不会删除 Windows 应用。",
-  "Removed {n} apps": "已删除 {n} 个应用"
+  "Removed {n} apps": "已删除 {n} 个应用",
+  "Deleted": "已删除",
+  "Restore apps you previously deleted": "恢复您之前删除的应用",
+  "Deleted ({n})": "已删除 ({n})",
+  "Restoring {n} app(s) — re-scanning…": "正在恢复 {n} 个应用 — 重新扫描…",
+  "Reset": "重置",
+  "Restore the auto-detected profile + icon": "恢复自动检测的配置 + 图标",
+  "Deleted Apps": "已删除的应用",
+  "Restore deleted apps": "恢复已删除的应用",
+  "Apps you removed are tombstoned so discovery won't re-add them. Restore brings one back on the next scan.": "您删除的应用会被标记，以免重新扫描时再次添加。恢复后将在下次扫描时重新出现。",
+  "No deleted apps.": "没有已删除的应用。",
+  "Restore all": "全部恢复",
+  "Restore": "恢复"
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -514,6 +514,53 @@ def test_batch_remove_aborts_on_no(monkeypatch, tmp_path):
     assert host._selected_names == {"keep"}  # selection preserved
 
 
+# -- restore deleted apps (#530 follow-up) --------------------------------
+
+
+def test_clear_suppressed_slugs(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from winpodx.core.app import (
+        clear_suppressed_slugs,
+        suppress_app_slug,
+        suppressed_app_slugs,
+    )
+
+    assert clear_suppressed_slugs() == 0  # nothing to clear
+    suppress_app_slug("paint")
+    suppress_app_slug("notepad")
+    assert suppressed_app_slugs() == {"paint", "notepad"}
+    assert clear_suppressed_slugs() == 2  # both tombstones dropped
+    assert suppressed_app_slugs() == set()
+
+
+def test_restore_deleted_slugs_partial_vs_all(monkeypatch, tmp_path):
+    """The GUI restore handler clears all tombstones for a full restore, else
+    unsuppresses just the chosen slugs -- driven on a minimal fake host."""
+    import pytest
+
+    pytest.importorskip("PySide6")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from winpodx.core.app import suppress_app_slug, suppressed_app_slugs
+    from winpodx.gui._main_window_library import LibraryPageMixin
+
+    for s in ("paint", "notepad", "wordpad"):
+        suppress_app_slug(s)
+
+    refreshed = []
+    host = type("H", (), {})()
+    host._on_refresh_apps = lambda: refreshed.append(True)
+    host.info_label = type("L", (), {"setText": lambda self, t: None})()
+
+    # partial restore -> only that slug comes off the tombstone list
+    LibraryPageMixin._restore_deleted_slugs(host, ["notepad"])
+    assert suppressed_app_slugs() == {"paint", "wordpad"}
+    assert refreshed == [True]  # re-scan triggered
+
+    # restoring the remaining set (== full list) clears everything
+    LibraryPageMixin._restore_deleted_slugs(host, ["paint", "wordpad"])
+    assert suppressed_app_slugs() == set()
+
+
 # -- checksum-gated re-extraction (periodic icon refresh) ------------------
 
 _H1 = "a" * 64


### PR DESCRIPTION
Follow-ups to #572 (#530), from maintainer testing on the GUI.

## Fixes
- **Multi-select checkbox was invisible** on the dark theme — the select-mode tile checkbox used a bare `margin-left` stylesheet that wiped the themed `QCheckBox::indicator`, so the box had no contrast against the tile. Now uses the shared `CHECKBOX` style (bordered box, blue when checked).

## Features
- **Restore deleted apps.** Deleting an app tombstones its slug so discovery won't re-add it, with no way back. New `core.app.clear_suppressed_slugs()` + a **"Deleted (N)"** toolbar button (shown only when tombstones exist) that opens a dialog listing removed apps with per-app **Restore** and **Restore all** — restoring un-suppresses and re-runs discovery so the app reappears.
- **Discoverability:** surface **"Reset"** as a visible per-tile button (not just the right-click menu) when an app is an edited override with a detected twin to revert to.

## Tests / i18n
- `clear_suppressed_slugs` + the restore handler's partial-vs-full-clear logic (fake-host).
- 18 new UI strings across all 6 locale catalogs.

Targets 0.7.1.
