### PR TITLE
fix(install): atomic swap must handle a missing INSTALL_DIR on upgrade (#716 follow-up)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1544,12 +1544,18 @@ if [ "$WORK_DIR" != "$INSTALL_DIR" ]; then
     log "Swapping in the upgraded install..."
     INSTALL_DIR_ASIDE="$INSTALL_DIR.old"
     rm -rf "$INSTALL_DIR_ASIDE" 2>/dev/null || true
-    mv "$INSTALL_DIR" "$INSTALL_DIR_ASIDE"
-    SWAP_IN_PROGRESS=1
+    # The upgrade flag is keyed off the config, which a non-purge uninstall
+    # KEEPS while removing the install dir — so we can be on the "upgrade" path
+    # with no INSTALL_DIR to move aside. Only stash it (and arm the mid-swap
+    # rollback) when it actually exists; otherwise this is a fresh drop-in.
+    if [ -d "$INSTALL_DIR" ]; then
+        mv "$INSTALL_DIR" "$INSTALL_DIR_ASIDE"
+        SWAP_IN_PROGRESS=1
+    fi
     mv "$WORK_DIR" "$INSTALL_DIR"
     SWAP_IN_PROGRESS=0
     UPGRADE_SWAP_DONE=1
-    rm -rf "$INSTALL_DIR_ASIDE"
+    rm -rf "$INSTALL_DIR_ASIDE" 2>/dev/null || true
     log "Upgrade swapped in; previous install removed."
 fi
 


### PR DESCRIPTION
Real-smoke regression from #720. Sequence: `uninstall.sh --confirm` (non-purge)
then reinstall with `install.sh --main`.

A non-purge uninstall **removes `~/.local/bin/winpodx-app` but KEEPS the config**.
The reinstall keys the upgrade flag off the config → takes the upgrade path
(`WORK_DIR = $INSTALL_DIR.new`) → the atomic-swap block ran
`mv "$INSTALL_DIR" "$INSTALL_DIR.old"` — but there was no `$INSTALL_DIR` to move:

```
mv: cannot stat ".../winpodx-app": No such file or directory
[warn] Install failed during an upgrade — leaving the existing WinPodX install intact.
```

…and the install aborted, leaving no winpodx installed at all.

**Fix:** only stash `$INSTALL_DIR` (and arm the mid-swap rollback) when it
actually exists; otherwise drop the staged tree straight into place. Verified via
a 3-case smoke: upgrade-with-dir (normal swap), upgrade-without-dir (the bug — now
a clean drop-in), and fresh (unchanged). `bash -n` clean; install.sh tests pass.

The #716 storage guard itself worked perfectly in that smoke (`preserved VM
storage`, config kept, container kept) — this is purely the swap edge case.

Refs #716