### PR TITLE
feat(host-open): --verbose shows why a .desktop was dropped (#594)

### DIFF
--- a/src/winpodx/cli/host_open.py
+++ b/src/winpodx/cli/host_open.py
@@ -194,8 +194,20 @@ def _print_human_list(apps: list[LinuxApp], stream) -> None:
 
 def _cmd_refresh(args: argparse.Namespace) -> int:
     cfg = Config.load()
-    apps = discover_apps(include_nodisplay=args.include_nodisplay)
+    drops: list[tuple[Path, str]] | None = [] if getattr(args, "verbose", False) else None
+    apps = discover_apps(include_nodisplay=args.include_nodisplay, drops=drops)
     kept, skipped = _filter_apps(apps, cfg)
+
+    if drops is not None:
+        # --verbose: show every scanned .desktop that wasn't discovered + why,
+        # so a "my app is missing" report (e.g. #594) is self-diagnosable.
+        print(
+            f"Discovered {len(apps)} mime-handling app(s); "
+            f"dropped {len(drops)} .desktop entry(ies):"
+        )
+        for path, reason in sorted(drops, key=lambda d: str(d[0])):
+            print(f"  - {path}: {reason}")
+        print("")
 
     icons_dir = _icons_dir()
     icons_dir.mkdir(parents=True, exist_ok=True)
@@ -665,6 +677,13 @@ def add_subcommand(top_subparsers: argparse._SubParsersAction) -> None:
         "--include-nodisplay",
         action="store_true",
         help="Include entries marked NoDisplay=true (protocol handlers etc.)",
+    )
+    refresh.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="List every scanned .desktop that was NOT discovered, with the reason "
+        "(diagnose a missing app, e.g. #594).",
     )
 
     lst = sub.add_parser("list", help="Print discovered or cached apps")

--- a/src/winpodx/reverse_open/discovery.py
+++ b/src/winpodx/reverse_open/discovery.py
@@ -348,6 +348,7 @@ def discover_apps(
     *,
     extra_dirs: Iterable[Path] | None = None,
     include_nodisplay: bool = False,
+    drops: list[tuple[Path, str]] | None = None,
 ) -> list[LinuxApp]:
     """Walk the XDG application directories and return mime-handling apps.
 
@@ -363,9 +364,18 @@ def discover_apps(
       A list of :class:`LinuxApp`, deduplicated by basename (first hit
       wins, matching xdg-open shadowing semantics). Stable order:
       sorted by slug.
+
+      drops: if a list is passed, every scanned ``.desktop`` that is NOT
+        returned is appended as ``(path, reason)`` — the diagnostic behind
+        ``winpodx host-open refresh --verbose`` so "why is my app missing?"
+        is answerable without guessing.
     """
     desktops = _current_desktops()
     defaults = _read_default_handlers()
+
+    def _drop(path: Path, reason: str) -> None:
+        if drops is not None:
+            drops.append((path, reason))
 
     seen_basenames: set[str] = set()
     apps: dict[str, LinuxApp] = {}
