### PR TITLE
fix(discovery): don't drop apps with non-ASCII (CJK) names (#553)

### DIFF
--- a/src/winpodx/core/discovery/__init__.py
+++ b/src/winpodx/core/discovery/__init__.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import base64
 import binascii
 import errno
+import hashlib
 import json
 import logging
 import os
@@ -1073,10 +1074,23 @@ def _slugify_name(raw: str) -> str:
 
     Lowercases, replaces runs of unsafe chars with ``-``, trims leading
     and trailing dashes and underscores, and bounds the length.
+
+    A name with NO ASCII-safe characters at all (e.g. a purely Chinese /
+    Japanese / Korean app name) would otherwise sanitize to an empty slug and
+    the app would be silently dropped from discovery (#553). The slug is only
+    an internal key (the ``.desktop`` filename, ``/wm-class``, and
+    ``winpodx app run <slug>``); the human-visible name is ``full_name``, which
+    keeps the original characters. So when sanitization is empty we fall back to
+    a STABLE ASCII slug derived from the raw name (same name -> same slug, so a
+    re-scan doesn't duplicate it) instead of discarding the app.
     """
-    slug = _NAME_SANITIZE_RE.sub("-", raw.strip().lower()).strip("-_")
+    raw = raw.strip()
+    slug = _NAME_SANITIZE_RE.sub("-", raw.lower()).strip("-_")
     if not slug:
-        return ""
+        if not raw:
+            return ""
+        digest = hashlib.sha1(raw.encode("utf-8")).hexdigest()[:10]
+        return f"app-{digest}"
     if len(slug) > 64:
         slug = slug[:64].rstrip("-_")
     if not _SAFE_NAME_RE.match(slug):

--- a/tests/test_discovery/test_discovery.py
+++ b/tests/test_discovery/test_discovery.py
@@ -196,10 +196,25 @@ def test_slugify_strips_leading_trailing_punctuation():
     assert _slugify_name("  ---Foo---  ") == "foo"
 
 
-def test_slugify_unicode_maps_to_empty_or_dash():
-    # Non-ASCII chars get collapsed to '-'; pure-Unicode names resolve to
-    # empty slugs (which the caller rejects).
-    assert _slugify_name("한글") == ""
+def test_slugify_pure_unicode_falls_back_to_stable_hash():
+    # #553: a name with NO ASCII-safe chars (Chinese/Korean/Japanese app names)
+    # must NOT be dropped — it gets a stable, safe `app-<hash>` slug so the app
+    # is discoverable (full_name keeps the original characters for display).
+    import re
+
+    safe = re.compile(r"^[a-zA-Z0-9_-]+$")
+    for name in ("한글", "东方财富", "同花顺"):
+        slug = _slugify_name(name)
+        assert slug.startswith("app-")
+        assert safe.match(slug)
+    # Stable (re-scan doesn't duplicate) and unique across distinct names.
+    assert _slugify_name("东方财富") == _slugify_name("东方财富")
+    assert _slugify_name("东方财富") != _slugify_name("同花顺")
+    # A name with SOME ASCII keeps that part instead of hashing.
+    assert _slugify_name("微信WeChat") == "wechat"
+    # Genuinely empty / whitespace-only is still rejected (empty slug).
+    assert _slugify_name("") == ""
+    assert _slugify_name("   ") == ""
 
 
 def test_slugify_bounds_length():


### PR DESCRIPTION
## Summary

#553 (hermitguo) reports that a Chinese stock-trading app never appears on discovery refresh — forcing a manual add. **Root cause:** `_slugify_name` replaces every non-`[a-zA-Z0-9_-]` char with `-` and strips, so a *purely* Chinese/Japanese/Korean name sanitizes to an **empty slug** → `_entry_to_discovered` returns `None` → the app is silently dropped. This is the shared root of the reporter's "not friendly to Chinese characters" + "can't refresh to find the app" symptoms.

## Fix
The slug is only an internal key (the `.desktop` filename, `/wm-class`, `winpodx app run <slug>`); the human-visible name is `full_name`, which already round-trips non-ASCII (UTF-8 TOML/.desktop, see the existing Korean/Japanese desktop-entry tests). So when sanitization yields empty **and** the raw name isn't blank, fall back to a **stable** `app-<sha1[:10]>` slug derived from the raw name:
- same name → same slug (a re-scan doesn't create duplicates),
- unique across distinct names,
- mixed names keep their ASCII part (`微信WeChat` → `wechat`),
- genuinely blank/whitespace names are still rejected (empty slug).

## Verification
`pytest tests/test_discovery/` 95 passed (incl. updated CJK slug test); `ruff` clean.

## Not covered here
The reporter's third symptom — a **GUI crash when adding an app manually** (`/var/crash/_usr_bin_winpodx.crash`) — is a separate SIGSEGV that needs the crash backtrace to pin down; requested on the issue. With this fix the Chinese app is discovered automatically, so the manual-add path shouldn't be needed in the first place.

Ships in the next release.