### PR TITLE
fix(gui): debloat picker opens roomy + busy dialog auto-closes (#550)

### DIFF
--- a/src/winpodx/gui/_main_window_maintenance.py
+++ b/src/winpodx/gui/_main_window_maintenance.py
@@ -428,7 +428,13 @@ class MaintenanceMixin:
                 # Marshal the close back onto the GUI thread.
                 QTimer.singleShot(0, dlg.finish)
 
-        threading.Thread(target=_do, daemon=True).start()
+        # Start the worker only once dlg.exec()'s nested event loop is running
+        # (#550): a fast op (e.g. the "speed" debloat preset) could otherwise
+        # finish and call dlg.finish() -> accept() BEFORE exec() began, so the
+        # accept was a no-op and the dialog hung open until the user closed it.
+        # Deferring the start via a 0-timer guarantees the thread launches from
+        # inside the running loop, so finish() always lands on a live dialog.
+        QTimer.singleShot(0, lambda: threading.Thread(target=_do, daemon=True).start())
         dlg.exec()
 
     def _on_cleanup(self) -> None:

--- a/src/winpodx/gui/debloat_picker.py
+++ b/src/winpodx/gui/debloat_picker.py
@@ -108,6 +108,9 @@ class DebloatPickerDialog(QDialog):
 
         self.setWindowTitle(tr("Debloat picker"))
         self.setMinimumWidth(560)
+        # Open roomy enough to show the preset row + several catalog items at
+        # once instead of a cramped default (#550); still resizable + scrolls.
+        self.resize(760, 720)
         self.setModal(True)
         self.setStyleSheet(DIALOG + CHECKBOX + RADIO + SCROLL_AREA)
 

--- a/tests/test_debloat_picker.py
+++ b/tests/test_debloat_picker.py
@@ -39,6 +39,16 @@ def catalog():
 
 
 class TestDialogInitialState:
+    def test_opens_with_roomy_starting_size(self, qapp, catalog):
+        # #550: the picker must open large enough to show preset + items,
+        # not at a cramped default.
+        dlg = DebloatPickerDialog(catalog)
+        try:
+            assert dlg.width() >= 700
+            assert dlg.height() >= 640
+        finally:
+            dlg.deleteLater()
+
     def test_opens_with_normal_preset_seeded(self, qapp, catalog):
         dlg = DebloatPickerDialog(catalog)
         try:


### PR DESCRIPTION
## Summary

Two Debloat UX bugs reported in #550 (@ismikes):

1. **Picker opens cramped.** `DebloatPickerDialog` only set `setMinimumWidth(560)` with no starting size. Now `resize(760, 720)` on open — still resizable and scrolls.

2. **The 'running debloat' window never closes itself** (esp. with the fast/'speed' preset) — the user had to close it manually after the completion toast. **Root cause:** `_run_busy_op` started the worker thread *before* `dlg.exec()`, so a fast op could call `dlg.finish()` → `accept()` **before** exec()'s nested event loop began; the accept was a no-op and exec() then hung open. Fix: defer the worker start via `QTimer.singleShot(0, ...)` so it launches from inside the running loop — `finish()` always lands on a live dialog. This fixes **every** `_run_busy_op` caller (debloat, grow-disk, apply-fixes, …), not just debloat.

## Verification
- `pytest tests/test_debloat_picker.py` 8 passed (incl. new starting-size regression test); `ruff` clean.

Ships in the next release.