### PR TITLE
fix(discovery): disable GFX on the headless exec channel — XWayland rc=12 (#694)

### DIFF
--- a/src/winpodx/core/windows_exec.py
+++ b/src/winpodx/core/windows_exec.py
@@ -240,6 +240,16 @@ def run_in_windows(
         "+home-drive",
         "/sec:tls",
         "/cert:ignore",
+        # #694 (notnotno, Fedora Kinoite / FreeRDP 3.27 / KDE XWayland): this
+        # exec/discovery RemoteApp is headless — it runs a PowerShell script and
+        # writes a result file, the window is never shown. But FreeRDP's default
+        # GFX pipeline still tries to map a RAIL surface, and on XWayland that
+        # fails ("xf_MapWindowForSurface: function not implemented"), aborting
+        # the session with no result file (surfaces as "Discovery channel
+        # failure ... FreeRDP rc=12"). GFX buys nothing on a headless exec, so
+        # disable it and fall back to the legacy GDI path — same class of
+        # workaround as #393/#661, applied unconditionally to this channel.
+        "-gfx",
         app_arg,
     ]
     if cfg.rdp.domain:


### PR DESCRIPTION
## Problem

While verifying the #421/#694 URL-scheme fix (shipped in v0.9.0), @notnotno hit a **new, unrelated** failure running `winpodx app refresh` on Fedora Kinoite 44 / FreeRDP 3.27.1 / KDE Plasma Wayland+XWayland:

```
FreeRDP-fallback: agent unavailable (/health timed out after 5.0s); using FreeRDP
ERROR: Discovery channel failure: No result file written (FreeRDP rc=12).
stderr tail: 'xf_MapWindowForSurface]: function not implemented ...'
```

Two independent things happened:
1. **agent unavailable** → discovery fell back to the FreeRDP exec channel (separate guest-side issue, being followed up with the reporter);
2. **the FreeRDP fallback itself failed with rc=12** on XWayland.

## Root cause of (2)

`run_in_windows()` (the exec/discovery channel) is **headless** — it launches a PowerShell script as a RemoteApp, which writes a result file and exits; the window is never shown. But the FreeRDP argv set no GFX option, so the default GFX pipeline still tried to map a RAIL surface. On XWayland that fails (`xf_MapWindowForSurface: function not implemented`), the session aborts, no result file is written → `FreeRDP rc=12`. This is the same XWayland GFX-surface class already documented for the visible RAIL path (#393/#661), but there it's a user-set `rdp.extra_flags` workaround — the exec channel builds its own argv and never got it.

## Fix

Add `-gfx` to the exec channel's FreeRDP argv so it uses the legacy GDI path. GFX is pointless on a headless exec (nothing is rendered), so this is safe on every host and removes the XWayland failure mode. Only the exec/discovery channel is touched; visible RAIL app launches are unchanged.

## Verify

- `test_windows_exec.py` + exec/transport/discovery suites green (279 passed locally; the one `test_storage_migration` failure is a pre-existing local-env config-isolation artifact, not from this change — reproduces on `main` too, passes in clean CI).
- Real confirmation needs @notnotno's XWayland environment (I can't reproduce rc=12 on my host); asked them to also check why the agent is unavailable, since a live agent avoids the FreeRDP fallback entirely.