### PR TITLE
fix(tray): drop aboutToShow so session/USB submenus open on Plasma (#573)

### DIFF
--- a/src/winpodx/desktop/tray.py
+++ b/src/winpodx/desktop/tray.py
@@ -451,7 +451,13 @@ def run_tray() -> None:
             act.triggered.connect(_make_session_kill(s.app_name))
             sessions_menu.addAction(act)
 
-    sessions_menu.aboutToShow.connect(_rebuild_sessions_menu)
+    # NO aboutToShow here (#573): on KDE/Plasma the tray menu is rendered over
+    # DBusMenu, and an aboutToShow-driven submenu is exported with *deferred*
+    # children that Plasma never fills (the nested aboutToShow round-trip
+    # doesn't reach Qt), so the submenu wouldn't even open. Populate eagerly
+    # like the Launch App / Maintenance submenus (which work), and keep it fresh
+    # from the refresh_status timer tick instead — Plasma reads the current
+    # children via DBusMenu GetLayout when the submenu is opened.
     _rebuild_sessions_menu()
     menu.addMenu(sessions_menu)
 
@@ -524,7 +530,9 @@ def run_tray() -> None:
             act.triggered.connect(_make_device_toggle(host))
             devices_menu.addAction(act)
 
-    devices_menu.aboutToShow.connect(_rebuild_devices_menu)
+    # Eager populate + timer refresh, no aboutToShow — see the Terminate-Session
+    # submenu above (#573): aboutToShow-deferred submenus don't open under
+    # Plasma's DBusMenu.
     _rebuild_devices_menu()
     menu.addMenu(devices_menu)
 


### PR DESCRIPTION
## Summary

Follow-up to #602. Smoke test on KDE/Plasma Wayland showed the **Terminate Session** and **USB Devices** submenus don't open *at all* (not merely stale). The only difference from the **Launch App** / **Maintenance** submenus (which open fine) was the `aboutToShow` connection.

## Root cause
Plasma renders the tray menu over **DBusMenu**. A submenu with an `aboutToShow` handler is exported with **deferred** children that Qt only fills when the nested `aboutToShow` fires — which doesn't happen over DBusMenu — so Plasma sees an empty deferred submenu and never opens it.

## Fix
Remove the `aboutToShow` connections from both submenus. They're already populated eagerly at build (`_rebuild_*()`) and kept fresh by the `refresh_status` timer tick (#602); Plasma reads the current children via DBusMenu `GetLayout` when the submenu opens. Native Qt / GNOME keep working (the timer refresh replaces the lost aboutToShow refresh).

## Verification
- `ruff` clean; tray imports clean (offscreen).
- ⚠️ KDE-Wayland DBusMenu behavior isn't reproducible headless — maintainer is smoke-testing.

Ships in the next release.