### PR TITLE
fix(wait-ready): drop [container] prefix on the verbose download heartbeat

### DIFF
--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -1413,7 +1413,7 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
                         if verbose:
                             now = _time.monotonic()
                             if now - last_verbose[0] >= 15:
-                                print(f"       [container] (downloading Windows ISO... {clock})")
+                                print(f"       (downloading Windows ISO... {clock})")
                                 last_verbose[0] = now
                         elif _live.usable:
                             _live.set(f"  Downloading Windows ISO...  ({clock})")


### PR DESCRIPTION
The verbose download heartbeat (`(downloading Windows ISO... Nm Ns)`) is winpodx's own self-timed line, not a drained dockur container log line, so it shouldn't carry the `[container]` tag. Cosmetic follow-up to #749.