### PR TITLE
fix(install,doctor): ensure podman-compose + flag missing rootless subuid/subgid (#580)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -580,6 +580,12 @@ if command -v podman >/dev/null 2>&1; then
     fi
 fi
 
+# winpodx requires the standalone `podman-compose` (NOT `podman compose`, which
+# delegates to docker-compose and breaks our keep-groups extension -- #288).
+# It's a separate package the `podman` package doesn't pull in.
+PODMAN_COMPOSE_PRESENT=false
+command -v podman-compose >/dev/null 2>&1 && PODMAN_COMPOSE_PRESENT=true
+
 DOCKER_PRESENT=false
 command -v docker >/dev/null 2>&1 && DOCKER_PRESENT=true
 # FreeRDP detection — track native client, Flatpak client, and the Flatpak
@@ -919,6 +925,10 @@ case "${WINPODX_BACKEND:-podman}" in
                 warn "podman is present but too old (major $PODMAN_MAJOR); see the note above. Continuing — pod start may fail until you upgrade podman or switch to --backend docker."
             fi
         fi
+        # podman-compose is required but ships separately from podman; without
+        # it pod creation later fails with "compose command not found" (#503,
+        # #580). Install it alongside podman.
+        [ "$PODMAN_COMPOSE_PRESENT" = false ] && MISSING+=("podman-compose")
         ;;
     docker)
         [ "$DOCKER_PRESENT" = false ] && MISSING+=("docker")

--- a/src/winpodx/cli/doctor.py
+++ b/src/winpodx/cli/doctor.py
@@ -164,6 +164,7 @@ def _collect_findings(*, quick: bool, do_fix: bool) -> list[Finding]:
     findings.append(_check_install_source())
     findings.append(_check_freerdp())
     findings.append(_check_kvm())
+    findings.append(_check_rootless_subid())
     findings.extend(_check_container_backend())
     findings.append(_check_config_state())
     findings.append(_check_pending_setup())
@@ -281,6 +282,53 @@ def _check_kvm() -> Finding:
             "load via one pkexec prompt); if /dev/kvm is still absent, enable "
             "VT-x / AMD-V (SVM) in your BIOS/UEFI."
         ),
+    )
+
+
+def _check_rootless_subid() -> Finding | None:
+    """Rootless podman needs /etc/subuid + /etc/subgid entries for the user.
+
+    A renamed account (entries left under the old name), or a never-configured
+    host, makes rootless podman unable to create the container — surfacing as a
+    cryptic ``Error: no container with name ... found`` at pod start (#580).
+    Flag it clearly here, pointing at the existing one-shot fixer. Only relevant
+    for the podman backend; ``None`` (skipped) otherwise.
+    """
+    try:
+        from winpodx.core.config import Config
+
+        if Config.load().pod.backend != "podman":
+            return None
+    except Exception:  # noqa: BLE001 — config issues are reported by their own check
+        return None
+
+    try:
+        from winpodx.setup_wizard.host_state import detect_host_state
+
+        state = detect_host_state()
+    except Exception:  # noqa: BLE001 — never let a probe crash doctor
+        return None
+
+    if state.subuid_configured and state.subgid_configured:
+        return Finding("ok", "rootless subuid/subgid configured")
+
+    missing = ", ".join(
+        path
+        for path, ok in (
+            ("/etc/subuid", state.subuid_configured),
+            ("/etc/subgid", state.subgid_configured),
+        )
+        if not ok
+    )
+    return Finding(
+        "fail",
+        f"rootless podman id-mapping missing ({missing})",
+        detail=(
+            "Rootless Podman can't create the container without a subuid/subgid "
+            "range for your user — pod start fails with 'no container ... found'. "
+            "Common after renaming your account (the entries keep the old name)."
+        ),
+        suggestion="Run `winpodx setup-host --apply` to add the entries via one pkexec prompt.",
     )
 
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from types import SimpleNamespace
 
 import pytest
 
@@ -168,6 +169,39 @@ class TestCheckFreerdp:
         assert _check_freerdp().severity == "fail"
 
 
