### PR TITLE
fix(rdp): allow bare +gfx/-gfx to disable the GFX pipeline (#393)

### DIFF
--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -630,6 +630,16 @@ _BARE_FLAGS: frozenset[str] = frozenset(
         "/gfx",
         "/rfx",
         "/smartcard",
+        # #393 (ismikes, Ubuntu 26.04 KDE Wayland+XWayland): RAIL windows on the
+        # GFX pipeline (Calculator etc.) warp / go blue / "bounce" on fast moves,
+        # while plain-GDI windows (PowerShell, Notepad) are fine — and even
+        # `/gfx:RFX` doesn't help, so the GFX channel surface mapping itself is
+        # the culprit under XWayland. `/gfx` is an OPTIONAL-value flag, so the
+        # bare disable `-gfx` (fall back to the legacy GDI path the unaffected
+        # apps use) is a valid workaround — it was only ever blocked by our
+        # allowlist, not by xfreerdp. Expose `+gfx` / `-gfx` as bare toggles.
+        "+gfx",
+        "-gfx",
         # ---- codec / graphics toggles (#126 diagnosis, 2026-05-06/07) ----
         # FreeRDP 3.x splits codec flags into BOOL (`+/-foo` toggles) vs
         # OPTIONAL/REQUIRED (`/foo:value` only). xiyeming's first test of

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -117,6 +117,16 @@ class TestExtraFlagsWhitelist:
         )
         assert result == []
 
+    def test_gfx_bare_toggle_allows_disable_workaround(self):
+        # #393: `-gfx` (disable the GFX channel → legacy GDI path) is a valid
+        # FreeRDP workaround for the XWayland RAIL render glitch and must pass;
+        # `/gfx:RFX` value form keeps working; the OPTIONAL sub-option
+        # `-gfx-h264` stays blocked (it's not a bare toggle).
+        assert _filter_extra_flags("-gfx") == ["-gfx"]
+        assert _filter_extra_flags("+gfx") == ["+gfx"]
+        assert _filter_extra_flags("/gfx:RFX") == ["/gfx:RFX"]
+        assert _filter_extra_flags("-gfx-h264") == []
+
     def test_cache_option_rejects_file_path_and_injection(self):
         # persist-file:<path> and bad values must not slip through /cache.
         for bad in (


### PR DESCRIPTION
## Summary

#393 (ismikes, Ubuntu 26.04 KDE Wayland+XWayland): RAIL windows on the GFX pipeline (Calculator) warp / go blue / "bounce" on fast window moves, while plain-GDI windows (PowerShell, Notepad) render fine — and `/gfx:RFX` doesn't help. That points at the **GFX channel surface mapping under XWayland**, not multi-monitor handling (the move-across-monitors freeze was the earlier #401 span fix).

Disabling the GFX channel (`-gfx` → fall back to the legacy GDI path the unaffected apps use) is a valid FreeRDP workaround, but the reporter hit `Blocked unsafe extra_flag: -gfx` — our extra-args allowlist never listed the bare toggle.

## Change
- `/gfx` is an OPTIONAL-value flag, so `+gfx` / `-gfx` are valid bare toggles → added to `_BARE_FLAGS`. `/gfx:<value>` keeps working; the OPTIONAL sub-option `-gfx-h264` stays blocked (not a bare toggle). + test.

## Scope
This unblocks the **workaround**, not a root-cause fix for the XWayland GFX glitch (likely upstream FreeRDP). Reporter can now set `--extra-args="-gfx"` to get a working (GDI-rendered) Calculator. Ships in the next release.

## Verification
`pytest tests/test_security.py tests/test_rdp.py` 134 passed; `ruff` clean.