### PR TITLE
fix(tray): parent top-level QActions so Plasma doesn't GC them (#725)

### DIFF
--- a/src/winpodx/desktop/tray.py
+++ b/src/winpodx/desktop/tray.py
@@ -105,23 +105,23 @@ def run_tray() -> None:
 
     menu = QMenu()
 
-    dashboard_action = QAction(tr("Open Dashboard"))
+    dashboard_action = QAction(tr("Open Dashboard"), menu)
     menu.addAction(dashboard_action)
     menu.addSeparator()
 
-    status_action = QAction(tr("Status: checking..."))
+    status_action = QAction(tr("Status: checking..."), menu)
     status_action.setEnabled(False)
     menu.addAction(status_action)
 
-    sessions_action = QAction(tr("Sessions: 0"))
+    sessions_action = QAction(tr("Sessions: 0"), menu)
     sessions_action.setEnabled(False)
     menu.addAction(sessions_action)
 
     menu.addSeparator()
 
-    start_action = QAction(tr("Start Pod"))
-    stop_action = QAction(tr("Stop Pod"))
-    restart_action = QAction(tr("Restart Pod"))
+    start_action = QAction(tr("Start Pod"), menu)
+    stop_action = QAction(tr("Stop Pod"), menu)
+    restart_action = QAction(tr("Restart Pod"), menu)
 
     def _open_dashboard() -> None:
         """Launch the main GUI window as a detached subprocess.
@@ -385,17 +385,17 @@ def run_tray() -> None:
         return launcher
 
     for app_info in available_apps[:20]:
-        action = QAction(app_info.full_name)
+        action = QAction(app_info.full_name, apps_menu)
         action.triggered.connect(make_launcher(app_info.executable, app_info.full_name))
         apps_menu.addAction(action)
 
     if not available_apps:
-        no_apps = QAction(tr("(no apps - run 'winpodx setup')"))
+        no_apps = QAction(tr("(no apps - run 'winpodx setup')"), apps_menu)
         no_apps.setEnabled(False)
         apps_menu.addAction(no_apps)
 
     apps_menu.addSeparator()
-    desktop_action = QAction(tr("Full Desktop"))
+    desktop_action = QAction(tr("Full Desktop"), apps_menu)
 
     def on_desktop() -> None:
         try:
@@ -555,7 +555,8 @@ def run_tray() -> None:
     info_action = QAction(
         tr("Display: {session} / {de}").format(
             session=info["session_type"], de=info["desktop_environment"]
-        )
+        ),
+        menu,
     )
     info_action.setEnabled(False)
     menu.addAction(info_action)
@@ -564,7 +565,7 @@ def run_tray() -> None:
 
     maint_menu = QMenu(tr("Maintenance"))
 
-    cleanup_action = QAction(tr("Clean Lock Files"))
+    cleanup_action = QAction(tr("Clean Lock Files"), maint_menu)
 
     def on_cleanup() -> None:
         from winpodx.core.daemon import cleanup_lock_files
@@ -580,7 +581,7 @@ def run_tray() -> None:
     cleanup_action.triggered.connect(on_cleanup)
     maint_menu.addAction(cleanup_action)
 
-    timesync_action = QAction(tr("Sync Windows Time"))
+    timesync_action = QAction(tr("Sync Windows Time"), maint_menu)
 
     def on_timesync() -> None:
         from winpodx.core.daemon import sync_windows_time
@@ -592,7 +593,7 @@ def run_tray() -> None:
     timesync_action.triggered.connect(on_timesync)
     maint_menu.addAction(timesync_action)
 
-    suspend_action = QAction(tr("Suspend Pod"))
+    suspend_action = QAction(tr("Suspend Pod"), maint_menu)
 
     def on_suspend() -> None:
         from winpodx.core.daemon import suspend_pod
@@ -608,7 +609,7 @@ def run_tray() -> None:
 
     menu.addSeparator()
 
-    quit_action = QAction(tr("Quit WinPodX"))
+    quit_action = QAction(tr("Quit WinPodX"), menu)
 
     def _confirmed_quit() -> None:
         """Tear down GUI + pod before closing the tray.


### PR DESCRIPTION
## Problem

On KDE Plasma (Bazzite / Wayland), the tray right-click **Stop Pod** (and Start Pod) do nothing, while `winpodx pod stop` on the CLI works (#725, @realahmed7777).

## Root cause

The #573 fix parented the *submenu* actions (sessions / devices) to their menus, but the **top-level** menu actions — Start/Stop/Restart Pod, Open Dashboard, Quit, Full Desktop, the Maintenance entries — were still created parentless (`QAction(text)`). On Plasma the tray menu is exported over **DBusMenu**, and a parentless `QAction` whose only Python reference is a local in the menu-builder can be garbage-collected, so its `triggered` signal never fires and the entry becomes a silent no-op. This is the same failure mode as #573, just on the top-level entries.

## Fix

Parent every `QAction` to its owning menu (`menu` / `apps_menu` / `maint_menu`), matching what #573 did for the submenus. No behavior change beyond keeping the actions alive.

## Verify

- `ruff` clean, tray suite green (6 passed), syntax OK.
- Real confirmation needs @realahmed7777's Plasma env (I can't reproduce the GC timing locally); it's the exact #573 pattern though, so high confidence.

## Note

The reporter also said the **GUI** square Stop button no-ops. That's a `QPushButton` (not GC-prone) on a separate process, so it's a different path — I've asked for diagnostics on the issue to pin it before touching `_on_stop_pod`.