### PR TITLE
feat(wait-ready): stream dockur v6.02's live download percentage (#735 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 ### Changed
 
 - **dockur/windows image pin rolled forward to v6.02** (#735, requested by @kroese). Brings the QEMU base image v7.37, improved download-progress output in the container log (the upstream follow-up to v6.01's buffered download), better Windows reinstall detection, and QEMU errors surfaced on unexpected exit. Existing pods pick the new image up on the next recreate; `winpodx setup --update-image` applies it explicitly.
+- **The download line now shows a real percentage again on dockur v6.02** (#735 follow-up). v6.02 writes the ISO-download progress to the container log as one line that grows without a newline until the download finishes, so a line-based reader never sees it mid-download. `winpodx pod wait-ready` now reads the log byte-wise and folds the latest `NN%` into the elapsed clock: `Downloading Windows ISO... 42% (5m 12s)` (clean and `--verbose` modes both; falls back to the bare clock on older images).
 
 ### Fixed
 

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -12,6 +12,7 @@
 ### Changed
 
 - **dockur/windows 이미지 pin을 v6.02로 롤포워드** (#735, @kroese 요청). QEMU base 이미지 v7.37, 컨테이너 로그의 다운로드 진행 출력 개선(v6.01 버퍼링 다운로드에 대한 upstream 후속), Windows 재설치 감지 개선, 예기치 않은 종료 시 QEMU 오류 표시가 포함됩니다. 기존 pod는 다음 recreate 때 새 이미지를 사용하며, `winpodx setup --update-image`로 즉시 적용할 수 있습니다.
+- **dockur v6.02에서 다운로드 라인에 실제 퍼센트를 다시 표시** (#735 후속). v6.02는 ISO 다운로드 진행률을 개행 없이 자라는 한 줄로 컨테이너 로그에 기록해서, 라인 단위 리더는 다운로드 중에 이를 볼 수 없습니다. 이제 `winpodx pod wait-ready`가 로그를 바이트 단위로 읽어 최신 `NN%`를 경과 시계에 합쳐 표시합니다: `Downloading Windows ISO... 42% (5m 12s)` (clean/`--verbose` 모두, 구버전 이미지에서는 기존 시계로 폴백).
 
 ### Fixed
 

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -1142,6 +1142,98 @@ class _LiveLine:
             self._tty = None
 
 
+# dockur v6.02's progress.sh (qemus/qemu src/progress.sh
+# printPercentProgress) writes the ISO-download percentage as ONE line that
+# grows byte-by-byte with NO trailing newline until the download finishes:
+# "10%" -> "10% → 20%" -> "10% → 20% → 30%" ... (#735). Only the bare
+# percentage is needed -- unlike v6.01's wget meter there's no speed/ETA
+# mid-line, just the running chain of milestones.
+_DOWNLOAD_PCT_RE = re.compile(r"([0-9]{1,3})%")
+
+
+class _LineSplitter:
+    """Splits incrementally-arriving bytes into decoded, right-stripped
+    lines without blocking until a newline shows up the way iterating a
+    file object (``for line in stream``) does.
+
+    Needed for dockur v6.02 (#735): its no-newline-until-done download
+    percentage line would otherwise sit invisibly in Python's line-buffering
+    for the entire download. Feeding raw chunks here lets a caller inspect
+    the still-growing ``partial`` tail for progress while every complete
+    line is still produced exactly once, in the same order, with the same
+    trailing-newline/whitespace stripped as the old ``line.rstrip()`` did.
+    """
+
+    def __init__(self, encoding: str = "utf-8") -> None:
+        # utf-8 matches what podman/docker container logs are in practice --
+        # the same assumption ``Popen(..., text=True)`` made via the locale
+        # default on any modern Linux host.
+        self._encoding = encoding
+        self._buf = b""
+
+    def feed(self, chunk: bytes) -> list[str]:
+        """Add *chunk* and return any newly-completed lines. Splitting on
+        ``b"\\n"`` first (before decoding) is always UTF-8-safe: the 0x0A
+        byte never appears inside a multi-byte codepoint's encoding, so a
+        split can never land mid-character."""
+        if not chunk:
+            return []
+        self._buf += chunk
+        *complete, self._buf = self._buf.split(b"\n")
+        return [piece.decode(self._encoding, errors="replace").rstrip() for piece in complete]
+
+    @property
+    def partial(self) -> str:
+        """The current newline-less tail (best-effort decode -- a chunk
+        boundary can land mid-character here, unlike in ``feed``)."""
+        return self._buf.decode(self._encoding, errors="ignore")
+
+    def flush(self) -> str | None:
+        """Return + clear the trailing remainder as a final line, mirroring
+        how ``for line in stream`` yields one last newline-less line before
+        EOF. Returns ``None`` when nothing is buffered."""
+        if not self._buf:
+            return None
+        line = self._buf.decode(self._encoding, errors="replace").rstrip()
+        self._buf = b""
+        return line
+
+
+def _iter_container_lines(stream, dl_state: dict, stop: threading.Event):  # type: ignore[no-untyped-def]
+    """Read *stream* (an unbuffered binary subprocess pipe) incrementally and
+    yield decoded, right-stripped lines as they complete.
+
+    Replaces plain ``for line in stream`` so dockur v6.02's no-newline-until-
+    done download percentage (see ``_DOWNLOAD_PCT_RE`` above, #735) doesn't
+    sit hidden in the pipe for the whole download: while *dl_state* shows a
+    download in progress, the still-growing partial tail is scanned each
+    read for its latest ``NN%`` and stashed on ``dl_state["pct"]`` for
+    ``_download_heartbeat`` to render. The partial tail itself is never
+    consumed here -- it still becomes a normal yielded line once its
+    newline arrives.
+    """
+    splitter = _LineSplitter()
+    while not stop.is_set():
+        try:
+            # bufsize=0 on the Popen call below makes *stream* a raw
+            # io.FileIO, so .read(n) is a single non-looping syscall (i.e.
+            # read1 semantics) instead of blocking to fill the buffer.
+            chunk = stream.read(65536)
+        except (OSError, ValueError):
+            break
+        if not chunk:
+            break  # EOF: container process exited or closed the pipe.
+        for line in splitter.feed(chunk):
+            yield line
+        if dl_state.get("start") is not None:
+            matches = _DOWNLOAD_PCT_RE.findall(splitter.partial)
+            if matches:
+                dl_state["pct"] = min(int(matches[-1]), 100)
+    tail = splitter.flush()
+    if tail:
+        yield tail
+
+
 def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
     """v0.2.0.5: multi-phase wait for the Windows VM to finish first-boot.
 
@@ -1282,12 +1374,15 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
             # stale first-boot history. Both stdout and stderr are drained
             # because dockur splits progress across both (download bytes/sec on
             # one, boot phase on the other).
+            # bufsize=0 (binary, unbuffered): _iter_container_lines needs raw,
+            # non-looping reads off the pipe to see dockur v6.02's growing
+            # download-percentage line before its newline arrives (#735). A
+            # text-mode or buffered pipe would only expose complete lines.
             log_proc = Popen(
                 [cfg.pod.backend, "logs", "-f", "--tail", _log_tail, cfg.pod.container_name],
                 stdout=PIPE,
                 stderr=PIPE,
-                text=True,
-                bufsize=1,
+                bufsize=0,
             )
 
             # Rewrite dockur's container-internal VNC web URL to the host
@@ -1321,21 +1416,24 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
             # progress line only every few percent instead of on every wget
             # tick. Shared list so the closure can mutate it.
             _last_pct: list[int] = [-100]
-            # dockur v6.01 buffers the ISO-download progress inside the container
-            # (wget's output only reaches us when the whole download finishes), so
-            # winpodx can't stream a live percentage. Instead the drain sets this
-            # to a monotonic start when "Downloading Windows" appears and clears it
-            # on the next build milestone; the heartbeat below turns it into a
-            # ticking elapsed clock + deadline liveness.
-            dl_state: dict[str, float | None] = {"start": None}
+            # dockur v6.01 buffered the ISO-download progress inside the container
+            # (wget's output only reached us when the whole download finished), so
+            # winpodx couldn't stream a live percentage -- the drain set "start" to
+            # a monotonic clock when "Downloading Windows" appears and cleared it on
+            # the next build milestone, and the heartbeat below turned that into a
+            # ticking elapsed clock + deadline liveness. dockur v6.02 (#735) writes
+            # a real percentage again, just as one no-newline-until-done line
+            # (_DOWNLOAD_PCT_RE / _iter_container_lines above), so "pct" carries the
+            # latest value scraped off that growing line; it's cleared alongside
+            # "start" so a stale percentage from a prior download can't linger.
+            dl_state: dict[str, float | int | None] = {"start": None, "pct": None}
 
             def _drain(stream) -> None:  # type: ignore[no-untyped-def]
                 if stream is None:
                     return
-                for line in stream:
+                for line in _iter_container_lines(stream, dl_state, log_stop):
                     if log_stop.is_set():
                         break
-                    line = line.rstrip()
                     if not line:
                         continue
                     if (
@@ -1349,18 +1447,21 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
                     if eta_secs is not None:
                         _maybe_extend_deadline(eta_secs)
 
-                    # dockur v6.01 buffers the ISO-download progress, so we can't
-                    # stream a live percentage. Mark the download window off the
-                    # "Downloading Windows" milestone (the next build line ends
-                    # it); the heartbeat thread times it and keeps the deadline
-                    # alive so a slow download can't false-timeout.
+                    # Mark the download window off the "Downloading Windows"
+                    # milestone (the next build line ends it); the heartbeat
+                    # thread times it and keeps the deadline alive so a slow
+                    # download can't false-timeout. "pct" is reset on both
+                    # edges so a stale percentage never bleeds from one
+                    # download window into the next (#735).
                     if "Downloading Windows" in line:
                         dl_state["start"] = _time.monotonic()
+                        dl_state["pct"] = None
                     elif dl_state["start"] is not None and any(
                         m in line
                         for m in ("Extracting", "Adding", "Building", "Creating", "Booting")
                     ):
                         dl_state["start"] = None
+                        dl_state["pct"] = None
 
                     if verbose:
                         # --verbose: raw, every container line, permanent.
@@ -1395,14 +1496,18 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
             threading.Thread(target=_drain, args=(log_proc.stderr,), daemon=True).start()
 
             def _download_heartbeat() -> None:
-                # dockur buffers the ISO-download bytes, so winpodx times the
-                # download itself: a ticking elapsed clock proves it's alive, and
-                # extending the deadline each tick means a slow download can't hit
-                # the wall while it's still going. Active only between the
-                # "Downloading Windows" milestone and the first build line.
-                # Clean mode updates a self-erasing line every second; --verbose
-                # (no self-erasing line) prints a sparse heartbeat every 15s so
-                # the download isn't a silent multi-minute gap there either.
+                # winpodx times the download itself: a ticking elapsed clock
+                # proves it's alive, and extending the deadline each tick means
+                # a slow download can't hit the wall while it's still going.
+                # Active only between the "Downloading Windows" milestone and
+                # the first build line. Clean mode updates a self-erasing line
+                # every second; --verbose (no self-erasing line) prints a
+                # sparse heartbeat every 15s so the download isn't a silent
+                # multi-minute gap there either. dockur v6.02 (#735) reports a
+                # real percentage (dl_state["pct"], scraped by
+                # _iter_container_lines); when it's known both modes fold it
+                # into the message, falling back to the bare clock when it
+                # isn't (older dockur, or before the first "%" line arrives).
                 last_verbose = [0.0]
                 while not log_stop.is_set():
                     dl = dl_state["start"]
@@ -1410,13 +1515,20 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
                         _maybe_extend_deadline_liveness()
                         el = int(_time.monotonic() - dl)
                         clock = f"{el // 60}m {el % 60:02d}s"
+                        pct = dl_state.get("pct")
                         if verbose:
                             now = _time.monotonic()
                             if now - last_verbose[0] >= 15:
-                                print(f"       (downloading Windows ISO... {clock})")
+                                if pct is not None:
+                                    print(f"       (downloading Windows ISO... {pct}%, {clock})")
+                                else:
+                                    print(f"       (downloading Windows ISO... {clock})")
                                 last_verbose[0] = now
                         elif _live.usable:
-                            _live.set(f"  Downloading Windows ISO...  ({clock})")
+                            if pct is not None:
+                                _live.set(f"  Downloading Windows ISO... {pct}% ({clock})")
+                            else:
+                                _live.set(f"  Downloading Windows ISO...  ({clock})")
                     else:
                         last_verbose[0] = 0.0
                     log_stop.wait(1.0)

--- a/tests/test_wait_ready_eta.py
+++ b/tests/test_wait_ready_eta.py
@@ -131,3 +131,112 @@ def test_format_wget_progress_rejects_non_progress() -> None:
     assert _format_wget_progress("BdsDxe: starting Boot0004") is None
     assert _format_wget_progress("Sysprep specialize") is None
     assert _format_wget_progress("") is None
+
+
+# dockur v6.02 (#735) writes the ISO-download percentage as ONE line that
+# grows byte-by-byte with no trailing newline until the download finishes
+# (qemus/qemu src/progress.sh printPercentProgress: "10%" -> "10% -> 20%" ->
+# ...), unlike v6.01's discrete wget lines above. Plain `for line in stream`
+# buffers those bytes invisibly for the whole download, so the drain now
+# reads raw chunks via `_LineSplitter` / `_iter_container_lines` instead.
+
+
+def test_line_splitter_yields_complete_lines_across_chunk_boundaries() -> None:
+    """Ordinary complete lines split across arbitrary chunk boundaries must
+    still reassemble intact, in order, exactly once -- the incremental
+    reader must not change behavior for lines that already had a newline."""
+    from winpodx.cli.pod import _LineSplitter
+
+    splitter = _LineSplitter()
+    assert splitter.feed(b"hel") == []
+    assert splitter.feed(b"lo wor") == []
+    assert splitter.feed(b"ld\nsecond line\n") == ["hello world", "second line"]
+
+
+def test_line_splitter_partial_tail_visible_but_not_emitted() -> None:
+    """A no-newline-yet tail (dockur's still-growing download percentage)
+    must not be emitted as a line -- it has to survive to be completed
+    later -- but it IS visible via ``partial`` so the drain can scrape a
+    live percentage out of it via ``_DOWNLOAD_PCT_RE``."""
+    from winpodx.cli.pod import _DOWNLOAD_PCT_RE, _LineSplitter
+
+    splitter = _LineSplitter()
+    lines = splitter.feed("Downloading Windows ISO\n10% → 20%".encode())
+    assert lines == ["Downloading Windows ISO"]
+    assert splitter.partial == "10% → 20%"
+    matches = _DOWNLOAD_PCT_RE.findall(splitter.partial)
+    assert min(int(matches[-1]), 100) == 20
+
+
+def test_line_splitter_completes_pending_line_exactly_once() -> None:
+    """Once the newline finally arrives, the whole accumulated tail is
+    emitted as ONE line -- not re-emitted on any later feed()."""
+    from winpodx.cli.pod import _LineSplitter
+
+    splitter = _LineSplitter()
+    splitter.feed("10% → 20%".encode())
+    completed = splitter.feed(" → 30%\nExtracting Windows image\n".encode())
+    assert completed == ["10% → 20% → 30%", "Extracting Windows image"]
+    assert splitter.feed(b"more\n") == ["more"]
+
+
+def test_line_splitter_flush_returns_trailing_remainder_once() -> None:
+    """At EOF (container process exited mid-line), the leftover tail must
+    still surface as one final line -- mirroring how iterating a file
+    object yields a last newline-less line before returning "" -- and only
+    once."""
+    from winpodx.cli.pod import _LineSplitter
+
+    splitter = _LineSplitter()
+    splitter.feed(b"unterminated tail")
+    assert splitter.flush() == "unterminated tail"
+    assert splitter.flush() is None
+
+
+def test_download_pct_regex_last_match_wins_and_clamps_at_100() -> None:
+    """``_DOWNLOAD_PCT_RE`` must pick the LAST "NN%" in dockur's chained
+    growing line, and the caller clamps it to 100 -- dockur can't actually
+    emit over 100%, but the parser must never store an out-of-range value."""
+    from winpodx.cli.pod import _DOWNLOAD_PCT_RE
+
+    matches = _DOWNLOAD_PCT_RE.findall("10% → 20% → 150%")
+    assert matches[-1] == "150"
+    assert min(int(matches[-1]), 100) == 100
+
+
+def test_iter_container_lines_tracks_pct_and_yields_lines_end_to_end() -> None:
+    """Full lifecycle through ``_iter_container_lines``: a milestone line,
+    then a growing no-newline percentage tail (scraped into
+    ``dl_state["pct"]``, clamped, last-match-wins), then the newline that
+    finally completes it alongside the next milestone, then EOF. The
+    percentage must never be lost, never double-counted, and the
+    previously-partial text must reappear verbatim once completed."""
+    import threading
+
+    from winpodx.cli.pod import _iter_container_lines
+
+    class _FakeStream:
+        """Hands out one scripted chunk per ``read()`` call, then EOF."""
+
+        def __init__(self, chunks: list[bytes]) -> None:
+            self._chunks = list(chunks)
+
+        def read(self, _size: int) -> bytes:
+            return self._chunks.pop(0) if self._chunks else b""
+
+    stream = _FakeStream(
+        [
+            b"Downloading Windows ISO\n",
+            "10% → 20% → 150%".encode(),  # still growing: no "\n" yet
+            b"\nExtracting Windows image\n",
+            b"",
+        ]
+    )
+    dl_state: dict[str, float | int | None] = {"start": 0.0, "pct": None}
+    lines = list(_iter_container_lines(stream, dl_state, threading.Event()))
+    assert lines == [
+        "Downloading Windows ISO",
+        "10% → 20% → 150%",
+        "Extracting Windows image",
+    ]
+    assert dl_state["pct"] == 100


### PR DESCRIPTION
dockur v6.02 writes the ISO-download progress to the container log again, but as one line that grows with no newline until the download finishes (qemus/qemu progress.sh: `10% -> 20% -> ...`), so a line-based reader only sees it after the fact.

- `winpodx pod wait-ready` now reads the podman-logs pipe byte-wise (`_LineSplitter` + `_iter_container_lines`, `bufsize=0`): complete lines keep identical semantics, and while the download window is open the still-growing partial tail is scanned for its latest `NN%`.
- The download heartbeat folds it into the clock: `Downloading Windows ISO... 42% (5m 12s)` in clean mode, `(downloading Windows ISO... 42%, 5m 12s)` under `--verbose`. Falls back to the bare elapsed clock when no percentage has arrived (older dockur images).
- The percentage resets on both edges of the download window so a stale value can't bleed into a later download.

Tests: 7 new unit tests for the splitter/scraper (chunk-boundary reassembly, partial-tail scrape without emission, single emission on completion, EOF flush, last-match + clamp); 56 passed on the touched files + test_pod 13 passed; ruff clean.

Needs the real-download smoke on v6.02 to confirm the percentage renders live end-to-end.