### PR TITLE
fix(gui): pin app-list vertical scrollbar to stop Refresh SIGSEGV (#567)

### DIFF
--- a/src/winpodx/gui/_main_window_library.py
+++ b/src/winpodx/gui/_main_window_library.py
@@ -268,6 +268,16 @@ class LibraryPageMixin:
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        # Vertical scrollbar ALWAYS on (#567): with widgetResizable=True an
+        # AsNeeded vertical bar fluctuates as content height changes, which
+        # changes the viewport width, which makes QScrollArea.updateScrollBars
+        # re-query the layout's heightForWidth — and with the word-wrapped app
+        # name labels below that QBoxLayout::heightForWidth feedback recurses
+        # without bound and SIGSEGVs the whole GUI on "Refresh Apps" (confirmed
+        # by the crash backtrace; same family as #532). Pinning the bar on keeps
+        # the viewport width stable so the loop can't form. The SCROLL_AREA
+        # stylesheet keeps it visually unobtrusive.
+        scroll.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOn)
         scroll.setStyleSheet(SCROLL_AREA)
 
         self.app_list_container = QWidget()


### PR DESCRIPTION
## Summary

#567 (bangetto, Fedora 44 / KDE Plasma 6 Wayland / Qt6 / Python 3.14, winpodx 0.7.0): clicking **Refresh Apps** crashes the GUI — the apps *do* refresh and the tray survives, only the window dies. The attached crash report is a SIGSEGV from unbounded `QBoxLayout::heightForWidth` recursion:

```
#0 QBoxLayoutPrivate::calcHfw
#1 QBoxLayout::heightForWidth      ← recurses
...
#6 QLayout::totalHeightForWidth
#8 QScrollAreaPrivate::updateScrollBars
#9 QScrollArea::event
```

## Root cause
The app list is a `widgetResizable` `QScrollArea` whose **vertical scrollbar was AsNeeded**. As the rebuilt content height crosses the viewport, the bar appears/disappears → the viewport width changes → `updateScrollBars` re-queries the layout's `heightForWidth` → with the **word-wrapped app-name labels** that feedback recurses without bound → SIGSEGV. Same family as the #532 filter-rebuild crash, but a pure-Qt recursion that the existing Python re-entrancy guard can't stop.

## Fix
Pin the vertical scrollbar **AlwaysOn** so the viewport width is stable and the feedback loop can't form. Minimal and targeted at the backtrace; the `SCROLL_AREA` stylesheet keeps the bar unobtrusive.

## Verification
- `pytest -k 'library or bringup or main_window or launcher'` 43 passed; `ruff` clean.
- ⚠️ I can't reproduce the exact recursion locally (it's Qt-version/Wayland-specific), so this is a targeted fix-forward — asking the reporter to confirm on their setup.

Ships in the next release.