### PR TITLE
fix(tray): parent session/USB QActions so submenus aren't GC'd empty (#573)

### DIFF
--- a/src/winpodx/desktop/tray.py
+++ b/src/winpodx/desktop/tray.py
@@ -441,13 +441,21 @@ def run_tray() -> None:
         except Exception as e:  # noqa: BLE001 — never crash the tray on enumeration
             log.warning("sessions menu: enumeration failed: %s", e)
             active = []
+        # Parent each QAction to the submenu (#573). A parentless QAction added
+        # via addAction() is kept on the *Python* side only; when this closure
+        # returns, the local refs drop and PySide6 garbage-collects the actions,
+        # so the submenu ends up empty — which DBusMenu/Plasma exports as a
+        # submenu with ZERO children that can't be opened (confirmed via
+        # `dbusmenu GetLayout`: Terminate/USB had no children while the eagerly
+        # built Launch App / Maintenance submenus did). Giving the QAction a C++
+        # parent (the menu) makes it outlive the closure.
         if not active:
-            empty = QAction(tr("(no active sessions)"))
+            empty = QAction(tr("(no active sessions)"), sessions_menu)
             empty.setEnabled(False)
             sessions_menu.addAction(empty)
             return
         for s in active:
-            act = QAction(tr("Terminate: {name}").format(name=s.app_name))
+            act = QAction(tr("Terminate: {name}").format(name=s.app_name), sessions_menu)
             act.triggered.connect(_make_session_kill(s.app_name))
             sessions_menu.addAction(act)
 
@@ -515,14 +523,16 @@ def run_tray() -> None:
         except Exception as e:  # noqa: BLE001 — never crash the tray on enumeration
             log.warning("device menu: enumeration failed: %s", e)
             usb, assigned = [], set()
+        # Parent QActions to the submenu so they survive this closure (#573) —
+        # see _rebuild_sessions_menu for the GC / empty-DBusMenu-children detail.
         if not usb:
-            empty = QAction(tr("(no USB devices detected)"))
+            empty = QAction(tr("(no USB devices detected)"), devices_menu)
             empty.setEnabled(False)
             devices_menu.addAction(empty)
             return
         for host in usb:
             dc = host.to_device_config()
-            act = QAction(host.label or dc.did)
+            act = QAction(host.label or dc.did, devices_menu)
             act.setCheckable(True)
             act.setChecked(dc.key in assigned)
             # `triggered` (not `toggled`) fires only on user clicks, so the


### PR DESCRIPTION
## Summary

The real fix for #573, confirmed by dumping the **live DBusMenu export** of the running tray.

`com.canonical.dbusmenu.GetLayout` showed the **Terminate Session** and **USB Devices** submenus exported with `children-display=submenu` but **zero children**, while the eagerly-built **Launch App** / **Maintenance** submenus had theirs — so Plasma drew the arrow but had nothing to open (matches the "submenu doesn't open at all" report).

## Root cause
`_rebuild_sessions_menu` / `_rebuild_devices_menu` create their QActions **without a parent** inside a closure and add them via `addAction()`. A parentless QAction is owned only on the Python side; when the closure returns, the local refs drop and PySide6 garbage-collects the actions, emptying the submenu.

Verified headless:
```
PARENTLESS after GC: 0
PARENTED   after GC: 3
```

## Fix
Give each QAction the submenu as its C++ parent — `QAction(text, menu)` — so it outlives the closure. (The earlier #602 timer-refresh and #603 aboutToShow removal addressed the wrong layer; they're harmless but this is the actual fix.)

## Verification
- Headless GC test confirms parented actions survive; parentless drop to 0.
- DBusMenu export was the diagnostic that pinned it.
- `ruff` clean; tray imports clean.

Ships in the next release.