### PR TITLE
feat(rdp): propagate pod.keyboard to FreeRDP /kbd:layout (#660)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added
+
+- **Your `[pod] keyboard` setting now drives the FreeRDP session keyboard layout** (#660). The locale you pick for the Windows install (e.g. `keyboard = "hu-HU"`) is now mapped to the matching Windows layout and passed to FreeRDP as `/kbd:layout:0x…`, so a non-US keyboard works in the RemoteApp window without hand-writing `rdp.extra_flags`. The default `en-US` is left untouched (FreeRDP keeps auto-detecting your host XKB layout, so users who never changed the setting aren't forced onto US), an explicit `/kbd` in `rdp.extra_flags` always wins, and an unmapped locale falls back to auto-detect. (Passing `/kbd` manually via `rdp.extra_flags` was already unblocked in 0.7.4.)
+
 ### Changed
 
 - **Bundled rdprrap bumped 0.1.3 → 0.3.0.** rdprrap (the multi-session RDP wrapper that lets each RemoteApp window get its own session) now derives its `termsrv.dll` patch sites **dynamically** — it disassembles each target function at runtime and encodes the patch bytes, instead of relying on hardcoded struct offsets / register choices / byte templates. This keeps multi-session working across Windows build-to-build `termsrv.dll` struct-layout shifts. OEM version 27 → 28, so existing installs pick it up on the next `winpodx guest sync` / `apply-fixes`.

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`[pod] keyboard` 설정이 이제 FreeRDP 세션 키보드 레이아웃에 반영됨** (#660). Windows 설치용으로 고른 로케일(예: `keyboard = "hu-HU"`)이 대응하는 Windows 레이아웃으로 매핑되어 FreeRDP에 `/kbd:layout:0x…`로 전달됩니다. 비-US 키보드가 `rdp.extra_flags`를 손으로 안 써도 RemoteApp 창에서 동작합니다. 기본값 `en-US`는 그대로 둬서(FreeRDP가 호스트 XKB 레이아웃 자동감지 유지 — 설정을 안 건드린 유저가 US로 강제되지 않음), `rdp.extra_flags`에 명시한 `/kbd`가 항상 우선하고, 매핑에 없는 로케일은 자동감지로 폴백합니다. (`rdp.extra_flags`로 `/kbd`를 직접 넘기는 건 0.7.4에서 이미 허용됨.)
+
 ### Changed
 
 - **번들 rdprrap 0.1.3 → 0.3.0.** rdprrap(각 RemoteApp 창에 독립 세션을 주는 멀티세션 RDP wrapper)이 `termsrv.dll` 패치 지점을 **동적으로** 도출합니다 — 하드코딩된 struct 오프셋/레지스터/바이트 템플릿 대신 런타임에 각 타겟 함수를 디스어셈블해 패치 바이트를 인코딩. Windows 빌드별 `termsrv.dll` 구조 변화에도 멀티세션이 유지됩니다. OEM 버전 27 → 28이라 기존 설치는 다음 `winpodx guest sync` / `apply-fixes` 때 반영.

--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -627,6 +627,14 @@ def build_rdp_command(
     if extra_args:
         cmd += _filter_extra_flags(extra_args)
 
+    # #660: auto-propagate cfg.pod.keyboard to FreeRDP as /kbd:layout, but only
+    # when the user hasn't already supplied a /kbd via extra_flags (their flag
+    # wins) and the locale maps to a non-default layout (see _auto_kbd_flag).
+    if not any(c.startswith("/kbd") for c in cmd):
+        kbd = _auto_kbd_flag(cfg)
+        if kbd:
+            cmd.append(kbd)
+
     return cmd, password
 
 
@@ -813,6 +821,103 @@ def _filter_extra_flags(flags_str: str) -> list[str]:
         else:
             log.warning("Blocked unsafe extra_flag: %s", part)
     return safe
+
+
+# #660: map the dockur-style ``cfg.pod.keyboard`` locale (the value that also
+# drives the guest install KEYBOARD env) to a Windows keyboard-layout ID so we
+# can hand FreeRDP a ``/kbd:layout:0x...`` flag. Keyed by lower-cased culture
+# name; the bare two-letter language is also accepted as a fallback for the
+# most common locales. KLIDs are the standard low-word == primary-LCID form.
+_KEYBOARD_LCID: dict[str, str] = {
+    "en-us": "00000409",
+    "en-gb": "00000809",
+    "de-de": "00000407",
+    "de": "00000407",
+    "de-ch": "00000807",
+    "fr-fr": "0000040c",
+    "fr": "0000040c",
+    "fr-ca": "00000c0c",
+    "fr-ch": "0000100c",
+    "es-es": "0000040a",
+    "es": "0000040a",
+    "es-mx": "0000080a",
+    "it-it": "00000410",
+    "it": "00000410",
+    "pt-br": "00000416",
+    "pt-pt": "00000816",
+    "pt": "00000816",
+    "nl-nl": "00000413",
+    "nl": "00000413",
+    "ru-ru": "00000419",
+    "ru": "00000419",
+    "ja-jp": "00000411",
+    "ja": "00000411",
+    "ko-kr": "00000412",
+    "ko": "00000412",
+    "zh-cn": "00000804",
+    "zh-tw": "00000404",
+    "pl-pl": "00000415",
+    "pl": "00000415",
+    "sv-se": "0000041d",
+    "sv": "0000041d",
+    "nb-no": "00000414",
+    "no": "00000414",
+    "da-dk": "00000406",
+    "da": "00000406",
+    "fi-fi": "0000040b",
+    "fi": "0000040b",
+    "cs-cz": "00000405",
+    "cs": "00000405",
+    "hu-hu": "0000040e",
+    "hu": "0000040e",
+    "tr-tr": "0000041f",
+    "tr": "0000041f",
+    "el-gr": "00000408",
+    "el": "00000408",
+    "he-il": "0000040d",
+    "he": "0000040d",
+    "ar-sa": "00000401",
+    "ar": "00000401",
+    "th-th": "0000041e",
+    "th": "0000041e",
+    "uk-ua": "00000422",
+    "uk": "00000422",
+    "ro-ro": "00000418",
+    "ro": "00000418",
+    "sk-sk": "0000041b",
+    "sk": "0000041b",
+    "bg-bg": "00000402",
+    "bg": "00000402",
+    "hr-hr": "0000041a",
+    "hr": "0000041a",
+    "sl-si": "00000424",
+    "sl": "00000424",
+    "et-ee": "00000425",
+    "et": "00000425",
+    "lv-lv": "00000426",
+    "lv": "00000426",
+    "lt-lt": "00000427",
+    "lt": "00000427",
+}
+
+
+def _auto_kbd_flag(cfg: Config) -> str | None:
+    """Derive a ``/kbd:layout:0x...`` flag from ``cfg.pod.keyboard`` (#660).
+
+    Returns ``None`` (no flag — FreeRDP keeps auto-detecting the host XKB
+    layout) when the value is unset, the ``en-US`` default, or unmapped. We
+    deliberately skip the default so users who never touched the setting but run
+    a non-US host keyboard are not silently forced onto the US layout.
+    """
+    raw = (getattr(cfg.pod, "keyboard", "") or "").strip()
+    if not raw or raw.lower() == "en-us":
+        return None
+    key = raw.lower()
+    lcid = _KEYBOARD_LCID.get(key) or _KEYBOARD_LCID.get(key.split("-")[0])
+    if not lcid:
+        log.debug("No FreeRDP /kbd mapping for keyboard=%r; leaving auto-detect", raw)
+        return None
+    return f"/kbd:layout:0x{lcid}"
 
 
 def _open_file_in_session(cfg: Config, app_executable: str, file_path: str) -> None:

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import pytest
 
 from winpodx.core.config import Config
-from winpodx.core.rdp import build_rdp_command, linux_to_unc
+from winpodx.core.rdp import _auto_kbd_flag, build_rdp_command, linux_to_unc
 
 
 def test_linux_to_unc_home(monkeypatch, tmp_path):
@@ -1114,3 +1114,80 @@ def test_redact_cmd_for_log_masks_password():
     assert "/gp:***" in out
     assert "/u:User" in out  # non-secret tokens are preserved
     assert "/v:127.0.0.1:3390" in out
+
+
+# #660: cfg.pod.keyboard -> FreeRDP /kbd:layout propagation
+
+
+class TestKeyboardLayoutPropagation:
+    def test_auto_kbd_flag_default_en_us_is_none(self):
+        c = Config()
+        c.pod.keyboard = "en-US"
+        assert _auto_kbd_flag(c) is None
+
+    def test_auto_kbd_flag_empty_is_none(self):
+        c = Config()
+        c.pod.keyboard = ""
+        assert _auto_kbd_flag(c) is None
+
+    def test_auto_kbd_flag_full_culture(self):
+        c = Config()
+        c.pod.keyboard = "de-DE"
+        assert _auto_kbd_flag(c) == "/kbd:layout:0x00000407"
+
+    def test_auto_kbd_flag_bare_language_fallback(self):
+        c = Config()
+        c.pod.keyboard = "hu"
+        assert _auto_kbd_flag(c) == "/kbd:layout:0x0000040e"
+
+    def test_auto_kbd_flag_culture_prefix_fallback(self):
+        # Unknown region but known language prefix -> falls back to the language.
+        c = Config()
+        c.pod.keyboard = "fr-BE"
+        assert _auto_kbd_flag(c) == "/kbd:layout:0x0000040c"
+
+    def test_auto_kbd_flag_unmapped_is_none(self):
+        c = Config()
+        c.pod.keyboard = "xx-YY"
+        assert _auto_kbd_flag(c) is None
+
+    def _cfg(self):
+        c = Config()
+        c.rdp.ip = "127.0.0.1"
+        c.rdp.port = 3390
+        c.rdp.user = "TestUser"
+        c.rdp.password = "secret"
+        c.rdp.extra_flags = ""
+        c.pod.backend = "manual"
+        return c
+
+    def test_non_default_keyboard_appends_kbd(self, monkeypatch):
+        monkeypatch.setattr(
+            "winpodx.core.rdp.find_freerdp",
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
+        )
+        cfg = self._cfg()
+        cfg.pod.keyboard = "hu-HU"
+        cmd, _ = build_rdp_command(cfg)
+        assert "/kbd:layout:0x0000040e" in cmd
+
+    def test_default_keyboard_does_not_append_kbd(self, monkeypatch):
+        monkeypatch.setattr(
+            "winpodx.core.rdp.find_freerdp",
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
+        )
+        cfg = self._cfg()  # default en-US
+        cmd, _ = build_rdp_command(cfg)
+        assert not any(c.startswith("/kbd") for c in cmd)
+
+    def test_user_extra_flags_kbd_wins(self, monkeypatch):
+        monkeypatch.setattr(
+            "winpodx.core.rdp.find_freerdp",
+            lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"),
+        )
+        cfg = self._cfg()
+        cfg.pod.keyboard = "hu-HU"  # would auto-map to 0x040e
+        cfg.rdp.extra_flags = "/kbd:layout:0x00000409"  # user forces US
+        cmd, _ = build_rdp_command(cfg)
+        kbd_flags = [c for c in cmd if c.startswith("/kbd")]
+        assert kbd_flags == ["/kbd:layout:0x00000409"]  # only the user's, no auto


### PR DESCRIPTION
Refs #660 (Problem 2).

## Background
#660 had two parts:
- **Problem 1** — `/kbd` blocked by the `extra_flags` allowlist → **already fixed in 0.7.4** (`/kbd` is in `_SIMPLE_VALUE_FLAGS`).
- **Problem 2** — `[pod] keyboard` not propagated to FreeRDP → **this PR**.

## What it does
`cfg.pod.keyboard` (the dockur install locale, e.g. `hu-HU`) is mapped to the
matching Windows keyboard-layout id and appended to the FreeRDP command as
`/kbd:layout:0x…`, so a non-US keyboard works in the RemoteApp window without
hand-writing `rdp.extra_flags`.

## Safe by default (no regression)
FreeRDP **without** `/kbd` auto-detects the host XKB layout. `pod.keyboard`
defaults to `en-US` (the *install* locale, not necessarily the host keyboard),
so blindly forcing `/kbd:0x409` for everyone would break users with a non-US
host keyboard who never touched the setting. Therefore:

- `en-US` / empty → **no flag appended** (FreeRDP keeps auto-detecting).
- a `/kbd` already present in `rdp.extra_flags` / per-launch `--extra-args`
  **always wins** (we skip auto-append if any `/kbd` is in the cmd).
- an unmapped locale → no flag + a debug log (auto-detect preserved).

## Implementation
- `_KEYBOARD_LCID`: ~40 common dockur cultures → Windows KLIDs (exact, plus a
  bare two-letter language fallback, e.g. `fr-BE` → `fr` → `0x040c`).
- `_auto_kbd_flag(cfg)`: returns the flag or `None`.
- `build_rdp_command`: appends it after the `extra_flags` merge, guarded by
  "no `/kbd` already present".

## Tests
`tests/test_rdp.py::TestKeyboardLayoutPropagation` — 10 cases (unit: default /
empty / full culture / bare-lang / culture-prefix / unmapped; integration:
non-default appends, default does not, user `/kbd` wins). Full suite: 2041
passed, 1 skipped; `ruff check` + `ruff format --check` clean.