### PR TITLE
fix(gui): detach 'winpodx gui' from the terminal (#549)

### DIFF
--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -466,7 +466,12 @@ def cli(argv: list[str] | None = None) -> None:
     )
 
     # --- other commands ---
-    sub.add_parser("gui", help="Launch graphical interface (requires PySide6)")
+    gui_parser = sub.add_parser("gui", help="Launch graphical interface (requires PySide6)")
+    gui_parser.add_argument(
+        "--foreground",
+        action="store_true",
+        help="Run in the foreground (block the terminal) instead of detaching (#549).",
+    )
     sub.add_parser(
         "launch", help="Open the quick app launcher (requires PySide6); bind to a DE shortcut"
     )
@@ -964,12 +969,23 @@ def _dispatch(args: argparse.Namespace) -> None:
     elif cmd == "gui":
         try:
             from winpodx.gui.main_window import run_gui
-
-            run_gui()
         except ImportError:
             from winpodx.utils.install_source import pyside6_install_hint
 
             print(pyside6_install_hint())
+        else:
+            # #549: a bare `winpodx gui` from a terminal used to block the
+            # prompt until the window closed. Detach into its own session and
+            # return immediately; the re-spawned `--foreground` child runs the
+            # real Qt loop. Non-interactive / --foreground launches stay inline.
+            from winpodx.gui.spawn import should_detach_gui, spawn_gui_detached
+
+            if should_detach_gui(foreground=getattr(args, "foreground", False)) and (
+                spawn_gui_detached()
+            ):
+                print("WinPodX GUI launched. (run `winpodx gui --foreground` to stay attached)")
+            else:
+                run_gui()
     elif cmd == "launch":
         try:
             from winpodx.gui.launcher import show_launcher

