### PR TITLE
feat(pod): SSD emulation for the Windows disk (#606)

### DIFF
--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -283,6 +283,15 @@ def _decide_storage_mode(cfg: Config, *, non_interactive: bool) -> None:
             print(tr("    You can retry manually: chattr +C"), target)
     cfg.pod.storage_path = str(target)
 
+    # SSD emulation default (#606): if the host storage device is non-rotational,
+    # present the guest disk as an SSD too (TRIM + no scheduled defrag). Only
+    # flip ON for a confirmed SSD; HDD / undetectable keeps the HDD default.
+    from winpodx.utils.btrfs import host_storage_is_ssd
+
+    if host_storage_is_ssd(target) is True:
+        cfg.pod.ssd = True
+        print(tr("  Host storage is an SSD — the Windows disk will emulate SSD (TRIM, no defrag)."))
+
 
 def _handle_migrate_storage(args: argparse.Namespace) -> int:
     """Move storage from the legacy ``winpodx-data`` named volume to a host

--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -299,6 +299,15 @@ class PodConfig:
     # a safety reserve). Set a dockur size (e.g. "512G", "1T") to impose an
     # explicit upper bound regardless of host capacity.
     disk_max_size: str = ""
+    # #606: present the Windows disk as an SSD (non-rotational) rather than a
+    # spinning HDD. Injects QEMU `rotation_rate=1` on the ATA/SCSI disk device,
+    # so Windows enables TRIM + skips scheduled defrag and treats it like an
+    # SSD (the Proxmox "SSD emulation" checkbox). Disguise-safe: it keeps the
+    # current disk bus + the disguise's INQUIRY model masking, and a
+    # non-rotational disk is *more* bare-metal-realistic on modern hardware.
+    # Auto-set from the host storage device at setup; override with
+    # `winpodx config set pod.ssd true|false`. Takes effect on next pod create.
+    ssd: bool = False
     # v0.5.x: guest sync. After a host upgrade, push the refreshed guest
     # artifacts (agent.ps1, urlacl, rdprrap/shim, registry fixes) into the
     # running guest instead of forcing a wipe-reinstall. Auto-runs once per
@@ -525,6 +534,8 @@ class PodConfig:
                 self.disk_max_size = ""
         if not isinstance(self.guest_autosync, bool):
             self.guest_autosync = True
+        if not isinstance(self.ssd, bool):
+            self.ssd = bool(self.ssd)
         # storage_path: keep empty (named-volume mode) or coerce to a
         # safe absolute string under the user's home or under a known
         # winpodx-managed root. The caller responsible for materialising
@@ -872,6 +883,7 @@ class Config:
                 "disk_autogrow_target_free_pct": self.pod.disk_autogrow_target_free_pct,
                 "disk_autogrow_increment": self.pod.disk_autogrow_increment,
                 "disk_max_size": self.pod.disk_max_size,
+                "ssd": self.pod.ssd,
                 "guest_autosync": self.pod.guest_autosync,
                 "max_sessions": self.pod.max_sessions,
                 "storage_path": self.pod.storage_path,

--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -293,6 +293,18 @@ def _qemu_arguments_for_host(cfg: Config | None = None) -> str:
         # the disguise image.
         extra_args += ["-acpitable", "file=/usr/share/qemu/winpodx-wsmt.aml"]
 
+    # SSD emulation (#606): make the guest disk report as non-rotational so
+    # Windows enables TRIM + skips scheduled defrag and treats it as an SSD
+    # (the Proxmox "SSD emulation" checkbox). `-global <driver>.rotation_rate=1`
+    # sets the property on whichever ATA/SCSI disk device dockur creates; QEMU
+    # ignores a `-global` whose driver isn't instantiated (non-fatal), so it's
+    # safe to set both regardless of the DISK_TYPE bus in use. virtio-blk has no
+    # rotation concept, so this is a no-op there. Disguise-safe: no bus change,
+    # so the disguise's INQUIRY model masking is untouched.
+    if cfg.pod.ssd:
+        extra_args += ["-global", "ide-hd.rotation_rate=1"]
+        extra_args += ["-global", "scsi-hd.rotation_rate=1"]
+
     return " ".join(extra_args)
 
 

--- a/src/winpodx/utils/btrfs.py
+++ b/src/winpodx/utils/btrfs.py
@@ -112,6 +112,59 @@ def detect_path_fs(path: Path) -> str:
     return stdout.strip().lower()
 
 
+def host_storage_is_ssd(path: Path) -> bool | None:
+    """Best-effort: is the block device backing ``path`` non-rotational (SSD)?
+
+    Resolves ``path`` to its mount source via ``findmnt -no SOURCE``, strips the
+    partition suffix to the parent disk, and reads
+    ``/sys/block/<disk>/queue/rotational`` (0 = SSD/flash, 1 = spinning). Used to
+    pick the default for ``cfg.pod.ssd`` (#606).
+
+    Returns ``True`` (SSD), ``False`` (HDD), or ``None`` when it can't tell —
+    network / device-mapper / LVM / btrfs-multidevice sources, no findmnt, or an
+    unreadable sysfs node. Callers default to HDD behaviour on ``None``.
+    """
+    if shutil.which("findmnt") is None:
+        return None
+    probe = path
+    try:
+        for _ in range(64):
+            if probe.exists():
+                break
+            parent = probe.parent
+            if parent == probe:
+                break
+            probe = parent
+    except OSError:
+        probe = path
+    rc, stdout, _ = _run(["findmnt", "-no", "SOURCE", "--target", str(probe)])
+    source = stdout.strip()
+    # Only handle a plain /dev/<disk>[partition] source. Anything else
+    # (mapper/LVM "/dev/mapper/...", "UUID=", network "host:/export", a
+    # btrfs multi-device list) is too ambiguous to map to one rotational flag.
+    if rc != 0 or not source.startswith("/dev/") or "," in source or " " in source:
+        return None
+    dev = source[len("/dev/") :]
+    if "/" in dev:  # e.g. /dev/mapper/... -> "mapper/..."
+        return None
+    # Strip the partition suffix to the parent disk: sda3 -> sda,
+    # nvme0n1p2 -> nvme0n1, mmcblk0p1 -> mmcblk0.
+    import re
+
+    disk = re.sub(r"p?\d+$", "", dev) if re.search(r"\d", dev) else dev
+    if re.match(r"^(nvme|mmcblk)", dev):
+        disk = re.sub(r"p\d+$", "", dev)
+    try:
+        val = Path(f"/sys/block/{disk}/queue/rotational").read_text().strip()
+    except OSError:
+        return None
+    if val == "0":
+        return True
+    if val == "1":
+        return False
+    return None
+
+
 def is_cow_disabled(path: Path) -> bool | None:
     """Return ``True`` if ``+C`` is set on ``path``, ``False`` if not, ``None`` if unknown.
 

--- a/tests/test_btrfs.py
+++ b/tests/test_btrfs.py
@@ -209,3 +209,33 @@ class TestDoesNotTouchGraphRoot:
                 f"btrfs.py must not expose {forbidden!r} — would re-introduce "
                 f"the graph-root chattr behaviour we explicitly rejected"
             )
+
+
+class TestHostStorageIsSsd:
+    """#606: map a path -> backing disk -> /sys/block/<disk>/queue/rotational."""
+
+    def _patch(self, monkeypatch, *, source, rotational=None, has_findmnt=True):
+        fake, _ = _run_factory([(0, source + "\n", "")])
+        monkeypatch.setattr(btrfs, "_run", fake)
+        monkeypatch.setattr(
+            btrfs.shutil, "which", lambda *_: "/usr/bin/findmnt" if has_findmnt else None
+        )
+        if rotational is not None:
+            monkeypatch.setattr(btrfs.Path, "read_text", lambda self, *a, **k: rotational + "\n")
+
+    def test_ssd_when_rotational_zero(self, tmp_path, monkeypatch):
+        self._patch(monkeypatch, source="/dev/nvme0n1p2", rotational="0")
+        assert btrfs.host_storage_is_ssd(tmp_path) is True
+
+    def test_hdd_when_rotational_one(self, tmp_path, monkeypatch):
+        self._patch(monkeypatch, source="/dev/sda3", rotational="1")
+        assert btrfs.host_storage_is_ssd(tmp_path) is False
+
+    def test_none_for_devmapper_source(self, tmp_path, monkeypatch):
+        # device-mapper / LVM is too ambiguous to map to one rotational flag.
+        self._patch(monkeypatch, source="/dev/mapper/vg-root")
+        assert btrfs.host_storage_is_ssd(tmp_path) is None
+
+    def test_none_when_findmnt_missing(self, tmp_path, monkeypatch):
+        self._patch(monkeypatch, source="/dev/sda1", has_findmnt=False)
+        assert btrfs.host_storage_is_ssd(tmp_path) is None

--- a/tests/test_compose_arch.py
+++ b/tests/test_compose_arch.py
@@ -68,6 +68,24 @@ def test_compose_cpu_flags_x86_64(monkeypatch):
     assert 'CPU_FLAGS: "arch_capabilities=off"' in content
 
 
+def test_compose_ssd_emulation_off_by_default(monkeypatch):
+    monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
+    content = _build_compose_content(_cfg())
+    assert "rotation_rate" not in content
+
+
+def test_compose_ssd_emulation_injects_rotation_rate(monkeypatch):
+    # #606: pod.ssd -> -global <driver>.rotation_rate=1 so Windows sees an SSD.
+    monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
+    cfg = _cfg()
+    cfg.pod.ssd = True
+    content = _build_compose_content(cfg)
+    assert "ide-hd.rotation_rate=1" in content
+    assert "scsi-hd.rotation_rate=1" in content
+
+
 def test_compose_cpu_flags_aarch64(monkeypatch):
     """aarch64 hosts emit empty CPU_FLAGS -- dockur picks the host CPU.
 


### PR DESCRIPTION
## Summary

#606 (ismikes): a Proxmox-style **SSD emulation** option. Adds `pod.ssd` so the guest disk reports as non-rotational — Windows then enables TRIM, skips scheduled defrag, and treats it as an SSD.

## How
QEMU `-global ide-hd.rotation_rate=1` + `scsi-hd.rotation_rate=1` injected into `ARGUMENTS`. It applies to whichever ATA/SCSI disk dockur creates; QEMU **ignores a `-global` whose driver isn't instantiated** (non-fatal), so it's boot-safe regardless of `DISK_TYPE` (no-op on virtio-blk).

## Bare-metal disguise: safe (no weakening)
Deliberately **not** `DISK_TYPE=nvme` — switching the bus would (a) risk Windows boot on an existing install and (b) expose unmasked NVMe identify strings, hurting the disguise. `rotation_rate=1` keeps the current bus, so the disguise's INQUIRY model masking is untouched — and a non-rotational disk is *more* bare-metal-realistic on modern hardware, so it can only help VM-detection evasion.

## Auto-detect
`host_storage_is_ssd()` maps the storage path → backing disk via `findmnt` + `/sys/block/<disk>/queue/rotational`; setup defaults `pod.ssd` ON only for a **confirmed** SSD (HDD / undetectable keeps HDD). Override: `winpodx config set pod.ssd true|false`. Takes effect on next pod create.

## Verification
- `pytest tests/test_compose_arch.py tests/test_btrfs.py tests/test_config.py` 120 passed (compose injection, config roundtrip, host detection); `ruff` clean (whole tree).
- ⚠️ Guest disk behaviour — needs a real-Windows smoke (boot + Windows reports SSD/Optimize-Drives shows 'Solid state drive'). Maintainer will smoke.

Ships in the next release.