### PR TITLE
chore(deps): baseline dockur-arm to v5.16 (#682)

### DIFF
--- a/config/oem/VERSIONS.txt
+++ b/config/oem/VERSIONS.txt
@@ -20,5 +20,5 @@
 # Format: <key>=<value>
 dockur=v5.16
 dockur-digest=sha256:3633f055f31aadf76bb650b1ca86897ab45b76ad8eb2cf81e86389ace5eb45ac
-dockur-arm=v5.15
-dockur-arm-digest=sha256:7c28ddbbe69eb02900bef3b7ab3ad60fbd5fb409524a307a60a3c934f80a9dd5
+dockur-arm=v5.16
+dockur-arm-digest=sha256:ece93263254567c6cd4ce420b1fff793d2326f4535555bdf592f40ab173a7bed


### PR DESCRIPTION
The weekly upstream checker flagged `dockur/windows-arm` v5.15 → v5.16.

This updates the `VERSIONS.txt` baseline (release tag + `:latest` digest) so it
reflects current upstream and the checker stops re-flagging.

**Pin intentionally not rolled forward.** Per the pin philosophy documented in
`VERSIONS.txt`, `DOCKUR_IMAGE_ARM_PIN` is winpodx's *tested* image — and there is
no aarch64 host available to smoke-test `v5.16-arm`. So the ARM pin stays at
v5.15 (a security rebuild) and rolling it forward is deferred until ARM host
support is validated (#140, #141). x86 already tracks v5.16.

- Baseline-only change; `DOCKUR_IMAGE_ARM_PIN` / `DOCKUR_IMAGE_PIN` unchanged.
- No test couples the baseline to the pin (`test_audit5_core.py` asserts the
  pin only); 30 audit-core tests pass.

Refs #682