### PR TITLE
fix(security): close guest web-handler hijack + reaper mis-kill races (0.8.1 gate)

### DIFF
--- a/src/winpodx/core/daemon.py
+++ b/src/winpodx/core/daemon.py
@@ -410,9 +410,7 @@ def run_session_window_reaper(
                         seen.add(name)
                         gone_since.pop(name, None)
                     elif name in seen:
-                        armed_at, armed_pid = gone_since.setdefault(
-                            name, (now, live_pids[name])
-                        )
+                        armed_at, armed_pid = gone_since.setdefault(name, (now, live_pids[name]))
                         if armed_pid != live_pids[name]:
                             # A fresh session replaced the one we armed against
                             # (its window just hasn't mapped yet). Re-arm on the

--- a/src/winpodx/core/daemon.py
+++ b/src/winpodx/core/daemon.py
@@ -339,13 +339,20 @@ def _rail_window_classes(wmctrl: str) -> set[str] | None:
     app_name slug, so ``wmctrl -lx`` column 3 is ``RAIL.<app_name>``.
     """
     try:
-        out = subprocess.run(
+        proc = subprocess.run(
             [wmctrl, "-lx"], capture_output=True, text=True, timeout=4, check=False
-        ).stdout
+        )
     except (OSError, subprocess.SubprocessError):
         return None
+    # A non-zero exit means the scan failed (e.g. wmctrl "Cannot get client list
+    # properties" while the WM is transitioning), NOT that there are zero
+    # windows. Treating an empty stdout as "no windows" here would arm every
+    # live session for reaping and, after the debounce, kill them all on two
+    # transient failures. Return None so callers hold their state instead.
+    if proc.returncode != 0:
+        return None
     classes: set[str] = set()
-    for line in out.splitlines():
+    for line in proc.stdout.splitlines():
         parts = line.split(None, 4)  # id, desktop, wm_class, host, title
         if len(parts) >= 3 and parts[2].startswith("RAIL."):
             classes.add(parts[2][len("RAIL.") :])
@@ -380,10 +387,15 @@ def run_session_window_reaper(
         return
     log.info("Session window-reaper started")
     seen: set[str] = set()  # app_names whose RAIL window has appeared at least once
-    gone_since: dict[str, float] = {}
+    # name -> (armed_at, pid): the monotonic time the window went away AND the
+    # session PID that owned it. Binding to a PID stops a relaunch race -- if the
+    # user closes a doc and immediately reopens (the .cproc is overwritten with a
+    # fresh session's PID), we must reap the OLD session, not the newcomer.
+    gone_since: dict[str, tuple[float, int]] = {}
     while not stop_event.is_set():
         try:
-            live = {s.app_name for s in list_active_sessions()}
+            live_pids = {s.app_name: s.pid for s in list_active_sessions()}
+            live = set(live_pids)
             # Forget state for sessions that have ended.
             seen.intersection_update(live)
             for name in list(gone_since):
@@ -398,14 +410,22 @@ def run_session_window_reaper(
                         seen.add(name)
                         gone_since.pop(name, None)
                     elif name in seen:
-                        first_gone = gone_since.setdefault(name, now)
-                        if now - first_gone >= _WINDOW_REAP_DEBOUNCE_SECS:
+                        armed_at, armed_pid = gone_since.setdefault(
+                            name, (now, live_pids[name])
+                        )
+                        if armed_pid != live_pids[name]:
+                            # A fresh session replaced the one we armed against
+                            # (its window just hasn't mapped yet). Re-arm on the
+                            # new PID instead of reaping the newcomer.
+                            gone_since[name] = (now, live_pids[name])
+                            continue
+                        if now - armed_at >= _WINDOW_REAP_DEBOUNCE_SECS:
                             log.info(
                                 "session %r windows gone %.0fs after close; reaping",
                                 name,
                                 _WINDOW_REAP_DEBOUNCE_SECS,
                             )
-                            kill_session(name)
+                            kill_session(name, expected_pid=armed_pid)
                             seen.discard(name)
                             gone_since.pop(name, None)
         except Exception as e:  # noqa: BLE001 -- never kill the monitor

--- a/src/winpodx/core/process.py
+++ b/src/winpodx/core/process.py
@@ -134,8 +134,16 @@ def list_active_sessions() -> list[TrackedProcess]:
     return sessions
 
 
-def kill_session(app_name: str) -> bool:
-    """Terminate an active RDP session by app name (SIGTERM the tracked PID)."""
+def kill_session(app_name: str, expected_pid: int | None = None) -> bool:
+    """Terminate an active RDP session by app name (SIGTERM the tracked PID).
+
+    ``expected_pid`` guards against a relaunch race: the ``.cproc`` for an app is
+    overwritten in place when a fresh session of the same app spawns. A window
+    reaper that armed against one session must not SIGTERM the session that
+    replaced it (close a doc, immediately open the next -- a very common flow).
+    When ``expected_pid`` is given and the current marker no longer holds it, a
+    newer session owns the slot, so we leave it alone and report no-kill.
+    """
     pid_file = runtime_dir() / f"{app_name}.cproc"
     if not pid_file.exists():
         return False
@@ -144,6 +152,11 @@ def kill_session(app_name: str) -> bool:
         pid = int(pid_file.read_text().strip())
     except (ValueError, OSError):
         pid_file.unlink(missing_ok=True)
+        return False
+
+    if expected_pid is not None and pid != expected_pid:
+        # A fresh session replaced the one the caller armed against; don't reap
+        # the newcomer (and don't touch its .cproc).
         return False
 
     if not _pid_alive(pid):

--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -1237,13 +1237,18 @@ def _count_rail_windows(wmctrl: str, target: str) -> int | None:
     with res_class == the ``/wm-class`` token (our app_name slug).
     """
     try:
-        out = subprocess.run(
+        proc = subprocess.run(
             [wmctrl, "-lx"], capture_output=True, text=True, timeout=4, check=False
-        ).stdout
+        )
     except (OSError, subprocess.SubprocessError):
         return None
+    # Non-zero exit = scan failed (WM transitioning), not "zero windows". Return
+    # None so the caller treats it as a transient failure and holds its state
+    # rather than counting it as the app's windows having closed.
+    if proc.returncode != 0:
+        return None
     count = 0
-    for line in out.splitlines():
+    for line in proc.stdout.splitlines():
         parts = line.split(None, 4)  # id, desktop, wm_class, host, title
         if len(parts) >= 3 and parts[2] == target:
             count += 1
@@ -1309,7 +1314,10 @@ def _window_reaper(session: RDPSession, wm_class: str) -> None:
                     session.app_name,
                     _WINDOW_REAP_DEBOUNCE,
                 )
