### PR TITLE
fix(install): honor --main/--ref/--source/--image-tar on Atomic Fedora (#548)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -491,7 +491,13 @@ install_pkg() {
 # rpm-ostree's RPM install path is wholly separate from the venv flow below,
 # so it disarms the rollback trap (its artifacts are an OBS repo file +
 # layered RPM, neither of which the venv rollback should touch) and exits.
-if command -v rpm-ostree >/dev/null 2>&1; then
+#
+# An EXPLICIT source override (--main / --ref / --source / --image-tar) always
+# wins: the OBS RPM only ships tagged releases, so honouring those flags means
+# falling through to the git/venv flow even on Atomic (#548 — custom-image
+# builders layer winpodx from main like any other Fedora package).
+if command -v rpm-ostree >/dev/null 2>&1 \
+   && [ -z "$WINPODX_REF" ] && [ -z "$WINPODX_SOURCE" ] && [ -z "$WINPODX_IMAGE_TAR" ]; then
     ROLLBACK_ARMED=0
     log "Detected rpm-ostree — Atomic Fedora install path."
     if [ ! -f /etc/os-release ]; then
@@ -524,6 +530,11 @@ if command -v rpm-ostree >/dev/null 2>&1; then
         fi
     fi
     exit 0
+elif command -v rpm-ostree >/dev/null 2>&1; then
+    # rpm-ostree present, but the user asked for a specific source above — note
+    # the bypass (the OBS RPM only ships tagged releases) and fall through to
+    # the git/venv install path below.
+    log "rpm-ostree detected, but --main/--ref/--source/--image-tar was set — installing from source via the venv path."
 fi
 
 # =====================================================================

--- a/tests/test_install_sh_provision.py
+++ b/tests/test_install_sh_provision.py
@@ -44,6 +44,26 @@ def test_invokes_winpodx_provision(script: str) -> None:
     assert '"$SYMLINK" "${PROVISION_CMD[@]}"' in script
 
 
+def test_atomic_rpm_path_honours_explicit_source_override(script: str) -> None:
+    # #548: on Atomic (rpm-ostree) install.sh defaults to the OBS RPM, but an
+    # explicit --main/--ref/--source/--image-tar must win and fall through to
+    # the git/venv flow (the OBS RPM only ships tagged releases). The gate must
+    # therefore require all three override vars to be empty before taking the
+    # rpm-ostree path.
+    lines = script.splitlines()
+    # The gate opens with `if command -v rpm-ostree ... \` and continues the
+    # compound `&& [ -z ... ]` condition on the next line.
+    gate = next(
+        (i for i, ln in enumerate(lines) if ln.lstrip().startswith("if command -v rpm-ostree")),
+        None,
+    )
+    assert gate is not None, "rpm-ostree gate must open the Atomic install path"
+    cond = " ".join(lines[gate : gate + 2])
+    assert '-z "$WINPODX_REF"' in cond
+    assert '-z "$WINPODX_SOURCE"' in cond
+    assert '-z "$WINPODX_IMAGE_TAR"' in cond
+
+
 def test_no_inline_health_curl_poll(script: str) -> None:
     # The 30× `curl .../health` settle poll moved into finish_provisioning.
     # (install.sh still uses curl elsewhere — e.g. the GitHub release check —


### PR DESCRIPTION
## Summary

#548: on Atomic Fedora (rpm-ostree), `install.sh` took the OBS-RPM layering path unconditionally and silently ignored `--main`. The OBS RPM only ships tagged releases, so `curl … | bash -s -- --main` installed a release instead of main.

The rpm-ostree path is now gated on the source-override vars being empty (`WINPODX_REF` / `WINPODX_SOURCE` / `WINPODX_IMAGE_TAR`). When one is set (`--main` / `--ref` / `--source` / `--image-tar`), install.sh falls through to the git/venv flow — like any other distro — and logs why. **Default Atomic installs are unchanged.**

## Changes
- Compound gate on the rpm-ostree `if` + an `elif` that logs the bypass.
- Parse-and-grep guard test asserting the gate keeps all three override checks.

## Verification
- `bash -n install.sh` clean; gate logic checked (default → OBS rpm; any override → source/venv).
- `pytest tests/test_install_sh_provision.py` 21 passed; `ruff` clean.