### PR TITLE
feat(gui): bulk 'Hide selected' in multi-select (#530)

### DIFF
--- a/src/winpodx/gui/_main_window_library.py
+++ b/src/winpodx/gui/_main_window_library.py
@@ -976,6 +976,11 @@ class LibraryPageMixin:
         self._batch_label.setStyleSheet(f"background: transparent; color: {C.SUBTEXT0};")
         row.addWidget(self._batch_label)
         row.addStretch()
+        self._batch_hide_btn = QPushButton(tr("Hide selected"))
+        self._batch_hide_btn.setStyleSheet(BTN_SECONDARY)
+        self._batch_hide_btn.setEnabled(False)
+        self._batch_hide_btn.clicked.connect(self._on_batch_hide)
+        row.addWidget(self._batch_hide_btn)
         self._batch_remove_btn = QPushButton(tr("Remove selected"))
         self._batch_remove_btn.setStyleSheet(BTN_DANGER)
         self._batch_remove_btn.setEnabled(False)
@@ -1018,6 +1023,23 @@ class LibraryPageMixin:
         self._batch_bar.setVisible(self._select_mode)
         self._batch_label.setText(tr("{n} selected").format(n=n))
         self._batch_remove_btn.setEnabled(n > 0)
+        self._batch_hide_btn.setEnabled(n > 0)
+
+    def _on_batch_hide(self) -> None:
+        """Hide all selected apps from the Linux menu (reversible, no confirm)."""
+        names = sorted(self._selected_names)
+        if not names:
+            return
+        from winpodx.core.app import set_app_hidden
+
+        hidden = sum(1 for name in names if set_app_hidden(name, True) is not None)
+        self._selected_names.clear()
+        self.btn_select.setChecked(False)
+        self._select_mode = False
+        self.btn_grid.setEnabled(True)
+        self._reload_apps()
+        self._update_batch_bar()
+        self.info_label.setText(tr("Hid {n} apps").format(n=hidden))
 
     def _on_batch_remove(self) -> None:
         names = sorted(self._selected_names)

--- a/src/winpodx/locale/de.json
+++ b/src/winpodx/locale/de.json
@@ -914,5 +914,7 @@
   "Apps you removed are tombstoned so discovery won't re-add them. Restore brings one back on the next scan.": "Entfernte Apps werden markiert, damit die Erkennung sie nicht erneut hinzufügt. Wiederherstellen bringt sie beim nächsten Scan zurück.",
   "No deleted apps.": "Keine gelöschten Apps.",
   "Restore all": "Alle wiederherstellen",
-  "Restore": "Wiederherstellen"
+  "Restore": "Wiederherstellen",
+  "Hide selected": "Auswahl ausblenden",
+  "Hid {n} apps": "{n} Apps ausgeblendet"
 }

--- a/src/winpodx/locale/fr.json
+++ b/src/winpodx/locale/fr.json
@@ -914,5 +914,7 @@
   "Apps you removed are tombstoned so discovery won't re-add them. Restore brings one back on the next scan.": "Les applications supprimées sont marquées pour que la détection ne les rajoute pas. La restauration les fait réapparaître au prochain scan.",
   "No deleted apps.": "Aucune application supprimée.",
   "Restore all": "Tout restaurer",
-  "Restore": "Restaurer"
+  "Restore": "Restaurer",
+  "Hide selected": "Masquer la sélection",
+  "Hid {n} apps": "{n} applications masquées"
 }

--- a/src/winpodx/locale/it.json
+++ b/src/winpodx/locale/it.json
@@ -914,5 +914,7 @@
   "Apps you removed are tombstoned so discovery won't re-add them. Restore brings one back on the next scan.": "Le app rimosse vengono contrassegnate così la rilevazione non le riaggiunge. Il ripristino le riporta alla scansione successiva.",
   "No deleted apps.": "Nessuna app eliminata.",
   "Restore all": "Ripristina tutto",
