### PR TITLE
fix(install): auto-load kvm module when /dev/kvm missing but CPU supports virt (#541)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1094,6 +1094,26 @@ fi
 # anyway. Without this guard the container starts but the VM never
 # boots, and the user sees a silent stall instead of the actionable
 # diagnostic below.
+#
+# #541: /dev/kvm is often absent simply because the kvm kernel module
+# isn't loaded -- even though the CPU fully supports virtualization
+# (vmx/svm flags present; e.g. confirmed by VirtualBox working on the
+# same box). Try to load it before failing -- many "virtualization
+# unsupported" reports just needed a modprobe.
+if [ ! -e /dev/kvm ] && grep -Eq '(vmx|svm)' /proc/cpuinfo 2>/dev/null; then
+    if grep -q 'vmx' /proc/cpuinfo 2>/dev/null; then KVM_MOD=kvm_intel; else KVM_MOD=kvm_amd; fi
+    log "/dev/kvm missing but the CPU reports virtualization (vmx/svm) -- loading $KVM_MOD..."
+    sudo modprobe "$KVM_MOD" 2>/dev/null || true
+    if [ -e /dev/kvm ]; then
+        KVM_PRESENT=true
+        log "/dev/kvm is now present -- hardware virtualization enabled."
+        # Persist so it auto-loads on the next boot (don't make the user redo this).
+        if [ -d /etc/modules-load.d ]; then
+            printf '%s\n' "$KVM_MOD" | sudo tee /etc/modules-load.d/winpodx-kvm.conf >/dev/null 2>&1 || true
+        fi
+    fi
+fi
+
 if [ ! -e /dev/kvm ]; then
     err "/dev/kvm still missing after package install."
     err ""


### PR DESCRIPTION
A box can have full CPU virtualization (vmx/svm, VirtualBox working) yet no /dev/kvm because the kvm module isn't loaded — install.sh aborted at the post-package gate reading as a hardware limitation. Now modprobe kvm_intel/kvm_amd when /dev/kvm is absent but vmx/svm are present, re-check, and persist to /etc/modules-load.d/winpodx-kvm.conf. Genuine BIOS-disabled cases still fall through to the existing diagnostic.