### PR TITLE
fix(discovery): read file associations from Capabilities (#545)

### DIFF
--- a/scripts/windows/discover_apps.ps1
+++ b/scripts/windows/discover_apps.ps1
@@ -246,33 +246,93 @@ if ($stableSamples -lt $stableSamplesNeeded) {
 $results = New-Object System.Collections.Generic.List[object]
 $seen    = @{}
 
-function Get-AppExtensions {
-    # Real file types an app handles (#545): the value names under
-    # HKCR\Applications\<exe>\SupportedTypes are the extensions it registered
-    # (e.g. ".docx"). The host maps these to MIME types for the .desktop
-    # MimeType= -- so only file types the app actually accepts are added, never
-    # made-up associations. Best-effort; returns @() on anything unexpected.
-    param([string]$ExePath)
-    $exts = New-Object System.Collections.Generic.List[string]
+# Build {exe(lower) -> [".ext", ...]} ONCE per run: the file types each app
+# registered, the same source Windows Settings > Default apps reads (#545).
+#   1. RegisteredApplications -> <Capabilities>\FileAssociations (ext -> ProgID),
+#      with the ProgID's open command resolved to the owning .exe. (This is what
+#      Notepad / Office / browsers use -- not Applications\<exe>\SupportedTypes.)
+#   2. Applications\<exe>\SupportedTypes (value names = extensions) as a backup.
+# The host maps the extensions to MIME types for the .desktop MimeType=.
+$script:WinpodxExtMap = $null
+
+function Add-ExtTo {
+    param([hashtable]$Map, [string]$Exe, [string]$Ext)
+    if (-not $Exe -or -not $Ext) { return }
+    $e = $Exe.ToLower(); $x = $Ext.ToLower()
+    if ($x -notmatch '^\.[a-z0-9]{1,16}$') { return }
+    if (-not $Map.ContainsKey($e)) { $Map[$e] = New-Object System.Collections.Generic.List[string] }
+    if (-not $Map[$e].Contains($x)) { $Map[$e].Add($x) }
+}
+
+function Resolve-ProgidExe {
+    param([string]$ProgId)
+    if (-not $ProgId) { return $null }
+    foreach ($hive in @('HKLM:\SOFTWARE\Classes', 'HKCU:\SOFTWARE\Classes')) {
+        $cmdKey = Join-Path $hive ("{0}\shell\open\command" -f $ProgId)
+        if (-not (Test-Path -LiteralPath $cmdKey)) { continue }
+        $cmd = [string](Get-ItemProperty -LiteralPath $cmdKey -ErrorAction SilentlyContinue).'(default)'
+        if ($cmd -and $cmd -match '([^\\/:*?"<>|\r\n]+\.exe)') {
+            return [System.IO.Path]::GetFileName($Matches[1].Trim())
+        }
+    }
+    return $null
+}
+
+function Build-ExtMap {
+    $map = @{}
     try {
-        if (-not $ExePath) { return @() }
-        $exe = [System.IO.Path]::GetFileName($ExePath)
-        if (-not $exe) { return @() }
-        foreach ($hive in @('HKLM:\SOFTWARE\Classes', 'HKCU:\SOFTWARE\Classes')) {
-            $key = Join-Path $hive ("Applications\{0}\SupportedTypes" -f $exe)
-            if (-not (Test-Path -LiteralPath $key)) { continue }
-            $props = Get-ItemProperty -LiteralPath $key -ErrorAction SilentlyContinue
-            if (-not $props) { continue }
-            foreach ($p in $props.PSObject.Properties) {
-                $n = ([string]$p.Name).ToLower()
-                if ($n -match '^\.[a-z0-9]{1,16}$' -and -not $exts.Contains($n)) {
-                    $exts.Add($n)
+        # 1. Per-app Capabilities\FileAssociations via RegisteredApplications.
+        foreach ($raHive in @('HKLM:\SOFTWARE\RegisteredApplications', 'HKCU:\SOFTWARE\RegisteredApplications')) {
+            if (-not (Test-Path -LiteralPath $raHive)) { continue }
+            $ra = Get-ItemProperty -LiteralPath $raHive -ErrorAction SilentlyContinue
+            if (-not $ra) { continue }
+            foreach ($prop in $ra.PSObject.Properties) {
+                if ($prop.Name -in @('PSPath', 'PSParentPath', 'PSChildName', 'PSDrive', 'PSProvider')) { continue }
+                $capRel = [string]$prop.Value
+                if (-not $capRel) { continue }
+                foreach ($root in @('HKLM:\', 'HKCU:\')) {
+                    $faKey = Join-Path $root ($capRel + '\FileAssociations')
+                    if (-not (Test-Path -LiteralPath $faKey)) { continue }
+                    $fa = Get-ItemProperty -LiteralPath $faKey -ErrorAction SilentlyContinue
+                    if (-not $fa) { continue }
+                    foreach ($p in $fa.PSObject.Properties) {
+                        $ext = [string]$p.Name
+                        if ($ext -notlike '.*') { continue }
+                        $exe = Resolve-ProgidExe ([string]$p.Value)
+                        if ($exe) { Add-ExtTo $map $exe $ext }
+                    }
                 }
             }
         }
+        # 2. Applications\<exe>\SupportedTypes backup.
+        foreach ($hive in @('HKLM:\SOFTWARE\Classes\Applications', 'HKCU:\SOFTWARE\Classes\Applications')) {
+            if (-not (Test-Path -LiteralPath $hive)) { continue }
+            Get-ChildItem -LiteralPath $hive -ErrorAction SilentlyContinue | ForEach-Object {
+                $exe = $_.PSChildName
+                $stKey = Join-Path $_.PSPath 'SupportedTypes'
+                if (-not (Test-Path -LiteralPath $stKey)) { return }
+                $st = Get-ItemProperty -LiteralPath $stKey -ErrorAction SilentlyContinue
+                if ($st) { foreach ($p in $st.PSObject.Properties) { Add-ExtTo $map $exe ([string]$p.Name) } }
+            }
+        }
+    } catch { }
+    return $map
+}
+
+function Get-AppExtensions {
+    # File extensions the given exe handles, from the per-run Capabilities map.
+    param([string]$ExePath)
+    try {
+        if (-not $ExePath) { return @() }
+        if ($null -eq $script:WinpodxExtMap) { $script:WinpodxExtMap = Build-ExtMap }
+        $exe = ([System.IO.Path]::GetFileName($ExePath)).ToLower()
+        if ($script:WinpodxExtMap.ContainsKey($exe)) {
+            $lst = $script:WinpodxExtMap[$exe]
+            if ($lst.Count -gt 64) { return @($lst.GetRange(0, 64)) }
+            return @($lst)
+        }
     } catch { return @() }
-    if ($exts.Count -gt 64) { return @($exts.GetRange(0, 64)) }
-    return @($exts)
+    return @()
 }
 
 function Add-Result {

--- a/src/winpodx/core/mime_map.py
+++ b/src/winpodx/core/mime_map.py
@@ -1,94 +1,92 @@
 # SPDX-License-Identifier: MIT
-"""Standard file-extension → MIME-type table for auto file-association (#545).
+"""File-extension → MIME-type resolution for auto file-association (#545).
 
-The Windows guest reports the *real* extensions each discovered app handles (via
-``discover_apps.ps1``'s registry scan); this maps those extensions to their
-freedesktop MIME types so the host can write the ``.desktop`` ``MimeType=``.
-
-The mapping is a universal extension→MIME constant (a ``.docx`` is always the
-Office wordprocessing type regardless of which app opens it), so the host owns
-it — only extensions the guest actually reported get mapped, which means no
-made-up associations. Unknown extensions are skipped.
+The MIME type of an extension is a system fact, not a winpodx opinion, so this
+resolves it from the host's freedesktop shared-mime-info database
+(``/usr/share/mime/globs``) — every file type the desktop knows about, not a
+hand-maintained list. The guest reports the real extensions each app handles;
+this maps them to the exact MIME the file manager uses for "Open with".
 """
 
 from __future__ import annotations
 
-# Extension (lowercase, leading dot) → MIME type. Conservative + standard.
-_EXT_TO_MIME: dict[str, str] = {
-    # Word processing
-    ".doc": "application/msword",
-    ".dot": "application/msword",
-    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    ".dotx": "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
-    ".docm": "application/vnd.ms-word.document.macroenabled.12",
-    ".odt": "application/vnd.oasis.opendocument.text",
-    ".rtf": "application/rtf",
-    # Spreadsheets
-    ".xls": "application/vnd.ms-excel",
-    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    ".xlsm": "application/vnd.ms-excel.sheet.macroenabled.12",
-    ".ods": "application/vnd.oasis.opendocument.spreadsheet",
-    ".csv": "text/csv",
-    # Presentations
-    ".ppt": "application/vnd.ms-powerpoint",
-    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-    ".pps": "application/vnd.ms-powerpoint",
-    ".ppsx": "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
-    ".odp": "application/vnd.oasis.opendocument.presentation",
-    # Documents / text
-    ".pdf": "application/pdf",
-    ".txt": "text/plain",
-    ".md": "text/markdown",
-    ".xml": "application/xml",
-    ".json": "application/json",
-    ".htm": "text/html",
-    ".html": "text/html",
-    # Images
-    ".png": "image/png",
-    ".jpg": "image/jpeg",
-    ".jpeg": "image/jpeg",
-    ".gif": "image/gif",
-    ".bmp": "image/bmp",
-    ".tif": "image/tiff",
-    ".tiff": "image/tiff",
-    ".webp": "image/webp",
-    ".svg": "image/svg+xml",
-    ".ico": "image/vnd.microsoft.icon",
-    ".psd": "image/vnd.adobe.photoshop",
-    # Audio
-    ".mp3": "audio/mpeg",
-    ".wav": "audio/x-wav",
-    ".flac": "audio/flac",
-    ".ogg": "audio/ogg",
-    ".m4a": "audio/mp4",
-    # Video
-    ".mp4": "video/mp4",
-    ".avi": "video/x-msvideo",
-    ".mkv": "video/x-matroska",
-    ".mov": "video/quicktime",
-    ".webm": "video/webm",
-    ".wmv": "video/x-ms-wmv",
-    # Archives
-    ".zip": "application/zip",
-    ".7z": "application/x-7z-compressed",
-    ".rar": "application/vnd.rar",
-}
+import mimetypes
+from functools import lru_cache
+from pathlib import Path
+
+# freedesktop shared-mime-info glob databases. The first one that exists wins;
+# ``globs2`` (weighted) is preferred over plain ``globs`` where both are present.
+_GLOBS_FILES: tuple[str, ...] = (
+    "/usr/share/mime/globs2",
+    "/usr/share/mime/globs",
+    "/usr/local/share/mime/globs2",
+    "/usr/local/share/mime/globs",
+)
+
+
+@lru_cache(maxsize=1)
+def _ext_mime_db() -> dict[str, str]:
+    """Build ``{".ext": "mime/type"}`` from the system shared-mime-info globs.
+
+    Parsed once. ``globs`` lines are ``mime:*.ext``; ``globs2`` lines are
+    ``weight:mime:*.ext`` (extra trailing fields ignored). Only simple
+    ``*.ext`` patterns are taken — literal globs, ``*.*``, and full-name
+    patterns are skipped. The highest-weight (first) entry for an extension
+    wins, matching how the file manager resolves it.
+    """
+    db: dict[str, str] = {}
+    for path in _GLOBS_FILES:
+        p = Path(path)
+        if not p.is_file():
+            continue
+        try:
+            text = p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for raw in text.splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split(":")
+            if len(parts) == 2:  # globs: mime:glob
+                mime, glob = parts[0], parts[1]
+            elif len(parts) >= 3 and parts[0].isdigit():  # globs2: weight:mime:glob[:...]
+                mime, glob = parts[1], parts[2]
+            else:
+                continue
+            if not glob.startswith("*."):
+                continue
+            stem = glob[2:]
+            if not stem or any(c in stem for c in "*?["):
+                continue
+            db.setdefault("." + stem.lower(), mime)
+        if db:
+            break  # first usable globs file is the authoritative one
+    return db
 
 
 def mime_for_extension(ext: str) -> str | None:
-    """MIME type for a single file extension (``.docx`` or ``docx``), or None."""
+    """MIME type for a file extension via the system MIME db, or None if unknown.
+
+    Accepts ``.docx`` or ``docx``. Falls back to Python's :mod:`mimetypes`
+    (``/etc/mime.types`` etc.) for anything the freedesktop globs didn't cover.
+    """
     if not ext:
         return None
     e = ext.strip().lower()
     if not e.startswith("."):
         e = "." + e
-    return _EXT_TO_MIME.get(e)
+    hit = _ext_mime_db().get(e)
+    if hit:
+        return hit
+    guess, _ = mimetypes.guess_type("x" + e)
+    return guess
 
 
 def mimes_for_extensions(extensions: list[str]) -> list[str]:
     """Map the guest-reported extensions to MIME types (deduped, order-stable).
 
-    Skips extensions we don't have a standard MIME for. Empty in → empty out.
+    Skips extensions with no known MIME. Empty in → empty out.
     """
     out: list[str] = []
     seen: set[str] = set()

--- a/tests/test_mime_map.py
+++ b/tests/test_mime_map.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-"""Guest-extension → MIME auto-association (#545)."""
+"""System-derived extension → MIME auto-association (#545)."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ try:
 except ModuleNotFoundError:  # pragma: no cover
     import tomli as tomllib
 
+import winpodx.core.mime_map as mime_map
 from winpodx.core.discovery import (
     DiscoveredApp,
     _backfill_mime_types,
@@ -17,66 +18,88 @@ from winpodx.core.discovery import (
 from winpodx.core.mime_map import mime_for_extension, mimes_for_extensions
 
 
-def test_mime_for_extension():
-    assert mime_for_extension(".docx").endswith("wordprocessingml.document")
-    assert mime_for_extension("xlsx").endswith("spreadsheetml.sheet")  # leading dot optional
+def _use_globs(monkeypatch, tmp_path, content: str, name: str = "globs"):
+    """Point the MIME db at a temp globs file and reset the cache."""
+    f = tmp_path / name
+    f.write_text(content, encoding="utf-8")
+    monkeypatch.setattr(mime_map, "_GLOBS_FILES", (str(f),))
+    mime_map._ext_mime_db.cache_clear()
+
+
+_GLOBS = (
+    "# comment line\n"
+    "application/msword:*.doc\n"
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document:*.docx\n"
+    "text/plain:*.txt\n"
+    "image/jpeg:*.jpg\n"
+    "image/jpeg:*.jpeg\n"
+    "application/x-something:*.*\n"  # wildcard pattern must be ignored
+)
+
+_GLOBS2 = (
+    "50:application/pdf:*.pdf\n"
+    "60:text/markdown:*.md\n"
+    "80:image/png:*.png:cs\n"  # trailing flag field tolerated
+)
+
+
+def test_parses_plain_globs(monkeypatch, tmp_path):
+    _use_globs(monkeypatch, tmp_path, _GLOBS)
+    assert mime_for_extension(".doc") == "application/msword"
+    assert mime_for_extension("docx").endswith("wordprocessingml.document")  # leading dot optional
+    assert mime_for_extension(".txt") == "text/plain"
+    # the "*.*" wildcard line must not leak in
+    assert mime_for_extension(".x") != "application/x-something"
+
+
+def test_parses_globs2_weighted(monkeypatch, tmp_path):
+    _use_globs(monkeypatch, tmp_path, _GLOBS2, name="globs2")
     assert mime_for_extension(".pdf") == "application/pdf"
-    assert mime_for_extension(".png") == "image/png"
-    assert mime_for_extension(".unknownext") is None
+    assert mime_for_extension(".md") == "text/markdown"
+    assert mime_for_extension(".png") == "image/png"  # trailing :cs ignored
 
 
-def test_mimes_for_extensions_dedupes_and_skips_unknown():
-    out = mimes_for_extensions([".jpg", ".jpeg", ".docx", ".zzz"])
-    assert out == [
-        "image/jpeg",
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    ]
+def test_falls_back_to_mimetypes_when_db_missing(monkeypatch, tmp_path):
+    # No globs file → empty db → Python mimetypes covers common types.
+    monkeypatch.setattr(mime_map, "_GLOBS_FILES", (str(tmp_path / "nope"),))
+    mime_map._ext_mime_db.cache_clear()
+    assert mime_for_extension(".txt") == "text/plain"
+    assert mime_for_extension(".zzqq") is None
 
 
-def test_render_app_toml_maps_extensions_when_enabled():
-    app = DiscoveredApp(
-        name="word", full_name="Word", executable="C:\\w.exe", extensions=[".doc", ".docx"]
-    )
+def test_mimes_for_extensions_dedupes(monkeypatch, tmp_path):
+    _use_globs(monkeypatch, tmp_path, _GLOBS)
+    out = mimes_for_extensions([".jpg", ".jpeg", ".doc", ".zzz"])
+    assert out == ["image/jpeg", "application/msword"]  # jpeg deduped, zzz skipped
+
+
+def test_render_app_toml_maps_extensions(monkeypatch, tmp_path):
+    _use_globs(monkeypatch, tmp_path, _GLOBS)
+    app = DiscoveredApp(name="word", full_name="Word", executable="C:\\w.exe", extensions=[".docx"])
     data = tomllib.loads(_render_app_toml(app, mime_enabled=True))
-    assert "application/msword" in data["mime_types"]
-
-
-def test_render_app_toml_empty_when_disabled():
-    app = DiscoveredApp(name="word", full_name="Word", executable="C:\\w.exe", extensions=[".docx"])
-    data = tomllib.loads(_render_app_toml(app, mime_enabled=False))
-    assert data["mime_types"] == []
-
-
-def test_backfill_fills_from_extensions(tmp_path):
-    p = tmp_path / "app.toml"
-    p.write_text('name = "word"\nmime_types = []\n', encoding="utf-8")
-    app = DiscoveredApp(name="word", full_name="Word", executable="C:\\w.exe", extensions=[".docx"])
-    _backfill_mime_types(p, app, mime_enabled=True)
-    data = tomllib.loads(p.read_text(encoding="utf-8"))
     assert data["mime_types"] == [
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     ]
+    # disabled -> empty regardless of extensions
+    assert tomllib.loads(_render_app_toml(app, mime_enabled=False))["mime_types"] == []
 
 
-def test_backfill_noop_when_disabled(tmp_path):
-    p = tmp_path / "app.toml"
+def test_backfill_fills_and_respects_toggle(monkeypatch, tmp_path):
+    _use_globs(monkeypatch, tmp_path, _GLOBS)
+    app = DiscoveredApp(name="word", full_name="Word", executable="C:\\w.exe", extensions=[".doc"])
+
+    p = tmp_path / "on.toml"
     p.write_text('name = "word"\nmime_types = []\n', encoding="utf-8")
-    app = DiscoveredApp(name="word", full_name="Word", executable="C:\\w.exe", extensions=[".docx"])
-    _backfill_mime_types(p, app, mime_enabled=False)
-    data = tomllib.loads(p.read_text(encoding="utf-8"))
-    assert data["mime_types"] == []
-
-
-def test_backfill_does_not_clobber_existing(tmp_path):
-    p = tmp_path / "app.toml"
-    p.write_text('name = "word"\nmime_types = ["text/custom"]\n', encoding="utf-8")
-    app = DiscoveredApp(name="word", full_name="Word", executable="C:\\w.exe", extensions=[".docx"])
     _backfill_mime_types(p, app, mime_enabled=True)
-    data = tomllib.loads(p.read_text(encoding="utf-8"))
-    assert data["mime_types"] == ["text/custom"]
+    assert tomllib.loads(p.read_text(encoding="utf-8"))["mime_types"] == ["application/msword"]
+
+    p2 = tmp_path / "off.toml"
+    p2.write_text('name = "word"\nmime_types = []\n', encoding="utf-8")
+    _backfill_mime_types(p2, app, mime_enabled=False)
+    assert tomllib.loads(p2.read_text(encoding="utf-8"))["mime_types"] == []
 
 
-def test_entry_to_discovered_parses_and_sanitizes_extensions():
+def test_entry_to_discovered_sanitizes_extensions():
     entry = {
         "name": "Word",
         "path": "C:\\w.exe",
@@ -84,5 +107,4 @@ def test_entry_to_discovered_parses_and_sanitizes_extensions():
     }
     app = _entry_to_discovered(entry)
     assert app is not None
-    # normalised to .ext lowercase; junk ('.bad ext', '../evil') dropped
-    assert app.extensions == [".docx", ".xlsx", ".pdf"]
+    assert app.extensions == [".docx", ".xlsx", ".pdf"]  # normalised; junk dropped


### PR DESCRIPTION
Follow-up to #582. The first extraction only read `Applications\<exe>\SupportedTypes` (Office has it, Notepad/UWP/browsers don't), so e.g. .txt never mapped to Notepad. Now builds the exe→extensions map from `RegisteredApplications → Capabilities\FileAssociations` (the source Windows Settings → Default apps reads), resolving each ProgID's open command to the owning exe, with SupportedTypes as backup. Guest-side — needs a real-Windows smoke.