### PR TITLE
fix(disguise): relabel SMBIOS blob so the container can read it after re-write

### DIFF
--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -651,13 +651,48 @@ def _write_disguise_smbios_blob(oem_dir: str) -> str | None:
         from winpodx.core.pod.smbios import build_disguise_smbios_blob
 
         blob = build_disguise_smbios_blob()
-        (Path(oem_dir) / "winpodx-smbios.bin").write_bytes(blob)
+        blob_file = Path(oem_dir) / "winpodx-smbios.bin"
+        blob_file.write_bytes(blob)
+        _relabel_blob_for_container(blob_file)
         return "/oem/winpodx-smbios.bin"
     except Exception:  # noqa: BLE001 — disguise must never break compose / boot
         logging.getLogger(__name__).exception(
             "disguise: failed to write SMBIOS blob; continuing without it"
         )
         return None
+
+
+def _relabel_blob_for_container(blob_file: Path) -> None:
+    """Give the freshly-written blob an SELinux label the QEMU container can read.
+
+    The ``/oem`` bind mount uses ``:Z``, which podman relabels to a *private*
+    MCS category (``container_file_t:s0:c<x>,c<y>``) **once, at container
+    creation**. The disguise blob lives in the package OEM dir, which an
+    ``install.sh`` update replaces — so the blob is often re-written *after* the
+    container already exists, keeping its default ``home_bin_t`` / user label.
+    A confined container then can't read it and QEMU aborts boot
+    (``Cannot read SMBIOS file /oem/winpodx-smbios.bin``) → the pod crash-loops.
+
+    Setting the blob to ``container_file_t:s0`` (no MCS category) makes it
+    readable by *any* ``:Z`` container, because a private category set dominates
+    the empty one. Best-effort: a no-op when SELinux isn't enforcing or ``chcon``
+    is missing, and never raises.
+    """
+    import shutil
+    import subprocess
+
+    chcon = shutil.which("chcon")
+    if not chcon:
+        return
+    try:
+        subprocess.run(
+            [chcon, "-t", "container_file_t", str(blob_file)],
+            check=False,
+            capture_output=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass
 
 
 def _disguise_disk_size(cfg: Config) -> str:

--- a/tests/test_smbios.py
+++ b/tests/test_smbios.py
@@ -172,3 +172,43 @@ def test_disguise_smbios_args_no_qemu_in_any_value(monkeypatch):
     for elem in args:
         assert "QEMU" not in elem, f"element {elem!r} contains 'QEMU'"
         assert "qemu" not in elem.lower(), f"element {elem!r} contains 'qemu'"
+
+
+# -- disguise blob SELinux relabel (crash-loop fix) -----------------------
+
+
+def test_relabel_blob_noop_without_chcon(monkeypatch, tmp_path):
+    import shutil
+    import subprocess
+
+    monkeypatch.setattr(shutil, "which", lambda _n: None)
+    called = []
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: called.append(a))
+    p = tmp_path / "winpodx-smbios.bin"
+    p.write_bytes(b"x")
+    _compose_module._relabel_blob_for_container(p)
+    assert called == []  # no chcon on PATH -> no subprocess call
+
+
+def test_relabel_blob_invokes_chcon(monkeypatch, tmp_path):
+    import shutil
+    import subprocess
+
+    monkeypatch.setattr(shutil, "which", lambda _n: "/usr/bin/chcon")
+    calls = []
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **k: calls.append(cmd))
+    p = tmp_path / "winpodx-smbios.bin"
+    p.write_bytes(b"x")
+    _compose_module._relabel_blob_for_container(p)
+    assert calls, "chcon should be invoked when present"
+    assert calls[0][:3] == ["/usr/bin/chcon", "-t", "container_file_t"]
+    assert calls[0][-1] == str(p)
+
+
+def test_write_blob_relabels_after_write(monkeypatch, tmp_path):
+    seen = []
+    monkeypatch.setattr(_compose_module, "_relabel_blob_for_container", lambda p: seen.append(p))
+    path = _compose_module._write_disguise_smbios_blob(str(tmp_path))
+    assert path == "/oem/winpodx-smbios.bin"
+    assert (tmp_path / "winpodx-smbios.bin").exists()
+    assert len(seen) == 1  # relabel attempted right after the write


### PR DESCRIPTION
The disguise SMBIOS blob lives in the package OEM dir, which an install.sh update replaces — so it's often re-written AFTER the QEMU container exists. The /oem mount is `:Z` (relabeled once at container creation), so a late-written blob keeps its `home_bin_t` label and a confined container can't read it → `Cannot read SMBIOS file` → crash loop (install.sh then reports 'missing — creating it'). Now `chcon -t container_file_t` the blob after writing so any `:Z` container can read it regardless of timing. Best-effort (no-op without SELinux/chcon). **Needs real-Windows smoke** (disguise boot path): install + verify the pod boots without a `pod recreate`. Recovery for an already-broken pod: `winpodx pod recreate`.