### PR TITLE
fix: correct usbredir not found error for Fedora/Debian-based distributions

### DIFF
--- a/src/winpodx/core/usbredir.py
+++ b/src/winpodx/core/usbredir.py
@@ -252,8 +252,10 @@ def attach(backend: str, container: str, dev: DeviceConfig) -> None:
     if not ured:
         raise HmpError(
             "usbredirect not found. Install the host 'usbredir' package "
-            "(openSUSE: sudo zypper install usbredir; Fedora: usbredir; "
-            "Debian/Ubuntu: usbredir)."
+            "(openSUSE: sudo zypper install usbredir; "
+            "Fedora: sudo dnf install usbredir-tools; "
+            "Atomic Fedora: rpm-ostree install --apply-live usbredir-tools; "
+            "Debian/Ubuntu: sudo apt install usbredirect)."
         )
     priv = _privilege_wrapper()
     if priv is None:


### PR DESCRIPTION
## Summary

If the `usbredir` binary isn't found when trying to connect a USB device to the pod, an error message is returned indicating how to install the binary on the host. However, the package listed to install either:
* Debian/Ubuntu: does not exist (instead packaged under `usbredirect`)
* Fedora: does not contain the `usbredir` binary (Fedora packages the binary under `usbredir-tools`)

openSUSE does package the binary in the `usbredir` package, so no change is needed there.

I only updated the error message, but I wonder if this should be handled by the install script and mentioned in the install instructions? That may be more manageable than maintaining every distribution and its package manager in the error message.

## Changes

- Error message in `usbredir.py` updated to reference distribution appropriate packages

## Related Issues

No relevant issue found.

## Checklist

- [x] `pytest tests/ -v`: all tests pass
- [x] `ruff check src/ tests/`: zero errors
- [x] `ruff format --check src/ tests/`: formatted
- [ ] Documentation updated (CHANGELOG, docs: both ko & en)
- [x] No hardcoded paths, credentials, or personal info

I'm unsure if there's any relevant documentation to update. USAGE.md doesn't seem to indicate that host packages are necessary, nor does it reference installing packages.

## Screenshots

If applicable, add screenshots for UI changes.