-  "Restore": "Ripristina"
+  "Restore": "Ripristina",
+  "Hide selected": "Nascondi selezionati",
+  "Hid {n} apps": "{n} app nascoste"
 }

--- a/src/winpodx/locale/ja.json
+++ b/src/winpodx/locale/ja.json
@@ -914,5 +914,7 @@
   "Apps you removed are tombstoned so discovery won't re-add them. Restore brings one back on the next scan.": "削除したアプリは再検出で再追加されないようマークされます。復元すると次のスキャンで再び表示されます。",
   "No deleted apps.": "削除されたアプリはありません。",
   "Restore all": "すべて復元",
-  "Restore": "復元"
+  "Restore": "復元",
+  "Hide selected": "選択項目を非表示",
+  "Hid {n} apps": "{n} 個のアプリを非表示にしました"
 }

--- a/src/winpodx/locale/ko.json
+++ b/src/winpodx/locale/ko.json
@@ -914,5 +914,7 @@
   "Apps you removed are tombstoned so discovery won't re-add them. Restore brings one back on the next scan.": "제거한 앱은 재검색에서 다시 추가되지 않도록 표시됩니다. 복원하면 다음 검색 때 다시 나타납니다.",
   "No deleted apps.": "삭제된 앱 없음.",
   "Restore all": "모두 복원",
-  "Restore": "복원"
+  "Restore": "복원",
+  "Hide selected": "선택 항목 숨기기",
+  "Hid {n} apps": "앱 {n}개 숨김"
 }

--- a/src/winpodx/locale/zh.json
+++ b/src/winpodx/locale/zh.json
@@ -914,5 +914,7 @@
   "Apps you removed are tombstoned so discovery won't re-add them. Restore brings one back on the next scan.": "您删除的应用会被标记，以免重新扫描时再次添加。恢复后将在下次扫描时重新出现。",
   "No deleted apps.": "没有已删除的应用。",
   "Restore all": "全部恢复",
-  "Restore": "恢复"
+  "Restore": "恢复",
+  "Hide selected": "隐藏所选",
+  "Hid {n} apps": "已隐藏 {n} 个应用"
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -514,6 +514,39 @@ def test_batch_remove_aborts_on_no(monkeypatch, tmp_path):
     assert host._selected_names == {"keep"}  # selection preserved
 
 
+def test_batch_hide_hides_selected(monkeypatch, tmp_path):
+    """Bulk 'Hide selected' flips every chosen app to hidden=true (#530)."""
+    import pytest
+
+    pytest.importorskip("PySide6")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    from winpodx.core.app import data_dir, find_app
+    from winpodx.gui._main_window_library import LibraryPageMixin
+
+    _patch_desktop_sync(monkeypatch)
+    for name in ("word", "excel"):
+        d = data_dir() / "apps" / name
+        d.mkdir(parents=True)
+        (d / "app.toml").write_text(
+            f'name = "{name}"\nfull_name = "{name}"\nexecutable = "C:\\\\x.exe"\n', encoding="utf-8"
+        )
+
+    host = type("H", (), {})()
+    host._selected_names = {"word", "excel"}
+    host._select_mode = True
+    host.btn_select = type("B", (), {"setChecked": lambda self, v: None})()
+    host.btn_grid = type("G", (), {"setEnabled": lambda self, v: None})()
+    host.info_label = type("L", (), {"setText": lambda self, t: None})()
+    host._reload_apps = lambda: None
+    host._update_batch_bar = lambda: None
+
+    LibraryPageMixin._on_batch_hide(host)
+    assert find_app("word").hidden is True
+    assert find_app("excel").hidden is True
+    assert host._selected_names == set()
+    assert host._select_mode is False
+
+
 # -- restore deleted apps (#530 follow-up) --------------------------------
 
 


### PR DESCRIPTION
Adds a 'Hide selected' action beside 'Remove selected' in multi-select mode, so users can declutter the launcher without deleting profiles. Hide is reversible (Hidden toggle) so no confirm dialog. 2 new UI strings across 6 catalogs + fake-host test. Targets 0.7.1.