### PR TITLE
fix(gui): give the maintenance task dialog a comfortable size floor (#550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 - **`install.sh --win-iso <path>` installs from a local Windows ISO instead of downloading** (#647, thanks @ismikes). Point the installer at a Windows ISO you already have and it's staged into the storage dir as dockur's `custom.iso`, so the install skips the ~5-8 GB Microsoft download — handy for repeated purge/reinstall cycles. Reflink-copied where the filesystem supports it (btrfs/xfs), so it costs no extra disk. (You could already drop a `custom.iso` into the storage dir by hand; this wires it to a flag and documents it in `--help`.)
 
+### Fixed
+
+- **The maintenance task dialog (Debloat, Grow Disk, Sync Guest, …) no longer opens cramped** (#550, thanks @ismikes). The `BusyDialog` progress window had only a 380px minimum width and sized its height to content, so it came up around 392×139 — too small to read comfortably, most visibly on the Debloat *Speed* run. Given a 480×168 floor. (The picker-window size and the fast-op auto-close were already addressed in 0.7.2.)
+
 ## [0.7.3] - 2026-06-20
 
 ### Added

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -13,6 +13,10 @@
 
 - **`install.sh --win-iso <path>`로 다운로드 대신 로컬 Windows ISO에서 설치** (#647, @ismikes 기여 감사). 이미 가진 Windows ISO 경로를 넘기면 storage 디렉터리에 dockur의 `custom.iso`로 스테이징돼 ~5-8 GB Microsoft 다운로드를 건너뜁니다 — 반복 purge/reinstall 사이클에 유용. 파일시스템이 지원하면(btrfs/xfs) reflink 복사라 추가 디스크 비용 없음. (직접 storage에 `custom.iso`를 둘 수도 있었지만, 이걸 플래그로 연결하고 `--help`에 문서화함.)
 
+### Fixed
+
+- **유지보수 작업 다이얼로그(Debloat, Grow Disk, Sync Guest 등)가 더 이상 비좁게 열리지 않음** (#550, @ismikes 기여 감사). `BusyDialog` 진행 창이 최소 너비 380px에 높이는 내용에 맞춰져 약 392×139로 떠 읽기에 너무 작았습니다(특히 Debloat *Speed* 실행). 480×168 하한 부여. (picker 창 크기와 빠른 작업 자동 닫힘은 0.7.2에서 이미 처리됨.)
+
 ## [0.7.3] - 2026-06-20
 
 ### Added

--- a/src/winpodx/gui/_widget_helpers.py
+++ b/src/winpodx/gui/_widget_helpers.py
@@ -345,7 +345,10 @@ class BusyDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle(title)
         self.setModal(True)
-        self.setMinimumWidth(380)
+        # #550: the old 380-wide / content-height dialog opened cramped (the
+        # debloat task window was ~392x139). Give it a comfortable floor so the
+        # message + progress bar + ETA hint aren't squeezed.
+        self.setMinimumSize(480, 168)
         self.setStyleSheet(DIALOG)
         self._cancel_cbs: list[Callable[[], None]] = []
 


### PR DESCRIPTION
## #550 — Debloat task window opens too small

Two-part report from @ismikes. The **picker** window size and the fast-op **auto-close** were already fixed in 0.7.2 (@ismikes confirmed the picker; the auto-close race fix — defer the worker-thread start so a sub-`exec()` `finish()` isn't a no-op — landed after their 2026-06-14 comment). This PR is the **remaining half**: the task/progress window opened cramped.

### What
`BusyDialog` (the modal progress window behind Debloat / Grow Disk / Sync Guest / …) had only `setMinimumWidth(380)` and let its height size to content, so it came up ~392×139 — too small to read comfortably, most visibly on the Debloat *Speed* run. Given a **480×168** floor (`setMinimumSize`).

### Test
`ruff` clean; instantiated `BusyDialog` under `QT_QPA_PLATFORM=offscreen` and verified `minimumSize == 480×168` and the `finish()`→`accept()` auto-close path is intact. GUI-only, host-side — no guest change.

Note for @ismikes: the auto-close should already work on 0.7.2+/0.7.3 (your comment predates that fix) — worth re-confirming alongside the larger window.