### PR TITLE
docs(changelog): log #593 usbredir install-hint fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 ### Fixed
 
 - **`media_monitor.ps1` is now delivered to the guest** (#613). It was the only first-boot guest script not shipped in the OEM bundle, so dockur never staged it to `C:\OEM\` and `install.bat` couldn't find it — the `C:\winpodx-scripts` mount it looked for was never wired, and the `\\tsclient` fallbacks aren't available during dockur's unattended first boot (no RDP session yet). The result was a `media_monitor.ps1 not found` warning and the USB media auto-mapper never being registered, on every install. The script now ships in `config/oem/` like every other guest script and is copied from `C:\OEM\` at first boot.
+- **The `usbredirect not found` hint now names the right package per distro** (#593, thanks @techabsol). Debian/Ubuntu is `usbredirect`, Fedora is `usbredir-tools` (plus an Atomic Fedora `rpm-ostree` form), and openSUSE stays `usbredir` — the previous message pointed at packages that don't carry the binary.
 
 ## [0.7.2] - 2026-06-15
 

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - **`media_monitor.ps1`가 이제 게스트에 전달됨** (#613). first-boot 게스트 스크립트 중 유일하게 OEM 번들에 포함되지 않아 dockur가 `C:\OEM\`로 스테이징하지 못했고, `install.bat`도 찾지 못했습니다 — 찾던 `C:\winpodx-scripts` 마운트는 구현된 적이 없고, `\\tsclient` 폴백은 dockur 무인 first-boot(아직 RDP 세션 없음)에는 사용할 수 없습니다. 그 결과 모든 설치에서 `media_monitor.ps1 not found` 경고가 뜨고 USB 미디어 자동 매핑이 등록되지 않았습니다. 이제 다른 게스트 스크립트처럼 `config/oem/`로 배송되어 first-boot에 `C:\OEM\`에서 복사됩니다.
+- **`usbredirect not found` 안내가 배포판별로 올바른 패키지를 안내** (#593, @techabsol 기여 감사). Debian/Ubuntu는 `usbredirect`, Fedora는 `usbredir-tools`(Atomic Fedora는 `rpm-ostree` 형태 추가), openSUSE는 `usbredir` 유지 — 기존 메시지는 바이너리가 들어있지 않은 패키지를 안내했습니다.
 
 ## [0.7.2] - 2026-06-15
 


### PR DESCRIPTION
Adds the `[Unreleased]` CHANGELOG entry (EN + KO) for #593, which corrected the per-distro `usbredirect not found` install hint. Credits @techabsol. Docs-only.