### PR TITLE
fix(oem): quote the urlacl SDDL so install.bat doesn't syntax-error (#614)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 - **`media_monitor.ps1` is now delivered to the guest** (#613). It was the only first-boot guest script not shipped in the OEM bundle, so dockur never staged it to `C:\OEM\` and `install.bat` couldn't find it — the `C:\winpodx-scripts` mount it looked for was never wired, and the `\\tsclient` fallbacks aren't available during dockur's unattended first boot (no RDP session yet). The result was a `media_monitor.ps1 not found` warning and the USB media auto-mapper never being registered, on every install. The script now ships in `config/oem/` like every other guest script and is copied from `C:\OEM\` at first boot.
 - **The `usbredirect not found` hint now names the right package per distro** (#593, thanks @techabsol). Debian/Ubuntu is `usbredirect`, Fedora is `usbredir-tools` (plus an Atomic Fedora `rpm-ostree` form), and openSUSE stays `usbredir` — the previous message pointed at packages that don't carry the binary.
+- **`install.bat` no longer throws a syntax error reserving the agent URL** (#614, thanks @zephir2008). The `netsh http add urlacl … sddl=D:(A;;GX;;;WD)` line left the SDDL unquoted, so `cmd.exe` treated its `(`, `;`, and `)` as metacharacters (`")" was unexpected at this time`) and the reservation failed — which can stop the guest agent from binding port 8765. The SDDL value is now quoted.
 
 ## [0.7.2] - 2026-06-15
 

--- a/config/oem/install.bat
+++ b/config/oem/install.bat
@@ -516,7 +516,7 @@ echo [agent-install] step=urlacl status=enter>>"%SETUP_LOG%"
 netsh http delete urlacl url=http://127.0.0.1:8765/ >>"%SETUP_LOG%" 2>&1
 netsh http delete urlacl url=http://*:8765/ >>"%SETUP_LOG%" 2>&1
 netsh http delete urlacl url=http://+:8765/ >>"%SETUP_LOG%" 2>&1
-netsh http add urlacl url=http://+:8765/ sddl=D:(A;;GX;;;WD) >>"%SETUP_LOG%" 2>&1
+netsh http add urlacl url=http://+:8765/ sddl="D:(A;;GX;;;WD)" >>"%SETUP_LOG%" 2>&1
 echo [agent-install] urlacl add rc=%ERRORLEVEL%>>"%SETUP_LOG%"
 netsh http show urlacl url=http://+:8765/ >>"%SETUP_LOG%" 2>&1
 echo [agent-install] step=urlacl status=exit>>"%SETUP_LOG%"

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -17,8 +17,7 @@
 
 - **`media_monitor.ps1`가 이제 게스트에 전달됨** (#613). first-boot 게스트 스크립트 중 유일하게 OEM 번들에 포함되지 않아 dockur가 `C:\OEM\`로 스테이징하지 못했고, `install.bat`도 찾지 못했습니다 — 찾던 `C:\winpodx-scripts` 마운트는 구현된 적이 없고, `\\tsclient` 폴백은 dockur 무인 first-boot(아직 RDP 세션 없음)에는 사용할 수 없습니다. 그 결과 모든 설치에서 `media_monitor.ps1 not found` 경고가 뜨고 USB 미디어 자동 매핑이 등록되지 않았습니다. 이제 다른 게스트 스크립트처럼 `config/oem/`로 배송되어 first-boot에 `C:\OEM\`에서 복사됩니다.
 - **`usbredirect not found` 안내가 배포판별로 올바른 패키지를 안내** (#593, @techabsol 기여 감사). Debian/Ubuntu는 `usbredirect`, Fedora는 `usbredir-tools`(Atomic Fedora는 `rpm-ostree` 형태 추가), openSUSE는 `usbredir` 유지 — 기존 메시지는 바이너리가 들어있지 않은 패키지를 안내했습니다.
-
-## [0.7.2] - 2026-06-15
+- **`install.bat`가 에이전트 URL 예약 시 더 이상 구문 오류를 내지 않음** (#614, @zephir2008 기여 감사). `netsh http add urlacl … sddl=D:(A;;GX;;;WD)` 줄에서 SDDL 값을 따옴표로 감싸지 않아 `cmd.exe`가 `(`, `;`, `)`를 메타문자로 해석(`")" was unexpected`)하여 예약이 실패했고 — 게스트 에이전트가 8765 포트를 바인딩하지 못할 수 있었습니다. 이제 SDDL 값을 따옴표로 감쌉니다.
 
 ### Fixed
 


### PR DESCRIPTION
## Problem (#614, reported by @zephir2008)

`c:\OEM\install.bat` logs a syntax error on the agent URL reservation:

```
netsh http add urlacl url=http://+:8765/ sddl=D:(A;;GX;;;WD) >>"%SETUP_LOG%" 2>&1
```

The `sddl=D:(A;;GX;;;WD)` value is unquoted, so `cmd.exe` parses its `(`, `;`, and `)` as metacharacters and the line fails with `")" was unexpected at this time`. The urlacl reservation is never created, which can leave the guest agent unable to bind `http://+:8765/`.

## Fix

Quote the SDDL value:

```
netsh http add urlacl url=http://+:8765/ sddl="D:(A;;GX;;;WD)" >>"%SETUP_LOG%" 2>&1
```

netsh strips the quotes and receives the identical descriptor `D:(A;;GX;;;WD)`; the quotes only stop `cmd.exe` from treating the parens/semicolons as syntax. The SDDL form itself (added in #269/#506) is unchanged. The neighbouring `netsh http delete` lines have no special characters and are unaffected.

CHANGELOG `[Unreleased]` updated (EN + KO).