### PR TITLE
chore(image): roll dockur/windows pin forward to v6.02 (#735)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Changed
+
+- **dockur/windows image pin rolled forward to v6.02** (#735, requested by @kroese). Brings the QEMU base image v7.37, improved download-progress output in the container log (the upstream follow-up to v6.01's buffered download), better Windows reinstall detection, and QEMU errors surfaced on unexpected exit. Existing pods pick the new image up on the next recreate; `winpodx setup --update-image` applies it explicitly.
+
 ### Fixed
 
 - **The guest agent could look like it kept dying under load, even though `agent.log` showed it running the whole time** (#751, thanks @notnotno). `agent.ps1`'s HTTP listener ran a single-threaded accept loop, so a long `POST /exec` (up to the 300s `WaitForExit`) blocked the next `GET /health` request until it finished; the host's 5s health-check timeout then declared the agent unavailable and fell back to the slow FreeRDP path mid-session. `/exec` now runs on a background runspace pool (max 4 concurrent), so `/health` keeps answering instantly while a long exec is still in flight. The host-side protocol is unchanged.

--- a/config/oem/VERSIONS.txt
+++ b/config/oem/VERSIONS.txt
@@ -18,7 +18,7 @@
 # describes what winpodx deliberately uses.
 #
 # Format: <key>=<value>
-dockur=v6.01
-dockur-digest=sha256:7886c2e1a37074220b213732de3574df2664a13fedac751fc69ef4130c5f83e0
+dockur=v6.02
+dockur-digest=sha256:8cc6f8bc4a60c078141fd3bcf7d2df69ae063a11d98be31a57429afe0dca66da
 dockur-arm=v5.16
 dockur-arm-digest=sha256:ece93263254567c6cd4ce420b1fff793d2326f4535555bdf592f40ab173a7bed

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **dockur/windows 이미지 pin을 v6.02로 롤포워드** (#735, @kroese 요청). QEMU base 이미지 v7.37, 컨테이너 로그의 다운로드 진행 출력 개선(v6.01 버퍼링 다운로드에 대한 upstream 후속), Windows 재설치 감지 개선, 예기치 않은 종료 시 QEMU 오류 표시가 포함됩니다. 기존 pod는 다음 recreate 때 새 이미지를 사용하며, `winpodx setup --update-image`로 즉시 적용할 수 있습니다.
+
 ### Fixed
 
 - **부하가 걸리면 게스트 에이전트가 계속 죽는 것처럼 보였지만, `agent.log`에는 계속 살아있는 것으로 기록됨** (#751, @notnotno 감사). `agent.ps1`의 HTTP 리스너가 단일 스레드 accept 루프로 동작해서, 오래 걸리는 `POST /exec`(최대 300초 `WaitForExit`)이 완료될 때까지 다음 `GET /health` 요청을 막았습니다. 호스트의 5초 헬스체크 timeout이 이를 에이전트 사용 불가로 판단해 세션 도중 느린 FreeRDP 경로로 폴백했습니다. 이제 `/exec`는 백그라운드 runspace pool(최대 4개 동시 실행)에서 돌아가므로, 긴 exec가 진행 중이어도 `/health`가 즉시 응답합니다. 호스트측 프로토콜은 변경되지 않았습니다.

--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -158,12 +158,13 @@ def _validate_device_entry(entry: object) -> str | None:
 # current ``:latest`` digest, paste below. See ``winpodx setup --update
 # -image`` for the runtime equivalent users invoke explicitly.
 #
-# As of 2026-07-16 (dockur/windows v6.01 — @kroese's rootless-Podman NAT
-# port-forwarding rewrite; fixes the #269/#387 "NAT set up but ports never
-# reach the VM" case that forced NETWORK=user, #735):
+# As of 2026-07-18 (dockur/windows v6.02 — QEMU base v7.37, improved
+# download-progress output in the container log (upstream follow-up to the
+# v6.01 buffered-download saga), Windows reinstall detection, QEMU errors
+# surfaced on unexpected exit; requested by @kroese in #735):
 DOCKUR_IMAGE_PIN = (
     "docker.io/dockurr/windows@sha256:"
-    "7886c2e1a37074220b213732de3574df2664a13fedac751fc69ef4130c5f83e0"
+    "8cc6f8bc4a60c078141fd3bcf7d2df69ae063a11d98be31a57429afe0dca66da"
 )
 
 # Pinned dockur/windows-arm image — used as the default ``cfg.pod.image``


### PR DESCRIPTION
Rolls the dockur/windows image pin forward to v6.02, requested by @kroese in #735.

- QEMU base image v7.37; improved download-progress output in the container log (the upstream follow-up to v6.01's buffered download); better Windows reinstall detection; QEMU errors surfaced on unexpected exit.
- Pin is the manifest-list digest of `:6.02` (`8cc6f8bc...`); `config/oem/VERSIONS.txt` updated to match. ARM pin unchanged (`dockur-arm` v5.16).
- Targeted tests green (80 passed: compose network, CLI issue guards, image-pin defaults, migrate) + ruff clean.

Smoke before release: pod recreate on the new image, then the usual bring-up including the download-progress display (that path changed upstream again).