### PR TITLE
fix(install): don't let the rpm-ostree path shadow an existing venv install (#752)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -629,8 +629,21 @@ install_pkg() {
 # wins: the OBS RPM only ships tagged releases, so honouring those flags means
 # falling through to the git/venv flow even on Atomic (#548 — custom-image
 # builders layer winpodx from main like any other Fedora package).
+#
+# Also gated on there being no existing venv install (#752): this branch
+# used to fire on `command -v rpm-ostree` alone, so a bare `curl | bash`
+# re-run on a host that already has a curl/venv install (e.g. Bazzite,
+# installed before the OBS repo existed) would layer a SECOND winpodx
+# binary at /usr/bin/winpodx instead of upgrading the one actually in use.
+# Since ~/.local/bin precedes /usr/bin on PATH, that layered copy never
+# runs — the user's `winpodx` stayed pinned to whatever version the venv
+# install last had, forever. The gate is VENV presence, NOT
+# IS_FRESH_INSTALL: an RPM-only host has a prior config too (which zeroes
+# IS_FRESH_INSTALL), and re-running the installer there should keep
+# updating the RPM, not silently switch topology to a venv install.
 if command -v rpm-ostree >/dev/null 2>&1 \
-   && [ -z "$WINPODX_REF" ] && [ -z "$WINPODX_SOURCE" ] && [ -z "$WINPODX_IMAGE_TAR" ]; then
+   && [ -z "$WINPODX_REF" ] && [ -z "$WINPODX_SOURCE" ] && [ -z "$WINPODX_IMAGE_TAR" ] \
+   && [ ! -e "$VENV_DIR" ]; then
     ROLLBACK_ARMED=0
     log "Detected rpm-ostree — Atomic Fedora install path."
     if [ ! -f /etc/os-release ]; then
@@ -663,6 +676,15 @@ if command -v rpm-ostree >/dev/null 2>&1 \
         fi
     fi
     exit 0
+elif command -v rpm-ostree >/dev/null 2>&1 \
+   && [ -z "$WINPODX_REF" ] && [ -z "$WINPODX_SOURCE" ] && [ -z "$WINPODX_IMAGE_TAR" ]; then
+    # #752: same condition as the branch above, minus the venv check — so
+    # getting here means rpm-ostree is present, no explicit source
+    # override was given, and $VENV_DIR already exists (a prior curl/venv
+    # install). Don't layer a second binary that PATH order would never
+    # actually run; upgrade the install that's already in use via the
+    # git/venv flow below instead.
+    warn "rpm-ostree detected, but an existing venv install was found at $INSTALL_DIR — upgrading that install in place (avoids a PATH-shadowed dual install)."
 elif command -v rpm-ostree >/dev/null 2>&1; then
     # rpm-ostree present, but the user asked for a specific source above — note
     # the bypass (the OBS RPM only ships tagged releases) and fall through to
@@ -1616,6 +1638,21 @@ if ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
     warn "$HOME/.local/bin is not in PATH"
     warn "Add this to your ~/.bashrc or ~/.zshrc:"
     warn '  export PATH="$HOME/.local/bin:$PATH"'
+fi
+
+# --- PATH-shadow check (#752) ---
+# A distro package (OBS RPM, AUR, .deb) can drop its own `winpodx` at
+# /usr/bin, and this curl/venv install always lives at $SYMLINK
+# ($HOME/.local/bin/winpodx). Only one of them is what the shell actually
+# runs, decided purely by PATH order -- so if `command -v winpodx` doesn't
+# resolve to the copy this run just installed/updated, tell the user which
+# copy is shadowing which instead of leaving them to discover it via a
+# version that silently never changes (see uninstall.sh's find_winpodx_bin
+# for the same PATH-precedence concern on the removal side).
+RESOLVED_WINPODX="$(command -v winpodx 2>/dev/null || true)"
+if [ -n "$RESOLVED_WINPODX" ] && [ "$RESOLVED_WINPODX" != "$SYMLINK" ]; then
+    warn "PATH resolves 'winpodx' to $RESOLVED_WINPODX, not $SYMLINK (the copy this run just installed/updated)."
+    warn "That other copy is what actually runs. Remove it, or reorder PATH so $HOME/.local/bin comes first, for this install to take effect."
 fi
 
 # --- Run setup ---


### PR DESCRIPTION
On an rpm-ostree host (Bazzite), a bare `curl | bash` re-run always took the Atomic RPM-layering branch and `exit 0`'d without touching an existing `~/.local/bin/winpodx-app` venv install. `~/.local/bin` precedes `/usr/bin` on PATH, so the layered RPM copy never actually ran and the user's `winpodx` stayed pinned to the old venv version no matter how many times they reinstalled. That's the exact #752 report (0.10.0 forever, even after an rpm-ostree remove + reinstall, which only touches the RPM side).

- Gate the RPM-layering branch on there being **no existing venv install**. Deliberately not `IS_FRESH_INSTALL`: an RPM-only host has a prior config too (which zeroes that flag), and re-running the installer there should keep updating the RPM rather than silently switching install topology.
- rpm-ostree present + venv exists: warn and fall through to the normal git/venv upgrade path.
- Post-install PATH-shadow check: if `command -v winpodx` resolves to a different copy than the one this run installed, name both paths and how to fix — catches this whole class of dual-install confusion for every install method.

Validation: `bash -n` clean, shellcheck zero new warnings, `test_install_sh_provision.py` 22 passed (incl. the explicit-source-override guard), adjacent install/uninstall suites 23 passed.