-                kill_session(session.app_name)
+                # Guard the relaunch race: only reap if the .cproc still holds
+                # THIS session's PID. If the user reopened the app meanwhile, a
+                # fresh session overwrote the marker -- leave the newcomer alone.
+                kill_session(session.app_name, expected_pid=proc.pid)
                 return
         else:
             gone_since = None

--- a/src/winpodx/core/url_schemes.py
+++ b/src/winpodx/core/url_schemes.py
@@ -51,6 +51,19 @@ DANGEROUS_SCHEMES: frozenset[str] = frozenset(
     }
 )
 
+# Schemes that stay routable + registerable as *candidate* handlers, but that we
+# must never seize the SYSTEM DEFAULT for from a discovered (semi-trusted) guest
+# app. http/https carry session tokens / password-reset links, so a guest app
+# silently becoming the host's web-link handler is a trust-boundary hole: every
+# link the user clicks on Linux would be handed to a Windows app that may be
+# malware. `winpodx app run <browser> https://…` and the "Open with" menu still
+# work (the .desktop keeps the x-scheme-handler entry) -- the user just has to
+# opt in explicitly to make a Windows browser their default. Distinct from
+# DANGEROUS_SCHEMES (which blocks routing entirely); these route fine, they just
+# never become the auto-default. mailto / vendor schemes (slack, zoommtg, …) are
+# intentionally NOT here -- routing a mailto: link to Outlook is the #421 goal.
+NEVER_AUTO_DEFAULT_SCHEMES: frozenset[str] = frozenset({"http", "https"})
+
 
 def is_safe_scheme(scheme: str) -> bool:
     """True if ``scheme`` is routable (syntactically valid + not dangerous).

--- a/src/winpodx/desktop/mime.py
+++ b/src/winpodx/desktop/mime.py
@@ -25,7 +25,20 @@ def register_mime_types(app: AppInfo) -> None:
     # File MIME types + URL scheme handlers (#421/#694): making the Windows app
     # the default handler for its declared schemes (e.g. x-scheme-handler/mailto
     # -> Outlook) so a host mailto: link opens in it.
-    scheme_mimes = [f"x-scheme-handler/{s}" for s in (app.url_schemes or [])]
+    #
+    # NEVER_AUTO_DEFAULT_SCHEMES (http/https) are deliberately excluded here: a
+    # discovered guest app must not silently seize the host's web-link default
+    # (it would receive every URL the user clicks, tokens included). They still
+    # get their x-scheme-handler entry in the .desktop (candidate + "Open with"),
+    # so the user can opt in manually; we just never run `xdg-mime default` for
+    # them. mailto / vendor schemes still auto-default (the #421 use case).
+    from winpodx.core.url_schemes import NEVER_AUTO_DEFAULT_SCHEMES
+
+    scheme_mimes = [
+        f"x-scheme-handler/{s}"
+        for s in (app.url_schemes or [])
+        if s not in NEVER_AUTO_DEFAULT_SCHEMES
+    ]
     for mime in list(app.mime_types) + scheme_mimes:
         try:
             result = subprocess.run(

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -17,6 +17,35 @@ from winpodx.core.daemon import (
 )
 
 
+def test_rail_window_classes_none_on_nonzero_exit(monkeypatch):
+    """Security/robustness: a non-zero wmctrl exit (WM transitioning) must return
+    None, not an empty set -- an empty set would arm every live session for
+    reaping and kill them all on two transient scan failures."""
+    from winpodx.core.daemon import _rail_window_classes
+
+    class _R:
+        returncode = 1
+        stdout = ""  # wmctrl printed nothing because it failed
+
+    monkeypatch.setattr("winpodx.core.daemon.subprocess.run", lambda *a, **k: _R())
+    assert _rail_window_classes("wmctrl") is None
+
+
+def test_rail_window_classes_parses_on_success(monkeypatch):
+    from winpodx.core.daemon import _rail_window_classes
+
+    class _R:
+        returncode = 0
+        stdout = (
+            "0x01 0 RAIL.winword host Doc\n"
+            "0x02 0 RAIL.excel host Sheet\n"
+            "0x03 0 Navigator.firefox host Web\n"
+        )
+
+    monkeypatch.setattr("winpodx.core.daemon.subprocess.run", lambda *a, **k: _R())
+    assert _rail_window_classes("wmctrl") == {"winword", "excel"}
+
+
 def test_cleanup_lock_files(tmp_path):
     # Lock files should be removed, normal files preserved.
     lock = tmp_path / "~$test.docx"
@@ -283,7 +312,11 @@ def test_rail_window_classes_parses_res_class(monkeypatch):
         "0x02 0 RAIL.winword host Doc\n"
         "0x03 0 firefox.Firefox host web\n"
     )
-    monkeypatch.setattr(daemon.subprocess, "run", lambda *a, **k: type("R", (), {"stdout": out})())
+    monkeypatch.setattr(
+        daemon.subprocess,
+        "run",
+        lambda *a, **k: type("R", (), {"stdout": out, "returncode": 0})(),
+    )
     assert daemon._rail_window_classes("wmctrl") == {"excel", "winword"}
 
 
@@ -311,7 +344,7 @@ def _reaper_env(monkeypatch, scans):
     stop = threading.Event()
     killed: list[str] = []
 
-    def _kill(name):
+    def _kill(name, expected_pid=None):
         killed.append(name)
         stop.set()  # one reap is enough for the test
 
@@ -348,7 +381,9 @@ def test_session_window_reaper_never_reaps_unseen_window(monkeypatch):
 
     monkeypatch.setattr(daemon, "_rail_window_classes", _scan)
     killed: list[str] = []
-    monkeypatch.setattr(daemon, "kill_session", lambda name: killed.append(name))
+    monkeypatch.setattr(
+        daemon, "kill_session", lambda name, expected_pid=None: killed.append(name)
+    )
 
     daemon.run_session_window_reaper(Config(), stop)
     assert killed == []

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -381,9 +381,7 @@ def test_session_window_reaper_never_reaps_unseen_window(monkeypatch):
 
     monkeypatch.setattr(daemon, "_rail_window_classes", _scan)
     killed: list[str] = []
-    monkeypatch.setattr(
-        daemon, "kill_session", lambda name, expected_pid=None: killed.append(name)
-    )
+    monkeypatch.setattr(daemon, "kill_session", lambda name, expected_pid=None: killed.append(name))
 
     daemon.run_session_window_reaper(Config(), stop)
     assert killed == []

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -12,7 +12,7 @@ from winpodx.core.app import AppInfo
 from winpodx.desktop import entry as entry_mod
 from winpodx.desktop.entry import DESKTOP_TEMPLATE, install_desktop_entry
 from winpodx.desktop.icons import bundled_data_path
-from winpodx.desktop.mime import unregister_mime_types
+from winpodx.desktop.mime import register_mime_types, unregister_mime_types
 
 
 def test_desktop_template():
@@ -43,6 +43,46 @@ def test_desktop_template():
     assert "Categories=Office;WordProcessor;" in content
     assert "MimeType=application/msword;" in content
     assert "StartupWMClass=winword" in content
+
+
+def test_register_mime_excludes_http_https_from_default_grab(tmp_path, monkeypatch):
+    """Security: a discovered (semi-trusted) guest app must never seize the host
+    http/https default handler. register_mime_types runs `xdg-mime default` for
+    file mimes + mailto/vendor schemes, but NOT for http/https (#421/#694
+    trust-boundary hardening)."""
+    apps_dir = tmp_path / "applications"
+    apps_dir.mkdir()
+    monkeypatch.setattr("winpodx.desktop.mime.applications_dir", lambda: apps_dir)
+    (apps_dir / "winpodx-edge.desktop").write_text("[Desktop Entry]\n", encoding="utf-8")
+
+    registered: list[str] = []
+
+    class _R:
+        returncode = 0
+        stderr = ""
+
+    def _fake_run(argv, **kw):
+        # argv = ["xdg-mime", "default", "<desktop>", "<mime>"]
+        registered.append(argv[-1])
+        return _R()
+
+    monkeypatch.setattr("winpodx.desktop.mime.subprocess.run", _fake_run)
+
+    app = AppInfo(
+        name="edge",
+        full_name="Microsoft Edge",
+        executable="C:\\edge.exe",
+        mime_types=["text/html"],
+        url_schemes=["http", "https", "mailto", "webcal"],
+    )
+    register_mime_types(app)
+
+    assert "x-scheme-handler/http" not in registered
+    assert "x-scheme-handler/https" not in registered
+    # mailto + vendor schemes still auto-default (the #421 use case); file mimes too.
+    assert "x-scheme-handler/mailto" in registered
+    assert "x-scheme-handler/webcal" in registered
+    assert "text/html" in registered
 
 
 # D1: unregister_mime_types must not destroy mimeapps.list structure

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -184,6 +184,40 @@ class TestKillSession:
         assert signal.SIGKILL in sigs  # escalated
         assert not cproc.exists()
 
+    def test_expected_pid_mismatch_not_signalled(self, tmp_path, monkeypatch):
+        # Relaunch race: a reaper armed against PID 4242, but the .cproc now
+        # holds 5555 (a fresh session of the same app overwrote it). With
+        # expected_pid=4242 we must NOT reap the newcomer, and must leave its
+        # marker intact.
+        monkeypatch.setattr("winpodx.core.process.runtime_dir", lambda: tmp_path)
+        monkeypatch.setattr("winpodx.core.process._pid_alive", lambda pid: True)
+        monkeypatch.setattr("winpodx.core.process.is_freerdp_pid", lambda pid: True)
+        calls = []
+        monkeypatch.setattr("winpodx.core.process.os.kill", lambda pid, sig: calls.append(pid))
+        monkeypatch.setattr("winpodx.core.process.os.killpg", lambda pgid, sig: calls.append(pgid))
+        cproc = tmp_path / "app.cproc"
+        cproc.write_text("5555")
+        assert kill_session("app", expected_pid=4242) is False
+        assert calls == []
+        assert cproc.exists()  # newcomer's marker left untouched
+        assert cproc.read_text() == "5555"
+
+    def test_expected_pid_match_signals(self, tmp_path, monkeypatch):
+        # Same PID the reaper armed against is still in the marker -> reap it.
+        monkeypatch.setattr("winpodx.core.process.runtime_dir", lambda: tmp_path)
+        monkeypatch.setattr("winpodx.core.process.is_freerdp_pid", lambda pid: True)
+        monkeypatch.setattr("winpodx.core.process.os.getpgid", lambda pid: pid)
+        monkeypatch.setattr("winpodx.core.process.time.sleep", lambda s: None)
+        alive = iter([True, False, False])
+        monkeypatch.setattr("winpodx.core.process._pid_alive", lambda pid: next(alive, False))
+        sigs = []
+        monkeypatch.setattr("winpodx.core.process.os.killpg", lambda pgid, sig: sigs.append(pgid))
+        cproc = tmp_path / "app.cproc"
+        cproc.write_text("4242")
+        assert kill_session("app", expected_pid=4242) is True
+        assert sigs == [4242]
+        assert not cproc.exists()
+
     def test_reused_pid_not_signalled(self, tmp_path, monkeypatch):
         # PID-reuse guard: a live PID that is NOT our FreeRDP client must never
         # be signalled (we'd kill an innocent process). Just drop the stale file.

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -1121,7 +1121,11 @@ def test_count_rail_windows_matches_res_class(monkeypatch):
         "0x03 0 RAIL.winword host Doc\n"
         "0x04 0 firefox.Firefox host web\n"
     )
-    monkeypatch.setattr(rdp_mod.subprocess, "run", lambda *a, **k: type("R", (), {"stdout": out})())
+    monkeypatch.setattr(
+        rdp_mod.subprocess,
+        "run",
+        lambda *a, **k: type("R", (), {"stdout": out, "returncode": 0})(),
+    )
     assert rdp_mod._count_rail_windows("wmctrl", "RAIL.excel") == 2
     assert rdp_mod._count_rail_windows("wmctrl", "RAIL.winword") == 1
     assert rdp_mod._count_rail_windows("wmctrl", "RAIL.none") == 0
@@ -1138,6 +1142,8 @@ def test_count_rail_windows_none_on_scan_error(monkeypatch):
 
 
 class _AliveProc:
+    pid = 4242  # the reaper passes this as expected_pid to kill_session
+
     def poll(self):
         return None  # never exits on its own -- the watcher must reap it
 
@@ -1162,7 +1168,10 @@ def test_window_reaper_reaps_after_windows_close(monkeypatch):
     monkeypatch.setattr(rdp_mod, "_count_rail_windows", lambda *a: next(seq, 0))
 
     killed: list[str] = []
-    monkeypatch.setattr("winpodx.core.process.kill_session", lambda name: killed.append(name))
+    monkeypatch.setattr(
+        "winpodx.core.process.kill_session",
+        lambda name, expected_pid=None: killed.append(name),
+    )
 
     session = RDPSession(app_name="excel")
     session.process = _AliveProc()
@@ -1181,7 +1190,10 @@ def test_window_reaper_never_reaps_if_no_window_appears(monkeypatch):
     monkeypatch.setattr(rdp_mod, "_count_rail_windows", lambda *a: 0)  # never appears
 
     killed: list[str] = []
-    monkeypatch.setattr("winpodx.core.process.kill_session", lambda name: killed.append(name))
+    monkeypatch.setattr(
+        "winpodx.core.process.kill_session",
+        lambda name, expected_pid=None: killed.append(name),
+    )
 
     session = RDPSession(app_name="excel")
     session.process = _AliveProc()
@@ -1198,7 +1210,10 @@ def test_window_reaper_noop_without_wmctrl(monkeypatch):
     scanned: list = []
     monkeypatch.setattr(rdp_mod, "_count_rail_windows", lambda *a: scanned.append(a))
     killed: list[str] = []
-    monkeypatch.setattr("winpodx.core.process.kill_session", lambda name: killed.append(name))
+    monkeypatch.setattr(
+        "winpodx.core.process.kill_session",
+        lambda name, expected_pid=None: killed.append(name),
+    )
 
     session = RDPSession(app_name="excel")
     session.process = _AliveProc()

--- a/tests/test_url_schemes.py
+++ b/tests/test_url_schemes.py
@@ -44,6 +44,20 @@ def test_is_safe_scheme_rejects_malformed(bad: str) -> None:
 def test_url_scheme_of_routes_urls_not_paths() -> None:
     assert url_scheme_of("mailto:a@b.com") == "mailto"
     assert url_scheme_of("https://example.com/x") == "https"
+
+
+def test_never_auto_default_covers_web_schemes_only() -> None:
+    # http/https stay routable (is_safe_scheme True) but must be flagged so the
+    # host never auto-seizes their system default from a guest app; mailto and
+    # vendor schemes are intentionally NOT flagged (the #421 auto-route goal).
+    from winpodx.core.url_schemes import NEVER_AUTO_DEFAULT_SCHEMES
+
+    assert "http" in NEVER_AUTO_DEFAULT_SCHEMES
+    assert "https" in NEVER_AUTO_DEFAULT_SCHEMES
+    assert "mailto" not in NEVER_AUTO_DEFAULT_SCHEMES
+    assert "slack" not in NEVER_AUTO_DEFAULT_SCHEMES
+    # still routable -- this is a default-grab policy, not a routing denylist
+    assert is_safe_scheme("http") and is_safe_scheme("https")
     assert url_scheme_of("SLACK://team") == "slack"
     # file paths + file: URIs are NOT routed (file: is denylisted -> UNC path)
     assert url_scheme_of("/home/me/doc.txt") is None


### PR DESCRIPTION
Pre-release security gate for 0.8.1 found three confirmed issues (adversarially
verified; two overstated findings were refuted and dropped).

### 1. Guest web-handler hijack — trust boundary (medium)
`DANGEROUS_SCHEMES` blocks `file:`/`javascript:`/… but not `http`/`https`, so a
discovered (semi-trusted) guest app could become the host's **default** web-link
handler via the `xdg-mime default` grab in `register_mime_types` (reachable from
`app install --mime` and `doctor --fix`). Every web link the user then clicks —
session tokens, reset links — would route into a Windows app that may be malware.

**Fix:** new `NEVER_AUTO_DEFAULT_SCHEMES = {http, https}` in `core/url_schemes.py`;
`register_mime_types` no longer runs `xdg-mime default` for them. They stay
**routable** (`app run <browser> https://…`, live-tested) and **candidate**
handlers (the `.desktop` keeps the `x-scheme-handler` entry, so "Open with"
works) — the user just opts in explicitly to make a Windows browser the default.
`mailto` / vendor schemes still auto-default, preserving the #421 use case.

### 2. Reaper mass-kill on transient scan failure (medium)
`_rail_window_classes` / `_count_rail_windows` treated a **non-zero `wmctrl` exit**
(WM transitioning) as "zero windows" — two transient failures in a row armed and
reaped **every live session**. **Fix:** return `None` on `returncode != 0`.

### 3. Reaper relaunch mis-kill (medium)
The window-reaper keyed state by `app_name`; `kill_session` resolves the
`.cproc`, which a fresh spawn **overwrites**. Close a doc and immediately reopen
(a very common flow) and the reaper SIGTERM'd the **newcomer**. **Fix:**
`kill_session` gains `expected_pid`; both reapers snapshot the PID they armed
against and reap only if the marker still holds it (the tray reaper re-arms on a
PID change).

### Tests
New: `expected_pid` match/mismatch, `http`/`https` excluded from the default
grab (mailto/file-mime still registered), `NEVER_AUTO_DEFAULT` policy, wmctrl
non-zero → `None`. Updated the reaper-loop test mocks for the new `kill_session`
signature. **Full suite: 2153 passed, 2 skipped; ruff clean.**

Refs #421 #694 #680