### PR TITLE
fix(rdp): stamp the app icon on RAIL windows via _NET_WM_ICON (#702)

### DIFF
--- a/src/winpodx/cli/app.py
+++ b/src/winpodx/cli/app.py
@@ -342,6 +342,7 @@ def _run_app(name: str, file: str | None, wait: bool, *, extra_args: str = "") -
             wm_class_hint=app_info.wm_class_hint or None,
             default_args=app_info.args or None,
             extra_args=extra_args,
+            app_icon=app_info.icon_path or None,
         )
         print(
             tr("Launching {app_name}... (stderr log: {log})").format(

--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -9,6 +9,7 @@ import re
 import shlex
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -1218,6 +1219,122 @@ def _relist_uwp_taskbar(wm_class: str) -> None:
         time.sleep(0.8)
 
 
+def _window_icon_cardinals(icon_path: str) -> list[int] | None:
+    """Decode an icon file into the ``_NET_WM_ICON`` layout ``[w, h, ARGB...]``.
+
+    Uses Qt (already an optional GUI dependency) to read PNG/SVG. Best-effort:
+    returns ``None`` when Qt is missing, the file can't be read, or the icon is
+    absurdly large. ``0xAARRGGBB`` pixels are exactly what ``_NET_WM_ICON`` wants.
+    """
+    try:
+        os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+        from PySide6.QtGui import QImage
+    except Exception:  # noqa: BLE001 -- Qt optional; icon injection is best-effort
+        return None
+    try:
+        img = QImage(icon_path)
+        if img.isNull():
+            return None
+        img = img.convertToFormat(QImage.Format.Format_ARGB32)
+        w, h = img.width(), img.height()
+        if w <= 0 or h <= 0 or w * h > 256 * 256:
+            return None
+        data = [w, h]
+        for y in range(h):
+            for x in range(w):
+                data.append(img.pixel(x, y) & 0xFFFFFFFF)
+        return data
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _set_net_wm_icon(win_id: int, cardinals: list[int]) -> bool:
+    """Set ``_NET_WM_ICON`` on an X11 window via libX11 (ctypes). Best-effort.
+
+    No new dependency: libX11 is present wherever an X server / XWayland runs
+    (FreeRDP is an X11 client, so it's always there for a live RAIL window).
+    ``argtypes`` MUST be declared or ctypes mis-marshals the pointer args on
+    64-bit and the call silently no-ops (or crashes).
+    """
+    import ctypes as c
+
+    try:
+        x11 = c.CDLL("libX11.so.6")
+    except OSError:
+        return False
+    x11.XOpenDisplay.restype = c.c_void_p
+    x11.XOpenDisplay.argtypes = [c.c_char_p]
+    x11.XInternAtom.restype = c.c_ulong
+    x11.XInternAtom.argtypes = [c.c_void_p, c.c_char_p, c.c_int]
+    x11.XChangeProperty.argtypes = [
+        c.c_void_p,
+        c.c_ulong,
+        c.c_ulong,
+        c.c_ulong,
+        c.c_int,
+        c.c_int,
+        c.c_void_p,
+        c.c_int,
+    ]
+    x11.XFlush.argtypes = [c.c_void_p]
+    x11.XCloseDisplay.argtypes = [c.c_void_p]
+    dpy = x11.XOpenDisplay(None)
+    if not dpy:
+        return False
+    try:
+        atom = x11.XInternAtom(dpy, b"_NET_WM_ICON", False)
+        arr = (c.c_long * len(cardinals))(*cardinals)
+        # type=XA_CARDINAL(6), format=32, mode=PropModeReplace(0)
+        x11.XChangeProperty(dpy, win_id, atom, 6, 32, 0, c.cast(arr, c.c_void_p), len(cardinals))
+        x11.XFlush(dpy)
+    except Exception:  # noqa: BLE001
+        return False
+    finally:
+        x11.XCloseDisplay(dpy)
+    return True
+
+
+def _apply_window_icon(wm_class: str, icon_path: str) -> None:
+    """Best-effort: stamp the app's icon onto its RAIL window as ``_NET_WM_ICON``.
+
+    X11 panels match a RAIL window to its ``.desktop`` (hence its icon) by
+    ``res_class == StartupWMClass``. Some X11 DEs (Cinnamon, GNOME-X11) fail that
+    match for FreeRDP RAIL windows -- ``res_name`` is the fixed ``"RAIL"`` and no
+    ``_NET_WM_ICON`` is set -- so they fall back to FreeRDP's own icon (#702).
+    Setting ``_NET_WM_ICON`` directly makes the correct icon show regardless of
+    DE matching. X11 / XWayland only; a clean no-op when Qt / libX11 / wmctrl are
+    absent or no window matches. FreeRDP maps the window late and may re-map, so
+    retry over a short window and re-apply per new window id.
+    """
+    import time
+
+    wmctrl = shutil.which("wmctrl")
+    if not wmctrl or not icon_path or not Path(icon_path).exists():
+        return
+    cardinals = _window_icon_cardinals(icon_path)
+    if not cardinals:
+        return
+    target = f"RAIL.{wm_class}"
+    applied: set[int] = set()
+    for _ in range(12):  # ~10s at 0.8s cadence -- covers a late window map
+        try:
+            out = subprocess.run(
+                [wmctrl, "-lx"], capture_output=True, text=True, timeout=4, check=False
+            ).stdout
+        except (OSError, subprocess.SubprocessError):
+            return
+        for line in out.splitlines():
+            parts = line.split(None, 4)  # id, desktop, wm_class, host, title
+            if len(parts) >= 3 and parts[2] == target:
+                try:
+                    win_id = int(parts[0], 16)
+                except ValueError:
+                    continue
+                if win_id not in applied and _set_net_wm_icon(win_id, cardinals):
+                    applied.add(win_id)
+        time.sleep(0.8)
+
+
 # _window_reaper tuning (#680): reap a RAIL session when its windows close even
 # though xfreerdp stays connected (Office keeps the process + RemoteApp session
 # resident after the document window closes, so `_reaper_thread`'s proc.wait()
@@ -1332,6 +1449,7 @@ def launch_app(
     wm_class_hint: str | None = None,
     default_args: str | None = None,
     extra_args: str = "",
+    app_icon: str | None = None,
 ) -> RDPSession:
     """Launch a Windows app via RDP and return the session handle.
 
@@ -1505,12 +1623,28 @@ def launch_app(
             args=(session, session.app_name),
             daemon=True,
         ).start()
-    if launch_uri is not None:
-        threading.Thread(
-            target=_relist_uwp_taskbar,
-            args=(session.app_name,),
-            daemon=True,
-        ).start()
+    # #472 / #702: post-launch window setup -- clear a UWP window's SKIP_TASKBAR
+    # and stamp the app's icon as _NET_WM_ICON -- runs in a DETACHED helper
+    # process, not a daemon thread. An app launched from its .desktop entry is a
+    # short-lived `winpodx app run` that exits before the RAIL window maps, which
+    # would kill a daemon thread (that's why #680's reaper moved to the tray).
+    # The helper outlives us and does both jobs. RemoteApp only (a full desktop
+    # has no RAIL.<wm_class> window to touch).
+    if is_remoteapp:
+        setup_args = [sys.executable, "-m", "winpodx.desktop.window_setup", session.app_name]
+        if app_icon:
+            setup_args += ["--icon", app_icon]
+        if launch_uri is not None:
+            setup_args += ["--uwp"]
+        try:
+            subprocess.Popen(
+                setup_args,
+                start_new_session=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except OSError as e:
+            log.debug("window_setup helper spawn failed: %s", e)
 
     return session
 

--- a/src/winpodx/desktop/window_setup.py
+++ b/src/winpodx/desktop/window_setup.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+"""Detached post-launch window setup for a RAIL app window.
+
+Run as::
+
+    python -m winpodx.desktop.window_setup <wm_class> [--icon PATH] [--uwp]
+
+``rdp.launch_app`` spawns this **detached** (``start_new_session=True``) right
+after starting the FreeRDP client, instead of running the same work on a daemon
+thread. The daemon-thread approach only survived while the launching process
+lived, so it silently did nothing for the common case -- an app started from
+its ``.desktop`` menu entry (``winpodx app run``) is a short-lived process that
+exits immediately, taking the daemon thread with it before the RAIL window ever
+maps (#702, and the same reason #680's reaper moved into the long-lived tray).
+
+As its own process this helper outlives the launcher and does two best-effort,
+X11-only things once the window appears:
+
+- ``_relist_uwp_taskbar`` (#472): clear FreeRDP's ``SKIP_TASKBAR`` / ``SKIP_PAGER``
+  on a UWP RAIL window so it shows in the panel.
+- ``_apply_window_icon`` (#702): stamp the app's own icon as ``_NET_WM_ICON`` so
+  X11 DEs that don't match ``res_class`` -> ``.desktop`` (Cinnamon, GNOME-X11)
+  stop showing FreeRDP's icon.
+
+Both are clean no-ops off X11 / when their tools are missing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import threading
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="winpodx.desktop.window_setup")
+    parser.add_argument("wm_class", help="the /wm-class token (== .desktop StartupWMClass)")
+    parser.add_argument("--icon", default=None, help="path to the app icon file (PNG/SVG)")
+    parser.add_argument("--uwp", action="store_true", help="also clear UWP SKIP_TASKBAR")
+    args = parser.parse_args(argv[1:])
+
+    # Import lazily so `-m` startup stays cheap and this module carries no
+    # import-time cost for the launcher.
+    from winpodx.core.rdp import _apply_window_icon, _relist_uwp_taskbar
+
+    threads: list[threading.Thread] = []
+    if args.uwp:
+        threads.append(threading.Thread(target=_relist_uwp_taskbar, args=(args.wm_class,)))
+    if args.icon:
+        threads.append(threading.Thread(target=_apply_window_icon, args=(args.wm_class, args.icon)))
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/winpodx/gui/_main_window_pod.py
+++ b/src/winpodx/gui/_main_window_pod.py
@@ -77,6 +77,7 @@ class PodStatusMixin:
                     launch_uri=app.launch_uri or None,
                     wm_class_hint=app.wm_class_hint or None,
                     default_args=app.args or None,
+                    app_icon=app.icon_path or None,
                 )
             except Exception:  # noqa: BLE001
                 import traceback

--- a/tests/test_window_setup.py
+++ b/tests/test_window_setup.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: MIT
+"""Detached window-setup helper dispatch (#472 relist + #702 icon)."""
+
+from __future__ import annotations
+
+import winpodx.core.rdp as rdp
+from winpodx.desktop.window_setup import main
+
+
+def _patch(monkeypatch):
+    calls: list[tuple] = []
+    monkeypatch.setattr(rdp, "_apply_window_icon", lambda wc, ic: calls.append(("icon", wc, ic)))
+    monkeypatch.setattr(rdp, "_relist_uwp_taskbar", lambda wc: calls.append(("relist", wc)))
+    return calls
+
+
+def test_uwp_with_icon_runs_both(monkeypatch):
+    calls = _patch(monkeypatch)
+    rc = main(["prog", "winpodx-foo", "--icon", "/tmp/x.png", "--uwp"])
+    assert rc == 0
+    assert ("relist", "winpodx-foo") in calls
+    assert ("icon", "winpodx-foo", "/tmp/x.png") in calls
+
+
+def test_win32_icon_only_no_relist(monkeypatch):
+    # A classic Win32 app (no --uwp) gets the icon but not the SKIP_TASKBAR clear.
+    calls = _patch(monkeypatch)
+    rc = main(["prog", "winpodx-bar", "--icon", "/tmp/y.png"])
+    assert rc == 0
+    assert ("icon", "winpodx-bar", "/tmp/y.png") in calls
+    assert not any(c[0] == "relist" for c in calls)
+
+
+def test_no_icon_no_uwp_is_noop(monkeypatch):
+    calls = _patch(monkeypatch)
+    rc = main(["prog", "winpodx-baz"])
+    assert rc == 0
+    assert calls == []


### PR DESCRIPTION
## Problem

A RemoteApp (RAIL) window shows **FreeRDP's icon instead of the app's** on X11 desktops (#702 — @twkirk161 on Ubuntu Cinnamon, confirmed by @MirzaAyBaig12 on GNOME).

X11 panels match a RAIL window to its `.desktop` (and thus its icon) by `res_class == StartupWMClass`. winpodx already keeps those byte-identical, but for FreeRDP RAIL windows `res_name` is the fixed `"RAIL"` and **no `_NET_WM_ICON` is set**, so some X11 DEs (Cinnamon, GNOME-X11) fail the match and fall back to FreeRDP's own icon. Wayland compositors match `res_class` fine — that's why it only bites X11.

(FreeRDP's `/app:…,icon:` suboption was tried first; it does **not** set the client-side X11 icon — verified with `xprop`.)

## Fix

Set `_NET_WM_ICON` directly on the window: Qt decodes the app icon to ARGB, ctypes `libX11` `XChangeProperty` writes it — the correct icon shows regardless of DE matching.

Crucially this runs in a **detached helper process** (`winpodx.desktop.window_setup`), not a daemon thread. An app launched from its `.desktop` menu entry is a short-lived `winpodx app run` that exits before the RAIL window maps, which silently killed the old daemon-thread work (the same reason #680's reaper moved to the tray). The helper outlives the launcher and carries **both** the icon stamp (#702) **and** the UWP `SKIP_TASKBAR` clear (#472), so taskbar re-listing finally works from the menu path too — not only from a long-lived GUI/tray.

## Verify

- Verified on XWayland (nowait `app run`, the menu-entry path): `_NET_WM_ICON(88x88)` set + `_NET_WM_STATE` SKIP_TASKBAR cleared → icon shows and window re-lists in the taskbar.
- New `test_window_setup.py` (dispatch matrix) + rdp/compose suites green; ruff clean.
- X11 / XWayland only; clean no-op off X11 or when Qt / libX11 / wmctrl are absent.
- **Needs Cinnamon / GNOME-X11 confirmation** from the reporters (I can only test XWayland here).