@@ -385,49 +395,61 @@ def discover_apps(
         for path in files:
             basename = path.name
             if basename in seen_basenames:
+                _drop(path, "shadowed by an earlier entry with the same filename")
                 continue
             seen_basenames.add(basename)
 
             entry = _parse_desktop(path)
             if entry is None:
+                _drop(path, "unparseable .desktop ([Desktop Entry] missing/invalid)")
                 continue
             if entry.get("Type", "Application").strip() != "Application":
+                _drop(path, f"Type={entry.get('Type', '').strip()!r} (not Application)")
                 continue
 
             mime_value = entry.get("MimeType", "").strip()
             if not mime_value:
+                _drop(path, "no MimeType= (handles no file type / URL scheme)")
                 continue
 
             if not include_nodisplay and not _is_displayed(entry, desktops):
+                _drop(path, "NoDisplay/Hidden/OnlyShowIn/NotShowIn excludes it here")
                 continue
             if include_nodisplay and entry.get("Hidden", "false").strip().lower() == "true":
                 # Even with --include-nodisplay, Hidden=true is a tombstone.
+                _drop(path, "Hidden=true (tombstone)")
                 continue
 
             try_exec = entry.get("TryExec", "").strip()
             if try_exec and not _resolve_try_exec(try_exec):
+                _drop(path, f"TryExec={try_exec!r} not found on PATH")
                 continue
 
             exec_line = entry.get("Exec", "").strip()
             if not exec_line:
+                _drop(path, "empty Exec=")
                 continue
             try:
                 argv = shlex.split(exec_line, posix=True)
             except ValueError:
                 # Unbalanced quotes etc. — skip rather than guess.
+                _drop(path, "Exec= has unbalanced quotes")
                 continue
             argv = _strip_field_codes(argv)
             if not _exec_is_safe(exec_line, argv):
+                _drop(path, "Exec= rejected by the safety filter (shell metachar / wrapper)")
                 continue
 
             name = (entry.get("Name") or "").strip() or path.stem
             if name.startswith(_WINPODX_NAME_PREFIX):
+                _drop(path, "winpodx-generated Windows-app entry (skip recursion)")
                 continue
             comment = (entry.get("Comment") or "").strip()
             icon_name = (entry.get("Icon") or "").strip()
 
             mime_types = _split_mimes(mime_value)
             if not mime_types:
+                _drop(path, "MimeType= parsed to no valid types")
                 continue
 
             slug = slug_for_desktop(path)

--- a/tests/test_reverse_open_discovery.py
+++ b/tests/test_reverse_open_discovery.py
@@ -173,6 +173,27 @@ def test_discover_apps_skips_entries_without_mime() -> None:
     assert discover_apps() == []
 
 
+def test_discover_apps_drops_records_reason() -> None:
+    # #594: the `drops` out-param records every scanned .desktop that wasn't
+    # returned, with a human reason — the data behind `host-open refresh -v`.
+    p = _write_desktop(
+        "settings.desktop",
+        "[Desktop Entry]\nType=Application\nName=Settings\nExec=settings\n",
+    )
+    drops: list = []
+    apps = discover_apps(drops=drops)
+    assert apps == []
+    assert (p, "no MimeType= (handles no file type / URL scheme)") in drops
+
+
+def test_discover_apps_drops_empty_when_app_kept() -> None:
+    _write_desktop("org.kde.kate.desktop", _kate_entry())
+    drops: list = []
+    apps = discover_apps(drops=drops)
+    assert len(apps) == 1
+    assert drops == []
+
+
 def test_discover_apps_skips_nodisplay_by_default() -> None:
     _write_desktop("kate.desktop", _kate_entry("NoDisplay=true\n"))
     assert discover_apps() == []


### PR DESCRIPTION
## Summary

#594 (notnotno): `winpodx host-open refresh` stages only a subset of installed Linux apps (Brave missing). `discover_apps` silently drops every `.desktop` that lacks `MimeType=`, is NoDisplay/OnlyShowIn-filtered, has an unsafe `Exec`, a failed `TryExec`, or is basename-shadowed — with **no way to see why** a given app was excluded.

Verified: Brave's *standard* rpm `.desktop` IS discovered (all filters pass), and Chrome/Firefox are picked up here — so the reporter's miss is **environment-specific**. This adds the diagnostic to pin it down.

## Change
- `discover_apps(..., drops=[])` out-param records `(path, reason)` for every skipped entry.
- `winpodx host-open refresh --verbose` (`-v`) prints each scanned-but-dropped `.desktop` with a human reason (no-MimeType / NoDisplay / unsafe-Exec / TryExec-fail / shadowed / …).

## Verification
- `pytest tests/test_reverse_open_discovery.py tests/test_cli_host_open.py` 53 passed (incl. new drop-reason tests); `ruff` clean (whole tree). On this machine: 97 discovered, 441 dropped — all with reasons.

Ships in the next release; lets the reporter run `host-open refresh -v` and paste the line for Brave.