### PR TITLE
docs(changelog): log #613 + #590/#625 under Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added
+
+- **Debloat disables more telemetry and ad surfaces** (#590 / #625, thanks @GameSoul7Eugene). The *Ads & suggestions* item now clears additional `ContentDeliveryManager` suggestion keys and the rotating lock-screen ads, and the *Unnecessary scheduled tasks* item disables more pure-telemetry tasks (`AitAgent`, `ProgramInventoryUpdater`, CEIP `BthSQM`, `Feedback\Siuf`, `WindowsAI` Copilot/Insights data collection, and the Office telemetry agents). Security- and system-critical tasks (Windows Defender, licensing/activation, certificate services, Windows Update repair, language packs, Windows Hello) are deliberately left untouched so debloat can't break activation, updates, or the IME.
+
+### Fixed
+
+- **`media_monitor.ps1` is now delivered to the guest** (#613). It was the only first-boot guest script not shipped in the OEM bundle, so dockur never staged it to `C:\OEM\` and `install.bat` couldn't find it — the `C:\winpodx-scripts` mount it looked for was never wired, and the `\\tsclient` fallbacks aren't available during dockur's unattended first boot (no RDP session yet). The result was a `media_monitor.ps1 not found` warning and the USB media auto-mapper never being registered, on every install. The script now ships in `config/oem/` like every other guest script and is copied from `C:\OEM\` at first boot.
+
 ## [0.7.2] - 2026-06-15
 
 ### Fixed

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Debloat가 더 많은 텔레메트리·광고 항목을 비활성화** (#590 / #625, @GameSoul7Eugene 기여 감사). *Ads & suggestions* 항목이 추가 `ContentDeliveryManager` 추천 키와 회전 잠금화면 광고를 제거하고, *불필요한 예약 작업* 항목이 순수 텔레메트리 작업(`AitAgent`, `ProgramInventoryUpdater`, CEIP `BthSQM`, `Feedback\Siuf`, `WindowsAI` Copilot/Insights 데이터 수집, Office 텔레메트리 에이전트)을 추가로 비활성화합니다. 보안·시스템 핵심 작업(Windows Defender, 라이선스/활성화, 인증서 서비스, Windows Update 복구, 언어 팩, Windows Hello)은 활성화·업데이트·IME가 깨지지 않도록 의도적으로 건드리지 않습니다.
+
+### Fixed
+
+- **`media_monitor.ps1`가 이제 게스트에 전달됨** (#613). first-boot 게스트 스크립트 중 유일하게 OEM 번들에 포함되지 않아 dockur가 `C:\OEM\`로 스테이징하지 못했고, `install.bat`도 찾지 못했습니다 — 찾던 `C:\winpodx-scripts` 마운트는 구현된 적이 없고, `\\tsclient` 폴백은 dockur 무인 first-boot(아직 RDP 세션 없음)에는 사용할 수 없습니다. 그 결과 모든 설치에서 `media_monitor.ps1 not found` 경고가 뜨고 USB 미디어 자동 매핑이 등록되지 않았습니다. 이제 다른 게스트 스크립트처럼 `config/oem/`로 배송되어 first-boot에 `C:\OEM\`에서 복사됩니다.
+
 ## [0.7.2] - 2026-06-15
 
 ### Fixed


### PR DESCRIPTION
Backfills the `[Unreleased]` CHANGELOG entries (EN + KO mirror) that were missed when #618 (#613) and #625 (#590) merged:

- **Added** — debloat now disables more telemetry/ad surfaces (#590 / #625), with security/system-critical tasks deliberately excluded.
- **Fixed** — `media_monitor.ps1` is now delivered to the guest via the OEM bundle (#613).

Docs-only.