### PR TITLE
fix(rdp): fail fast on empty username instead of a cryptic FreeRDP ioctl error (#569)

### DIFF
--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -399,6 +399,19 @@ def build_rdp_command(
     if not found:
         raise RuntimeError("FreeRDP 3+ not found. Install xfreerdp3 or xfreerdp.")
 
+    # An empty username is never a valid RDP launch: xfreerdp would fall back to
+    # an interactive credential prompt, which under a GUI / no-tty launch dies
+    # with "set_terminal_nonblock: tcgetattr() failed with Inappropriate ioctl
+    # for device" and ERRCONNECT_CONNECT_CANCELLED — the cryptic "ioctl error"
+    # users hit when setup left the config without credentials (#569). Fail fast
+    # with a clear, actionable message instead of launching a broken command.
+    if not (cfg.rdp.user or "").strip():
+        raise RuntimeError(
+            "Windows credentials are not configured (empty username). "
+            "Run `winpodx setup` to provision the guest, or set one with "
+            "`winpodx config set rdp.user <name>`."
+        )
+
     binary, variant = found
 
     # FreeRDP runs directly on the host. Rootless podman publishes the

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -72,8 +72,25 @@ def test_launch_app_remoteapp_without_display_raises(monkeypatch, tmp_path):
     monkeypatch.setattr("winpodx.core.process.runtime_dir", lambda: tmp_path)
     monkeypatch.delenv("DISPLAY", raising=False)
 
+    # A real launch has credentials; set one so we reach the display/XWayland
+    # guard rather than the empty-username guard (#569).
+    cfg = Config()
+    cfg.rdp.user = "TestUser"
     with pytest.raises(RuntimeError, match="XWayland"):
-        rdp_mod.launch_app(Config(), app_executable="notepad.exe")
+        rdp_mod.launch_app(cfg, app_executable="notepad.exe")
+
+
+def test_build_rdp_command_empty_user_raises_clear_error(monkeypatch):
+    # #569: an empty username made xfreerdp fall back to an interactive prompt
+    # that died with "Inappropriate ioctl for device" under a GUI launch. Fail
+    # fast with an actionable message instead.
+    from winpodx.core import rdp as rdp_mod
+
+    monkeypatch.setattr(rdp_mod, "find_freerdp", lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"))
+    cfg = Config()
+    cfg.rdp.user = ""
+    with pytest.raises(RuntimeError, match="credentials are not configured"):
+        rdp_mod.build_rdp_command(cfg)
 
 
 def test_find_freerdp_returns_tuple_or_none():


### PR DESCRIPTION
## Summary

#569 (CachyOS Handheld / KDE Plasma Wayland / FreeRDP 3.26): apps don't open; the FreeRDP window shows
```
[ERROR][com.freerdp.utils.passphrase] set_terminal_nonblock: tcgetattr() failed with Inappropriate ioctl for device
[ERROR][com.freerdp.client.common] client_cli_read_string: freerdp_interruptible_get_line returned Inappropriate ioctl for device
[ERROR][com.freerdp.core] transport_connect_tls: ERRCONNECT_CONNECT_CANCELLED
```

## Root cause
From the attached log, every launch line is `/u: ...` — the **RDP username (and password) are empty**. With no credentials, xfreerdp falls back to an **interactive credential prompt**, and under a GUI / no-tty launch `tcgetattr/tcsetattr` fail with *Inappropriate ioctl for device* → the connection is cancelled. The empty credentials are a symptom of an **incomplete `winpodx setup`** (the same log shows `no such object: winpodx-windows` and the agent never reachable).

## Fix
`build_rdp_command` now refuses to launch with an empty username and raises a clear, actionable `RuntimeError` ("Windows credentials are not configured … run `winpodx setup`") instead of emitting a broken `/u:` command that surfaces as the cryptic ioctl failure. (Empty *password* stays supported — askpass / blank-password guests — so only the always-invalid empty username is guarded.)

## Verification
`pytest tests/test_rdp.py tests/test_security.py` 135 passed (incl. new guard test); `ruff` clean.

## Not fully resolved
This converts the cryptic error into clear guidance; the reporter still needs to **complete setup** so credentials get provisioned. Asked on the issue for `winpodx doctor` / pod status to see why setup didn't finish on CachyOS Handheld.

Ships in the next release.