### PR TITLE
feat(setup): default the VM to 8 GB RAM on 24 GB+ hosts (#630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
+- **Fresh installs on a 24 GB+ host now default the VM to 8 GB RAM instead of 6** (#630, thanks @ismikes). Windows 11 runs noticeably smoother with 8 GB, and a host with ≥24 GB can spare it — the auto-tier that pre-fills `pod.ram_gb` during `winpodx setup` bumps the mid tier from 6 to 8 GB on those hosts (CPU sizing unchanged; ≥32 GB / ≥12-thread hosts still get the 12 GB high tier). Existing installs keep your configured value; change it any time in Settings or with `winpodx config set pod.ram_gb 8`.
 - **`install.sh --win-iso <path>` installs from a local Windows ISO instead of downloading** (#647, thanks @ismikes). Point the installer at a Windows ISO you already have and it's staged into the storage dir as dockur's `custom.iso`, so the install skips the ~5-8 GB Microsoft download — handy for repeated purge/reinstall cycles. Reflink-copied where the filesystem supports it (btrfs/xfs), so it costs no extra disk. (You could already drop a `custom.iso` into the storage dir by hand; this wires it to a flag and documents it in `--help`.)
 
 ### Fixed

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -11,6 +11,7 @@
 
 ### Added
 
+- **24GB+ 호스트의 신규 설치는 VM RAM 기본값이 6 대신 8GB** (#630, @ismikes 기여 감사). Windows 11은 8GB에서 눈에 띄게 부드럽고, ≥24GB 호스트는 이를 감당할 수 있습니다 — `winpodx setup`이 `pod.ram_gb`를 미리 채우는 auto-tier가 해당 호스트에서 mid 티어를 6→8GB로 올립니다(CPU 사이징 불변; ≥32GB/≥12스레드는 여전히 12GB high 티어). 기존 설치는 설정값 유지 — Settings 또는 `winpodx config set pod.ram_gb 8`로 언제든 변경.
 - **`install.sh --win-iso <path>`로 다운로드 대신 로컬 Windows ISO에서 설치** (#647, @ismikes 기여 감사). 이미 가진 Windows ISO 경로를 넘기면 storage 디렉터리에 dockur의 `custom.iso`로 스테이징돼 ~5-8 GB Microsoft 다운로드를 건너뜁니다 — 반복 purge/reinstall 사이클에 유용. 파일시스템이 지원하면(btrfs/xfs) reflink 복사라 추가 디스크 비용 없음. (직접 storage에 `custom.iso`를 둘 수도 있었지만, 이걸 플래그로 연결하고 `--help`에 문서화함.)
 
 ### Fixed

--- a/src/winpodx/utils/specs.py
+++ b/src/winpodx/utils/specs.py
@@ -12,7 +12,8 @@ Tier policy (deliberate, not auto-derived):
 
     Host RAM      Host CPU      Tier   VM CPU   VM RAM
     >=32 GB       >=12 thr      high     8       12 GB
-    16-32 GB       6-12 thr     mid      4        6 GB
+    24-32 GB       6-12 thr     mid      4        8 GB   (#630)
+    16-24 GB       6-12 thr     mid      4        6 GB
     <16 GB         <6 thr       low      2        4 GB
 
 Both axes must clear the threshold to land in mid/high — a 64 GB
@@ -23,7 +24,7 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 log = logging.getLogger(__name__)
@@ -82,6 +83,11 @@ def recommend_tier(specs: HostSpecs) -> TierPreset:
     if specs.ram_gb >= 32 and specs.cpu_threads >= 12:
         return _TIER_HIGH
     if specs.ram_gb >= 16 and specs.cpu_threads >= 6:
+        # #630: Windows 11 runs noticeably better with 8 GB, and a host with
+        # >=24 GB can spare it while still leaving the host comfortable. Bump
+        # the mid VM from 6 to 8 GB on those hosts (CPU tier unchanged).
+        if specs.ram_gb >= 24:
+            return replace(_TIER_MID, ram_gb=8)
         return _TIER_MID
     return _TIER_LOW
 

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -24,10 +24,21 @@ class TestRecommendTier:
         assert t.ram_gb == 12
 
     def test_mid_when_both_axes_clear_mid(self):
-        t = recommend_tier(HostSpecs(cpu_threads=8, ram_gb=24))
+        t = recommend_tier(HostSpecs(cpu_threads=8, ram_gb=20))
         assert t.name == "mid"
         assert t.cpu_cores == 4
         assert t.ram_gb == 6
+
+    def test_mid_bumps_to_8gb_at_24gb_host(self):
+        # #630: a >=24 GB host (still mid CPU tier) gets an 8 GB VM instead of
+        # 6 — Windows 11 runs better with 8 GB and the host can spare it.
+        for ram in (24, 28, 31):
+            t = recommend_tier(HostSpecs(cpu_threads=8, ram_gb=ram))
+            assert t.name == "mid", ram
+            assert t.cpu_cores == 4, ram
+            assert t.ram_gb == 8, ram
+        # Just under 24 GB stays at 6.
+        assert recommend_tier(HostSpecs(cpu_threads=8, ram_gb=23)).ram_gb == 6
 
     def test_low_for_small_machines(self):
         t = recommend_tier(HostSpecs(cpu_threads=2, ram_gb=8))


### PR DESCRIPTION
## #630 — bump the VM to 8 GB on 24 GB+ hosts

@ismikes: Windows 11 runs better with 8 GB, and a host with ≥24 GB can spare it — auto-size for it instead of making the user figure out the config.

### What
winpodx already has a host-adaptive tier (`specs.recommend_tier`) that `winpodx setup` uses to pre-fill `pod.cpu_cores` / `pod.ram_gb`. The whole 16–32 GB mid band mapped to a **6 GB** VM. Now:

| Host RAM | CPU | VM CPU | VM RAM |
|----------|-----|--------|--------|
| ≥32 GB | ≥12 thr | 8 | 12 GB |
| **24–32 GB** | 6–12 thr | 4 | **8 GB** ← #630 |
| 16–24 GB | 6–12 thr | 4 | 6 GB |
| <16 GB | <6 thr | 2 | 4 GB |

CPU sizing is unchanged. **Default-on** (no flag — it just makes `setup`'s pre-filled default smarter, per the project's defaults policy). **Existing installs are untouched** — this only changes what a *fresh* setup pre-fills; any value you configured is preserved (and editable in Settings / `winpodx config set pod.ram_gb 8`).

I skipped @ismikes's alternative (prompt during *migration* if currently 6) — winpodx avoids mid-flow yes/no prompts, and silently raising an existing user's RAM would be surprising.

### Test
`test_specs` extended: 24 / 28 / 31 GB hosts → 8 GB, 23 GB → 6 GB, high/low tiers unchanged. `pytest tests/test_specs.py` green, ruff clean. Host-side default — no guest change.