### PR TITLE
fix(#545): UWP-aware file associations + auto-apply on update

### DIFF
--- a/scripts/windows/discover_apps.ps1
+++ b/scripts/windows/discover_apps.ps1
@@ -246,73 +246,59 @@ if ($stableSamples -lt $stableSamplesNeeded) {
 $results = New-Object System.Collections.Generic.List[object]
 $seen    = @{}
 
-# Build {exe(lower) -> [".ext", ...]} ONCE per run: the file types each app
-# registered, the same source Windows Settings > Default apps reads (#545).
-#   1. RegisteredApplications -> <Capabilities>\FileAssociations (ext -> ProgID),
-#      with the ProgID's open command resolved to the owning .exe. (This is what
-#      Notepad / Office / browsers use -- not Applications\<exe>\SupportedTypes.)
-#   2. Applications\<exe>\SupportedTypes (value names = extensions) as a backup.
-# The host maps the extensions to MIME types for the .desktop MimeType=.
+# Build {identity -> [".ext", ...]} ONCE per run, where identity is the app a
+# file type opens with: "aumid:<AppUserModelID>" for UWP apps (Notepad, Paint,
+# Photos, the browsers...) or "exe:<basename>" for Win32. This is the source
+# Windows Settings > Default apps reads -- the per-extension UserChoice -- so it
+# covers UWP and Win32 uniformly (UWP ProgIDs have no .exe open command, so an
+# exe-only scan misses them entirely, the original #545 bug). The host maps the
+# extensions to MIME types for the .desktop MimeType=.
 $script:WinpodxExtMap = $null
+$script:WinpodxIdCache = @{}
 
 function Add-ExtTo {
-    param([hashtable]$Map, [string]$Exe, [string]$Ext)
-    if (-not $Exe -or -not $Ext) { return }
-    $e = $Exe.ToLower(); $x = $Ext.ToLower()
+    param([hashtable]$Map, [string]$Id, [string]$Ext)
+    if (-not $Id -or -not $Ext) { return }
+    $x = $Ext.ToLower()
     if ($x -notmatch '^\.[a-z0-9]{1,16}$') { return }
-    if (-not $Map.ContainsKey($e)) { $Map[$e] = New-Object System.Collections.Generic.List[string] }
-    if (-not $Map[$e].Contains($x)) { $Map[$e].Add($x) }
+    if (-not $Map.ContainsKey($Id)) { $Map[$Id] = New-Object System.Collections.Generic.List[string] }
+    if (-not $Map[$Id].Contains($x)) { $Map[$Id].Add($x) }
 }
 
-function Resolve-ProgidExe {
+function Resolve-Identity {
+    # A handler ProgID -> "aumid:<AUMID>" (UWP) or "exe:<basename>" (Win32). UWP
+    # ProgIDs carry the app's AppUserModelID under \Application; Win32 ProgIDs
+    # carry an .exe open command. Cached -- the same ProgID handles many types.
     param([string]$ProgId)
     if (-not $ProgId) { return $null }
-    foreach ($hive in @('HKLM:\SOFTWARE\Classes', 'HKCU:\SOFTWARE\Classes')) {
-        $cmdKey = Join-Path $hive ("{0}\shell\open\command" -f $ProgId)
-        if (-not (Test-Path -LiteralPath $cmdKey)) { continue }
-        $cmd = [string](Get-ItemProperty -LiteralPath $cmdKey -ErrorAction SilentlyContinue).'(default)'
-        if ($cmd -and $cmd -match '([^\\/:*?"<>|\r\n]+\.exe)') {
-            return [System.IO.Path]::GetFileName($Matches[1].Trim())
+    if ($script:WinpodxIdCache.ContainsKey($ProgId)) { return $script:WinpodxIdCache[$ProgId] }
+    $res = $null
+    foreach ($root in @('HKCU:\SOFTWARE\Classes', 'HKLM:\SOFTWARE\Classes')) {
+        $aumid = [string](Get-ItemProperty -LiteralPath "$root\$ProgId\Application" -ErrorAction SilentlyContinue).AppUserModelID
+        if ($aumid) { $res = "aumid:$aumid"; break }
+        $cmd = [string](Get-ItemProperty -LiteralPath "$root\$ProgId\shell\open\command" -ErrorAction SilentlyContinue).'(default)'
+        if ($cmd -and $cmd -match '([a-zA-Z]:\\[^"]*?\.exe)') {
+            $res = "exe:" + ([System.IO.Path]::GetFileName($Matches[1])).ToLower()
+            break
         }
     }
-    return $null
+    $script:WinpodxIdCache[$ProgId] = $res
+    return $res
 }
 
 function Build-ExtMap {
     $map = @{}
     try {
-        # 1. Per-app Capabilities\FileAssociations via RegisteredApplications.
-        foreach ($raHive in @('HKLM:\SOFTWARE\RegisteredApplications', 'HKCU:\SOFTWARE\RegisteredApplications')) {
-            if (-not (Test-Path -LiteralPath $raHive)) { continue }
-            $ra = Get-ItemProperty -LiteralPath $raHive -ErrorAction SilentlyContinue
-            if (-not $ra) { continue }
-            foreach ($prop in $ra.PSObject.Properties) {
-                if ($prop.Name -in @('PSPath', 'PSParentPath', 'PSChildName', 'PSDrive', 'PSProvider')) { continue }
-                $capRel = [string]$prop.Value
-                if (-not $capRel) { continue }
-                foreach ($root in @('HKLM:\', 'HKCU:\')) {
-                    $faKey = Join-Path $root ($capRel + '\FileAssociations')
-                    if (-not (Test-Path -LiteralPath $faKey)) { continue }
-                    $fa = Get-ItemProperty -LiteralPath $faKey -ErrorAction SilentlyContinue
-                    if (-not $fa) { continue }
-                    foreach ($p in $fa.PSObject.Properties) {
-                        $ext = [string]$p.Name
-                        if ($ext -notlike '.*') { continue }
-                        $exe = Resolve-ProgidExe ([string]$p.Value)
-                        if ($exe) { Add-ExtTo $map $exe $ext }
-                    }
-                }
-            }
-        }
-        # 2. Applications\<exe>\SupportedTypes backup.
-        foreach ($hive in @('HKLM:\SOFTWARE\Classes\Applications', 'HKCU:\SOFTWARE\Classes\Applications')) {
-            if (-not (Test-Path -LiteralPath $hive)) { continue }
-            Get-ChildItem -LiteralPath $hive -ErrorAction SilentlyContinue | ForEach-Object {
-                $exe = $_.PSChildName
-                $stKey = Join-Path $_.PSPath 'SupportedTypes'
-                if (-not (Test-Path -LiteralPath $stKey)) { return }
-                $st = Get-ItemProperty -LiteralPath $stKey -ErrorAction SilentlyContinue
-                if ($st) { foreach ($p in $st.PSObject.Properties) { Add-ExtTo $map $exe ([string]$p.Name) } }
+        # Per-extension current handler (UserChoice) under the user's FileExts.
+        # Bounded to extensions the user actually has associations for, so it's
+        # fast (a full HKCR\.* scan times out) and matches Settings > Default apps.
+        $fe = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FileExts'
+        if (Test-Path -LiteralPath $fe) {
+            Get-ChildItem -LiteralPath $fe -ErrorAction SilentlyContinue | ForEach-Object {
+                $ext = $_.PSChildName
+                if ($ext -notmatch '^\.[a-z0-9]{1,16}$') { return }
+                $uc = [string](Get-ItemProperty -LiteralPath "$fe\$ext\UserChoice" -ErrorAction SilentlyContinue).ProgId
+                Add-ExtTo $map (Resolve-Identity $uc) $ext
             }
         }
     } catch { }
@@ -320,16 +306,23 @@ function Build-ExtMap {
 }
 
 function Get-AppExtensions {
-    # File extensions the given exe handles, from the per-run Capabilities map.
-    param([string]$ExePath)
+    # Extensions the given app handles, matched by AUMID (UWP, from launch_uri =
+    # "shell:AppsFolder\<AUMID>") then by exe basename (Win32).
+    param([string]$ExePath, [string]$LaunchUri)
     try {
-        if (-not $ExePath) { return @() }
         if ($null -eq $script:WinpodxExtMap) { $script:WinpodxExtMap = Build-ExtMap }
-        $exe = ([System.IO.Path]::GetFileName($ExePath)).ToLower()
-        if ($script:WinpodxExtMap.ContainsKey($exe)) {
-            $lst = $script:WinpodxExtMap[$exe]
-            if ($lst.Count -gt 64) { return @($lst.GetRange(0, 64)) }
-            return @($lst)
+        $keys = New-Object System.Collections.Generic.List[string]
+        if ($LaunchUri) {
+            $aumid = $LaunchUri -replace '^shell:AppsFolder\\', ''
+            if ($aumid) { $keys.Add("aumid:$aumid") }
+        }
+        if ($ExePath) { $keys.Add("exe:" + ([System.IO.Path]::GetFileName($ExePath)).ToLower()) }
+        foreach ($k in $keys) {
+            if ($script:WinpodxExtMap.ContainsKey($k)) {
+                $lst = $script:WinpodxExtMap[$k]
+                if ($lst.Count -gt 64) { return @($lst.GetRange(0, 64)) }
+                return @($lst)
+            }
         }
     } catch { return @() }
     return @()
@@ -366,7 +359,7 @@ function Add-Result {
         launch_uri    = [string]$Entry.launch_uri
         icon_b64      = [string]$Entry.icon_b64
         exe_hash      = Get-ExeHash $path
-        extensions    = @(Get-AppExtensions $path)
+        extensions    = @(Get-AppExtensions $path $Entry.launch_uri)
     }) | Out-Null
 }
 

--- a/src/winpodx/cli/migrate.py
+++ b/src/winpodx/cli/migrate.py
@@ -253,7 +253,21 @@ def run_migrate(args: argparse.Namespace) -> int:
     if skip_refresh:
         print(tr("\nSkipping app discovery (--no-refresh)."))
     elif non_interactive:
-        print(tr("\nSkipping app discovery (--non-interactive)."))
+        # An upgrade (install.sh) must auto-apply discovery-dependent changes
+        # (file associations, icons, new metadata) without a manual
+        # `winpodx app refresh`. Queue discovery as a pending step: the next
+        # winpodx launch resumes it automatically (every run calls
+        # _maybe_resume_pending on startup) once the guest is ready. No prompt,
+        # never blocks the installer.
+        from winpodx.utils import pending
+
+        pending.add_step("discovery")
+        print(
+            tr(
+                "\nApp discovery queued — runs automatically on next launch "
+                "(applies file associations / icons from this update)."
+            )
+        )
     elif _prompt_yes(tr("\nRun app discovery now? (scans Windows pod for installed apps)")):
         _attempt_refresh()
 

--- a/src/winpodx/utils/pending.py
+++ b/src/winpodx/utils/pending.py
@@ -64,6 +64,25 @@ def list_pending() -> list[str]:
     return ordered
 
 
+def add_step(step: str) -> None:
+    """Record ``step`` as pending (idempotent), preserving canonical order.
+
+    Used to defer a step so the next winpodx launch resumes it automatically —
+    e.g. an upgrade records ``discovery`` so newly-added discovery-dependent
+    behaviour (file associations, icons) applies without a manual refresh.
+    """
+    if step not in _VALID_STEPS:
+        return
+    steps = set(list_pending()) | {step}
+    ordered = [s for s in ("wait_ready", "migrate", "discovery") if s in steps]
+    p = _path()
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("\n".join(ordered) + "\n", encoding="utf-8")
+    except OSError as e:
+        log.debug("could not record pending step %s: %s", step, e)
+
+
 def remove_step(step: str) -> None:
     """Remove ``step`` from the pending list. Deletes the file when empty."""
     p = _path()

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -363,17 +363,23 @@ def test_run_migrate_upgrade_skips_refresh_when_flagged(tmp_path, monkeypatch, c
     assert (tmp_path / "installed_version.txt").read_text().strip() == current
 
 
-def test_run_migrate_non_interactive_skips_prompt(tmp_path, monkeypatch, capsys):
+def test_run_migrate_non_interactive_queues_discovery(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr("winpodx.cli.migrate.config_dir", lambda: tmp_path)
+    # isolate the pending file too (add_step writes via pending.config_dir)
+    monkeypatch.setattr("winpodx.utils.pending.config_dir", lambda: tmp_path)
     (tmp_path / "installed_version.txt").write_text("0.1.0\n", encoding="utf-8")
-    # no_refresh=False but non_interactive=True -> must not block on input.
+    # no_refresh=False but non_interactive=True -> must not block on input, and
+    # must auto-apply the update by queuing discovery for the next launch (#545
+    # follow-up: upgrades apply discovery-dependent changes without a manual refresh).
     called = []
     monkeypatch.setattr("builtins.input", lambda _: called.append(True) or "y")
     rc = run_migrate(_args(no_refresh=False, non_interactive=True))
     assert rc == 0
-    assert called == []  # input() must never have been called
-    out = capsys.readouterr().out.lower()
-    assert "--non-interactive" in out
+    assert called == []  # input() must never have been called (no prompt)
+
+    from winpodx.utils import pending
+
+    assert "discovery" in pending.list_pending()  # queued → auto-resumes on next launch
 
 
 # --- L2: marker-file size cap + strict semver regex ---

--- a/tests/test_pending.py
+++ b/tests/test_pending.py
@@ -31,6 +31,26 @@ class TestHasPending:
         assert pending.has_pending() is False
 
 
+class TestAddStep:
+    def test_records_step(self, patched_config_dir):
+        pending.add_step("discovery")
+        assert pending.list_pending() == ["discovery"]
+
+    def test_idempotent(self, patched_config_dir):
+        pending.add_step("discovery")
+        pending.add_step("discovery")
+        assert pending.list_pending() == ["discovery"]
+
+    def test_preserves_canonical_order(self, patched_config_dir):
+        pending.add_step("discovery")
+        pending.add_step("wait_ready")
+        assert pending.list_pending() == ["wait_ready", "discovery"]
+
+    def test_ignores_invalid_step(self, patched_config_dir):
+        pending.add_step("bogus")
+        assert pending.list_pending() == []
+
+
 class TestListPending:
     def test_returns_canonical_order(self, patched_config_dir):
         # Even if the file has them in random order, list_pending returns


### PR DESCRIPTION
Makes #545 (file associations in "Open with") actually work end-to-end, and auto-apply on update. Two parts:

## 1. UWP-aware extraction (the real bug)
The earlier extraction resolved handler ProgIDs to a `.exe` only, so it missed **every UWP app** — Notepad, Paint, Photos, the browsers register AppX ProgIDs with no `.exe` open command — leaving `.txt` / `.png` / etc. with no handler in "Open with".

Now the guest builds the ext→app map from the **per-extension UserChoice** (the source Windows *Settings → Default apps* reads), resolving each handler ProgID to an identity: `aumid:<AppUserModelID>` for UWP (matched to a discovered app's `launch_uri`) or `exe:<basename>` for Win32. Bounded to HKCU `FileExts` so it's fast (a full `HKCR\.*` scan timed out).

**Verified against the live guest registry via the agent:** notepad→`.txt/.ini/.ps1`, photos→`.png/.jpg/all-images`, paint→`.emf/.wmf`, explorer→`.zip`. Host side unchanged (maps the extensions to MIME via the system shared-mime-info db).

## 2. Auto-apply on non-interactive upgrade
A non-interactive `migrate` (install.sh upgrade) **skipped** discovery, so discovery-dependent changes never applied without a manual `winpodx app refresh`. It now queues `discovery` as a pending step (new `pending.add_step`); the next winpodx launch resumes it automatically once the guest is ready — no prompt, never blocks the installer.

Host tests pass; the guest `.ps1` was validated against the real registry through the agent (pwsh-on-Linux can't run it).
