### PR TITLE
feat: auto file associations for discovered apps (Open with) (#545)

### DIFF
--- a/scripts/windows/discover_apps.ps1
+++ b/scripts/windows/discover_apps.ps1
@@ -246,6 +246,35 @@ if ($stableSamples -lt $stableSamplesNeeded) {
 $results = New-Object System.Collections.Generic.List[object]
 $seen    = @{}
 
+function Get-AppExtensions {
+    # Real file types an app handles (#545): the value names under
+    # HKCR\Applications\<exe>\SupportedTypes are the extensions it registered
+    # (e.g. ".docx"). The host maps these to MIME types for the .desktop
+    # MimeType= -- so only file types the app actually accepts are added, never
+    # made-up associations. Best-effort; returns @() on anything unexpected.
+    param([string]$ExePath)
+    $exts = New-Object System.Collections.Generic.List[string]
+    try {
+        if (-not $ExePath) { return @() }
+        $exe = [System.IO.Path]::GetFileName($ExePath)
+        if (-not $exe) { return @() }
+        foreach ($hive in @('HKLM:\SOFTWARE\Classes', 'HKCU:\SOFTWARE\Classes')) {
+            $key = Join-Path $hive ("Applications\{0}\SupportedTypes" -f $exe)
+            if (-not (Test-Path -LiteralPath $key)) { continue }
+            $props = Get-ItemProperty -LiteralPath $key -ErrorAction SilentlyContinue
+            if (-not $props) { continue }
+            foreach ($p in $props.PSObject.Properties) {
+                $n = ([string]$p.Name).ToLower()
+                if ($n -match '^\.[a-z0-9]{1,16}$' -and -not $exts.Contains($n)) {
+                    $exts.Add($n)
+                }
+            }
+        }
+    } catch { return @() }
+    if ($exts.Count -gt 64) { return @($exts.GetRange(0, 64)) }
+    return @($exts)
+}
+
 function Add-Result {
     param([hashtable]$Entry)
     if (-not $Entry) { return }
@@ -277,6 +306,7 @@ function Add-Result {
         launch_uri    = [string]$Entry.launch_uri
         icon_b64      = [string]$Entry.icon_b64
         exe_hash      = Get-ExeHash $path
+        extensions    = @(Get-AppExtensions $path)
     }) | Out-Null
 }
 

--- a/src/winpodx/cli/config_cmd.py
+++ b/src/winpodx/cli/config_cmd.py
@@ -102,6 +102,13 @@ def _show() -> None:
     print(tr("  auto_start    = {auto_start}").format(auto_start=cfg.pod.auto_start))
     print(tr("  idle_timeout  = {idle_timeout}").format(idle_timeout=cfg.pod.idle_timeout))
 
+    print(tr("[desktop]"))
+    print(
+        tr("  mime_associations = {v}  (file types in 'Open with')").format(
+            v=cfg.desktop.mime_associations
+        )
+    )
+
     warning = check_session_budget(cfg)
     if warning:
         print()

--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -747,6 +747,24 @@ class UIConfig:
 
 
 @dataclass
+class DesktopConfig:
+    """Linux desktop-integration behaviour for discovered Windows apps.
+
+    ``mime_associations`` (default ON) lets a discovered app surface its real
+    file associations in the file manager's "Open with" menu: the guest reports
+    the extensions each app actually handles, the host writes them as the
+    ``.desktop`` ``MimeType=`` and refreshes the mime cache. It NEVER sets the
+    app as the *default* handler (no ``xdg-mime default``) — it only adds it as
+    an option. Turn it off to keep discovered apps out of "Open with".
+    """
+
+    mime_associations: bool = True
+
+    def __post_init__(self) -> None:
+        self.mime_associations = bool(self.mime_associations)
+
+
+@dataclass
 class Config:
     # SCHEMA_VERSION is written by save() and read by load(); see the
     # module-level comment on SCHEMA_VERSION + _migrate_config() for the
@@ -758,6 +776,7 @@ class Config:
     install: InstallConfig = field(default_factory=InstallConfig)
     logging: LoggingConfig = field(default_factory=LoggingConfig)
     ui: UIConfig = field(default_factory=UIConfig)
+    desktop: DesktopConfig = field(default_factory=DesktopConfig)
 
     @classmethod
     def path(cls) -> Path:
@@ -798,12 +817,14 @@ class Config:
         _apply(cfg.install, data.get("install", {}))
         _apply(cfg.logging, data.get("logging", {}))
         _apply(cfg.ui, data.get("ui", {}))
+        _apply(cfg.desktop, data.get("desktop", {}))
         cfg.rdp.__post_init__()
         cfg.pod.__post_init__()
         cfg.reverse_open.__post_init__()
         cfg.install.__post_init__()
         cfg.logging.__post_init__()
         cfg.ui.__post_init__()
+        cfg.desktop.__post_init__()
         return cfg
 
     def save(self) -> None:
@@ -886,6 +907,9 @@ class Config:
             },
             "ui": {
                 "language": self.ui.language,
+            },
+            "desktop": {
+                "mime_associations": self.desktop.mime_associations,
             },
         }
 