+class TestCheckRootlessSubid:
+    """#580: rootless podman needs /etc/subuid + /etc/subgid for the user."""
+
+    def _state(self, **kw):
+        base = {"subuid_configured": True, "subgid_configured": True}
+        base.update(kw)
+        return SimpleNamespace(**base)
+
+    def _run(self, monkeypatch, *, backend="podman", state=None):
+        from winpodx.cli.doctor import _check_rootless_subid
+
+        monkeypatch.setattr(
+            "winpodx.core.config.Config.load",
+            classmethod(lambda cls: SimpleNamespace(pod=SimpleNamespace(backend=backend))),
+        )
+        if state is not None:
+            monkeypatch.setattr("winpodx.setup_wizard.host_state.detect_host_state", lambda: state)
+        return _check_rootless_subid()
+
+    def test_skipped_for_docker_backend(self, monkeypatch):
+        assert self._run(monkeypatch, backend="docker") is None
+
+    def test_ok_when_configured(self, monkeypatch):
+        f = self._run(monkeypatch, state=self._state())
+        assert f.severity == "ok"
+
+    def test_fails_when_subuid_missing(self, monkeypatch):
+        f = self._run(monkeypatch, state=self._state(subuid_configured=False))
+        assert f.severity == "fail"
+        assert "/etc/subuid" in f.title
+        assert "setup-host" in f.suggestion
+
+
 class TestHandleDoctor:
     def test_exits_zero_on_no_fail(self, tmp_path, monkeypatch, capsys):
         """All checks return OK or WARN -> exit 0."""
@@ -179,6 +213,7 @@ class TestHandleDoctor:
             "_check_install_source",
             "_check_freerdp",
             "_check_kvm",
+            "_check_rootless_subid",
             "_check_config_state",
             "_check_pending_setup",
             "_check_autostart_entry",
@@ -201,6 +236,7 @@ class TestHandleDoctor:
             "_check_install_source",
             "_check_freerdp",
             "_check_kvm",
+            "_check_rootless_subid",
             "_check_config_state",
             "_check_pending_setup",
             "_check_autostart_entry",

--- a/tests/test_install_sh_provision.py
+++ b/tests/test_install_sh_provision.py
@@ -44,6 +44,15 @@ def test_invokes_winpodx_provision(script: str) -> None:
     assert '"$SYMLINK" "${PROVISION_CMD[@]}"' in script
 
 
+def test_installs_podman_compose_with_podman(script: str) -> None:
+    # #580/#503: winpodx hard-requires the standalone podman-compose, which the
+    # podman package doesn't pull in. install.sh must detect it and add it to
+    # the install set so pod creation doesn't fail with "compose command not
+    # found".
+    assert "PODMAN_COMPOSE_PRESENT" in script
+    assert 'MISSING+=("podman-compose")' in script
+
+
 def test_atomic_rpm_path_honours_explicit_source_override(script: str) -> None:
     # #548: on Atomic (rpm-ostree) install.sh defaults to the OBS RPM, but an
     # explicit --main/--ref/--source/--image-tar must win and fall through to


### PR DESCRIPTION
## Summary

Two gaps surfaced by #580 (Nobara 43; reporter self-resolved but the failure modes are real and also hit #503):

### 1. install.sh never installed `podman-compose`
winpodx hard-requires the **standalone** `podman-compose` (not `podman compose`, #288), but install.sh's missing-deps detection only covered podman/docker/freerdp/flatpak/python3/kvm. A host with podman but no podman-compose failed later at pod creation with *"compose command not found"*. install.sh now detects it (`PODMAN_COMPOSE_PRESENT`) and adds `podman-compose` to the install set for the podman backend — the package name is identical across dnf/apt/zypper/pacman.

### 2. Cryptic "no container found" when rootless id-mapping is missing
Rootless podman needs `/etc/subuid` + `/etc/subgid` entries for the user; a **renamed account** leaves them under the old name → pod start fails with `Error: no container ... found`. `winpodx doctor` now checks this (podman backend only) and points at the existing one-shot fixer `winpodx setup-host --apply`.

## Verification
- `bash -n install.sh`; `pytest tests/test_doctor.py tests/test_install_sh_provision.py` 65 passed (incl. new podman-compose guard + subuid ok/fail/skip tests); `ruff` clean (whole tree).

Ships in the next release.