--- a/src/winpodx/gui/spawn.py
+++ b/src/winpodx/gui/spawn.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: MIT
+"""Detach ``winpodx gui`` from the controlling terminal (#549).
+
+Running ``winpodx gui`` from a terminal used to block the prompt for the
+whole lifetime of the window (``app.exec()`` is a blocking event loop), so
+the user couldn't keep using the shell until they closed the dashboard.
+
+When launched interactively we instead re-spawn ``winpodx gui --foreground``
+in a new session (``start_new_session=True``, stdio to /dev/null) and return
+immediately — the same detach pattern the tray already uses
+(``desktop/tray_spawn.maybe_spawn_tray``). The ``--foreground`` child runs the
+real Qt loop and does NOT re-detach, so there is exactly one GUI process.
+
+No PySide6 import here: this runs in the parent before Qt is touched.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+
+log = logging.getLogger(__name__)
+
+
+def should_detach_gui(*, foreground: bool) -> bool:
+    """True when ``winpodx gui`` should re-spawn itself detached.
+
+    Only detaches for an interactive terminal launch: ``--foreground`` (the
+    re-spawned child, or an explicit debug run) and non-tty launches (.desktop
+    autostart, the quick launcher's subprocess) run the Qt loop in place — they
+    don't tie up a shell and their caller already owns the process lifecycle.
+    """
+    if foreground:
+        return False
+    try:
+        return sys.stdout.isatty() or sys.stdin.isatty()
+    except (ValueError, OSError):
+        return False
+
+
+def spawn_gui_detached() -> bool:
+    """Re-spawn ``winpodx gui --foreground`` in a new session, detached.
+
+    Returns True on a successful spawn, False otherwise. Best-effort: on
+    failure the caller falls back to running the GUI in the foreground.
+    """
+    cmd = shutil.which("winpodx")
+    if cmd is None:
+        # Source-checkout fallback: ``python -m winpodx`` works as long as
+        # PYTHONPATH already includes ``src/``.
+        args = [sys.executable, "-m", "winpodx", "gui", "--foreground"]
+    else:
+        args = [cmd, "gui", "--foreground"]
+
+    try:
+        subprocess.Popen(
+            args,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+            env=os.environ.copy(),
+        )
+    except (FileNotFoundError, OSError) as e:
+        log.debug("Could not spawn detached GUI: %s", e)
+        return False
+    return True

--- a/tests/test_gui_spawn.py
+++ b/tests/test_gui_spawn.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: MIT
+"""Tests for detached ``winpodx gui`` launch (#549)."""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+from winpodx.gui import spawn
+
+
+class TestShouldDetachGui:
+    def test_foreground_never_detaches(self):
+        assert spawn.should_detach_gui(foreground=True) is False
+
+    def test_interactive_tty_detaches(self):
+        with patch("sys.stdout") as so, patch("sys.stdin") as si:
+            so.isatty.return_value = True
+            si.isatty.return_value = False
+            assert spawn.should_detach_gui(foreground=False) is True
+
+    def test_non_tty_stays_inline(self):
+        # .desktop autostart / launcher subprocess: no terminal to free.
+        with patch("sys.stdout") as so, patch("sys.stdin") as si:
+            so.isatty.return_value = False
+            si.isatty.return_value = False
+            assert spawn.should_detach_gui(foreground=False) is False
+
+    def test_isatty_raising_is_safe(self):
+        with patch("sys.stdout") as so:
+            so.isatty.side_effect = ValueError("detached")
+            assert spawn.should_detach_gui(foreground=False) is False
+
+
+class TestSpawnGuiDetached:
+    def test_spawns_foreground_child_in_new_session(self):
+        with (
+            patch("winpodx.gui.spawn.shutil.which", return_value="/usr/bin/winpodx"),
+            patch("winpodx.gui.spawn.subprocess.Popen") as popen,
+        ):
+            assert spawn.spawn_gui_detached() is True
+        args, kw = popen.call_args
+        assert args[0] == ["/usr/bin/winpodx", "gui", "--foreground"]
+        assert kw["start_new_session"] is True
+
+    def test_source_checkout_fallback(self):
+        with (
+            patch("winpodx.gui.spawn.shutil.which", return_value=None),
+            patch("winpodx.gui.spawn.subprocess.Popen") as popen,
+        ):
+            assert spawn.spawn_gui_detached() is True
+        cmd = popen.call_args[0][0]
+        assert cmd[1:] == ["-m", "winpodx", "gui", "--foreground"]
+
+    def test_popen_failure_returns_false(self):
+        with (
+            patch("winpodx.gui.spawn.shutil.which", return_value="/usr/bin/winpodx"),
+            patch("winpodx.gui.spawn.subprocess.Popen", side_effect=OSError("boom")),
+        ):
+            assert spawn.spawn_gui_detached() is False
+
+
+class TestGuiDispatch:
+    def _dispatch(self, foreground):
+        from winpodx.cli.main import _dispatch
+
+        _dispatch(argparse.Namespace(command="gui", foreground=foreground))
+
+    def test_interactive_detaches_without_running_loop(self, capsys):
+        with (
+            patch("winpodx.gui.main_window.run_gui") as run_gui,
+            patch("winpodx.gui.spawn.should_detach_gui", return_value=True),
+            patch("winpodx.gui.spawn.spawn_gui_detached", return_value=True) as sp,
+        ):
+            self._dispatch(foreground=False)
+        sp.assert_called_once()
+        run_gui.assert_not_called()
+        assert "launched" in capsys.readouterr().out.lower()
+
+    def test_foreground_runs_loop_inline(self):
+        with (
+            patch("winpodx.gui.main_window.run_gui") as run_gui,
+            patch("winpodx.gui.spawn.should_detach_gui", return_value=False),
+            patch("winpodx.gui.spawn.spawn_gui_detached") as sp,
+        ):
+            self._dispatch(foreground=True)
+        run_gui.assert_called_once()
+        sp.assert_not_called()
+
+    def test_spawn_failure_falls_back_to_inline(self):
+        # Detach wanted but the spawn failed -> still show a GUI in-process.
+        with (
+            patch("winpodx.gui.main_window.run_gui") as run_gui,
+            patch("winpodx.gui.spawn.should_detach_gui", return_value=True),
+            patch("winpodx.gui.spawn.spawn_gui_detached", return_value=False),
+        ):
+            self._dispatch(foreground=False)
+        run_gui.assert_called_once()
+
+
+def test_gui_subparser_accepts_foreground():
+    from winpodx.cli.main import cli
+
+    # --foreground must parse; we stub the heavy dispatch so nothing launches.
+    with (
+        patch("winpodx.cli.main._dispatch") as disp,
+        patch("winpodx.cli.first_run.maybe_run_first_run_prompt"),
+    ):
+        try:
+            cli(["gui", "--foreground"])
+        except SystemExit:
+            pytest.fail("`gui --foreground` should parse cleanly")
+    assert disp.call_args[0][0].foreground is True

--- a/tests/test_gui_spawn.py
+++ b/tests/test_gui_spawn.py
@@ -4,11 +4,17 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 from unittest.mock import patch
 
 import pytest
 
 from winpodx.gui import spawn
+
+# The dispatch path imports winpodx.gui.main_window (PySide6); the spawn helper
+# itself does not. CI's test job installs .[dev] without [gui], so guard only
+# the dispatch tests — should_detach/spawn coverage still runs everywhere.
+_HAS_PYSIDE6 = importlib.util.find_spec("PySide6") is not None
 
 
 class TestShouldDetachGui:
@@ -62,6 +68,7 @@ class TestSpawnGuiDetached:
             assert spawn.spawn_gui_detached() is False
 
 
+@pytest.mark.skipif(not _HAS_PYSIDE6, reason="GUI dispatch path requires PySide6")
 class TestGuiDispatch:
     def _dispatch(self, foreground):
         from winpodx.cli.main import _dispatch


### PR DESCRIPTION
## Summary

#549: a bare `winpodx gui` ran the Qt event loop in-process (`app.exec()`), blocking the terminal for the window's whole lifetime. The user had to close the dashboard to free the shell, then restart from the tray.

`winpodx gui` now, **when launched interactively**, re-spawns `winpodx gui --foreground` in a new session (`start_new_session=True`, stdio → /dev/null) and returns immediately — the same detach pattern the tray already uses (`desktop/tray_spawn`). The `--foreground` child runs the real loop and does not re-detach, so there's exactly one GUI process.

## Behaviour
- Interactive terminal → detach + return (prints a one-line confirmation).
- `--foreground` (new flag) → run inline (debugging / supervisors).
- Non-tty launches (.desktop autostart, the quick launcher's subprocess) → run inline; they don't tie up a shell and already own the process lifecycle.
- Detached spawn fails → falls back to running the GUI in the foreground.

## Changes
- New `winpodx/gui/spawn.py` (`should_detach_gui`, `spawn_gui_detached`) — no PySide6 import; runs in the parent before Qt.
- `gui` subparser gains `--foreground`; dispatch detaches by default.

## Verification
- `pytest tests/test_gui_spawn.py` 11 passed (detach matrix + dispatch + parser); taxonomy regression clean.
- `ruff check` / `ruff format --check` clean (whole tree).