### PR TITLE
fix(install): auto-install libxcb-cursor0 for the Qt GUI on minimal desktops (#712)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed
+
+- **The GUI's `libxcb-cursor0` dependency is now auto-installed on a minimal desktop** (#712, thanks @numericOverflow). Qt 6.5+ (PySide6) refuses to start its `xcb` platform plugin without `libxcb-cursor.so.0` — "could not load the Qt platform plugin 'xcb'" — and it isn't pulled in transitively on a fresh minimal install (e.g. Linux Mint 22). `install.sh` now installs it (distro-mapped: `libxcb-cursor0` on Debian/Ubuntu/openSUSE, `xcb-util-cursor` on Fedora/Arch) when the GUI is enabled and the runtime lib isn't already present.
+
 ## [0.9.0] - 2026-07-11
 
 ### Added

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **최소 데스크톱에서 GUI의 `libxcb-cursor0` 의존성을 자동 설치** (#712, @numericOverflow 기여 감사). Qt 6.5+ (PySide6)는 `libxcb-cursor.so.0` 없이는 `xcb` 플랫폼 플러그인을 시작하지 못하는데("could not load the Qt platform plugin 'xcb'"), 새 최소 설치(예: Linux Mint 22)에선 전이 의존성으로 딸려오지 않습니다. 이제 `install.sh`가 GUI가 켜져 있고 런타임 lib가 없을 때 이를 설치합니다(배포판 매핑: Debian/Ubuntu/openSUSE는 `libxcb-cursor0`, Fedora/Arch는 `xcb-util-cursor`).
+
 ## [0.9.0] - 2026-07-11
 
 ### Added

--- a/install.sh
+++ b/install.sh
@@ -430,6 +430,7 @@ pkg_name() {
                 docker)         echo "docker" ;;
                 freerdp)        echo "freerdp" ;;
                 kvm)            echo "qemu-kvm" ;;
+                xcb-cursor)     echo "libxcb-cursor0" ;;
             esac ;;
         fedora|rhel|centos|rocky|alma)
             case "$dep" in
@@ -439,6 +440,7 @@ pkg_name() {
                 docker)         echo "docker" ;;
                 freerdp)        echo "freerdp" ;;
                 kvm)            echo "qemu-kvm" ;;
+                xcb-cursor)     echo "xcb-util-cursor" ;;
             esac ;;
         ubuntu|debian|linuxmint|pop)
             case "$dep" in
@@ -500,6 +502,7 @@ pkg_name() {
                         echo "$kvm_first"
                     fi
                     ;;
+                xcb-cursor)     echo "libxcb-cursor0" ;;
             esac ;;
         arch|manjaro|endeavouros)
             case "$dep" in
@@ -509,6 +512,7 @@ pkg_name() {
                 docker)         echo "docker" ;;
                 freerdp)        echo "freerdp" ;;
                 kvm)            echo "qemu-full" ;;
+                xcb-cursor)     echo "xcb-util-cursor" ;;
             esac ;;
         *)
             echo "$dep" ;;
@@ -1024,6 +1028,19 @@ esac
 
 # python3 is mandatory (venv host interpreter).
 [ "$PYTHON3_PRESENT" = false ] && MISSING+=("python3")
+
+# The Qt6 GUI (PySide6) needs the xcb-cursor platform-plugin runtime library
+# (libxcb-cursor.so.0). Qt 6.5+ refuses to start its xcb platform plugin
+# without it -- "could not load the Qt platform plugin 'xcb'" -- and it isn't
+# pulled in transitively on a minimal desktop (e.g. fresh Linux Mint 22, #712).
+# Only when the GUI is enabled and the lib isn't already present; keyed off the
+# runtime .so via ldconfig so it's distro-agnostic and stays out of the install
+# plan when it's already there.
+if [ -z "$WINPODX_NO_GUI" ]; then
+    if ! ldconfig -p 2>/dev/null | grep -q 'libxcb-cursor\.so\.0'; then
+        MISSING+=("xcb-cursor")
+    fi
+fi
 
 if [ "$KVM_PRESENT" = false ]; then
     # Pre-install hint. A surprising fraction of user bug reports start


### PR DESCRIPTION
On a fresh minimal desktop (e.g. Linux Mint 22), starting the WinPodX GUI fails
with:

```
could not load the Qt platform plugin "xcb"
```

Qt 6.5+ (PySide6) requires `libxcb-cursor.so.0` for its xcb platform plugin, and
that lib isn't pulled in transitively on a minimal install. `install.sh` never
installed it, so the one-liner completed but the GUI wouldn't start.

**Fix:** when the GUI is enabled and `libxcb-cursor.so.0` isn't already present
(probed via `ldconfig` — distro-agnostic), add it to the install set, mapped
per-distro:

| distro | package |
|---|---|
| Debian / Ubuntu / Mint / openSUSE | `libxcb-cursor0` |
| Fedora / RHEL / Arch | `xcb-util-cursor` |

- `--no-gui` installs skip it; already-present lib stays out of the install plan.
- `bash -n` clean; pkg_name mapping + GUI-gate logic smoke-tested; install.sh
  test suite passes.

Refs #712
Reported-by: @numericOverflow (#712)

---
Note on the sibling report **#711 (podman-compose)**: `install.sh` already
auto-installs `podman-compose` when it's missing on the podman backend (since
#580/#610). Handling that separately — likely needs the reporter's install log.