### PR TITLE
docs(changelog): credit 0.7.2 bug reporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - **`-gfx` can be passed to disable the GFX pipeline** (#393) as a workaround for RAIL render glitches (blue/warping windows) on some XWayland/Plasma setups; the bare `+gfx`/`-gfx` toggles were previously blocked by the extra-args allow-list.
 - **The Debloat picker opens at a usable size**, and the "running debloat" dialog now closes itself when the run finishes (a fast preset could leave it hanging) (#550).
 
+### Contributors
+
+Thanks to @ismikes (#393, #550, #573), @notnotno (#380), @hermitguo (#553), @bangetto (#567), and @biskasarchaniotakis (#569) for the bug reports that drove this release.
+
 ## [0.7.1] - 2026-06-13
 
 ### Added

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -22,6 +22,10 @@
 - **`-gfx`로 GFX 파이프라인 비활성화 가능** (#393) — 일부 XWayland/Plasma에서 RAIL 렌더 깨짐(파란/뭉개진 창) 워크어라운드; bare `+gfx`/`-gfx` 토글이 이전엔 allow-list에 막혀 있었음.
 - **Debloat 피커가 적절한 크기로 열리고**, "debloat 실행 중" 창이 작업 완료 시 자동으로 닫힘(빠른 프리셋에서 안 닫히던 문제) (#550).
 
+### Contributors
+
+이번 릴리즈를 이끈 버그 제보를 해주신 @ismikes (#393, #550, #573), @notnotno (#380), @hermitguo (#553), @bangetto (#567), @biskasarchaniotakis (#569) 님께 감사드립니다.
+
 ## [0.7.1] - 2026-06-13
 
 ### Added


### PR DESCRIPTION
The [0.7.2] CHANGELOG entry was missing its Contributors section. Adds @ismikes (#393/#550/#573), @notnotno (#380), @hermitguo (#553), @bangetto (#567), @biskasarchaniotakis (#569) — EN + KO. The published v0.7.2 release body has been updated to match.