### PR TITLE
fix(install): stage --win-iso before compose-up so dockur uses it (#647)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed
 
+- **`--win-iso` now actually installs from your ISO instead of downloading Windows anyway** (#647, thanks @ismikes). The local ISO was staged into `<storage>/custom.iso` *after* `winpodx setup` had already run `compose up` — so the container had booted and dockur had started its Microsoft download before the file existed (dockur looks for `custom.iso` the moment it boots). The staging now happens **inside `winpodx setup`**, after the storage path is resolved but **before the container is (re)created**, so dockur finds the ISO and installs from it. Also exposed as `winpodx setup --win-iso <path>`.
 - **The reverse-open listener now self-heals on app launch instead of staying dead until the next `pod start`.** A `winpodx pod stop` / tray Quit stops the listener (`stop_listener()`); while the pod kept running, nothing re-spawned the watcher, so "Open with → a Linux app" from Windows silently did nothing. `ensure_ready` (every `winpodx app run` / GUI launch) now idempotently ensures the listener is up when `reverse_open` is enabled. Surfaced during the v0.7.4 smoke.
 
 ## [0.7.4] - 2026-06-23

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- **`--win-iso`가 이제 다운로드 대신 실제로 그 ISO에서 설치함** (#647, @ismikes 기여 감사). 로컬 ISO가 `winpodx setup`이 이미 `compose up`을 돌린 *뒤*에 `<storage>/custom.iso`로 스테이징돼서, 컨테이너가 이미 부팅되고 dockur가 Microsoft 다운로드를 시작한 다음에야 파일이 생겼습니다(dockur는 부팅 순간 `custom.iso`를 찾음). 이제 스테이징이 **`winpodx setup` 내부**에서 storage 경로 확정 후 **컨테이너 (재)생성 전**에 일어나, dockur가 ISO를 찾아 설치합니다. `winpodx setup --win-iso <path>`로도 노출.
 - **reverse-open 리스너가 다음 `pod start`까지 죽어있지 않고 앱 실행 시 자가복구됨.** `winpodx pod stop` / 트레이 Quit이 리스너를 멈추는데(`stop_listener()`), pod는 계속 돌고 있으면 watcher를 다시 띄우는 게 없어 Windows의 "연결 프로그램 → Linux 앱"이 조용히 무반응이었습니다. 이제 `ensure_ready`(모든 `winpodx app run` / GUI 실행)가 `reverse_open` 활성 시 리스너를 idempotent하게 보장합니다. v0.7.4 스모크 중 발견.
 
 ## [0.7.4] - 2026-06-23

--- a/install.sh
+++ b/install.sh
@@ -1455,6 +1455,12 @@ else
         SETUP_ARGS+=(--storage-path "$WINPODX_STORAGE_DIR")
         log "Storage location: $WINPODX_STORAGE_DIR"
     fi
+    # #647: hand the local ISO to setup so it stages <storage>/custom.iso
+    # BEFORE compose-up (dockur needs it present when the container boots).
+    if [ -n "$WINPODX_WIN_ISO" ]; then
+        SETUP_ARGS+=(--win-iso "$WINPODX_WIN_ISO")
+        log "Local Windows ISO: $WINPODX_WIN_ISO"
+    fi
     # Persist the resolved FreeRDP source so the launcher honours it
     # (cfg.rdp.freerdp_source). Skip "auto" — that's the default.
     if [ -n "${WINPODX_FREERDP_SOURCE:-}" ] && [ "$WINPODX_FREERDP_SOURCE" != "auto" ]; then
@@ -1467,36 +1473,10 @@ else
     WINPODX_NO_PROVISION=1 "$VENV_PY" -m winpodx setup "${SETUP_ARGS[@]}" 2>/dev/null || true
 fi
 
-# --- Stage a user-provided Windows ISO (--win-iso, #647) ---
-# dockur installs from `<storage>/custom.iso` if present, skipping the
-# ~5-8 GB Microsoft download. Runs after setup (which has written the config
-# + storage_path) and before `winpodx provision` (which triggers the boot).
-# Reflink-copy where the filesystem supports it (btrfs/xfs → no extra space),
-# plain copy otherwise.
-if [ -n "$WINPODX_WIN_ISO" ] && [ -z "$WINPODX_MANUAL" ]; then
-    WIN_ISO_STORAGE="$("$VENV_PY" -c 'import os
-from winpodx.core.config import Config
-p = Config.load().pod.storage_path
-print(os.path.expanduser(p) if p else "")' 2>/dev/null)"
-    if [ -z "$WIN_ISO_STORAGE" ]; then
-        log "WARNING: --win-iso needs the bind-mount storage layout, but this install uses the legacy named volume."
-        log "         Run 'winpodx setup --migrate-storage' once, then re-run with --win-iso. Continuing with the normal download."
-    else
-        mkdir -p "$WIN_ISO_STORAGE"
-        WIN_ISO_DST="$WIN_ISO_STORAGE/custom.iso"
-        if [ "$WINPODX_WIN_ISO" -ef "$WIN_ISO_DST" ]; then
-            log "Local ISO already in place: $WIN_ISO_DST (skipping copy)"
-        else
-            log "Staging local ISO -> $WIN_ISO_DST (skipping Microsoft download)..."
-            if ! cp --reflink=auto "$WINPODX_WIN_ISO" "$WIN_ISO_DST" 2>/dev/null \
-                && ! cp "$WINPODX_WIN_ISO" "$WIN_ISO_DST"; then
-                err "Failed to stage --win-iso into $WIN_ISO_DST"
-                exit 1
-            fi
-            log "  Local ISO staged ($(du -h "$WIN_ISO_DST" 2>/dev/null | cut -f1)); dockur will install from it."
-        fi
-    fi
-fi
+# NOTE: --win-iso staging now happens INSIDE `winpodx setup` (passed via
+# SETUP_ARGS above), before compose-up, so dockur finds custom.iso when the
+# container boots (#647). It used to be staged here, after setup had already
+# started the container + dockur had begun downloading — too late.
 
 # --- Install winpodx GUI desktop entry & icon ---
 mkdir -p "$DESKTOP_DIR" "$ICON_DIR"

--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -476,6 +476,17 @@ def cli(argv: list[str] | None = None) -> None:
         ),
     )
     setup_p.add_argument(
+        "--win-iso",
+        metavar="PATH",
+        help=(
+            "Install from a local Windows ISO at PATH instead of downloading "
+            "from Microsoft (#647). Staged into the storage dir as dockur's "
+            "`custom.iso` BEFORE the container boots so dockur installs from "
+            "it. Reflink-copied where the filesystem supports it. Fresh "
+            "installs only (needs the bind-mount storage layout)."
+        ),
+    )
+    setup_p.add_argument(
         "--yes",
         "-y",
         action="store_true",

--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -319,6 +319,53 @@ def _decide_storage_mode(
         print(tr("  Host storage is an SSD — the Windows disk will emulate SSD (TRIM, no defrag)."))
 
 
+def _stage_win_iso(cfg: Config, iso_path: str | None) -> None:
+    """Stage a user-provided Windows ISO as dockur's ``<storage>/custom.iso`` (#647).
+
+    MUST run after :func:`_decide_storage_mode` (so ``storage_path`` is
+    resolved) and BEFORE ``_recreate_container`` does ``compose up`` — dockur's
+    ``findFile()`` looks for ``custom.iso`` the moment the container boots, so
+    the ISO has to already be in place or dockur downloads Windows anyway
+    (the #647 bug: install.sh staged it *after* the container had started).
+
+    Reflink-copies where the filesystem supports it (btrfs/xfs → instant, no
+    extra space). No-op on the legacy named-volume layout (no host storage dir).
+    """
+    if not iso_path:
+        return
+    import shutil
+    import subprocess
+
+    src = Path(iso_path).expanduser()
+    if not src.is_file():
+        print(tr("--win-iso: no such file: {path}").format(path=src))
+        return
+    storage = (cfg.pod.storage_path or "").strip()
+    if not storage:
+        print(
+            tr(
+                "--win-iso: needs the bind-mount storage layout — the legacy named "
+                "volume has no host directory to stage into. Run "
+                "`winpodx setup --migrate-storage` first. Skipping (Windows will download)."
+            )
+        )
+        return
+    storage_dir = Path(storage).expanduser()
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    dst = storage_dir / "custom.iso"
+    if src.resolve() == dst.resolve():
+        print(tr("--win-iso: already staged at {dst}").format(dst=dst))
+        return
+    print(tr("Staging local ISO → {dst} (dockur installs from it; no download)…").format(dst=dst))
+    try:
+        # reflink where supported (btrfs/xfs); falls back to a full copy.
+        subprocess.run(["cp", "--reflink=auto", str(src), str(dst)], check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        shutil.copyfile(src, dst)
+    gib = dst.stat().st_size / (1024**3)
+    print(tr("  Local ISO staged ({gib:.1f} GB).").format(gib=gib))
+
+
 def _handle_migrate_storage(args: argparse.Namespace) -> int:
     """Move storage from the legacy ``winpodx-data`` named volume to a host
     bind mount, applying ``chattr +C`` automatically on btrfs.
@@ -887,6 +934,12 @@ def handle_setup(args: argparse.Namespace) -> None:
         _decide_storage_mode(
             cfg, non_interactive=non_interactive, explicit_target=_explicit_storage
         )
+
+        # Stage a user-provided ISO into <storage>/custom.iso BEFORE compose up
+        # so dockur picks it up instead of downloading Windows (#647). Must come
+        # after _decide_storage_mode (storage_path resolved) + before
+        # _recreate_container below.
+        _stage_win_iso(cfg, getattr(args, "win_iso", None))
 
         # #395: bail out with an actionable message if the selected backend's
         # daemon isn't reachable, rather than letting compose fail with a

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -485,3 +485,71 @@ class TestDecideStorageModeExplicitTarget:
         _decide_storage_mode(cfg, non_interactive=True, explicit_target=Path(tmp_path / "other"))
         # An already-configured install isn't relocated here (that's --migrate-storage).
         assert cfg.pod.storage_path == "/existing/storage"
+
+
+class TestStageWinIso:
+    """`_stage_win_iso` — #647: stage <storage>/custom.iso before compose-up."""
+
+    def _iso(self, tmp_path):
+        from pathlib import Path
+
+        p = Path(tmp_path) / "win.iso"
+        p.write_bytes(b"0" * 4096)
+        return p
+
+    def test_none_path_is_noop(self, tmp_path):
+        from winpodx.cli.setup_cmd import _stage_win_iso
+        from winpodx.core.config import Config
+
+        cfg = Config()
+        cfg.pod.storage_path = str(tmp_path / "storage")
+        _stage_win_iso(cfg, None)
+        assert not (tmp_path / "storage" / "custom.iso").exists()
+
+    def test_stages_to_custom_iso(self, tmp_path):
+        from pathlib import Path
+
+        from winpodx.cli.setup_cmd import _stage_win_iso
+        from winpodx.core.config import Config
+
+        iso = self._iso(tmp_path)
+        cfg = Config()
+        cfg.pod.storage_path = str(tmp_path / "storage")
+        _stage_win_iso(cfg, str(iso))
+        dst = Path(tmp_path) / "storage" / "custom.iso"
+        assert dst.is_file()
+        assert dst.read_bytes() == iso.read_bytes()
+
+    def test_no_storage_path_skips(self, tmp_path):
+        from winpodx.cli.setup_cmd import _stage_win_iso
+        from winpodx.core.config import Config
+
+        iso = self._iso(tmp_path)
+        cfg = Config()
+        cfg.pod.storage_path = ""  # legacy named-volume → no host dir
+        _stage_win_iso(cfg, str(iso))  # must not raise
+        # nothing to assert beyond "no crash"; named-volume has no host dir
+
+    def test_missing_iso_skips(self, tmp_path):
+        from winpodx.cli.setup_cmd import _stage_win_iso
+        from winpodx.core.config import Config
+
+        cfg = Config()
+        cfg.pod.storage_path = str(tmp_path / "storage")
+        _stage_win_iso(cfg, str(tmp_path / "nope.iso"))  # must not raise
+        assert not (tmp_path / "storage" / "custom.iso").exists()
+
+    def test_same_file_is_noop(self, tmp_path):
+        from pathlib import Path
+
+        from winpodx.cli.setup_cmd import _stage_win_iso
+        from winpodx.core.config import Config
+
+        storage = Path(tmp_path) / "storage"
+        storage.mkdir()
+        dst = storage / "custom.iso"
+        dst.write_bytes(b"0" * 4096)
+        cfg = Config()
+        cfg.pod.storage_path = str(storage)
+        _stage_win_iso(cfg, str(dst))  # src == dst → no error, no truncation
+        assert dst.read_bytes() == b"0" * 4096


### PR DESCRIPTION
## Root cause (verified against dockur v5.16)

`--win-iso` (v0.7.4) staged the local ISO into `<storage>/custom.iso` **after** `winpodx setup` had already run `compose up` — so the container booted and dockur started its Microsoft download **before the file existed**. dockur's `findFile()` (`/run/install.sh`) scans `/` then `/storage` for `custom.iso` *the moment it boots*, finds nothing, and downloads Windows. @ismikes' log shows the "Staging local ISO…" line printing **after** "Container started" (also reported as #663).

`/storage/custom.iso` is the correct path (confirmed in dockur's `findFile`) — the bug was purely **timing**.

## Fix

- **`setup_cmd._stage_win_iso(cfg, path)`** — runs **after** `_decide_storage_mode` (storage_path resolved) and **before** `_recreate_container` (`compose up`), copying the ISO to `<storage>/custom.iso` (reflink where the FS supports it). No-op on the legacy named-volume layout (no host dir); skips a missing/same file.
- **`winpodx setup --win-iso PATH`** (new arg) — setup now owns the staging + timing, so it works standalone too.
- **install.sh**: passes `--win-iso` through to setup (`SETUP_ARGS`); the old too-late post-setup staging block is removed.

## Test

`test_setup.py::TestStageWinIso` (5): none-path noop, stages to custom.iso, no-storage skip, missing-iso skip, same-file noop. ruff + `bash -n` clean.

⚠️ **Needs a real `--win-iso` install smoke on a host before release** (guest-side boot timing — can't fully verify in unit tests). The default download path is unchanged when `--win-iso` isn't passed.