### PR TITLE
fix(reverse-open): self-heal the listener on app launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed
+
+- **The reverse-open listener now self-heals on app launch instead of staying dead until the next `pod start`.** A `winpodx pod stop` / tray Quit stops the listener (`stop_listener()`); while the pod kept running, nothing re-spawned the watcher, so "Open with → a Linux app" from Windows silently did nothing. `ensure_ready` (every `winpodx app run` / GUI launch) now idempotently ensures the listener is up when `reverse_open` is enabled. Surfaced during the v0.7.4 smoke.
+
 ## [0.7.4] - 2026-06-23
 
 ### Added

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **reverse-open 리스너가 다음 `pod start`까지 죽어있지 않고 앱 실행 시 자가복구됨.** `winpodx pod stop` / 트레이 Quit이 리스너를 멈추는데(`stop_listener()`), pod는 계속 돌고 있으면 watcher를 다시 띄우는 게 없어 Windows의 "연결 프로그램 → Linux 앱"이 조용히 무반응이었습니다. 이제 `ensure_ready`(모든 `winpodx app run` / GUI 실행)가 `reverse_open` 활성 시 리스너를 idempotent하게 보장합니다. v0.7.4 스모크 중 발견.
+
 ## [0.7.4] - 2026-06-23
 
 ### Added

--- a/src/winpodx/cli/host_open.py
+++ b/src/winpodx/cli/host_open.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import re
 import sys
 from dataclasses import asdict
@@ -54,6 +55,8 @@ from winpodx.reverse_open.lifecycle import (
 )
 from winpodx.reverse_open.listener import ListenerConfig
 from winpodx.utils.paths import data_dir
+
+log = logging.getLogger(__name__)
 
 _SLUG_VALIDATE = re.compile(r"^[a-z0-9-]+$")
 
@@ -130,6 +133,34 @@ def _listener_config(cfg: Config) -> ListenerConfig:
         # the listener can open guest-local files (#616, origin="guest").
         guest_mount=lambda: ensure_guest_mount(cfg),
     )
+
+
+def ensure_listener_running(cfg: Config) -> str:
+    """Self-heal: start the reverse-open listener if it should be up but isn't.
+
+    Idempotent. Used by ``pod start``, the app-launch path (``ensure_ready``),
+    and the CLI so the listener doesn't stay dead after a ``pod stop`` / tray
+    Quit ``stop_listener()`` while the pod keeps running (which silently breaks
+    "Open with → Linux app" until the next ``pod start``).
+
+    Quiet — logs only; returns ``"disabled"`` (feature off), ``"running"``
+    (already up), ``"started"`` (newly spawned), or ``"failed"`` so callers can
+    surface their own user-facing message off the return value.
+    """
+    if not getattr(cfg.reverse_open, "enabled", False):
+        return "disabled"
+    if is_listener_running() is not None:
+        return "running"
+    listener_cfg = _listener_config(cfg)
+    try:
+        listener_cfg.incoming_dir.mkdir(parents=True, exist_ok=True)
+        listener_cfg.incoming_dir.chmod(0o700)
+        pid = start_listener(listener_cfg, _apps_json(), _seen_uuids_path())
+        log.info("reverse-open listener self-healed: started (pid %s)", pid)
+        return "started"
+    except (ListenerStartFailed, OSError) as exc:
+        log.warning("reverse-open listener self-heal failed: %s", exc)
+        return "failed"
 
 
 def _filter_apps(apps: list[LinuxApp], cfg: Config) -> tuple[list[LinuxApp], list[tuple[str, str]]]:

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -137,34 +137,17 @@ def _start(wait: bool, timeout: int, tuning_override: str | None = None) -> None
 
 
 def _maybe_start_reverse_open_listener(cfg) -> None:  # type: ignore[no-untyped-def]
-    if not getattr(cfg.reverse_open, "enabled", False):
-        return
     try:
-        from winpodx.cli.host_open import (
-            _apps_json,
-            _listener_config,
-            _seen_uuids_path,
-        )
-        from winpodx.reverse_open.lifecycle import (
-            ListenerStartFailed,
-            is_listener_running,
-            start_listener,
-        )
+        from winpodx.cli.host_open import ensure_listener_running
     except Exception:  # noqa: BLE001 — import surface should never break pod start
         return
-    if is_listener_running() is not None:
-        return
-    listener_cfg = _listener_config(cfg)
-    try:
-        listener_cfg.incoming_dir.mkdir(parents=True, exist_ok=True)
-        listener_cfg.incoming_dir.chmod(0o700)
-        pid = start_listener(listener_cfg, _apps_json(), _seen_uuids_path())
-        print(tr("  reverse-open listener: started (pid {pid})").format(pid=pid))
-    except (ListenerStartFailed, OSError) as exc:
-        print(
-            tr("  reverse-open listener: start failed ({error})").format(error=exc),
-            file=sys.stderr,
-        )
+    result = ensure_listener_running(cfg)
+    if result == "started":
+        from winpodx.reverse_open.lifecycle import is_listener_running
+
+        print(tr("  reverse-open listener: started (pid {pid})").format(pid=is_listener_running()))
+    elif result == "failed":
+        print(tr("  reverse-open listener: start failed (see log)"), file=sys.stderr)
 
 
 def _stop() -> None:

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -191,6 +191,17 @@ def ensure_ready(cfg: Config | None = None, timeout: int = 300) -> Config:
     # explicitly. ``ensure_ready`` stays cheap and side-effect-free.
     _ensure_desktop_entries()
 
