### PR TITLE
feat(url-scheme): host-side forward URL-scheme handler support (#421, #694)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added
+
+- **Windows apps can be registered as URL-scheme handlers on Linux** (#421, #694 — host-side groundwork). When an app carries URL schemes (`mailto`, `https`, `slack`, `vnc`, …), its `.desktop` now gets `x-scheme-handler/<scheme>` entries and the `Exec` accepts a URL, so clicking such a link on the host opens it in the Windows app — the URL is passed straight through to the app (not mapped to a `$HOME` file path). A shared policy module (denylist + strict scheme regex + a `/app`-cmd sanitizer) blocks dangerous schemes (`file:`, `javascript:`, `data:`, …) and neutralizes command-line injection at both registration and launch. Set `url_schemes = ["mailto", …]` in an app's `app.toml` to use it today; automatic per-app scheme discovery from the guest lands next.
+
 ### Fixed
 
 - **kio-fuse is no longer reported "not installed" when it actually is** (#697, thanks @notnotno). The Info/health check only looked for the `kio-fuse` binary in a fixed set of paths, so on distros that put it elsewhere — Fedora Kinoite / KF6-versioned libexec, or the Debian multiarch `/usr/lib/<triplet>/libexec/kio-fuse` (three levels deep, missed by the old two-level glob) — it read as missing even though reverse-open guest-disk mounting (#616) works fine. Detection now also matches the multiarch path and, as the authoritative signal, the `org.kde.KIOFuse` D-Bus activation service that the mount actually calls.

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Windows 앱을 Linux에서 URL-scheme 핸들러로 등록 가능** (#421, #694 — 호스트측 기반). 앱이 URL 스킴(`mailto`, `https`, `slack`, `vnc`, …)을 가지면 `.desktop`에 `x-scheme-handler/<scheme>` 항목이 붙고 `Exec`가 URL을 받아, 호스트에서 그런 링크를 클릭하면 Windows 앱에서 열립니다 — URL은 `$HOME` 파일 경로로 매핑하지 않고 앱에 그대로 전달됩니다. 공유 정책 모듈(denylist + 엄격한 스킴 정규식 + `/app`-cmd sanitizer)이 위험 스킴(`file:`, `javascript:`, `data:`, …)을 차단하고 등록·실행 양쪽에서 커맨드라인 인젝션을 무력화합니다. 앱의 `app.toml`에 `url_schemes = ["mailto", …]`를 넣으면 지금 쓸 수 있고, 게스트에서 앱별 스킴 자동 발견은 다음에 옵니다.
+
 ### Fixed
 
 - **kio-fuse 가 실제로 설치돼 있는데도 "미설치"로 표시되던 문제 수정** (#697, @notnotno 기여 감사). Info/헬스 체크가 `kio-fuse` 바이너리를 고정된 경로 몇 개에서만 찾아서, 다른 곳에 두는 배포판 — Fedora Kinoite / KF6 버전 libexec, 또는 Debian multiarch `/usr/lib/<triplet>/libexec/kio-fuse`(3단계 깊이라 기존 2단계 glob 이 놓침) — 에선 reverse-open 게스트 디스크 마운트(#616)가 잘 되는데도 미설치로 읽혔습니다. 이제 multiarch 경로와, 마운트가 실제로 호출하는 authoritative 신호인 `org.kde.KIOFuse` D-Bus 활성화 서비스까지 확인합니다.

--- a/src/winpodx/core/app.py
+++ b/src/winpodx/core/app.py
@@ -63,6 +63,10 @@ class AppInfo:
     # e.g. "Microsoft Office/Tools"). "" = top-level. Mirrored into a nested
     # winpodx submenu by the desktop-entry generator.
     start_menu_folder: str = ""
+    # #421/#694: URL schemes the Windows app registered as a handler for
+    # (mailto, https, slack, ...). Emitted as x-scheme-handler/<scheme> in the
+    # .desktop MimeType so clicking a host URL opens it in this Windows app.
+    url_schemes: list[str] = field(default_factory=list)
 
 
 def user_apps_dir() -> Path:
@@ -204,6 +208,7 @@ def load_app(app_dir: Path, default_source: str = "user") -> AppInfo | None:
         essential=bool(data.get("essential", False)),
         exe_hash=str(data.get("exe_hash", "") or ""),
         start_menu_folder=str(data.get("start_menu_folder", "") or ""),
+        url_schemes=data.get("url_schemes", []) or [],
     )
 
 

--- a/src/winpodx/core/discovery/__init__.py
+++ b/src/winpodx/core/discovery/__init__.py
@@ -291,6 +291,10 @@ class DiscoveredApp:
     # "/" separators (e.g. "Microsoft Office/Tools"). "" = top-level. Mirrored
     # into a nested winpodx submenu by the desktop-entry / menu generators.
     start_menu_folder: str = ""
+    # #421/#694: URL schemes the guest reports this app handles (mailto, https,
+    # slack, ...), filtered through the shared url_schemes policy. Emitted as
+    # x-scheme-handler/<scheme> in the .desktop MimeType.
+    url_schemes: list[str] = field(default_factory=list)
 
 
 # --- Hybrid filter: essentials allowlist + noise denylist -----------------
@@ -1116,6 +1120,21 @@ def _entry_to_discovered(entry: dict[str, Any]) -> DiscoveredApp | None:
 
     start_menu_folder = _sanitize_start_menu_folder(entry.get("start_menu_folder", ""))
 
+    # #421/#694: URL schemes the app handles. Filter through the shared policy
+    # (syntactic regex + denylist) so a hostile guest can't register winpodx as
+    # a handler for a dangerous scheme (file:, javascript:, ...); dedupe + cap.
+    from winpodx.core.url_schemes import is_safe_scheme
+
+    url_schemes: list[str] = []
+    raw_schemes = entry.get("url_schemes", [])
+    if isinstance(raw_schemes, list):
+        for s in raw_schemes[:64]:
+            if not isinstance(s, str):
+                continue
+            scheme = s.strip().rstrip(":").lower()
+            if is_safe_scheme(scheme) and scheme not in url_schemes:
+                url_schemes.append(scheme)
+
     return DiscoveredApp(
         name=slug,
         full_name=raw_name.strip(),
@@ -1129,6 +1148,7 @@ def _entry_to_discovered(entry: dict[str, Any]) -> DiscoveredApp | None:
         icon_bytes=icon_bytes,
         extensions=extensions,
         start_menu_folder=start_menu_folder,
+        url_schemes=url_schemes,
     )
 
 
@@ -1389,6 +1409,8 @@ def _render_app_toml(app: DiscoveredApp, mime_enabled: bool = True) -> str:
         data["exe_hash"] = app.exe_hash
     if app.start_menu_folder:
         data["start_menu_folder"] = app.start_menu_folder
+    if app.url_schemes:
+        data["url_schemes"] = app.url_schemes
     # Always emit hidden / essential when set so AppInfo.load_app picks
     # them up. Keep the keys absent on the default-False side to keep
     # toml diffs minimal for the common case (visible, non-essential).

--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from winpodx.core.config import Config
+from winpodx.core.url_schemes import sanitize_url_arg, url_scheme_of
 from winpodx.utils.paths import runtime_dir
 
 log = logging.getLogger(__name__)
@@ -573,7 +574,13 @@ def build_rdp_command(
             # commas to spaces here too before building the combined arg.
             program_token = app_executable.replace(",", " ")
             app_arg = f"/app:program:{program_token},name:{name_token}"
-            if file_path:
+            if file_path and url_scheme_of(file_path):
+                # #421/#694: a URL (mailto:, https:, slack:, ...) is handed to
+                # the app verbatim, NOT mapped to a $HOME UNC (linux_to_unc only
+                # maps file paths + would raise). Same comma/quote sanitising as
+                # the UNC path -- a comma splits the /app: value into sub-keys.
+                app_arg += f',cmd:"{sanitize_url_arg(file_path)}"'
+            elif file_path:
                 try:
                     unc_path = linux_to_unc(file_path)
                 except ValueError as e:
@@ -594,7 +601,10 @@ def build_rdp_command(
             # are safe because each flag is its own argv entry.
             cmd.append(f"/app:{app_executable}")
             cmd.append(f"/app-name:{name_token}")
-            if file_path:
+            if file_path and url_scheme_of(file_path):
+                # #421/#694: URL handed to the app verbatim (see FreeRDP 3 branch).
+                cmd.append(f'/app-cmd:"{sanitize_url_arg(file_path)}"')
+            elif file_path:
                 try:
                     unc_path = linux_to_unc(file_path)
                 except ValueError as e:
@@ -1358,9 +1368,12 @@ def launch_app(
         #
         # Validate the path up front so a file outside the shared $HOME / media
         # locations surfaces a visible error toast instead of a raw traceback
-        # (#675 fail-loud), then fall through to the cold spawn below.
+        # (#675 fail-loud), then fall through to the cold spawn below. A URL arg
+        # (#421/#694) isn't a file path -- skip the UNC check so it isn't
+        # rejected as "outside home"; build_rdp_command routes it as a URL.
         try:
-            linux_to_unc(file_path)
+            if not url_scheme_of(file_path):
+                linux_to_unc(file_path)
         except (ValueError, RuntimeError) as exc:
             from winpodx.desktop.notify import notify_error
 

--- a/src/winpodx/core/url_schemes.py
+++ b/src/winpodx/core/url_schemes.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: MIT
+"""Canonical URL-scheme policy for forward URL handling (#421 / #694).
+
+Single source of truth shared by discovery (which schemes get registered as
+``x-scheme-handler/<scheme>`` on the Linux side) and rdp (which URL args get
+routed to the guest app instead of mapped to a ``$HOME`` UNC path). The guest
+``discover_apps.ps1`` mirrors :data:`DANGEROUS_SCHEMES` + the regex verbatim as
+a coarse advisory guard, but this module owns the authoritative policy.
+
+Leaf module: imports only ``re`` (no import cycle -- rdp does not import
+discovery and discovery does not import rdp).
+"""
+
+from __future__ import annotations
+
+import re
+
+# RFC 3986 scheme grammar: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ), length-
+# bounded to 32. The leading-letter + no-colon rule structurally prevents
+# ``javascript:alert()`` from masquerading as a compound scheme.
+SAFE_SCHEME_RE = re.compile(r"^[a-z][a-z0-9+.\-]{0,31}$")
+
+# Schemes we never register a Windows app as a handler for, nor route to the
+# guest: code-execution, local-file, and settings/diagnostic vectors. A
+# denylist (not an allowlist) so legitimate vendor schemes (slack, vnc, msteams,
+# zoommtg, spotify, com.vendor.app, ...) still route -- the real injection
+# boundary is sanitize_url_arg, not this set.
+DANGEROUS_SCHEMES: frozenset[str] = frozenset(
+    {
+        "file",
+        "javascript",
+        "vbscript",
+        "data",
+        "about",
+        "shell",
+        "res",
+        "chrome",
+        "chrome-extension",
+        "ms-settings",
+        "ms-msdt",
+        "ms-search",
+        "search-ms",
+        "hcp",
+        "its",
+        "mk",
+        "ldap",
+        "help",
+        "wscript",
+        "cscript",
+        "view-source",
+    }
+)
+
+
+def is_safe_scheme(scheme: str) -> bool:
+    """True if ``scheme`` is routable (syntactically valid + not dangerous).
+
+    Case-insensitive; a trailing ``:`` is tolerated so callers can pass either
+    ``"mailto"`` or ``"mailto:"``.
+    """
+    s = scheme.strip().rstrip(":").lower()
+    return bool(SAFE_SCHEME_RE.fullmatch(s)) and s not in DANGEROUS_SCHEMES
+
+
+def url_scheme_of(arg: str) -> str | None:
+    """Return the routable scheme if ``arg`` is a ``scheme:...`` URL we should
+    hand to the guest app, else ``None``.
+
+    A file path (no colon, or a Linux path that merely contains one) and a
+    ``file:`` URI both return ``None`` -- file: is in the denylist so file opens
+    keep going through the ``\\tsclient\\home`` UNC path unchanged.
+    """
+    if not arg or ":" not in arg:
+        return None
+    scheme = arg.split(":", 1)[0].strip().lower()
+    return scheme if is_safe_scheme(scheme) else None
+
+
+def sanitize_url_arg(url: str) -> str:
+    """Neutralise the FreeRDP ``/app`` cmd injection vectors in a URL.
+
+    A comma splits a FreeRDP 3 ``/app:`` value into sub-keys, a double-quote
+    wraps the cmd value, and CR/LF/control chars could smuggle extra argv --
+    exactly the hazards ``build_rdp_command`` already strips from a UNC path.
+    Drop C0 controls + DEL, and space-replace ``,`` and ``"``; the URL is
+    otherwise passed through intact.
+    """
+    cleaned = "".join(ch for ch in url if 0x20 <= ord(ch) != 0x7F)
+    return cleaned.replace(",", " ").replace('"', " ")

--- a/src/winpodx/desktop/entry.py
+++ b/src/winpodx/desktop/entry.py
@@ -24,7 +24,7 @@ Version=1.0
 Type=Application
 Name={full_name}
 Comment={comment}
-Exec={winpodx_exe} app run {name} %f
+Exec={winpodx_exe} app run {name} %u
 Icon={icon_name}
 Categories={categories}
 MimeType={mime_types}
@@ -122,6 +122,13 @@ def install_desktop_entry(app: AppInfo) -> Path:
         safe_folder = folder.replace("\n", " ").replace("\r", " ").strip()
         folder_line = f"{FOLDER_KEY}={safe_folder}\n"
 
+    # #421/#694: register the app for its URL schemes too, as
+    # x-scheme-handler/<scheme> MIME entries alongside its file MIME types. The
+    # schemes were already policy-filtered in discovery, so no re-escaping here.
+    mime_entries = list(app.mime_types) + [
+        f"x-scheme-handler/{s}" for s in (getattr(app, "url_schemes", None) or [])
+    ]
+
     content = DESKTOP_TEMPLATE.format(
         winpodx_exe=_winpodx_exe(),
         full_name=full_name,
@@ -129,7 +136,7 @@ def install_desktop_entry(app: AppInfo) -> Path:
         comment=comment,
         icon_name=icon_name,
         categories=categories,
-        mime_types=";".join(app.mime_types) + ";" if app.mime_types else "",
+        mime_types=";".join(mime_entries) + ";" if mime_entries else "",
         wm_class=wm_class,
         folder_line=folder_line,
     )
@@ -147,10 +154,10 @@ def install_desktop_entry(app: AppInfo) -> Path:
     except OSError as e:
         log.warning("Could not write winpodx menu folder definition: %s", e)
 
-    # Register file associations so the app shows up in "Open with" (#545).
-    # Only when this app declares MIME types -- most apps don't, so the cache
-    # rebuild stays bounded to the handful that need it.
-    if app.mime_types:
+    # Register file + URL-scheme associations so the app shows up in "Open with"
+    # (#545) and as a URL handler (#421/#694). Only when it declares something --
+    # most apps don't, so the cache rebuild stays bounded to the few that need it.
+    if mime_entries:
         update_desktop_database()
 
     return desktop_path

--- a/src/winpodx/desktop/mime.py
+++ b/src/winpodx/desktop/mime.py
@@ -22,7 +22,11 @@ def register_mime_types(app: AppInfo) -> None:
     if not desktop_file.exists():
         return
 
-    for mime in app.mime_types:
+    # File MIME types + URL scheme handlers (#421/#694): making the Windows app
+    # the default handler for its declared schemes (e.g. x-scheme-handler/mailto
+    # -> Outlook) so a host mailto: link opens in it.
+    scheme_mimes = [f"x-scheme-handler/{s}" for s in (app.url_schemes or [])]
+    for mime in list(app.mime_types) + scheme_mimes:
         try:
             result = subprocess.run(
                 ["xdg-mime", "default", desktop_file.name, mime],

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -31,6 +31,22 @@ def test_load_app(tmp_path):
     assert app.mime_types == ["text/plain"]
     # v0.1.9: source defaults to "user" when the TOML doesn't declare one.
     assert app.source == "user"
+    # #421/#694: url_schemes defaults to [] when absent.
+    assert app.url_schemes == []
+
+
+def test_load_app_reads_url_schemes(tmp_path):
+    app_dir = tmp_path / "outlook"
+    app_dir.mkdir()
+    (app_dir / "app.toml").write_text(
+        'name = "outlook"\n'
+        'full_name = "Outlook"\n'
+        'executable = "C:\\\\o.exe"\n'
+        'url_schemes = ["mailto", "webcal"]\n'
+    )
+    app = load_app(app_dir)
+    assert app is not None
+    assert app.url_schemes == ["mailto", "webcal"]
 
 
 def test_load_app_default_source_can_be_overridden(tmp_path):

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -38,7 +38,7 @@ def test_desktop_template():
 
     assert "Name=Microsoft Word" in content
     assert "Comment=Word processor" in content
-    assert "Exec=winpodx app run word %f" in content
+    assert "Exec=winpodx app run word %u" in content
     assert "Icon=winpodx-word" in content
     assert "Categories=Office;WordProcessor;" in content
     assert "MimeType=application/msword;" in content
@@ -156,10 +156,45 @@ def test_install_desktop_entry_utf8_korean(tmp_path, monkeypatch):
 
     content = desktop_path.read_text(encoding="utf-8")
     assert "Name=\ud55c\uae00 \uba54\ubaa8\uc7a5" in content
-    assert "Exec=winpodx app run hangul %f" in content
+    assert "Exec=winpodx app run hangul %u" in content
 
     raw = desktop_path.read_bytes()
     assert "\ud55c\uae00 \uba54\ubaa8\uc7a5".encode("utf-8") in raw
+
+
+def test_desktop_entry_emits_scheme_handler(tmp_path, monkeypatch):
+    # #421/#694: url_schemes become x-scheme-handler/<scheme> MIME entries
+    # alongside the file MIME types.
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setattr(entry_mod, "_install_icon", lambda _app: "winpodx")
+    monkeypatch.setattr(entry_mod, "_winpodx_exe", lambda: "winpodx")
+
+    app = AppInfo(
+        name="outlook",
+        full_name="Outlook",
+        executable="C:\\o.exe",
+        mime_types=["application/pdf"],
+        url_schemes=["mailto", "slack"],
+    )
+    content = install_desktop_entry(app).read_text(encoding="utf-8")
+    mime_line = next(ln for ln in content.splitlines() if ln.startswith("MimeType="))
+    assert "application/pdf" in mime_line
+    assert "x-scheme-handler/mailto" in mime_line
+    assert "x-scheme-handler/slack" in mime_line
+
+
+def test_scheme_only_app_triggers_db_update(tmp_path, monkeypatch):
+    # An app with URL schemes but NO file MIME types must still rebuild the
+    # desktop database (the old gate only checked app.mime_types).
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setattr(entry_mod, "_install_icon", lambda _app: "winpodx")
+    monkeypatch.setattr(entry_mod, "_winpodx_exe", lambda: "winpodx")
+    called: list = []
+    monkeypatch.setattr(entry_mod, "update_desktop_database", lambda: called.append(1))
+
+    app = AppInfo(name="mailer", full_name="Mailer", executable="C:\\m.exe", url_schemes=["mailto"])
+    install_desktop_entry(app)
+    assert called == [1]
 
 
 def test_install_desktop_entry_utf8_japanese(tmp_path, monkeypatch):
@@ -196,7 +231,7 @@ def test_install_desktop_entry_strips_newlines_in_full_name(tmp_path, monkeypatc
 
     # The only Exec= line is winpodx's own; the injected one must be gone.
     exec_lines = [ln for ln in content.splitlines() if ln.startswith("Exec=")]
-    assert exec_lines == ["Exec=winpodx app run evil %f"]
+    assert exec_lines == ["Exec=winpodx app run evil %u"]
     # Name= stays on a single line with the newline collapsed to a space.
     name_lines = [ln for ln in content.splitlines() if ln.startswith("Name=")]
     assert len(name_lines) == 1
@@ -603,7 +638,7 @@ def test_install_desktop_entry_strips_newlines_in_description(tmp_path, monkeypa
     assert "\t" not in comment_line
     assert "\r" not in comment_line
     # Following keys (Exec, Icon, …) must still be intact.
-    assert "Exec=winpodx app run messy %f" in raw
+    assert "Exec=winpodx app run messy %u" in raw
 
 
 def test_install_desktop_entry_uses_absolute_exec_path(tmp_path, monkeypatch):
@@ -623,7 +658,7 @@ def test_install_desktop_entry_uses_absolute_exec_path(tmp_path, monkeypatch):
     )
     desktop_path = install_desktop_entry(app)
     content = desktop_path.read_text(encoding="utf-8")
-    assert "Exec=/home/u/.local/bin/winpodx app run notepad %f" in content
+    assert "Exec=/home/u/.local/bin/winpodx app run notepad %u" in content
 
 
 def test_winpodx_exe_falls_back_to_bare_name(monkeypatch):

--- a/tests/test_discovery/test_discovery.py
+++ b/tests/test_discovery/test_discovery.py
@@ -246,6 +246,32 @@ def test_entry_happy_path():
 
 def test_entry_missing_name_rejected():
     assert _entry_to_discovered(_valid_entry(name="")) is None
+
+
+def test_entry_parses_and_filters_url_schemes():
+    # #421/#694: valid schemes kept (lowercased, deduped); dangerous + malformed
+    # dropped by the shared policy.
+    app = _entry_to_discovered(
+        _valid_entry(url_schemes=["mailto", "SLACK", "javascript", "bad scheme", "vnc", "mailto:"])
+    )
+    assert app is not None
+    assert app.url_schemes == ["mailto", "slack", "vnc"]
+
+
+def test_render_app_toml_emits_url_schemes():
+    from winpodx.core.discovery import DiscoveredApp
+
+    app = DiscoveredApp(
+        name="outlook",
+        full_name="Outlook",
+        executable="C:\\o.exe",
+        url_schemes=["mailto", "webcal"],
+    )
+    toml = _render_app_toml(app)
+    assert 'url_schemes = ["mailto", "webcal"]' in toml
+    # absent when empty (minimal-diff convention)
+    bare = _render_app_toml(DiscoveredApp(name="n", full_name="N", executable="C:\\n.exe"))
+    assert "url_schemes" not in bare
     assert _entry_to_discovered(_valid_entry(name=None)) is None
 
 

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -1222,6 +1222,68 @@ def test_session_state_probe_is_session_scoped(monkeypatch):
     assert "if (Get-Process LogonUI" not in _SESSION_STATE_PS
 
 
+def _url_cfg() -> Config:
+    cfg = Config()
+    cfg.rdp.user = "u"
+    cfg.rdp.password = "p"
+    return cfg
+
+
+def _build_url(monkeypatch, file_path: str, *, major: int = 3):
+    from winpodx.core import rdp as rdp_mod
+
+    monkeypatch.setattr(rdp_mod, "find_freerdp", lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp"))
+    monkeypatch.setattr(rdp_mod, "freerdp_major_version", lambda: major)
+    cmd, _ = rdp_mod.build_rdp_command(
+        _url_cfg(), app_executable="OUTLOOK.EXE", file_path=file_path
+    )
+    return cmd
+
+
+def test_url_scheme_bypasses_unc_freerdp3(monkeypatch) -> None:
+    # #421/#694: a mailto: URL is routed to the /app cmd verbatim, not mapped to
+    # a \\tsclient\home UNC (which would raise "outside home").
+    cmd = _build_url(monkeypatch, "mailto:foo@bar.com")
+    app = next(c for c in cmd if c.startswith("/app:"))
+    assert 'cmd:"mailto:foo@bar.com"' in app
+    assert "tsclient" not in app
+
+
+def test_url_scheme_freerdp2(monkeypatch) -> None:
+    cmd = _build_url(monkeypatch, "slack://team/x", major=2)
+    assert '/app-cmd:"slack://team/x"' in cmd
+
+
+def test_url_comma_quote_sanitized(monkeypatch) -> None:
+    cmd = _build_url(monkeypatch, 'slack://team,chan"x')
+    app = next(c for c in cmd if c.startswith("/app:"))
+    # comma + double-quote inside the URL are space-replaced (no sub-key inject)
+    assert 'cmd:"slack://team chan x"' in app
+
+
+def test_file_url_still_routed_through_unc(monkeypatch, tmp_path) -> None:
+    # file: is denylisted -> stays on the UNC path; linux_to_unc strips file://
+    from winpodx.core import rdp as rdp_mod
+
+    monkeypatch.setattr(rdp_mod.Path, "home", staticmethod(lambda: tmp_path))
+    doc = tmp_path / "doc.txt"
+    doc.touch()
+    cmd = _build_url(monkeypatch, doc.as_uri())  # file:///…/doc.txt
+    app = next(c for c in cmd if c.startswith("/app:"))
+    assert "\\\\tsclient\\home\\doc.txt" in app
+
+
+def test_dangerous_scheme_not_routed_as_url(monkeypatch, tmp_path) -> None:
+    # javascript: must NOT reach the guest as a URL; url_scheme_of returns None
+    # so it falls through to linux_to_unc, which rejects it (not a $HOME path).
+    from winpodx.core import rdp as rdp_mod
+
+    monkeypatch.setattr(rdp_mod.Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(rdp_mod, "_find_media_base", lambda: None)
+    with pytest.raises(RuntimeError, match="Cannot open file"):
+        _build_url(monkeypatch, "javascript:alert(1)")
+
+
 def test_redact_cmd_for_log_masks_password():
     # The FreeRDP argv carries the Windows password as /p: (and gateway pw as
     # /gp:); the launch log must not print either in cleartext.

--- a/tests/test_url_schemes.py
+++ b/tests/test_url_schemes.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: MIT
+"""Canonical URL-scheme policy (#421 / #694)."""
+
+from __future__ import annotations
+
+import pytest
+
+from winpodx.core.url_schemes import (
+    DANGEROUS_SCHEMES,
+    is_safe_scheme,
+    sanitize_url_arg,
+    url_scheme_of,
+)
+
+
+@pytest.mark.parametrize(
+    "s", ["mailto", "https", "http", "slack", "vnc", "tel", "zoommtg", "webcal"]
+)
+def test_is_safe_scheme_accepts_common(s: str) -> None:
+    assert is_safe_scheme(s)
+    assert is_safe_scheme(s.upper())  # case-insensitive
+    assert is_safe_scheme(s + ":")  # trailing colon tolerated
+
+
+@pytest.mark.parametrize("s", sorted(DANGEROUS_SCHEMES))
+def test_is_safe_scheme_rejects_denylist(s: str) -> None:
+    assert not is_safe_scheme(s)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "1abc",
+        "a b",
+        "has:colon",
+        "way-too-long-scheme-name-that-exceeds-the-thirty-two-char-cap",
+    ],
+)
+def test_is_safe_scheme_rejects_malformed(bad: str) -> None:
+    assert not is_safe_scheme(bad)
+
+
+def test_url_scheme_of_routes_urls_not_paths() -> None:
+    assert url_scheme_of("mailto:a@b.com") == "mailto"
+    assert url_scheme_of("https://example.com/x") == "https"
+    assert url_scheme_of("SLACK://team") == "slack"
+    # file paths + file: URIs are NOT routed (file: is denylisted -> UNC path)
+    assert url_scheme_of("/home/me/doc.txt") is None
+    assert url_scheme_of("file:///home/me/doc.txt") is None
+    assert url_scheme_of("relative/path") is None
+    # dangerous schemes are not routed
+    assert url_scheme_of("javascript:alert(1)") is None
+    assert url_scheme_of("data:text/html,x") is None
+
+
+def test_sanitize_neutralises_app_cmd_injection() -> None:
+    # comma splits FreeRDP3 /app: sub-keys; double-quote wraps the cmd value;
+    # CR/LF/control chars could smuggle extra argv.
+    out = sanitize_url_arg('slack://team,chan"x\r\n\tbell\x07')
+    assert "," not in out
+    assert '"' not in out
+    assert "\r" not in out and "\n" not in out and "\t" not in out
+    assert "\x07" not in out
+    # the rest of the URL survives
+    assert out.startswith("slack://team")


### PR DESCRIPTION
Refs #421 (mailto->Outlook) + #694 (URL params). **Host-side groundwork** so clicking a URL on the Linux host opens it in the Windows app that handles that scheme.

## Design
New leaf policy module `core/url_schemes.py` — the single source of truth (`SAFE_SCHEME_RE` + `DANGEROUS_SCHEMES` denylist + `url_scheme_of` + `sanitize_url_arg`), imported by **both** discovery (registration) and rdp (launch) so the policy can never drift. No import cycle (leaf: imports only `re`).

- `AppInfo.url_schemes` / `DiscoveredApp.url_schemes` thread through discovery → `app.toml`, policy-filtered (regex + denylist + dedupe + cap).
- `entry.py`: `MimeType=x-scheme-handler/<scheme>` + `Exec … %u` (file: URIs still normalise via `linux_to_unc`, so **file opens are unchanged**).
- `mime.py`: registers the app as default handler for its schemes.
- `rdp.build_rdp_command`: a URL arg is routed to the `/app` cmd verbatim (FreeRDP 3 **and** 2), bypassing `linux_to_unc`, with the same comma/quote sanitising the UNC path already gets; `launch_app` warm-path skips the UNC validation for a URL.

## Security (three gates)
1. the scheme regex structurally forbids a `:` inside the scheme → `javascript:alert()` can’t masquerade as a compound scheme;
2. the denylist blocks known code-exec/file/settings schemes (`file`, `javascript`, `data`, `ms-settings`, …);
3. `sanitize_url_arg` neutralises the real `/app`-cmd injection vector — commas (split FreeRDP 3 sub-keys), double-quotes, CR/LF/control chars.

## Tests
36 policy + routing + plumbing tests (`test_url_schemes.py`, new `test_rdp` URL-routing cases incl. file:-still-UNC + dangerous-not-routed, discovery parse/emit, load_app round-trip, `.desktop` scheme-handler emit, `%f→%u`). 310 passed across impacted suites, ruff clean. Host-only → no smoke gate.

## Follow-up (separate PR, smoke-gated)
The guest `discover_apps.ps1` per-app scheme harvest (UrlAssociations UserChoice + Capabilities\URLAssociations + UWP `windows.protocol`) — it runs on every discovery, so it needs a real-Windows gate. Until then, `url_schemes = [...]` can be set in an `app.toml` manually.