--- a/src/winpodx/core/discovery/__init__.py
+++ b/src/winpodx/core/discovery/__init__.py
@@ -69,6 +69,9 @@ _VALID_SOURCES = frozenset({"uwp", "win32", "steam"})
 
 # Matches AppInfo's _SAFE_NAME_RE contract so a discovered app loads cleanly.
 _SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+# A plausible file extension: a dot + 1-16 alphanumerics (.docx, .7z). Guards
+# the guest-reported extension list before it reaches the .desktop MimeType=.
+_SAFE_EXT_RE = re.compile(r"^\.[a-z0-9]{1,16}$")
 _NAME_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9_-]+")
 
 # v0.2.0: junk filter. Discovery scans Registry App Paths, Start Menu
@@ -268,6 +271,10 @@ class DiscoveredApp:
     # the curated allowlist / noise denylist + any prior user override.
     hidden: bool = False
     essential: bool = False
+    # Real file extensions the guest reports this app handles (from the registry
+    # scan in discover_apps.ps1), e.g. [".docx", ".xlsx"]. Mapped to MIME types
+    # for the .desktop MimeType= when desktop.mime_associations is on (#545).
+    extensions: list[str] = field(default_factory=list)
 
 
 # --- Hybrid filter: essentials allowlist + noise denylist -----------------
@@ -1031,6 +1038,21 @@ def _entry_to_discovered(entry: dict[str, Any]) -> DiscoveredApp | None:
     if not slug:
         return None
 
+    # Real file extensions the guest reports this app handles (#545). Validate +
+    # normalise to ".ext" lowercase; drop junk so a hostile guest can't smuggle
+    # arbitrary strings into the .desktop MimeType=.
+    extensions: list[str] = []
+    raw_exts = entry.get("extensions", [])
+    if isinstance(raw_exts, list):
+        for e in raw_exts[:64]:
+            if not isinstance(e, str) or not e.strip():
+                continue
+            ext = e.strip().lower()
+            if not ext.startswith("."):
+                ext = "." + ext
+            if _SAFE_EXT_RE.match(ext) and ext not in extensions:
+                extensions.append(ext)
+
     return DiscoveredApp(
         name=slug,
         full_name=raw_name.strip(),
@@ -1042,6 +1064,7 @@ def _entry_to_discovered(entry: dict[str, Any]) -> DiscoveredApp | None:
         launch_uri=launch_uri,
         exe_hash=exe_hash,
         icon_bytes=icon_bytes,
+        extensions=extensions,
     )
 
 
