### PR TITLE
fix(rdp): drop stale FreeRDP-2 bare cache flags (#380)

### DIFF
--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -674,13 +674,14 @@ _BARE_FLAGS: frozenset[str] = frozenset(
         "-async-channels",
         "+auto-reconnect",
         "-auto-reconnect",
-        # Cache toggles (off-by-default usually saves bandwidth at cost of CPU).
-        "+bitmap-cache",
-        "-bitmap-cache",
-        "+offscreen-cache",
-        "-offscreen-cache",
-        "+glyph-cache",
-        "-glyph-cache",
+        # #380 (notnotno, FreeRDP 3.26, reopened 2026-06-11): the cache toggles
+        # are the SAME case as the gfx-* siblings above — FreeRDP 3.x folds them
+        # into the `/cache:` option (`/cache:bitmap:on|off`, `/cache:glyph:...`,
+        # `/cache:offscreen:...`, `/cache:codec:rfx|nsc`), so the bare FreeRDP-2
+        # spellings `+/-bitmap-cache`, `+/-offscreen-cache`, `+/-glyph-cache`
+        # passed our allowlist only to be rejected by xfreerdp's own parser.
+        # Removed; the `/cache` value-regex in _SIMPLE_VALUE_FLAGS accepts the
+        # correct forms.
         # Multi-monitor / repaint experiments (RAIL window-move corruption,
         # 2026-05-30). Bare forms; the value forms (/multimon:force, /gdi:sw,
         # /smart-sizing:WxH, /monitors:0,1) live in _SIMPLE_VALUE_FLAGS below.
@@ -720,6 +721,14 @@ _SIMPLE_VALUE_FLAGS: dict[str, re.Pattern[str]] = {
     "/monitors": re.compile(r"[0-9]{1,2}(,[0-9]{1,2}){0,7}"),  # /monitors:0,1
     "/smart-sizing": re.compile(r"[1-9][0-9]{1,4}x[1-9][0-9]{1,4}"),  # /smart-sizing:WxH
     "/window-position": re.compile(r"[0-9]{1,5}x[0-9]{1,5}"),  # /window-position:<x>x<y> (#380)
+    # /cache:bitmap:on|off, /cache:glyph:..., /cache:offscreen:..., /cache:codec:rfx|nsc,
+    # /cache:persist (and comma-joined combos). FreeRDP-3 replacement for the bare
+    # +/-{bitmap,offscreen,glyph}-cache toggles (#380). `persist-file:<path>` is
+    # intentionally NOT accepted — no file paths through the extra-args allowlist.
+    "/cache": re.compile(
+        r"(?:(?:bitmap|glyph|offscreen):(?:on|off)|codec:(?:rfx|nsc)|persist)"
+        r"(?:,(?:(?:bitmap|glyph|offscreen):(?:on|off)|codec:(?:rfx|nsc)|persist))*"
+    ),
 }
 
 # Device-redirection allowlist; empty set rejects all :value forms.

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -534,7 +534,10 @@ class TestBuildRdpCommand:
 
         (gfx-progressive / gfx-thin-client / gfx-small-cache were removed in
         #380 — they are `/gfx:` sub-options, not bare toggles; see
-        ``test_gfx_suboptions_and_window_position``.)"""
+        ``test_gfx_suboptions_and_window_position``. The bare cache toggles
+        -bitmap-cache / -offscreen-cache / -glyph-cache were likewise removed
+        when #380 reopened — they are `/cache:<sub>:on|off` sub-options; see
+        ``test_cache_suboptions``.)"""
         monkeypatch.setattr(
             "winpodx.core.rdp.find_freerdp",
             lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
@@ -545,15 +548,30 @@ class TestBuildRdpCommand:
             "-grab-keyboard +grab-keyboard -grab-mouse +grab-mouse "
             "-mouse-relative +mouse-relative "
             "-async-update +async-update -async-channels +async-channels "
-            "-auto-reconnect +auto-reconnect "
-            "-bitmap-cache +bitmap-cache "
-            "-offscreen-cache +offscreen-cache "
-            "-glyph-cache +glyph-cache"
+            "-auto-reconnect +auto-reconnect"
         )
         cfg.rdp.extra_flags = toggles
         cmd, _ = build_rdp_command(cfg)
         for toggle in toggles.split():
             assert toggle in cmd, f"toggle dropped by filter: {toggle!r}"
+
+    def test_cache_suboptions(self, cfg, monkeypatch):
+        """#380 (reopened, FreeRDP 3.26): cache toggles use `/cache:<sub>:on|off`,
+        not bare `+/-{bitmap,offscreen,glyph}-cache`."""
+        monkeypatch.setattr(
+            "winpodx.core.rdp.find_freerdp",
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
+        )
+        cfg.rdp.extra_flags = (
+            "/cache:bitmap:on /cache:offscreen:off /cache:glyph:on "
+            "+bitmap-cache -glyph-cache"  # stale bare forms must be dropped
+        )
+        cmd, _ = build_rdp_command(cfg)
+        assert "/cache:bitmap:on" in cmd
+        assert "/cache:offscreen:off" in cmd
+        assert "/cache:glyph:on" in cmd
+        assert "+bitmap-cache" not in cmd
+        assert "-glyph-cache" not in cmd
 
     def test_gfx_suboptions_and_window_position(self, cfg, monkeypatch):
         """#380 (notnotno, FreeRDP 3.26): the gfx sub-options and

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -95,6 +95,38 @@ class TestExtraFlagsWhitelist:
     def test_empty_flags(self):
         assert _filter_extra_flags("") == []
 
+    def test_freerdp3_cache_option_forms_pass(self):
+        # #380: FreeRDP 3.x folds cache toggles into /cache:<sub>:<val>.
+        for flag in (
+            "/cache:bitmap:on",
+            "/cache:bitmap:off",
+            "/cache:glyph:off",
+            "/cache:offscreen:on",
+            "/cache:codec:rfx",
+            "/cache:persist",
+            "/cache:bitmap:on,glyph:off,offscreen:on",
+        ):
+            assert _filter_extra_flags(flag) == [flag], flag
+
+    def test_stale_freerdp2_bare_cache_flags_blocked(self):
+        # #380 (reopened): the bare FreeRDP-2 spellings are rejected by xfreerdp
+        # 3.x, so they must not pass the allowlist.
+        result = _filter_extra_flags(
+            "+bitmap-cache -bitmap-cache +offscreen-cache -offscreen-cache "
+            "+glyph-cache -glyph-cache"
+        )
+        assert result == []
+
+    def test_cache_option_rejects_file_path_and_injection(self):
+        # persist-file:<path> and bad values must not slip through /cache.
+        for bad in (
+            "/cache:persist-file:/etc/passwd",
+            "/cache:bitmap:maybe",
+            "/cache:../etc",
+            "/cache:bitmap:on;rm -rf",
+        ):
+            assert _filter_extra_flags(bad) == [], bad
+
 
 # --- Device-redirection flag hardening (H1) ---
 


### PR DESCRIPTION
## Summary

#380 reopened (notnotno, FreeRDP 3.26): the bare cache toggles `+/-bitmap-cache`, `+/-offscreen-cache`, `+/-glyph-cache` are FreeRDP-2 spellings rejected by xfreerdp 3.x — same class as the gfx-* siblings fixed in #417. FreeRDP 3 folds them into the `/cache:` option.

## Changes
- Remove the six bare cache flags from `_BARE_FLAGS`.
- Add a `/cache` value-regex to `_SIMPLE_VALUE_FLAGS`: `/cache:bitmap:on|off`, `glyph`, `offscreen`, `codec:rfx|nsc`, `persist`, and comma-joined combos. `persist-file:<path>` is **not** accepted — no file paths through the extra-args allowlist.
- Tests (test_security.py + test_rdp.py): FreeRDP-3 cache forms pass; stale bare forms + path/injection attempts rejected.

## Verification
- `_filter_extra_flags` accept/reject matrix verified; `pytest tests/test_security.py tests/test_rdp.py` 133 passed; `ruff` clean.

Ships in the next release.