### PR TITLE
feat(doctor): warn on old FreeRDP 3.x with broken RemoteApp/RAIL (#546)

### DIFF
--- a/src/winpodx/cli/doctor.py
+++ b/src/winpodx/cli/doctor.py
@@ -33,6 +33,7 @@ probe has a short timeout, and the network never gets touched.
 from __future__ import annotations
 
 import argparse
+import re
 import shutil
 import subprocess
 import sys
@@ -40,6 +41,11 @@ from dataclasses import dataclass
 from typing import Callable
 
 from winpodx.core.i18n import tr
+
+# Oldest FreeRDP 3.x without the RemoteApp/RAIL window-mapping bugs that leave
+# an app connected but its window never shown (#546). 3.5.x and earlier are
+# affected; warn (not fail) below this, since the binary still works otherwise.
+_FREERDP_RAIL_FLOOR = (3, 6, 0)
 
 
 @dataclass(frozen=True)
@@ -211,6 +217,7 @@ def _check_freerdp() -> Finding:
         # --version doesn't downgrade the finding (binary exists, that's the
         # signal we care about for doctor).
         version_line = ""
+        ver: tuple[int, int, int] | None = None
         try:
             result = subprocess.run(
                 [dep.path, "--version"],
@@ -219,9 +226,31 @@ def _check_freerdp() -> Finding:
                 timeout=3,
                 check=False,
             )
+            blob = (result.stdout or "") + (result.stderr or "")
             version_line = result.stdout.splitlines()[0] if result.stdout else ""
+            m = re.search(r"FreeRDP version\s+(\d+)\.(\d+)\.(\d+)", blob)
+            if m:
+                ver = (int(m.group(1)), int(m.group(2)), int(m.group(3)))
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             pass
+        # Old FreeRDP 3.x RAIL: 3.5.x and earlier have window-ordering bugs that
+        # leave a RemoteApp connected but its window never mapped (only
+        # "xf_Pointer: Invalid appWindow" spam) -- see #546 (Ubuntu/Budgie 24.04
+        # ships FreeRDP 3.5.1 via apt). Advisory only: the binary works for
+        # full-desktop / many apps, so this is a warn, not a fail.
+        if ver is not None and ver[0] == 3 and ver < _FREERDP_RAIL_FLOOR:
+            shown = ".".join(str(p) for p in ver)
+            floor = ".".join(str(p) for p in _FREERDP_RAIL_FLOOR)
+            return Finding(
+                "warn",
+                f"freerdp {shown} is old; RemoteApp windows may not appear (#546)",
+                detail=version_line,
+                suggestion=(
+                    f"Upgrade FreeRDP to >= {floor} (newer distro package / PPA), or run "
+                    "the winpodx AppImage, which bundles a newer FreeRDP. Symptom: the "
+                    "app connects but no window appears ('Invalid appWindow' in stderr)."
+                ),
+            )
         return Finding("ok", f"freerdp present at {dep.path}", detail=version_line)
     return Finding(
         "fail",

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -12,12 +12,14 @@ from winpodx.cli.doctor import (
     Finding,
     _check_autostart_entry,
     _check_config_state,
+    _check_freerdp,
     _check_initialized_flag,
     _check_kvm,
     _check_pending_setup,
     handle_doctor,
 )
 from winpodx.core.config import Config
+from winpodx.utils.deps import DepCheck
 
 
 def _stub_new_checks(monkeypatch):
@@ -125,6 +127,45 @@ class TestKvmCheck:
         monkeypatch.setattr("pathlib.Path.exists", lambda self: False)
         f = _check_kvm()
         assert f.severity == "fail"
+
+
+class TestCheckFreerdp:
+    """#546: warn (not fail) on old FreeRDP 3.x with broken RAIL window mapping."""
+
+    def _patch(self, monkeypatch, *, found=True, version="3.5.1"):
+        monkeypatch.setattr(
+            "winpodx.utils.deps.check_freerdp",
+            lambda: DepCheck(name="xfreerdp", found=found, path="/usr/bin/xfreerdp3"),
+        )
+
+        class _Res:
+            stdout = f"This is FreeRDP version {version} (...)\n" if version else ""
+            stderr = ""
+
+        monkeypatch.setattr(doctor.subprocess, "run", lambda *a, **k: _Res())
+
+    def test_old_3x_warns(self, monkeypatch):
+        self._patch(monkeypatch, version="3.5.1")
+        f = _check_freerdp()
+        assert f.severity == "warn"
+        assert "546" in f.title and "3.5.1" in f.title
+
+    def test_floor_version_is_ok(self, monkeypatch):
+        self._patch(monkeypatch, version="3.6.0")
+        assert _check_freerdp().severity == "ok"
+
+    def test_newer_3x_is_ok(self, monkeypatch):
+        self._patch(monkeypatch, version="3.10.2")
+        assert _check_freerdp().severity == "ok"
+
+    def test_unparseable_version_is_ok(self, monkeypatch):
+        # No version string -> can't judge -> don't warn (binary exists).
+        self._patch(monkeypatch, version="")
+        assert _check_freerdp().severity == "ok"
+
+    def test_missing_fails(self, monkeypatch):
+        self._patch(monkeypatch, found=False)
+        assert _check_freerdp().severity == "fail"
 
 
 class TestHandleDoctor:


### PR DESCRIPTION
## Summary

#546 reports that no Windows app surfaces on Ubuntu/Budgie 24.04 (FreeRDP **3.5.1** via apt): the RemoteApp connects but the window is never mapped, and stderr fills with `xf_Pointer: Invalid appWindow`. winpodx builds the RemoteApp command correctly — the culprit is FreeRDP 3.5.x RAIL window-ordering bugs.

`winpodx doctor` now parses the FreeRDP version and, for a native xfreerdp **3.x below 3.6.0**, emits a **WARN** (not FAIL — the binary still works for full-desktop and many apps) suggesting an upgrade to >= 3.6 or the winpodx AppImage (which bundles a newer FreeRDP).

## Changes
- `_check_freerdp` parses `major.minor.patch` and gates on `_FREERDP_RAIL_FLOOR = (3, 6, 0)`.
- Advisory message points at the exact symptom (`Invalid appWindow`) and #546.
- 5 new tests (old→warn, floor/newer→ok, unparseable→ok, missing→fail).

## Verification
- `pytest tests/test_doctor.py` 40 passed; `ruff check` / `ruff format --check` clean (whole tree).