@@ -1101,6 +1124,7 @@ def persist_discovered(
     from winpodx.core.app import suppressed_app_slugs
 
     suppressed = suppressed_app_slugs()  # user-deleted discovered apps (#514)
+    mime_enabled = _mime_associations_enabled()  # file associations on? (#545)
 
     seen: set[str] = set()
     for app in apps:
@@ -1121,6 +1145,11 @@ def persist_discovered(
         # keeps an unchanged app's icon stable. Skipped for UWP / hashless
         # entries (exe_hash ""), which always re-write as before.
         if replace and app.exe_hash and _unchanged_on_disk(app_dir, app.exe_hash):
+            # Even when the exe is unchanged (so we keep the icon + skip the
+            # rewrite), backfill MIME associations into a TOML that predates the
+            # auto-map so existing Office/etc. apps gain file handlers on a plain
+            # refresh — without disturbing the icon (#545).
+            _backfill_mime_types(app_dir / "app.toml", app, mime_enabled)
             written.append(app_dir / "app.toml")
             continue
 
@@ -1153,7 +1182,7 @@ def persist_discovered(
 
         toml_path = app_dir / "app.toml"
         try:
-            toml_path.write_text(_render_app_toml(app), encoding="utf-8")
+            toml_path.write_text(_render_app_toml(app, mime_enabled), encoding="utf-8")
         except OSError as e:
             log.warning("Could not write %s: %s", toml_path, e)
             continue
@@ -1182,14 +1211,60 @@ def persist_discovered(
     return written
 
 
-def _render_app_toml(app: DiscoveredApp) -> str:
+def _mime_associations_enabled() -> bool:
+    """Whether to write file associations into discovered TOMLs (#545, default on)."""
+    try:
+        from winpodx.core.config import Config
+
+        return bool(Config.load().desktop.mime_associations)
+    except Exception:  # noqa: BLE001 — never let a config read break discovery
+        return True
+
+
+def _backfill_mime_types(toml_path: Path, app: DiscoveredApp, mime_enabled: bool = True) -> None:
+    """Add the guest's real MIME associations to an unchanged app's TOML (#545).
+
+    Apps that survive the checksum gate (unchanged exe) are never rewritten, so
+    one persisted before associations shipped would keep its empty
+    ``mime_types``. Patch it from the guest-reported extensions, ONLY when the
+    persisted list is empty (never clobber) and the feature is enabled.
+    Best-effort; preserves the icon and every other field.
+    """
+    if not mime_enabled:
+        return
+    from winpodx.core.mime_map import mimes_for_extensions
+
+    mimes = mimes_for_extensions(app.extensions)
+    if not mimes:
+        return
+    try:
+        data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError, OSError):
+        return
+    if data.get("mime_types"):
+        return  # already has associations — leave them
+    data["mime_types"] = mimes
+    try:
+        from winpodx.utils.toml_writer import dumps as toml_dumps
+
+        toml_path.write_text(toml_dumps(data), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _render_app_toml(app: DiscoveredApp, mime_enabled: bool = True) -> str:
     """Render a ``DiscoveredApp`` into the AppInfo-loadable TOML shape."""
+    from winpodx.core.mime_map import mimes_for_extensions
+
+    # Auto-register the file associations the guest actually reported (#545),
+    # mapped to standard MIME types. Off → empty. A user edit under apps/<slug>
+    # still wins (list_available_apps).
     data: dict[str, Any] = {
         "name": app.name,
         "full_name": app.full_name,
         "executable": app.executable,
         "categories": [],
-        "mime_types": [],
+        "mime_types": mimes_for_extensions(app.extensions) if mime_enabled else [],
     }
     if app.args:
         data["args"] = app.args

--- a/src/winpodx/core/mime_map.py
+++ b/src/winpodx/core/mime_map.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: MIT
+"""Standard file-extension → MIME-type table for auto file-association (#545).
+
+The Windows guest reports the *real* extensions each discovered app handles (via
+``discover_apps.ps1``'s registry scan); this maps those extensions to their
+freedesktop MIME types so the host can write the ``.desktop`` ``MimeType=``.
+
+The mapping is a universal extension→MIME constant (a ``.docx`` is always the
+Office wordprocessing type regardless of which app opens it), so the host owns
+it — only extensions the guest actually reported get mapped, which means no
+made-up associations. Unknown extensions are skipped.
+"""
+
+from __future__ import annotations
+
+# Extension (lowercase, leading dot) → MIME type. Conservative + standard.
+_EXT_TO_MIME: dict[str, str] = {
+    # Word processing
+    ".doc": "application/msword",
+    ".dot": "application/msword",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".dotx": "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+    ".docm": "application/vnd.ms-word.document.macroenabled.12",
+    ".odt": "application/vnd.oasis.opendocument.text",
+    ".rtf": "application/rtf",
+    # Spreadsheets
+    ".xls": "application/vnd.ms-excel",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".xlsm": "application/vnd.ms-excel.sheet.macroenabled.12",
+    ".ods": "application/vnd.oasis.opendocument.spreadsheet",
+    ".csv": "text/csv",
+    # Presentations
+    ".ppt": "application/vnd.ms-powerpoint",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".pps": "application/vnd.ms-powerpoint",
+    ".ppsx": "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+    ".odp": "application/vnd.oasis.opendocument.presentation",
+    # Documents / text
+    ".pdf": "application/pdf",
+    ".txt": "text/plain",
+    ".md": "text/markdown",
+    ".xml": "application/xml",
+    ".json": "application/json",
+    ".htm": "text/html",
+    ".html": "text/html",
+    # Images
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".bmp": "image/bmp",
+    ".tif": "image/tiff",
+    ".tiff": "image/tiff",
+    ".webp": "image/webp",
+    ".svg": "image/svg+xml",
+    ".ico": "image/vnd.microsoft.icon",
+    ".psd": "image/vnd.adobe.photoshop",
+    # Audio
+    ".mp3": "audio/mpeg",
+    ".wav": "audio/x-wav",
+    ".flac": "audio/flac",
+    ".ogg": "audio/ogg",
+    ".m4a": "audio/mp4",
+    # Video
+    ".mp4": "video/mp4",
+    ".avi": "video/x-msvideo",
+    ".mkv": "video/x-matroska",
+    ".mov": "video/quicktime",
+    ".webm": "video/webm",
+    ".wmv": "video/x-ms-wmv",
+    # Archives
+    ".zip": "application/zip",
+    ".7z": "application/x-7z-compressed",
+    ".rar": "application/vnd.rar",
+}
+
+
+def mime_for_extension(ext: str) -> str | None:
+    """MIME type for a single file extension (``.docx`` or ``docx``), or None."""
+    if not ext:
+        return None
+    e = ext.strip().lower()
+    if not e.startswith("."):
+        e = "." + e
+    return _EXT_TO_MIME.get(e)
+
+
+def mimes_for_extensions(extensions: list[str]) -> list[str]:
+    """Map the guest-reported extensions to MIME types (deduped, order-stable).
+
+    Skips extensions we don't have a standard MIME for. Empty in → empty out.
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    for ext in extensions:
+        mime = mime_for_extension(ext)
+        if mime and mime not in seen:
+            seen.add(mime)
+            out.append(mime)
+    return out

--- a/src/winpodx/desktop/entry.py
+++ b/src/winpodx/desktop/entry.py
@@ -35,6 +35,28 @@ StartupWMClass={wm_class}
 _DEFAULT_COMMENT = "Windows application via WinPodX"
 
 
+def update_desktop_database() -> None:
+    """Rebuild the applications ``mimeinfo.cache`` so ``MimeType=`` lines take
+    effect — without it, an app's declared file associations never surface in
+    the file manager's "Open with" menu (#545). Best-effort: no-op when
+    ``update-desktop-database`` isn't installed; never raises.
+    """
+    import subprocess
+
+    tool = shutil.which("update-desktop-database")
+    if not tool:
+        return
+    try:
+        subprocess.run(
+            [tool, str(applications_dir())],
+            check=False,
+            capture_output=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        log.debug("update-desktop-database failed", exc_info=True)
+
+
 def install_desktop_entry(app: AppInfo) -> Path:
     """Create and install a .desktop file for a Windows app."""
     dest_dir = applications_dir()
@@ -91,6 +113,12 @@ def install_desktop_entry(app: AppInfo) -> Path:
         install_menu_folder()
     except OSError as e:
         log.warning("Could not write winpodx menu folder definition: %s", e)
+
+    # Register file associations so the app shows up in "Open with" (#545).
+    # Only when this app declares MIME types -- most apps don't, so the cache
+    # rebuild stays bounded to the handful that need it.
+    if app.mime_types:
+        update_desktop_database()
 
     return desktop_path
 

--- a/src/winpodx/gui/_main_window_settings.py
+++ b/src/winpodx/gui/_main_window_settings.py
@@ -694,6 +694,39 @@ class SettingsPageMixin:
         applies_layout.addWidget(self.checkbox_autostart_tray)
         applies_layout.addSpacing(SPACE_M)
 
+        # File-association toggle (#545, default on). When on, discovered apps
+        # surface the file types they actually handle in the file manager's
+        # "Open with" menu -- never as the default handler. Takes effect on the
+        # next app refresh (that's when the .desktop MimeType= is rewritten).
+        from winpodx.core.config import Config as _MimeCfg
+
+        self.checkbox_mime_assoc = QCheckBox(
+            tr("Register file associations for discovered apps (Open with)")
+        )
+        try:
+            self.checkbox_mime_assoc.setChecked(_MimeCfg.load().desktop.mime_associations)
+        except Exception:  # noqa: BLE001
+            self.checkbox_mime_assoc.setChecked(True)
+        self.checkbox_mime_assoc.setStyleSheet(CHECKBOX)
+        self.checkbox_mime_assoc.setToolTip(
+            tr(
+                "Adds them to 'Open with' on the next refresh; never sets them "
+                "as the default app for a file type."
+            )
+        )
+
+        def _on_mime_assoc_toggled(checked: bool) -> None:
+            try:
+                cfg = _MimeCfg.load()
+                cfg.desktop.mime_associations = bool(checked)
+                cfg.save()
+            except Exception as e:  # noqa: BLE001
+                logging.getLogger(__name__).warning("Could not toggle file associations: %s", e)
+
+        self.checkbox_mime_assoc.toggled.connect(_on_mime_assoc_toggled)
+        applies_layout.addWidget(self.checkbox_mime_assoc)
+        applies_layout.addSpacing(SPACE_M)
+
         # winpodx UI language (the tray / GUI / CLI text itself -- distinct
         # from the *guest* install language above). Default 'auto' follows
         # the host locale. Applied to new winpodx processes (a note tells the

--- a/src/winpodx/locale/de.json
+++ b/src/winpodx/locale/de.json
@@ -916,5 +916,9 @@
   "Restore all": "Alle wiederherstellen",
   "Restore": "Wiederherstellen",
   "Hide selected": "Auswahl ausblenden",
-  "Hid {n} apps": "{n} Apps ausgeblendet"
+  "Hid {n} apps": "{n} Apps ausgeblendet",
+  "[desktop]": "[desktop]",
+  "  mime_associations = {v}  (file types in 'Open with')": "  mime_associations = {v}  (Dateitypen in 'Öffnen mit')",
+  "Register file associations for discovered apps (Open with)": "Dateizuordnungen für erkannte Apps registrieren (Öffnen mit)",
+  "Adds them to 'Open with' on the next refresh; never sets them as the default app for a file type.": "Werden beim nächsten Aktualisieren zu 'Öffnen mit' hinzugefügt; nie als Standard-App für einen Dateityp gesetzt."
 }

--- a/src/winpodx/locale/fr.json
+++ b/src/winpodx/locale/fr.json
@@ -916,5 +916,9 @@
   "Restore all": "Tout restaurer",
   "Restore": "Restaurer",
   "Hide selected": "Masquer la sélection",
-  "Hid {n} apps": "{n} applications masquées"
+  "Hid {n} apps": "{n} applications masquées",
+  "[desktop]": "[desktop]",
+  "  mime_associations = {v}  (file types in 'Open with')": "  mime_associations = {v}  (types de fichiers dans 'Ouvrir avec')",
+  "Register file associations for discovered apps (Open with)": "Enregistrer les associations de fichiers pour les apps détectées (Ouvrir avec)",
+  "Adds them to 'Open with' on the next refresh; never sets them as the default app for a file type.": "Ajoutées à 'Ouvrir avec' au prochain rafraîchissement ; jamais définies comme app par défaut d'un type de fichier."
 }

--- a/src/winpodx/locale/it.json
+++ b/src/winpodx/locale/it.json
@@ -916,5 +916,9 @@
   "Restore all": "Ripristina tutto",
   "Restore": "Ripristina",
   "Hide selected": "Nascondi selezionati",
-  "Hid {n} apps": "{n} app nascoste"
+  "Hid {n} apps": "{n} app nascoste",
+  "[desktop]": "[desktop]",
+  "  mime_associations = {v}  (file types in 'Open with')": "  mime_associations = {v}  (tipi di file in 'Apri con')",
+  "Register file associations for discovered apps (Open with)": "Registra le associazioni file per le app rilevate (Apri con)",
+  "Adds them to 'Open with' on the next refresh; never sets them as the default app for a file type.": "Aggiunte ad 'Apri con' al prossimo aggiornamento; mai impostate come app predefinita per un tipo di file."
 }

--- a/src/winpodx/locale/ja.json
+++ b/src/winpodx/locale/ja.json
@@ -916,5 +916,9 @@
   "Restore all": "すべて復元",
   "Restore": "復元",
   "Hide selected": "選択項目を非表示",
-  "Hid {n} apps": "{n} 個のアプリを非表示にしました"
+  "Hid {n} apps": "{n} 個のアプリを非表示にしました",
+  "[desktop]": "[desktop]",
+  "  mime_associations = {v}  (file types in 'Open with')": "  mime_associations = {v}  (「プログラムから開く」のファイル形式)",
+  "Register file associations for discovered apps (Open with)": "検出されたアプリのファイル関連付けを登録（プログラムから開く）",
+  "Adds them to 'Open with' on the next refresh; never sets them as the default app for a file type.": "次の更新時に「プログラムから開く」に追加されます。ファイル形式の既定アプリには設定しません。"
 }

--- a/src/winpodx/locale/ko.json
+++ b/src/winpodx/locale/ko.json
@@ -916,5 +916,9 @@
   "Restore all": "모두 복원",
   "Restore": "복원",
   "Hide selected": "선택 항목 숨기기",
-  "Hid {n} apps": "앱 {n}개 숨김"
+  "Hid {n} apps": "앱 {n}개 숨김",
+  "[desktop]": "[desktop]",
+  "  mime_associations = {v}  (file types in 'Open with')": "  mime_associations = {v}  ('연결 프로그램'에 파일 형식)",
+  "Register file associations for discovered apps (Open with)": "발견된 앱의 파일 연결 등록 (연결 프로그램)",
+  "Adds them to 'Open with' on the next refresh; never sets them as the default app for a file type.": "다음 새로고침 때 '연결 프로그램'에 추가됩니다. 파일 형식의 기본 앱으로는 절대 설정하지 않습니다."
 }

--- a/src/winpodx/locale/zh.json
+++ b/src/winpodx/locale/zh.json
@@ -916,5 +916,9 @@
   "Restore all": "全部恢复",
   "Restore": "恢复",
   "Hide selected": "隐藏所选",
-  "Hid {n} apps": "已隐藏 {n} 个应用"
+  "Hid {n} apps": "已隐藏 {n} 个应用",
+  "[desktop]": "[desktop]",
+  "  mime_associations = {v}  (file types in 'Open with')": "  mime_associations = {v}  (“打开方式”中的文件类型)",
+  "Register file associations for discovered apps (Open with)": "为发现的应用注册文件关联（打开方式）",
+  "Adds them to 'Open with' on the next refresh; never sets them as the default app for a file type.": "将在下次刷新时添加到“打开方式”；绝不会设为文件类型的默认应用。"
 }

--- a/tests/test_mime_map.py
+++ b/tests/test_mime_map.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MIT
+"""Guest-extension → MIME auto-association (#545)."""
+
+from __future__ import annotations
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
+
+from winpodx.core.discovery import (
+    DiscoveredApp,
+    _backfill_mime_types,
+    _entry_to_discovered,
+    _render_app_toml,
+)
+from winpodx.core.mime_map import mime_for_extension, mimes_for_extensions
+
+
+def test_mime_for_extension():
+    assert mime_for_extension(".docx").endswith("wordprocessingml.document")
+    assert mime_for_extension("xlsx").endswith("spreadsheetml.sheet")  # leading dot optional
+    assert mime_for_extension(".pdf") == "application/pdf"
+    assert mime_for_extension(".png") == "image/png"
+    assert mime_for_extension(".unknownext") is None
+
+
+def test_mimes_for_extensions_dedupes_and_skips_unknown():
+    out = mimes_for_extensions([".jpg", ".jpeg", ".docx", ".zzz"])
+    assert out == [
+        "image/jpeg",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ]
+
+
+def test_render_app_toml_maps_extensions_when_enabled():
+    app = DiscoveredApp(
+        name="word", full_name="Word", executable="C:\\w.exe", extensions=[".doc", ".docx"]
+    )
+    data = tomllib.loads(_render_app_toml(app, mime_enabled=True))
+    assert "application/msword" in data["mime_types"]
+
+
+def test_render_app_toml_empty_when_disabled():
+    app = DiscoveredApp(name="word", full_name="Word", executable="C:\\w.exe", extensions=[".docx"])
+    data = tomllib.loads(_render_app_toml(app, mime_enabled=False))
+    assert data["mime_types"] == []
+
+
+def test_backfill_fills_from_extensions(tmp_path):
+    p = tmp_path / "app.toml"
+    p.write_text('name = "word"\nmime_types = []\n', encoding="utf-8")
+    app = DiscoveredApp(name="word", full_name="Word", executable="C:\\w.exe", extensions=[".docx"])
+    _backfill_mime_types(p, app, mime_enabled=True)
+    data = tomllib.loads(p.read_text(encoding="utf-8"))
+    assert data["mime_types"] == [
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    ]
+
+
+def test_backfill_noop_when_disabled(tmp_path):
+    p = tmp_path / "app.toml"
+    p.write_text('name = "word"\nmime_types = []\n', encoding="utf-8")
+    app = DiscoveredApp(name="word", full_name="Word", executable="C:\\w.exe", extensions=[".docx"])
+    _backfill_mime_types(p, app, mime_enabled=False)
+    data = tomllib.loads(p.read_text(encoding="utf-8"))
+    assert data["mime_types"] == []
+
+
+def test_backfill_does_not_clobber_existing(tmp_path):
+    p = tmp_path / "app.toml"
+    p.write_text('name = "word"\nmime_types = ["text/custom"]\n', encoding="utf-8")
+    app = DiscoveredApp(name="word", full_name="Word", executable="C:\\w.exe", extensions=[".docx"])
+    _backfill_mime_types(p, app, mime_enabled=True)
+    data = tomllib.loads(p.read_text(encoding="utf-8"))
+    assert data["mime_types"] == ["text/custom"]
+
+
+def test_entry_to_discovered_parses_and_sanitizes_extensions():
+    entry = {
+        "name": "Word",
+        "path": "C:\\w.exe",
+        "extensions": [".DOCX", "xlsx", ".bad ext", "../evil", ".pdf"],
+    }
+    app = _entry_to_discovered(entry)
+    assert app is not None
+    # normalised to .ext lowercase; junk ('.bad ext', '../evil') dropped
+    assert app.extensions == [".docx", ".xlsx", ".pdf"]


### PR DESCRIPTION
Discovered Windows apps never appeared in the file manager's "Open with" menu for the file types they handle (#545), and winpodx never ran `update-desktop-database`, so even a manually-added `MimeType=` went unregistered.

## How it works
- **Guest** (`discover_apps.ps1`): for each app, reads the **real** extensions it registered (`HKCR\Applications\<exe>\SupportedTypes`) and emits them as `extensions`. Only file types the app actually accepts — no made-up associations.
- **Host**: a standard extension→MIME table (`core.mime_map`) maps those to MIME types; discovery writes them as the `.desktop` `MimeType=`, and `install_desktop_entry` now runs `update-desktop-database` so the association registers.
- **Default ON** via new `[desktop] mime_associations`; GUI Settings toggle + `winpodx config set desktop.mime_associations false` to disable.
- **Never sets the default app** (no `xdg-mime default`) — only adds to "Open with". Checksum-gated existing apps are backfilled in place.

## Testing
Host side: 212 passed, lint clean, 4 new strings × 6 locales.

⚠️ **The guest registry scan (`Get-AppExtensions`) needs a real-Windows smoke** — pwsh-on-Linux can't validate it. Merging so it can be tested on `main`: install → `winpodx app refresh` → right-click a `.docx` and confirm the Office app shows in "Open with".
