### PR TITLE
test: make doctor _all_ok_legacy hermetic re: rootless subid (#659)

### DIFF
--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -464,6 +464,11 @@ def _all_ok_legacy(monkeypatch):
     monkeypatch.setattr(doctor, "_check_freerdp", lambda: Finding("ok", "frdp"))
     monkeypatch.setattr(doctor, "_check_kvm", lambda: Finding("ok", "kvm"))
     monkeypatch.setattr(doctor, "_check_container_backend", lambda: [Finding("ok", "be")])
+    # Stub the rootless subuid/subgid probe so the "all OK" path is independent
+    # of host /etc/subuid state. Hermetic build sandboxes (e.g. nix, #659) have
+    # no UID/GID mappings, so the real probe returns FAIL there -> handle_doctor
+    # sys.exit(1) -> these tests spuriously error and block the build.
+    monkeypatch.setattr(doctor, "_check_rootless_subid", lambda: Finding("ok", "subid"))
     monkeypatch.setattr(doctor, "_check_config_state", lambda: Finding("ok", "cfg"))
     monkeypatch.setattr(doctor, "_check_pending_setup", lambda: Finding("ok", "pending"))
     monkeypatch.setattr(doctor, "_check_autostart_entry", lambda: Finding("ok", "auto"))


### PR DESCRIPTION
Refs #659.

## Problem
Building winpodx in a hermetic sandbox (e.g. NixOS, which has no UID/GID
mappings — no `/etc/subuid`/`/etc/subgid`) fails the test suite and blocks
`nixos-rebuild`.

## Root cause
`tests/test_doctor.py::_all_ok_legacy` stubs every doctor check to OK **except**
`_check_rootless_subid`. `handle_doctor` (`cli/doctor.py:167`) still calls the
real probe, which returns FAIL when the host has no subuid/subgid entries for
the user → `handle_doctor` hits `sys.exit(1)` → the `TestHandleDoctorFix`
"all OK returns 0" tests spuriously error. Passes on dev/CI hosts that happen
to have subid configured; fails in isolated build environments.

## Fix
Stub `_check_rootless_subid` in `_all_ok_legacy` like the other checks, so the
all-OK path is independent of host `/etc/subuid` state. Test-only change; no
runtime code touched.

## Verification
`pytest tests/test_doctor.py` → 43 passed; `ruff check` + `ruff format --check`
clean.