### PR TITLE
fix(tray): refresh Terminate-Session/USB submenus on the timer (#573)

### DIFF
--- a/src/winpodx/desktop/tray.py
+++ b/src/winpodx/desktop/tray.py
@@ -263,6 +263,22 @@ def run_tray() -> None:
             active = []
         sessions_action.setText(tr("Sessions: {n}").format(n=len(active)))
 
+        # Keep the Terminate-Session / USB-Devices submenus fresh from the timer
+        # tick (#573). KDE/Plasma's StatusNotifierItem renders the tray menu over
+        # DBusMenu, which does NOT reliably deliver a *nested* submenu's
+        # aboutToShow — so the two submenus (populated only via their own
+        # aboutToShow) stayed stuck at their build-time content ("(no active
+        # sessions)" / "(no USB devices detected)") and looked broken even though
+        # the top-level "Sessions: N" count (refreshed here) was correct.
+        # Rebuilding them on this always-firing QTimer tick keeps them current
+        # regardless of whether aboutToShow fires. Guarded: this is a QTimer slot
+        # and must never raise (an uncaught exception aborts app.exec()).
+        for _rebuild in (_rebuild_sessions_menu, _rebuild_devices_menu):
+            try:
+                _rebuild()
+            except Exception as e:  # noqa: BLE001 -- never crash the tray event loop
+                log.warning("tray submenu refresh failed: %s", e)
+
         # Re-assert the icon every tick. KDE/GNOME StatusNotifier hosts can
         # restart (plasmashell reload, panel reconfigure, host crash) and Qt
         # does NOT reliably re-register the item afterwards -> the icon


### PR DESCRIPTION
## Summary

#573 (ismikes) + reproduced by @kernalix7: the tray's **Terminate Session** and **USB Devices** submenus show nothing (or stale '(no … )') on KDE Plasma — even with a live session (the top-level menu reads **Sessions: 1**).

## Root cause
On KDE/Plasma the tray menu is rendered via StatusNotifierItem + **DBusMenu**, which does **not reliably deliver a nested submenu's `aboutToShow`** signal. Both submenus were populated *only* via their own `aboutToShow`, so under Plasma they froze at their build-time content (built when there were 0 sessions / before USB enumeration). The top-level `Sessions: N` label looked correct because it's refreshed on the 30s `QTimer` tick, not via aboutToShow — which is exactly the mechanism the submenus were missing.

## Fix
Rebuild both submenus from that same always-firing timer tick (`refresh_status`), guarded so it can't abort the event loop. The submenu `aboutToShow` connections stay for native Qt / GNOME where they work. Confirmed via the attached screenshot that the submenus *are* in the menu (with arrows) — only their contents were stale.

## Verification
- `ruff` clean; tray imports clean (offscreen).
- ⚠️ DBusMenu behavior is KDE-Wayland-specific and not reproducible in headless tests — asking the reporter to confirm, but the maintainer reproduces the bug and the mechanism is clear.

Ships in the next release.