### PR TITLE
fix(uninstall): non-purge must not delete the Windows VM disk (#716)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed
+
+- **A non-purge `uninstall.sh` no longer deletes the Windows VM disk** (#716, thanks @munir-abbasi — data-loss report). The default VM storage lives under the app-data dir (`~/.local/share/winpodx/storage/data.img`), and the "remove app definitions" step did a plain `rm -rf ~/.local/share/winpodx` — so a non-purge uninstall (documented as *keeping* the VM data), especially via the package-manager `postrm` re-entry where it runs unattended, recursively wiped the Windows VM out from under `storage/`. Uninstall now canonicalizes both paths and, when the storage dir is `DATA_DIR` itself or nested beneath it and `--purge` was **not** given, preserves the storage subtree and removes only the other app-data entries. A custom `WINPODX_STORAGE_PATH` outside the app-data dir is untouched as before, and `--purge` still wipes everything. Regression-tested via the uninstall smoke harness (nested-storage, external-storage, and purge cases).
+
 ### Added
 
 - **Launching a Linux app directly from its "Linux Apps" shortcut on Windows now runs it** (#616, thanks @notnotno). The reverse-open shims placed under Windows' Start Menu / Desktop "Linux Apps" folder are primarily "Open with…" chooser entries, but clicking one directly (with no file) used to do nothing — the guest shim silently exited because it required a file argument. It now emits a launch-only request (`origin: "launch"`, empty path) and the host runs the Linux app with no file (the `%f`/`%u` placeholder is stripped rather than filled), so the shortcuts double as plain app launchers. Requires the updated guest shim (re-provisions on the next `winpodx guest sync` / `apply-fixes`).

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **non-purge `uninstall.sh`가 Windows VM 디스크를 삭제하지 않도록 수정** (#716, @munir-abbasi 데이터 손실 리포트 감사). 기본 VM 저장소가 앱 데이터 디렉토리 하위에 있는데(`~/.local/share/winpodx/storage/data.img`), "앱 정의 제거" 단계가 `rm -rf ~/.local/share/winpodx`를 그냥 실행해서 — VM 데이터를 *보존*한다고 문서화된 non-purge 언인스톨이, 특히 무인 실행되는 패키지 매니저 `postrm` 재진입 경로에서 `storage/` 아래 Windows VM을 통째로 지웠습니다. 이제 두 경로를 정규화해서, 저장소 디렉토리가 `DATA_DIR` 자신이거나 그 하위이고 `--purge`가 **없으면** 저장소 서브트리를 보존하고 나머지 앱 데이터 항목만 삭제합니다. 앱 데이터 디렉토리 밖의 커스텀 `WINPODX_STORAGE_PATH`는 기존대로 손대지 않으며, `--purge`는 여전히 전부 삭제합니다. 언인스톨 스모크 하네스로 회귀 테스트(중첩 저장소·외부 저장소·purge 케이스).
+
 ### Added
 
 - **Windows의 "Linux Apps" 바로가기에서 Linux 앱을 파일 없이 직접 실행 가능** (#616, @notnotno 기여 감사). Windows 시작 메뉴/바탕화면 "Linux Apps" 폴더의 reverse-open shim은 주로 "연결 프로그램" 선택 항목인데, 파일 없이 직접 클릭하면 게스트 shim이 파일 인자를 요구해서 조용히 종료돼 아무 일도 안 일어났습니다. 이제 launch-only 요청(`origin: "launch"`, 빈 경로)을 보내 호스트가 파일 없이 Linux 앱을 실행하므로(`%f`/`%u` placeholder를 채우지 않고 제거), 그 바로가기가 일반 앱 런처로도 동작합니다. 갱신된 게스트 shim 필요(다음 `winpodx guest sync` / `apply-fixes` 때 재프로비저닝).

--- a/tests/uninstall_smoke.sh
+++ b/tests/uninstall_smoke.sh
@@ -119,4 +119,67 @@ if [ "$FAIL" -gt 0 ]; then
     exit 1
 fi
 
+# --- #716 data-loss regression: a non-purge uninstall must KEEP the VM disk ---
+#
+# The default VM storage lives under DATA_DIR (~/.local/share/winpodx/storage).
+# A non-purge `uninstall.sh --confirm` is documented to preserve Windows VM
+# data, so it must NOT rm -rf the parent DATA_DIR out from under storage/.
+assert_exists() {
+    if [ -e "$1" ]; then
+        echo "[smoke] OK:   preserved -- $1"
+    else
+        echo "[smoke] FAIL: deleted   -- $1" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Seed the full install topology so uninstall.sh (set -euo pipefail) runs to
+# completion — a missing ~/.local/share/applications makes an early `find` exit
+# non-zero and abort before the App-definitions step we're testing.
+_seed_topology() {
+    local sb="$1"
+    mkdir -p "$sb/.local/share/applications" \
+             "$sb/.local/share/icons/hicolor/scalable/apps" \
+             "$sb/.config/winpodx" "$sb/.config/autostart"
+    touch "$sb/.local/share/applications/winpodx.desktop"
+    echo '[Desktop Entry]' > "$sb/.local/share/applications/mimeinfo.cache"
+    echo 'placeholder' > "$sb/.config/winpodx/winpodx.toml"
+}
+
+echo "[smoke] #716 non-purge preserves nested VM storage"
+SB2="$(mktemp -d -p "$SANDBOX_BASE" winpodx-uninstall-nonpurge-XXXXXX)"
+trap 'rm -rf "$SANDBOX" "$SB2" "${SB3:-}"' EXIT
+_seed_topology "$SB2"
+mkdir -p "$SB2/.local/share/winpodx/storage" "$SB2/.local/share/winpodx/apps"
+echo 'VMDISK' > "$SB2/.local/share/winpodx/storage/data.img"
+echo 'app-data' > "$SB2/.local/share/winpodx/apps/notepad.toml"
+env -i HOME="$SB2" PATH="/usr/bin:/bin" \
+    XDG_RUNTIME_DIR="$SB2/run" XDG_DATA_HOME="$SB2/.local/share" \
+    XDG_CONFIG_HOME="$SB2/.config" XDG_CACHE_HOME="$SB2/.cache" \
+    WINPODX_BACKEND="true" WINPODX_CONTAINER_NAME="winpodx-windows-test" \
+    WINPODX_STORAGE_PATH="$SB2/.local/share/winpodx/storage" \
+    bash "$UNINSTALL_SH" --from-postrm --confirm >/dev/null 2>&1 || true
+assert_exists "$SB2/.local/share/winpodx/storage/data.img"    # VM disk kept
+assert_gone   "$SB2/.local/share/winpodx/apps/notepad.toml"   # app state gone
+
+echo "[smoke] #716 non-purge leaves an OUTSIDE custom storage untouched + removes DATA_DIR"
+SB3="$(mktemp -d -p "$SANDBOX_BASE" winpodx-uninstall-extstore-XXXXXX)"
+_seed_topology "$SB3"
+mkdir -p "$SB3/.local/share/winpodx/apps" "$SB3/ext-store"
+echo 'VMDISK' > "$SB3/ext-store/data.img"
+echo 'app-data' > "$SB3/.local/share/winpodx/apps/notepad.toml"
+env -i HOME="$SB3" PATH="/usr/bin:/bin" \
+    XDG_RUNTIME_DIR="$SB3/run" XDG_DATA_HOME="$SB3/.local/share" \
+    XDG_CONFIG_HOME="$SB3/.config" XDG_CACHE_HOME="$SB3/.cache" \
+    WINPODX_BACKEND="true" WINPODX_CONTAINER_NAME="winpodx-windows-test" \
+    WINPODX_STORAGE_PATH="$SB3/ext-store" \
+    bash "$UNINSTALL_SH" --from-postrm --confirm >/dev/null 2>&1 || true
+assert_exists "$SB3/ext-store/data.img"          # external storage untouched
+assert_gone   "$SB3/.local/share/winpodx"        # DATA_DIR removed wholesale
+
+if [ "$FAIL" -gt 0 ]; then
+    echo "[smoke] $FAIL assertion(s) failed" >&2
+    exit 1
+fi
+
 echo "[smoke] all assertions passed"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -66,7 +66,27 @@ done
 # in src/winpodx/core/config.py so the common case Just Works without
 # parsing the user's winpodx.toml from bash.
 CONTAINER_NAME="${WINPODX_CONTAINER_NAME:-winpodx-windows}"
-STORAGE_PATH="${WINPODX_STORAGE_PATH:-$HOME/.local/share/winpodx/storage}"
+STORAGE_PATH="${WINPODX_STORAGE_PATH:-}"
+if [[ -z "$STORAGE_PATH" ]]; then
+    # Resolve the ACTUAL configured storage path, not just the default: a user
+    # who relocated the VM with `--storage-dir` has their disk elsewhere, and
+    # both the #716 non-purge guard and the --purge wipe must act on the real
+    # location. Best-effort TOML parse of pod.storage_path; fall back to default.
+    _cfg="${XDG_CONFIG_HOME:-$HOME/.config}/winpodx/winpodx.toml"
+    if [[ -f "$_cfg" ]]; then
+        STORAGE_PATH="$(sed -n \
+            's/^[[:space:]]*storage_path[[:space:]]*=[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' \
+            "$_cfg" 2>/dev/null | head -n1)"
+    fi
+    STORAGE_PATH="${STORAGE_PATH:-$HOME/.local/share/winpodx/storage}"
+fi
+# Harden against a bogus STORAGE_PATH defeating the #716 nesting guard: a
+# relative path or a literal "~/..." (env-set, unexpanded) would not match the
+# DATA_DIR-prefix test and could re-enable rm -rf of the VM disk. Require an
+# absolute path; otherwise ignore it and use the safe default.
+if [[ "$STORAGE_PATH" != /* ]]; then
+    STORAGE_PATH="$HOME/.local/share/winpodx/storage"
+fi
 BACKEND_OVERRIDE="${WINPODX_BACKEND:-}"
 
 ask() {
@@ -357,8 +377,14 @@ if [[ -f "$DESKTOP_DIR/winpodx.desktop" ]]; then
     log "Removed WinPodX GUI launcher"
     REMOVED=$((REMOVED + 1))
 fi
-# Remove app desktop entries
-DESKTOP_COUNT=$(find "$DESKTOP_DIR" -maxdepth 1 -name "winpodx-*.desktop" 2>/dev/null | wc -l)
+# Remove app desktop entries. Guard the dir: under `set -euo pipefail` a find
+# over a missing DESKTOP_DIR exits non-zero and, via pipefail, aborts the whole
+# uninstall mid-cleanup (leaving a half-removed state) — seen in the #716 smoke.
+if [[ -d "$DESKTOP_DIR" ]]; then
+    DESKTOP_COUNT=$(find "$DESKTOP_DIR" -maxdepth 1 -name "winpodx-*.desktop" 2>/dev/null | wc -l)
+else
+    DESKTOP_COUNT=0
+fi
 if [[ "$DESKTOP_COUNT" -gt 0 ]]; then
     if ask "Remove $DESKTOP_COUNT app desktop entries?"; then
         rm -f "$DESKTOP_DIR"/winpodx-*.desktop
@@ -443,7 +469,12 @@ if [[ -d "$DATA_DIR" ]]; then
                 # STORAGE_PATH == DATA_DIR: nothing safe to delete recursively.
                 log "Kept $DATA_DIR (holds the Windows VM storage; use --purge to wipe)"
             else
-                find "$DATA_DIR" -mindepth 1 -maxdepth 1 ! -name "$_keep" \
+                # Belt-and-braces: always also preserve a top-level "storage"
+                # entry, not just the computed $_keep — if STORAGE_PATH ever
+                # resolves wrong, the conventional default VM disk still survives
+                # a non-purge uninstall.
+                find "$DATA_DIR" -mindepth 1 -maxdepth 1 \
+                    ! -name "$_keep" ! -name "storage" \
                     -exec rm -rf {} + 2>/dev/null || true
                 log "Removed $DATA_DIR contents (preserved VM storage: $STORAGE_PATH)"
                 REMOVED=$((REMOVED + 1))

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -424,9 +424,35 @@ fi
 DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/winpodx"
 if [[ -d "$DATA_DIR" ]]; then
     if ask "Remove app definitions ($DATA_DIR)?"; then
-        rm -rf "$DATA_DIR"
-        log "Removed $DATA_DIR"
-        REMOVED=$((REMOVED + 1))
+        # DATA-LOSS GUARD (#716): the default VM storage lives *under* DATA_DIR
+        # (~/.local/share/winpodx/storage/data.img). A non-purge uninstall is
+        # documented to KEEP the Windows VM data, so it must never rm -rf the
+        # parent DATA_DIR out from under the storage subtree. When STORAGE_PATH
+        # is DATA_DIR itself or nested beneath it and we are NOT purging,
+        # preserve the top-level storage component and remove only the rest.
+        _canon() { readlink -f "$1" 2>/dev/null || echo "${1%/}"; }
+        _dd="$(_canon "$DATA_DIR")"
+        _sp="$(_canon "$STORAGE_PATH")"
+        if [[ "$PURGE" != true ]] && { [[ "$_sp" == "$_dd" ]] || [[ "$_sp" == "$_dd"/* ]]; }; then
+            # First path component of STORAGE_PATH relative to DATA_DIR (e.g.
+            # "storage"). Keep that whole top-level entry; delete DATA_DIR's
+            # other top-level children (apps/, run/, icons cache, …).
+            _rel="${_sp#"$_dd"/}"
+            _keep="${_rel%%/*}"
+            if [[ "$_sp" == "$_dd" ]] || [[ -z "$_keep" ]]; then
+                # STORAGE_PATH == DATA_DIR: nothing safe to delete recursively.
+                log "Kept $DATA_DIR (holds the Windows VM storage; use --purge to wipe)"
+            else
+                find "$DATA_DIR" -mindepth 1 -maxdepth 1 ! -name "$_keep" \
+                    -exec rm -rf {} + 2>/dev/null || true
+                log "Removed $DATA_DIR contents (preserved VM storage: $STORAGE_PATH)"
+                REMOVED=$((REMOVED + 1))
+            fi
+        else
+            rm -rf "$DATA_DIR"
+            log "Removed $DATA_DIR"
+            REMOVED=$((REMOVED + 1))
+        fi
     fi
 fi
 


### PR DESCRIPTION
High-severity **data-loss** bug (thanks @munir-abbasi for the precise report).

**Root cause.** The default VM storage lives *under* the app-data dir:

```
DATA_DIR     = ~/.local/share/winpodx
STORAGE_PATH = ~/.local/share/winpodx/storage   (holds data.img — the VM disk)
```

The "remove app definitions" step ran a plain `rm -rf "$DATA_DIR"` with **no
`--purge` guard**, so a *non-purge* uninstall — documented as **keeping** the
Windows VM data — recursively deleted `storage/data.img` too. It bites hardest
via the package-manager `postrm` re-entry (`--from-postrm`, which sets
`AUTO=true`), where the deletion runs unattended with no prompt.

**Fix.** Canonicalize `DATA_DIR` + `STORAGE_PATH`; when storage is `DATA_DIR`
itself or nested beneath it and `--purge` was **not** given, preserve the
storage top-level component and remove only the other app-data entries. A custom
`WINPODX_STORAGE_PATH` outside `DATA_DIR` is wiped/kept exactly as before, and
`--purge` still removes everything.

**Regression tests** (`tests/uninstall_smoke.sh`, runs the real script via the
`postrm` path that triggers the loss):
- nested storage → `data.img` **preserved**, other app-data removed
- external `WINPODX_STORAGE_PATH` → untouched, `DATA_DIR` removed wholesale
- `--purge` → everything removed (unchanged)

`bash -n` clean; the guard logic also unit-smoked across 4 path shapes
(default-nested, external, purge, deep-nested).

Refs #716
Reported-by: @munir-abbasi (#716)