### PR TITLE
fix(doctor): don't flag hidden apps as missing desktop entries (#535)

### DIFF
--- a/src/winpodx/cli/doctor.py
+++ b/src/winpodx/cli/doctor.py
@@ -494,11 +494,20 @@ def _desktop_entry_path(app) -> "object":
 
 
 def _apps_missing_desktop_entries() -> list:
-    """Return AppInfo objects that have no ``.desktop`` file installed."""
+    """Return AppInfo objects that have no ``.desktop`` file installed.
+
+    Skips apps the user has hidden: hiding an app deliberately removes its
+    ``.desktop`` entry (see ``core.app.set_app_hidden``), so a hidden app
+    legitimately has none. Counting those as "missing" made ``doctor`` flag
+    every app the user cleaned out of the launcher and offer ``--fix`` to
+    re-register them — which would silently un-hide them all (#535).
+    """
     from winpodx.core.app import list_available_apps
 
     missing = []
     for app in list_available_apps():
+        if getattr(app, "hidden", False):
+            continue
         if not _desktop_entry_path(app).exists():
             missing.append(app)
     return missing

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -252,10 +252,11 @@ class TestStaleLockFixer:
 
 
 class _FakeApp:
-    def __init__(self, name, mime_types=None):
+    def __init__(self, name, mime_types=None, hidden=False):
         self.name = name
         self.full_name = name
         self.mime_types = mime_types or []
+        self.hidden = hidden
 
 
 class _ExistsPath:
@@ -276,6 +277,16 @@ class TestMissingDesktopEntryFixer:
         )
         missing = doctor._apps_missing_desktop_entries()
         assert [a.name for a in missing] == ["beta"]
+
+    def test_hidden_apps_not_flagged_missing(self, monkeypatch):
+        """A hidden app legitimately has no .desktop entry; doctor must not
+        report it as missing (which --fix would re-register = un-hide) (#535)."""
+        apps = [_FakeApp("alpha"), _FakeApp("hiddenapp", hidden=True)]
+        monkeypatch.setattr("winpodx.core.app.list_available_apps", lambda: apps)
+        # neither has a .desktop on disk
+        monkeypatch.setattr(doctor, "_desktop_entry_path", lambda app: _ExistsPath(False))
+        missing = doctor._apps_missing_desktop_entries()
+        assert [a.name for a in missing] == ["alpha"]  # hidden one skipped
 
     def test_fix_reregisters(self, monkeypatch):
         apps = [_FakeApp("beta", mime_types=["text/plain"])]


### PR DESCRIPTION
The original report (refresh re-adds removed apps) was already fixed by the suppress/tombstone mechanism (#514, shipped 0.7.0) and confirmed by the reporter.

This fixes the remaining sub-issue from the thread: **`winpodx doctor` flagged hidden apps as "missing a desktop entry."** Hiding an app deliberately removes its `.desktop` entry (`core.app.set_app_hidden`), so the check counted every app the user had cleaned out of the launcher as broken and suggested `winpodx doctor --fix` to re-register them — which would silently un-hide the whole set.

`_apps_missing_desktop_entries()` now skips `hidden=True` apps, so the false WARN is gone and `--fix` no longer un-hides. Test added.
