### PR TITLE
fix(install): detect libxcb-cursor by real .so on disk, not ldconfig (#712)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed
 
-- **The GUI's `libxcb-cursor0` dependency is now auto-installed on a minimal desktop** (#712, thanks @numericOverflow). Qt 6.5+ (PySide6) refuses to start its `xcb` platform plugin without `libxcb-cursor.so.0` — "could not load the Qt platform plugin 'xcb'" — and it isn't pulled in transitively on a fresh minimal install (e.g. Linux Mint 22). `install.sh` now installs it (distro-mapped: `libxcb-cursor0` on Debian/Ubuntu/openSUSE, `xcb-util-cursor` on Fedora/Arch) when the GUI is enabled and the runtime lib isn't already present.
+- **The GUI's `libxcb-cursor0` dependency is now auto-installed on a minimal desktop** (#712, thanks @numericOverflow). Qt 6.5+ (PySide6) refuses to start its `xcb` platform plugin without `libxcb-cursor.so.0` — "could not load the Qt platform plugin 'xcb'" — and it isn't pulled in transitively on a fresh minimal install (e.g. Linux Mint 22). `install.sh` now installs it (distro-mapped: `libxcb-cursor0` on Debian/Ubuntu/openSUSE, `xcb-util-cursor` on Fedora/Arch) when the GUI is enabled and the runtime lib isn't already present. Presence is detected by probing the real `.so` on disk across the standard lib dirs rather than `ldconfig -p` — on openSUSE the library lives in `/usr/lib64` but is absent from the ld.so cache, so an `ldconfig` probe re-prompted every run even with the package installed.
 
 ## [0.9.0] - 2026-07-11
 

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -15,7 +15,7 @@
 
 ### Fixed
 
-- **최소 데스크톱에서 GUI의 `libxcb-cursor0` 의존성을 자동 설치** (#712, @numericOverflow 기여 감사). Qt 6.5+ (PySide6)는 `libxcb-cursor.so.0` 없이는 `xcb` 플랫폼 플러그인을 시작하지 못하는데("could not load the Qt platform plugin 'xcb'"), 새 최소 설치(예: Linux Mint 22)에선 전이 의존성으로 딸려오지 않습니다. 이제 `install.sh`가 GUI가 켜져 있고 런타임 lib가 없을 때 이를 설치합니다(배포판 매핑: Debian/Ubuntu/openSUSE는 `libxcb-cursor0`, Fedora/Arch는 `xcb-util-cursor`).
+- **최소 데스크톱에서 GUI의 `libxcb-cursor0` 의존성을 자동 설치** (#712, @numericOverflow 기여 감사). Qt 6.5+ (PySide6)는 `libxcb-cursor.so.0` 없이는 `xcb` 플랫폼 플러그인을 시작하지 못하는데("could not load the Qt platform plugin 'xcb'"), 새 최소 설치(예: Linux Mint 22)에선 전이 의존성으로 딸려오지 않습니다. 이제 `install.sh`가 GUI가 켜져 있고 런타임 lib가 없을 때 이를 설치합니다(배포판 매핑: Debian/Ubuntu/openSUSE는 `libxcb-cursor0`, Fedora/Arch는 `xcb-util-cursor`). 존재 여부는 `ldconfig -p`가 아니라 표준 lib 디렉토리의 실제 `.so` 파일로 감지합니다 — openSUSE에선 라이브러리가 `/usr/lib64`에 있지만 ld.so 캐시엔 없어서, `ldconfig` 프로브가 패키지 설치 후에도 매번 다시 프롬프트를 띄웠습니다.
 
 ## [0.9.0] - 2026-07-11
 

--- a/install.sh
+++ b/install.sh
@@ -1033,13 +1033,24 @@ esac
 # (libxcb-cursor.so.0). Qt 6.5+ refuses to start its xcb platform plugin
 # without it -- "could not load the Qt platform plugin 'xcb'" -- and it isn't
 # pulled in transitively on a minimal desktop (e.g. fresh Linux Mint 22, #712).
-# Only when the GUI is enabled and the lib isn't already present; keyed off the
-# runtime .so via ldconfig so it's distro-agnostic and stays out of the install
-# plan when it's already there.
-if [ -z "$WINPODX_NO_GUI" ]; then
-    if ! ldconfig -p 2>/dev/null | grep -q 'libxcb-cursor\.so\.0'; then
-        MISSING+=("xcb-cursor")
-    fi
+# Only add it when the GUI is enabled and the lib isn't already present.
+#
+# Detection probes the real .so on disk, NOT `ldconfig -p`: on openSUSE the
+# library exists at /usr/lib64/libxcb-cursor.so.0 but is absent from the ld.so
+# cache, so the ldconfig probe false-negatived and re-prompted every run even
+# with libxcb-cursor0 installed (#712 follow-up). Check the standard lib dirs
+# (incl. Debian/Ubuntu multiarch) directly, then fall back to ldconfig for any
+# non-standard prefix.
+_has_libxcb_cursor() {
+    local d
+    for d in /usr/lib64 /usr/lib /lib64 /lib \
+             /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu; do
+        [ -e "$d/libxcb-cursor.so.0" ] && return 0
+    done
+    ldconfig -p 2>/dev/null | grep -q 'libxcb-cursor\.so\.0'
+}
+if [ -z "$WINPODX_NO_GUI" ] && ! _has_libxcb_cursor; then
+    MISSING+=("xcb-cursor")
 fi
 
 if [ "$KVM_PRESENT" = false ]; then


### PR DESCRIPTION
Follow-up to #712/#715. The GUI xcb-cursor dependency check used `ldconfig -p |
grep libxcb-cursor.so.0`, but that false-negatives on openSUSE:

```
$ rpm -q libxcb-cursor0        → libxcb-cursor0-0.1.6-1.4.x86_64   (installed)
$ ls /usr/lib64/libxcb-cursor.so.0  → exists
$ ldconfig -p | grep xcb-cursor     → (empty!)   ← the library is NOT in the ld.so cache
```

So on openSUSE the installer re-added `xcb-cursor` to the plan and re-prompted to
install it **every run**, even with the package already present.

**Fix:** probe the real `.so` on disk across the standard lib dirs
(`/usr/lib64`, `/usr/lib`, `/lib64`, `/lib`, and Debian/Ubuntu multiarch
`/usr/lib/<triplet>`), falling back to `ldconfig` only for a non-standard
prefix. Verified on this openSUSE Tumbleweed box: with `libxcb-cursor0`
installed the plan is now empty; with the lib absent it still adds `xcb-cursor`.

- `bash -n` clean; install.sh test suite 35 passed.

Refs #712