+    # Self-heal the reverse-open listener: a `pod stop` / tray Quit calls
+    # stop_listener(), so a pod-running-but-listener-dead state silently breaks
+    # "Open with → Linux app" until the next `pod start`. Launching any app
+    # now revives it. Best-effort + idempotent — never blocks the launch.
+    try:
+        from winpodx.cli.host_open import ensure_listener_running
+
+        ensure_listener_running(cfg)
+    except Exception as e:  # noqa: BLE001 — listener self-heal must never break a launch
+        log.debug("ensure_ready: reverse-open listener self-heal skipped: %s", e)
+
     return cfg
 
 

--- a/tests/test_cli_host_open.py
+++ b/tests/test_cli_host_open.py
@@ -339,3 +339,62 @@ def test_refresh_signals_running_daemon(capsys: pytest.CaptureFixture[str]) -> N
     finally:
         cli_main(["host-open", "stop-listener"])
         capsys.readouterr()
+
+
+class TestEnsureListenerRunning:
+    """`ensure_listener_running` self-heal (0.7.5) — listener revived after a
+    pod stop / tray Quit stop_listener() while the pod keeps running."""
+
+    def test_disabled_when_feature_off(self):
+        from winpodx.cli.host_open import ensure_listener_running
+
+        cfg = Config()
+        cfg.reverse_open.enabled = False
+        assert ensure_listener_running(cfg) == "disabled"
+
+    def test_running_when_already_up(self, monkeypatch):
+        import winpodx.cli.host_open as ho
+
+        monkeypatch.setattr(ho, "is_listener_running", lambda *a, **k: 4321)
+        started = {"n": 0}
+        monkeypatch.setattr(ho, "start_listener", lambda *a, **k: started.__setitem__("n", 1))
+        cfg = Config()
+        cfg.reverse_open.enabled = True
+        assert ho.ensure_listener_running(cfg) == "running"
+        assert started["n"] == 0  # must NOT spawn a second listener
+
+    def test_started_when_down(self, monkeypatch, tmp_path):
+        import winpodx.cli.host_open as ho
+
+        monkeypatch.setattr(ho, "is_listener_running", lambda *a, **k: None)
+        monkeypatch.setattr(
+            ho, "_listener_config", lambda _cfg: type("LC", (), {"incoming_dir": tmp_path / "in"})()
+        )
+        monkeypatch.setattr(ho, "_apps_json", lambda: tmp_path / "apps.json")
+        monkeypatch.setattr(ho, "_seen_uuids_path", lambda: tmp_path / "seen")
+        spawned = []
+        monkeypatch.setattr(ho, "start_listener", lambda *a, **k: spawned.append(a) or 9999)
+        cfg = Config()
+        cfg.reverse_open.enabled = True
+        assert ho.ensure_listener_running(cfg) == "started"
+        assert len(spawned) == 1
+        assert (tmp_path / "in").is_dir()  # incoming dir created
+
+    def test_failed_when_start_raises(self, monkeypatch, tmp_path):
+        import winpodx.cli.host_open as ho
+        from winpodx.reverse_open.lifecycle import ListenerStartFailed
+
+        monkeypatch.setattr(ho, "is_listener_running", lambda *a, **k: None)
+        monkeypatch.setattr(
+            ho, "_listener_config", lambda _cfg: type("LC", (), {"incoming_dir": tmp_path / "in"})()
+        )
+        monkeypatch.setattr(ho, "_apps_json", lambda: tmp_path / "apps.json")
+        monkeypatch.setattr(ho, "_seen_uuids_path", lambda: tmp_path / "seen")
+
+        def _boom(*a, **k):
+            raise ListenerStartFailed("boom")
+
+        monkeypatch.setattr(ho, "start_listener", _boom)
+        cfg = Config()
+        cfg.reverse_open.enabled = True
+        assert ho.ensure_listener_running(cfg) == "failed"


### PR DESCRIPTION
## Why

Surfaced during the v0.7.4 smoke: "Open with → a Linux app" from Windows suddenly did nothing. Root cause — a `winpodx pod stop` / tray Quit calls `stop_listener()` (pod.py), and while the pod keeps running **nothing re-spawns the reverse-open watcher**, so requests pile up in the incoming dir unprocessed until the next `pod start`. There was no continuous supervision.

## What

- **`cli/host_open.py`**: new reusable **`ensure_listener_running(cfg)`** — idempotent (checks `is_listener_running()`, starts only if down), quiet (logs only), returns `disabled` / `running` / `started` / `failed`.
- **`cli/pod.py`**: `_maybe_start_reverse_open_listener` now delegates to it (DRY; keeps its user-facing print off the return value).
- **`core/provisioner.py` → `ensure_ready`**: best-effort call (lazy import, matches the existing `_run_reverse_open` core→cli precedent) so **every `winpodx app run` / GUI launch revives a dead listener** when `reverse_open` is enabled. Wrapped so it never blocks a launch.

Covers: the common interactive flow (launch an app → listener ensured) + the existing `pod start` revival. Continuous tray supervision is a possible further enhancement but out of scope.

## Test

New `TestEnsureListenerRunning`: disabled (feature off), running (already up → **no double-spawn**), started (down → spawned + incoming dir created), failed (start raises → `failed`). `test_reverse_open_lifecycle` + the new class green (19 passed), ruff clean. Host-side only — no guest change.