### PR TITLE
fix(pod): stop keeps the container (compose stop, not down)

### DIFF
--- a/src/winpodx/backend/docker.py
+++ b/src/winpodx/backend/docker.py
@@ -49,9 +49,14 @@ class DockerBackend(Backend):
             raise
 
     def stop(self) -> None:
+        # `compose stop`, NOT `compose down`: `down` removes the container, so an
+        # update-while-stopped re-triggers the "container missing — creating it"
+        # heal + Windows reboot every time. `stop` keeps the stopped container so
+        # `start` (`compose up -d`) just restarts it. The disk volume is unaffected
+        # either way. Mirrors the podman backend.
         try:
             result = subprocess.run(
-                [*self._compose_cmd(), "down"],
+                [*self._compose_cmd(), "stop"],
                 capture_output=True,
                 text=True,
                 timeout=180,
@@ -59,12 +64,12 @@ class DockerBackend(Backend):
             )
             if result.returncode != 0:
                 log.warning(
-                    "docker compose down failed (rc=%d): %s",
+                    "docker compose stop failed (rc=%d): %s",
                     result.returncode,
                     result.stderr.strip(),
                 )
         except subprocess.TimeoutExpired:
-            log.error("docker compose down timed out (180s)")
+            log.error("docker compose stop timed out (180s)")
 
     def _container_state(self) -> str:
         """Return the lower-cased container state, or empty string if unavailable."""

--- a/src/winpodx/backend/podman.py
+++ b/src/winpodx/backend/podman.py
@@ -146,9 +146,17 @@ class PodmanBackend(Backend):
             raise subprocess.CalledProcessError(returncode=rc, cmd=cmd, output=out, stderr=out)
 
     def stop(self) -> None:
+        # `compose stop`, NOT `compose down`: `down` REMOVES the container, so a
+        # later `winpodx install` / `migrate` sees no container and "heals" it by
+        # recreating from compose every time the user updates while stopped
+        # ("Container 'winpodx-windows' is missing — creating it ...") — a needless
+        # Windows reboot. `stop` keeps the (stopped) container so `start`'s
+        # `compose up -d` just restarts it, and the heal path correctly no-ops
+        # because the container still exists. The persistent disk volume survives
+        # either way; the difference is whether the container object is kept.
         try:
             result = subprocess.run(
-                [*self._compose_cmd(), "down"],
+                [*self._compose_cmd(), "stop"],
                 capture_output=True,
                 text=True,
                 timeout=180,
@@ -156,12 +164,12 @@ class PodmanBackend(Backend):
             )
             if result.returncode != 0:
                 log.warning(
-                    "podman compose down failed (rc=%d): %s",
+                    "podman compose stop failed (rc=%d): %s",
                     result.returncode,
                     result.stderr.strip(),
                 )
         except subprocess.TimeoutExpired:
-            log.error("podman compose down timed out (180s)")
+            log.error("podman compose stop timed out (180s)")
 
     def _container_state(self) -> str:
         """Return the lower-cased container state, or empty string if unavailable."""

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -107,7 +107,11 @@ def test_podman_backend_stop_keeps_container():
     fake = MagicMock()
     fake.returncode = 0
     fake.stderr = ""
-    with patch("winpodx.backend.podman.subprocess.run", return_value=fake) as mock_run:
+    # Mock _compose_cmd too: it raises if podman-compose isn't on PATH (CI).
+    with (
+        patch.object(backend, "_compose_cmd", return_value=["podman-compose", "-f", "c.yaml"]),
+        patch("winpodx.backend.podman.subprocess.run", return_value=fake) as mock_run,
+    ):
         backend.stop()
     cmd = mock_run.call_args[0][0]
     assert "stop" in cmd
@@ -121,7 +125,10 @@ def test_docker_backend_stop_keeps_container():
     fake = MagicMock()
     fake.returncode = 0
     fake.stderr = ""
-    with patch("winpodx.backend.docker.subprocess.run", return_value=fake) as mock_run:
+    with (
+        patch.object(backend, "_compose_cmd", return_value=["docker", "compose", "-f", "c.yaml"]),
+        patch("winpodx.backend.docker.subprocess.run", return_value=fake) as mock_run,
+    ):
         backend.stop()
     cmd = mock_run.call_args[0][0]
     assert "stop" in cmd

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -97,6 +97,37 @@ def test_podman_backend_is_running_uses_configured_container_name():
     assert "name=winpodx-windows" not in cmd
 
 
+def test_podman_backend_stop_keeps_container():
+    # #573-session follow-up: stop must `compose stop` (keep the stopped
+    # container), NOT `compose down` (which removes it and makes an
+    # update-while-stopped recreate the container every time).
+    from winpodx.backend.podman import PodmanBackend
+
+    backend = PodmanBackend(Config())
+    fake = MagicMock()
+    fake.returncode = 0
+    fake.stderr = ""
+    with patch("winpodx.backend.podman.subprocess.run", return_value=fake) as mock_run:
+        backend.stop()
+    cmd = mock_run.call_args[0][0]
+    assert "stop" in cmd
+    assert "down" not in cmd
+
+
+def test_docker_backend_stop_keeps_container():
+    from winpodx.backend.docker import DockerBackend
+
+    backend = DockerBackend(Config())
+    fake = MagicMock()
+    fake.returncode = 0
+    fake.stderr = ""
+    with patch("winpodx.backend.docker.subprocess.run", return_value=fake) as mock_run:
+        backend.stop()
+    cmd = mock_run.call_args[0][0]
+    assert "stop" in cmd
+    assert "down" not in cmd
+
+
 def test_docker_backend_is_running_uses_configured_container_name():
     from winpodx.backend.docker import DockerBackend
 


### PR DESCRIPTION
## Summary

`winpodx pod stop` ran `<backend> compose down`, which **removes** the container. So updating winpodx while the pod was stopped found no container and the setup heal path recreated it from compose **every time** — `Container 'winpodx-windows' is missing — creating it from existing config + compose.yaml.` — an unnecessary Windows reboot on every update-while-stopped (reported by @kernalix7).

## Fix
Use `compose stop` (stops but **keeps** the container). Then:
- the heal check (`<backend> ps -a`) finds the stopped container and no-ops,
- `start` (`compose up -d`) just restarts the existing container (faster, no recreate).

The persistent disk volume is unaffected either way — only the container object is kept. Both podman + docker backends.

## Verification
- `pytest tests/test_backend.py` 16 passed (incl. new `stop uses stop not down` guards); `ruff` clean.
- ⚠️ Runtime behavior change — worth a stop→update→start smoke (no recreate, container resumes).

Ships in 0.7.2.