### PR TITLE
feat(pod): roll dockur image forward to v6.00 (passt networking) (#721)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Changed
+
+- **Rolled the pinned dockur/windows image forward to v6.00** (#721, requested by @kroese — the dockur/windows maintainer). v6.00 moves Podman networking to the user-mode **passt** backend, which fixes the rootless port-forwarding problems that affected earlier images. winpodx's compose already asks for `NETWORK: "user"` (dockur auto-selects passt on v6.00) and forwards the agent (`8765`) and guest-SMB (`445`→`4445`) ports through `USER_PORTS`; a boot smoke confirmed the container comes up in `Mode: User (passt)` with all three ports (RDP `3390`, agent `8765`, SMB `4445`) reachable and the bare-metal disguise (SMBIOS/ACPI) still applied. This release also adopts two v6.00 dedicated env knobs the "new way" instead of the old raw-QEMU workarounds: `BALLOONING: "N"` (winpodx deliberately runs the VM with memory ballooning **off** for stability — v6.00 promotes ballooning to a first-class toggle) and `DISK_IO: "io_uring"` when the host tuning profile calls for it (the profile already detected io_uring support but never wired it through to the guest). x86_64 only — the ARM image (`dockur/windows-arm`) pin is unchanged, since there is no ARM hardware to smoke-test the roll-forward.
+
 ## [0.9.1] - 2026-07-14
 
 ### Fixed

--- a/config/oem/VERSIONS.txt
+++ b/config/oem/VERSIONS.txt
@@ -18,7 +18,7 @@
 # describes what winpodx deliberately uses.
 #
 # Format: <key>=<value>
-dockur=v5.16
-dockur-digest=sha256:3633f055f31aadf76bb650b1ca86897ab45b76ad8eb2cf81e86389ace5eb45ac
+dockur=v6.00
+dockur-digest=sha256:5f8b87b0d135cb19834f052e8bf6479d1596f4cca1b5eb33937dad9b6fa0e06c
 dockur-arm=v5.16
 dockur-arm-digest=sha256:ece93263254567c6cd4ce420b1fff793d2326f4535555bdf592f40ab173a7bed

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **고정된 dockur/windows 이미지를 v6.00으로 롤포워드** (#721, dockur/windows 메인테이너 @kroese 요청). v6.00은 Podman 네트워킹을 사용자 모드 **passt** 백엔드로 전환하여, 이전 이미지에서 문제가 되던 rootless 포트 포워딩 이슈를 해결합니다. winpodx의 compose는 이미 `NETWORK: "user"`를 요청하고(v6.00에서 dockur가 passt를 자동 선택), 에이전트(`8765`)와 게스트 SMB(`445`→`4445`) 포트를 `USER_PORTS`로 포워딩합니다. 부팅 스모크 결과 컨테이너가 `Mode: User (passt)`로 기동되고 세 포트(RDP `3390`, 에이전트 `8765`, SMB `4445`)가 모두 도달 가능하며 베어메탈 위장(SMBIOS/ACPI)도 그대로 적용됨을 확인했습니다. 이번 릴리즈에서는 기존의 raw-QEMU 우회 대신 v6.00 전용 env 노브 두 가지를 "새로운 방식"으로 채택합니다: `BALLOONING: "N"`(winpodx는 안정성을 위해 메모리 벌루닝을 의도적으로 **끈** 상태로 VM을 실행 — v6.00이 벌루닝을 1급 토글로 승격)과, 호스트 튜닝 프로파일이 요구할 때의 `DISK_IO: "io_uring"`(프로파일은 io_uring 지원을 이미 감지했으나 게스트까지 전달한 적이 없었음). x86_64 전용이며, ARM 이미지(`dockur/windows-arm`) 핀은 롤포워드를 스모크 테스트할 ARM 하드웨어가 없어 변경하지 않았습니다.
+
 ## [0.9.1] - 2026-07-14
 
 ### Fixed

--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -158,10 +158,10 @@ def _validate_device_entry(entry: object) -> str | None:
 # current ``:latest`` digest, paste below. See ``winpodx setup --update
 # -image`` for the runtime equivalent users invoke explicitly.
 #
-# As of 2026-06-10 (dockur/windows v5.16):
+# As of 2026-07-14 (dockur/windows v6.00 — Podman networking fixes, #721):
 DOCKUR_IMAGE_PIN = (
     "docker.io/dockurr/windows@sha256:"
-    "3633f055f31aadf76bb650b1ca86897ab45b76ad8eb2cf81e86389ace5eb45ac"
+    "5f8b87b0d135cb19834f052e8bf6479d1596f4cca1b5eb33937dad9b6fa0e06c"
 )
 
 # Pinned dockur/windows-arm image — used as the default ``cfg.pod.image``

--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -70,7 +70,8 @@ name: "winpodx"
       CPU_FLAGS: "{cpu_flags}"
       VMX: "{vmx}"
       HV: "{hv}"
-      ARGUMENTS: "{qemu_arguments}"
+      BALLOONING: "N"
+{disk_io_env}      ARGUMENTS: "{qemu_arguments}"
       USER_PORTS: "{user_ports}"
     volumes:
       - {storage_mount}
@@ -224,6 +225,28 @@ def _vmx_env_for_host(cfg: Config | None = None) -> str:
     cap = detect_tuning_capability(vm_cpu_cores=cfg.pod.cpu_cores, vm_ram_gb=cfg.pod.ram_gb)
     profile = recommend_tuning_profile(cap, user_pref=cfg.pod.tuning_profile)
     return "Y" if profile.apply_nested_virt else "N"
+
+
+def _disk_io_env_for_host(cfg: Config | None) -> str:
+    """Compose ``DISK_IO:`` env block when the tuning profile wants io_uring.
+
+    winpodx's tuning profile detects io_uring support (kernel >= 5.6) but until
+    dockur v6.00 there was no way to actually apply it — the recommendation was
+    surfaced by ``winpodx info`` yet never reached QEMU. v6.00 exposes a
+    dedicated ``DISK_IO`` env, so wire the profile flag to it (same pattern as
+    the #287 CPU_FLAGS migration). Returns an empty string when the profile
+    doesn't want it, leaving dockur's default (``native``).
+    """
+    if cfg is None:
+        return ""
+
+    from winpodx.utils.specs import detect_tuning_capability, recommend_tuning_profile
+
+    cap = detect_tuning_capability(vm_cpu_cores=cfg.pod.cpu_cores, vm_ram_gb=cfg.pod.ram_gb)
+    profile = recommend_tuning_profile(cap, user_pref=cfg.pod.tuning_profile)
+    if getattr(profile, "apply_io_uring", False):
+        return '      DISK_IO: "io_uring"\n'
+    return ""
 
 
 def _qemu_arguments_for_host(cfg: Config | None = None) -> str:
@@ -857,6 +880,7 @@ def _build_compose_content(cfg: Config) -> str:
         adapter=adapter,
         mtu=mtu,
         usb_env=usb_env,
+        disk_io_env=_disk_io_env_for_host(cfg),
         vga=vga,
         hv=hv,
         user=_yaml_escape(cfg.rdp.user),

--- a/tests/test_compose_network.py
+++ b/tests/test_compose_network.py
@@ -44,3 +44,39 @@ def test_compose_user_ports_present_alongside_network():
     # user-mode, so both lines together are what forwards the agent port.
     assert 'NETWORK: "user"' in content
     assert "USER_PORTS:" in content
+
+
+def test_compose_ballooning_off_unconditional():
+    # dockur v6.00 promotes memory ballooning to a first-class env. winpodx
+    # deliberately runs the VM with ballooning OFF for stability, so
+    # BALLOONING: "N" is emitted unconditionally (independent of tuning).
+    content = _build_compose_content(_cfg())
+    assert 'BALLOONING: "N"' in content
+
+
+def test_compose_disk_io_absent_when_tuning_off():
+    # With tuning_profile "off" the profile never asks for io_uring, so no
+    # DISK_IO env is written (dockur keeps its own default).
+    content = _build_compose_content(_cfg())
+    assert "DISK_IO:" not in content
+
+
+def test_compose_disk_io_iouring_when_profile_enables_it(monkeypatch):
+    # When the host tuning profile enables io_uring, it is wired through to
+    # the guest as the v6.00 dedicated DISK_IO env (not a raw QEMU flag).
+    from winpodx.utils import specs
+
+    # A real TuningProfile so every other tuning consumer (virtio-rng, etc.)
+    # still finds its fields; only io_uring is turned on.
+    prof = specs.TuningProfile(
+        name="manual",
+        apply_invtsc=False,
+        apply_io_uring=True,
+        apply_hugepages=False,
+        apply_cpu_pinning=False,
+        apply_platform_tick=False,
+        apply_no_balloon=False,
+    )
+    monkeypatch.setattr(specs, "recommend_tuning_profile", lambda *a, **k: prof)
+    content = _build_compose_content(_cfg())
+    assert 'DISK_IO: "io_uring"' in content


### PR DESCRIPTION
## Summary

Rolls the pinned `dockur/windows` image forward to **v6.00**, requested by @kroese (the dockur/windows maintainer) in #721. v6.00 moves Podman networking to the user-mode **passt** backend, fixing the rootless port-forwarding problems that affected earlier images.

## Changes

- **Pin** `DOCKUR_IMAGE_PIN` → v6.00 (`5f8b87b0`, verified == current `:latest` list digest).
- **VERSIONS.txt** x86 baseline → v6.00. The `dockur/windows-arm` pin/baseline is left unchanged — no ARM hardware here to smoke-test the roll-forward.
- **Adopt two v6.00 dedicated env knobs the "new way"** instead of raw-QEMU workarounds:
  - `BALLOONING: "N"` unconditionally — winpodx deliberately runs the VM with memory ballooning off for stability; v6.00 promotes ballooning to a first-class toggle.
  - `DISK_IO: "io_uring"` when the host tuning profile calls for it — the profile already detected io_uring support but never wired it through to the guest.
- CHANGELOG (en + ko) + compose env regression tests.

## Smoke

Boot smoke on an x86_64 host: container comes up in `Mode: User (passt)`; RDP `3390` / agent `8765` / SMB `4445` all reachable; bare-metal disguise (SMBIOS/ACPI) still applied. Compose/config/pod suite green + 3 new env tests.

## Notes

- x86_64 only. ARM (`dockur/windows-arm`, a separate repo/release cadence) unchanged.
- Kept as raw `ARGUMENTS`/`-global` where v6.00 has **no** dedicated env yet: SMBIOS multi-type + file, `-acpitable`, virtio-rng, VFIO. `DISK_ROTATION` migration is deferred (v6.00 behaviour unconfirmed; the disguise-safe `-global rotation_rate=1` stays).