### PR TITLE
fix(deb): Recommends podman-compose + loud error on missing compose provider (#644)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed
 
+- **The Debian/Ubuntu `.deb` now pulls in `podman-compose`, and a missing compose provider fails loudly instead of cryptically** (#644, thanks @paolodongilli). On Debian 13 the `.deb` installed winpodx + podman but not `podman-compose`, so `winpodx setup` couldn't create the container and died downstream with `no such container "winpodx-windows"`. `podman-compose` is now a package `Recommends` (apt installs it by default), and if no compose provider is present at setup time winpodx prints an actionable error naming the package to install per distro instead of silently skipping container creation. (The `curl … install.sh` path already installed it — this closes the `.deb` gap.)
 - **The maintenance task dialog (Debloat, Grow Disk, Sync Guest, …) no longer opens cramped** (#550, thanks @ismikes). The `BusyDialog` progress window had only a 380px minimum width and sized its height to content, so it came up around 392×139 — too small to read comfortably, most visibly on the Debloat *Speed* run. Given a 480×168 floor. (The picker-window size and the fast-op auto-close were already addressed in 0.7.2.)
 
 ## [0.7.3] - 2026-06-20

--- a/debian/control
+++ b/debian/control
@@ -27,6 +27,7 @@ Depends:
  freerdp-x11 | freerdp3-x11 | freerdp2-x11
 Recommends:
  podman,
+ podman-compose,
  python3-pyside6.qtcore,
  python3-pyside6.qtgui,
  python3-pyside6.qtwidgets,

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 
+- **Debian/Ubuntu `.deb`가 이제 `podman-compose`를 끌어오고, compose provider 누락 시 cryptic 대신 명확히 실패** (#644, @paolodongilli 기여 감사). Debian 13에서 `.deb`가 winpodx + podman은 깔아도 `podman-compose`는 안 깔아 `winpodx setup`이 컨테이너를 못 만들고 나중에 `no such container "winpodx-windows"`로 죽었습니다. 이제 `podman-compose`가 패키지 `Recommends`(apt 기본 설치)이고, setup 시점에 compose provider가 없으면 배포판별 설치 패키지명을 알려주는 실행가능 에러를 출력합니다(조용히 건너뛰지 않음). (`curl … install.sh` 경로는 이미 설치했음 — `.deb` 빈틈을 메움.)
 - **유지보수 작업 다이얼로그(Debloat, Grow Disk, Sync Guest 등)가 더 이상 비좁게 열리지 않음** (#550, @ismikes 기여 감사). `BusyDialog` 진행 창이 최소 너비 380px에 높이는 내용에 맞춰져 약 392×139로 떠 읽기에 너무 작았습니다(특히 Debloat *Speed* 실행). 480×168 하한 부여. (picker 창 크기와 빠른 작업 자동 닫힘은 0.7.2에서 이미 처리됨.)
 
 ## [0.7.3] - 2026-06-20

--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -1060,7 +1060,32 @@ def _recreate_container(cfg: Config) -> None:
             compose_cmd = ["docker", "compose"]
 
     if not compose_cmd:
-        print(tr("Compose command not found, skipping container recreation."))
+        # No compose provider → the container is never created, and setup later
+        # fails with the cryptic `no such container "winpodx-windows"` (#644).
+        # Say so loudly + actionably instead of silently skipping.
+        if backend == "podman":
+            print(
+                tr(
+                    "ERROR: no compose provider found. winpodx creates the Windows "
+                    "container via compose, but neither `podman-compose` nor the "
+                    "`podman compose` plugin is installed, so the container can't be "
+                    "created (this is what later surfaces as "
+                    "'no such container \"winpodx-windows\"', #644).\n"
+                    "  Install it, then re-run `winpodx setup`:\n"
+                    "    Debian/Ubuntu:  sudo apt install podman-compose\n"
+                    "    Fedora:         sudo dnf install podman-compose\n"
+                    "    openSUSE:       sudo zypper install podman-compose\n"
+                    "    (fallback:      pipx install podman-compose)"
+                )
+            )
+        else:
+            print(
+                tr(
+                    "ERROR: no compose provider found for the docker backend. Install "
+                    "Docker Compose (the `docker compose` plugin or `docker-compose`), "
+                    "then re-run `winpodx setup`."
+                )
+            )
         return
 
     print(tr("\nRecreating container with new settings..."))


### PR DESCRIPTION
## #644 — Debian 13 .deb install fails with `no such container "winpodx-windows"`

@paolodongilli (Debian 13 trixie): after `apt install ./winpodx_*_debian13.deb` + `winpodx setup`, the container is never created and setup dies with `no such container "winpodx-windows"`. The fix was `apt install podman-compose`.

### Root cause
winpodx creates the Windows container via compose (prefers `podman-compose`, falls back to the `podman compose` plugin). **`podman-compose` was never in `debian/control`** — the `curl … install.sh` path installs it (#503), but the `.deb` only `Recommends: podman`. With no compose provider, `setup_cmd` hit `compose_cmd = None` and **silently** printed *"Compose command not found, skipping container recreation."* then returned — so the container wasn't created and the failure only surfaced later as the cryptic "no such container".

### Fix
- **`debian/control`**: add `podman-compose` to `Recommends` (apt installs Recommends by default, so `apt install ./...deb` now pulls it). Kept as Recommends, not Depends — the backend is user-choosable (podman/docker).
- **`setup_cmd`**: when no compose provider is found, print an **actionable** per-distro install hint (apt / dnf / zypper / pipx) referencing #644, instead of silently skipping.

### Test
ruff + setup_cmd import clean; verified the new error strings render. Host-side (`.deb` metadata + a setup message) — no guest change. A real `.deb`-on-Debian-13 install is the confirming smoke (the reporter's repro).