### PR TITLE
fix(discovery): resolve UWP display names via Get-StartApps (#545)

### DIFF
--- a/scripts/windows/discover_apps.ps1
+++ b/scripts/windows/discover_apps.ps1
@@ -467,6 +467,18 @@ foreach ($d in $startDirs) {
 Write-WinpodxProgress 'Scanning UWP / MSIX packages...'
 try {
     $pkgs = Get-AppxPackage -AllUsers -ErrorAction SilentlyContinue
+    # Canonical Start-menu names keyed by AUMID. Many UWP manifests give the
+    # display name as an `ms-resource:` indirection that PowerShell can't resolve
+    # non-interactively -- the package name then falls back to the dotted
+    # PackageFamilyName (e.g. "Microsoft.Windows.Photos"), which the host junk
+    # filter drops. Get-StartApps resolves the real label ("Photos"), so real
+    # apps aren't lost and we don't depend on a hardcoded allowlist (#545).
+    $startAppNames = @{}
+    try {
+        Get-StartApps -ErrorAction SilentlyContinue | ForEach-Object {
+            if ($_.AppID) { $startAppNames[[string]$_.AppID] = [string]$_.Name }
+        }
+    } catch { }
     foreach ($pkg in $pkgs) {
         try {
             if ($pkg.IsFramework) { continue }
@@ -506,6 +518,11 @@ try {
                         $dn = [string]$ve.DisplayName
                         if ($dn -and ($dn -notmatch '^ms-resource:')) {
                             $displayName = $dn
+                        }
+                        # Canonical Start-menu name wins (resolves ms-resource
+                        # display names so e.g. Photos isn't dropped as dotted junk).
+                        if ($startAppNames.ContainsKey($aumid)) {
+                            $displayName = $startAppNames[$aumid]
                         }
                         # AppxManifest's <VisualElements Description="..."> is the
                         # Start-menu tooltip -- exactly what we want for the


### PR DESCRIPTION
Follow-up to #584. UWP apps whose manifest DisplayName is an `ms-resource:` indirection (Photos, and others) couldn't be resolved non-interactively, so the name fell back to the dotted `PackageFamilyName` (`Microsoft.Windows.Photos`) and the host junk filter dropped it — the app never appeared, so its file types (.png/.jpg) never got a winpodx handler.

Now builds an AUMID→name map from `Get-StartApps` (the real Start-menu labels) and overrides the dotted fallback. Photos et al. get their proper name `Photos`, survive the filter, and are discovered — removing the dependency on the hardcoded `_UWP_DOTTED_ALLOWLIST` (now a pure fallback).

Verified against the live guest via the agent: `pkg.Name = Microsoft.Windows.Photos` (dotted → filtered), `Get-StartApps name = Photos` (clean → kept). Guest .ps1 only; host unchanged.