### PR TITLE
fix(pod): preflight host-port conflicts before start + doctor check (#754)

### DIFF
--- a/src/winpodx/cli/doctor.py
+++ b/src/winpodx/cli/doctor.py
@@ -166,6 +166,7 @@ def _collect_findings(*, quick: bool, do_fix: bool) -> list[Finding]:
     findings.append(_check_kvm())
     findings.append(_check_rootless_subid())
     findings.extend(_check_container_backend())
+    findings.append(_check_host_ports())
     findings.append(_check_config_state())
     findings.append(_check_pending_setup())
     findings.append(_check_autostart_entry())
@@ -356,6 +357,43 @@ def _check_container_backend() -> list[Finding]:
             )
         ]
     return [Finding("ok", f"backend {backend!r} at {path}")]
+
+
+def _check_host_ports() -> Finding | None:
+    """#754: winpodx's required host ports (RDP/VNC/agent/SMB) held by something else.
+
+    Common on Ubuntu, where GNOME's built-in Remote Desktop defaults to
+    ``127.0.0.1:3390`` -- the same port winpodx's RDP config defaults to.
+    Only relevant for the podman/docker backends (manual publishes no ports
+    of its own). Short-circuits to ok when winpodx's own pod is already
+    running: it's the thing holding those ports, not a conflict.
+    """
+    try:
+        from winpodx.core.config import Config
+
+        cfg = Config.load()
+    except Exception:  # noqa: BLE001 — config issues are reported by their own check
+        return None
+    if cfg.pod.backend not in ("podman", "docker"):
+        return None
+    if _pod_running(cfg):
+        return Finding("ok", "pod running — ports held by winpodx itself")
+
+    try:
+        from winpodx.core.pod.ports import check_host_ports, format_port_conflict_error
+
+        conflicts = check_host_ports(cfg)
+    except Exception as e:  # noqa: BLE001 — never let a probe crash doctor
+        return Finding("warn", "could not probe host ports", detail=str(e))
+
+    if not conflicts:
+        return Finding("ok", "required host ports are free")
+    return Finding(
+        "warn",
+        f"{len(conflicts)} required host port(s) already in use",
+        detail=format_port_conflict_error(conflicts),
+        suggestion="Free the port(s), or reconfigure winpodx to use different ones.",
+    )
 
 
 def _check_config_state() -> Finding:

--- a/src/winpodx/core/pod/lifecycle.py
+++ b/src/winpodx/core/pod/lifecycle.py
@@ -7,6 +7,7 @@ import logging
 
 from winpodx.core.config import Config
 from winpodx.core.pod.backend import PodState, PodStatus, get_backend
+from winpodx.core.pod.ports import check_host_ports, format_port_conflict_error
 
 log = logging.getLogger(__name__)
 
@@ -14,6 +15,26 @@ log = logging.getLogger(__name__)
 def start_pod(cfg: Config) -> PodStatus:
     """Start the Windows pod and wait up to boot_timeout for RDP readiness."""
     backend = get_backend(cfg)
+
+    # #754: probe for host port conflicts (e.g. GNOME Remote Desktop already
+    # holding 127.0.0.1:3390 on Ubuntu) before handing off to the backend --
+    # otherwise this fails silently inside `podman-compose up` and the user
+    # just sees an hour-long boot timeout with no diagnostics. Skip the
+    # preflight when the pod is already running/paused: it's the one holding
+    # its own ports at that point, not a conflict.
+    try:
+        already_up = backend.is_running()
+    except Exception as e:
+        log.error("Failed to probe pod state before start: %s", e)
+        return PodStatus(state=PodState.ERROR, error=str(e))
+
+    if not already_up:
+        conflicts = check_host_ports(cfg)
+        if conflicts:
+            msg = format_port_conflict_error(conflicts)
+            log.error(msg)
+            return PodStatus(state=PodState.ERROR, error=msg)
+
     try:
         backend.start()
     except Exception as e:

--- a/src/winpodx/core/pod/ports.py
+++ b/src/winpodx/core/pod/ports.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: MIT
+"""Host port preflight for pod start (#754).
+
+Ubuntu ships GNOME's built-in Remote Desktop (Settings > Sharing), which by
+default binds ``127.0.0.1:3390`` -- the same loopback port winpodx's RDP
+config defaults to. When something else already holds a port winpodx's
+compose file needs to publish on the host, ``podman-compose`` /
+``docker compose`` can't bind it and the pod never comes up; before #754
+this only surfaced as an hour-long boot timeout with no diagnostics.
+
+``check_host_ports`` runs a fast bind-test preflight so ``start_pod``
+(``winpodx.core.pod.lifecycle``) can fail immediately with an actionable
+message instead, and ``winpodx doctor`` can surface the same conflict
+before the user ever tries to start.
+"""
+
+from __future__ import annotations
+
+import re
+import socket
+import subprocess
+from dataclasses import dataclass
+
+from winpodx.core.agent import AGENT_PORT
+from winpodx.core.config import Config
+from winpodx.core.guest_disk import SMB_HOST_PORT
+
+# Matches the owning-process name out of `ss -H -tlnp` output, e.g.:
+#   LISTEN 0 511 127.0.0.1:3390 0.0.0.0:* users:(("gnome-remote-desktop",pid=1234,fd=7))
+_OWNER_RE = re.compile(r'users:\(\("([^"]+)"')
+
+
+@dataclass(frozen=True)
+class PortConflict:
+    port: int
+    label: str
+    owner: str = ""
+
+
+def _required_ports(cfg: Config) -> list[tuple[int, str]]:
+    """Host loopback ports winpodx's compose file needs to publish."""
+    return [
+        (cfg.rdp.port, "RDP"),
+        (cfg.pod.vnc_port, "VNC"),
+        (AGENT_PORT, "agent"),
+        (SMB_HOST_PORT, "SMB (reverse-open)"),
+    ]
+
+
+def _port_in_use(port: int) -> bool:
+    """True if ``127.0.0.1:port`` can't be bound right now.
+
+    Same bind-test idiom as ``core.usbredir``'s relay listener: a plain
+    connect-test would miss a port that's bound but not yet accepting, and
+    would false-negative against anything not speaking a known protocol.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        sock.bind(("127.0.0.1", port))
+        return False
+    except OSError:
+        return True
+    finally:
+        sock.close()
+
+
+def _owner_hint(port: int) -> str:
+    """Best-effort name of the process holding ``port``, via ``ss -H -tlnp``.
+
+    Empty string when ``ss`` is missing, times out, or the line can't be
+    parsed -- this is a diagnostic hint, not load-bearing.
+    """
+    try:
+        result = subprocess.run(
+            ["ss", "-H", "-tlnp"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return ""
+    for line in result.stdout.splitlines():
+        if f":{port} " not in line:
+            continue
+        m = _OWNER_RE.search(line)
+        if m:
+            return m.group(1)
+    return ""
+
+
+def check_host_ports(cfg: Config) -> list[PortConflict]:
+    """Preflight: which of winpodx's required host ports are already taken.
+
+    Only meaningful for container backends (``podman`` / ``docker``) -- the
+    ``manual`` backend doesn't publish any ports of its own, so this always
+    returns ``[]`` for it.
+
+    Callers must skip this (or accept false positives) when winpodx's own
+    pod is already running/paused: a live pod holds these ports itself,
+    which is not a conflict.
+    """
+    if cfg.pod.backend not in ("podman", "docker"):
+        return []
+    conflicts: list[PortConflict] = []
+    for port, label in _required_ports(cfg):
+        if _port_in_use(port):
+            conflicts.append(PortConflict(port=port, label=label, owner=_owner_hint(port)))
+    return conflicts
+
+
+def format_port_conflict_error(conflicts: list[PortConflict]) -> str:
+    """Render ``conflicts`` into the multi-line message shown to the user."""
+    lines = ["Cannot start pod — the following host port(s) are already in use:"]
+    for c in conflicts:
+        lines.append(f"  127.0.0.1:{c.port} [{c.label}] ({c.owner or 'unknown process'})")
+
+    affected = {c.label for c in conflicts}
+    if "RDP" in affected or "VNC" in affected:
+        lines.append(
+            "RDP and VNC ports are configurable: "
+            "`winpodx config set rdp.port <n>` / `winpodx config set pod.vnc_port <n>`."
+        )
+    if "RDP" in affected:
+        lines.append(
+            "On Ubuntu, GNOME's built-in Remote Desktop (Settings > Sharing) commonly "
+            "claims 3390 -- turn it off there, or move winpodx's RDP port instead."
+        )
+    return "\n".join(lines)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -76,6 +76,47 @@ def test_start_pod_start_failure_returns_error():
     assert "boom" in status.error
 
 
+def test_start_pod_returns_error_on_port_conflict():
+    """#754: a host port conflict must short-circuit before backend.start()."""
+    from winpodx.core.pod.ports import PortConflict
+
+    cfg = Config()
+    fake_backend = MagicMock()
+    fake_backend.is_running.return_value = False
+
+    conflict = PortConflict(port=3390, label="RDP", owner="gnome-remote-desktop")
+
+    with (
+        patch("winpodx.core.pod.lifecycle.get_backend", return_value=fake_backend),
+        patch("winpodx.core.pod.lifecycle.check_host_ports", return_value=[conflict]),
+    ):
+        status = start_pod(cfg)
+
+    fake_backend.start.assert_not_called()
+    fake_backend.wait_for_ready.assert_not_called()
+    assert status.state == PodState.ERROR
+    assert "3390" in status.error
+    assert "RDP" in status.error
+
+
+def test_start_pod_skips_port_check_when_pod_already_running():
+    """A running/paused pod holds its own ports -- preflight must not run."""
+    cfg = Config()
+    fake_backend = MagicMock()
+    fake_backend.is_running.return_value = True
+    fake_backend.wait_for_ready.return_value = True
+
+    with (
+        patch("winpodx.core.pod.lifecycle.get_backend", return_value=fake_backend),
+        patch("winpodx.core.pod.lifecycle.check_host_ports") as mock_check,
+    ):
+        status = start_pod(cfg)
+
+    mock_check.assert_not_called()
+    fake_backend.start.assert_called_once()
+    assert status.state == PodState.RUNNING
+
+
 def test_podman_backend_is_running_uses_configured_container_name():
     from winpodx.backend.podman import PodmanBackend
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -202,6 +202,44 @@ class TestCheckRootlessSubid:
         assert "setup-host" in f.suggestion
 
 
+class TestCheckHostPorts:
+    """#754: winpodx's required host ports already held by something else."""
+
+    def _run(self, monkeypatch, *, backend="podman", running=False, conflicts=None):
+        from winpodx.cli.doctor import _check_host_ports
+
+        monkeypatch.setattr(
+            "winpodx.core.config.Config.load",
+            classmethod(lambda cls: SimpleNamespace(pod=SimpleNamespace(backend=backend))),
+        )
+        monkeypatch.setattr(doctor, "_pod_running", lambda cfg: running)
+        if conflicts is not None:
+            monkeypatch.setattr("winpodx.core.pod.ports.check_host_ports", lambda cfg: conflicts)
+        return _check_host_ports()
+
+    def test_skipped_for_manual_backend(self, monkeypatch):
+        assert self._run(monkeypatch, backend="manual") is None
+
+    def test_ok_when_pod_already_running(self, monkeypatch):
+        f = self._run(monkeypatch, running=True)
+        assert f.severity == "ok"
+        assert "held by winpodx itself" in f.title
+
+    def test_ok_when_no_conflicts(self, monkeypatch):
+        f = self._run(monkeypatch, running=False, conflicts=[])
+        assert f.severity == "ok"
+
+    def test_warn_on_conflicts(self, monkeypatch):
+        from winpodx.core.pod.ports import PortConflict
+
+        conflicts = [PortConflict(port=3390, label="RDP", owner="gnome-remote-desktop")]
+        f = self._run(monkeypatch, running=False, conflicts=conflicts)
+        assert f.severity == "warn"
+        assert f.fix_id is None
+        assert "3390" in f.detail
+        assert f.suggestion
+
+
 class TestHandleDoctor:
     def test_exits_zero_on_no_fail(self, tmp_path, monkeypatch, capsys):
         """All checks return OK or WARN -> exit 0."""
@@ -214,6 +252,7 @@ class TestHandleDoctor:
             "_check_freerdp",
             "_check_kvm",
             "_check_rootless_subid",
+            "_check_host_ports",
             "_check_config_state",
             "_check_pending_setup",
             "_check_autostart_entry",
@@ -237,6 +276,7 @@ class TestHandleDoctor:
             "_check_freerdp",
             "_check_kvm",
             "_check_rootless_subid",
+            "_check_host_ports",
             "_check_config_state",
             "_check_pending_setup",
             "_check_autostart_entry",
@@ -469,6 +509,7 @@ def _all_ok_legacy(monkeypatch):
     # no UID/GID mappings, so the real probe returns FAIL there -> handle_doctor
     # sys.exit(1) -> these tests spuriously error and block the build.
     monkeypatch.setattr(doctor, "_check_rootless_subid", lambda: Finding("ok", "subid"))
+    monkeypatch.setattr(doctor, "_check_host_ports", lambda: Finding("ok", "ports"))
     monkeypatch.setattr(doctor, "_check_config_state", lambda: Finding("ok", "cfg"))
     monkeypatch.setattr(doctor, "_check_pending_setup", lambda: Finding("ok", "pending"))
     monkeypatch.setattr(doctor, "_check_autostart_entry", lambda: Finding("ok", "auto"))

--- a/tests/test_pod_ports.py
+++ b/tests/test_pod_ports.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the host port preflight (#754)."""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+
+from winpodx.core.config import Config
+from winpodx.core.pod.ports import (
+    PortConflict,
+    _owner_hint,
+    _port_in_use,
+    check_host_ports,
+    format_port_conflict_error,
+)
+
+
+class TestPortInUse:
+    def test_bound_port_is_in_use(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        port = sock.getsockname()[1]
+        try:
+            assert _port_in_use(port) is True
+        finally:
+            sock.close()
+
+    def test_freed_port_is_not_in_use(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+        sock.close()  # release it before probing
+        assert _port_in_use(port) is False
+
+
+class TestCheckHostPorts:
+    def test_manual_backend_returns_empty(self, monkeypatch):
+        cfg = Config()
+        cfg.pod.backend = "manual"
+        # Even if something were listening, manual publishes no ports.
+        monkeypatch.setattr("winpodx.core.pod.ports._port_in_use", lambda port: True)
+        assert check_host_ports(cfg) == []
+
+    def test_podman_backend_reports_conflicts(self, monkeypatch):
+        cfg = Config()
+        cfg.pod.backend = "podman"
+        monkeypatch.setattr(
+            "winpodx.core.pod.ports._port_in_use", lambda port: port == cfg.rdp.port
+        )
+        monkeypatch.setattr(
+            "winpodx.core.pod.ports._owner_hint", lambda port: "gnome-remote-desktop"
+        )
+        conflicts = check_host_ports(cfg)
+        assert len(conflicts) == 1
+        assert conflicts[0] == PortConflict(
+            port=cfg.rdp.port, label="RDP", owner="gnome-remote-desktop"
+        )
+
+    def test_docker_backend_no_conflicts_returns_empty(self, monkeypatch):
+        cfg = Config()
+        cfg.pod.backend = "docker"
+        monkeypatch.setattr("winpodx.core.pod.ports._port_in_use", lambda port: False)
+        assert check_host_ports(cfg) == []
+
+
+class TestOwnerHint:
+    def test_parses_ss_output(self, monkeypatch):
+        fake = subprocess.CompletedProcess(
+            args=["ss"],
+            returncode=0,
+            stdout=(
+                "LISTEN 0      511    127.0.0.1:3390 0.0.0.0:* "
+                'users:(("gnome-remote-desktop",pid=1234,fd=7))\n'
+            ),
+            stderr="",
+        )
+        monkeypatch.setattr("winpodx.core.pod.ports.subprocess.run", lambda *a, **k: fake)
+        assert _owner_hint(3390) == "gnome-remote-desktop"
+
+    def test_missing_ss_binary_returns_empty(self, monkeypatch):
+        def _boom(*a, **k):
+            raise FileNotFoundError()
+
+        monkeypatch.setattr("winpodx.core.pod.ports.subprocess.run", _boom)
+        assert _owner_hint(3390) == ""
+
+    def test_timeout_returns_empty(self, monkeypatch):
+        def _boom(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="ss", timeout=3)
+
+        monkeypatch.setattr("winpodx.core.pod.ports.subprocess.run", _boom)
+        assert _owner_hint(3390) == ""
+
+    def test_no_matching_line_returns_empty(self, monkeypatch):
+        fake = subprocess.CompletedProcess(
+            args=["ss"],
+            returncode=0,
+            stdout="LISTEN 0      511    127.0.0.1:9999 0.0.0.0:*\n",
+            stderr="",
+        )
+        monkeypatch.setattr("winpodx.core.pod.ports.subprocess.run", lambda *a, **k: fake)
+        assert _owner_hint(3390) == ""
+
+
+class TestFormatPortConflictError:
+    def test_includes_header_and_conflict_line(self):
+        conflicts = [PortConflict(port=3390, label="RDP", owner="gnome-remote-desktop")]
+        msg = format_port_conflict_error(conflicts)
+        assert "already in use" in msg
+        assert "127.0.0.1:3390 [RDP] (gnome-remote-desktop)" in msg
+
+    def test_unknown_owner_falls_back(self):
+        msg = format_port_conflict_error([PortConflict(port=3390, label="RDP")])
+        assert "(unknown process)" in msg
+
+    def test_config_hint_present_for_rdp_and_vnc(self):
+        rdp_msg = format_port_conflict_error([PortConflict(port=3390, label="RDP")])
+        assert "config set rdp.port" in rdp_msg
+        vnc_msg = format_port_conflict_error([PortConflict(port=8007, label="VNC")])
+        assert "config set" in vnc_msg
+
+    def test_config_hint_absent_for_agent_and_smb_only(self):
+        agent_msg = format_port_conflict_error([PortConflict(port=8765, label="agent")])
+        assert "config set" not in agent_msg
+        smb_msg = format_port_conflict_error([PortConflict(port=4445, label="SMB (reverse-open)")])
+        assert "config set" not in smb_msg
+
+    def test_gnome_hint_only_when_rdp_conflicts(self):
+        rdp_msg = format_port_conflict_error([PortConflict(port=3390, label="RDP")])
+        assert "GNOME" in rdp_msg
+        vnc_msg = format_port_conflict_error([PortConflict(port=8007, label="VNC")])
+        assert "GNOME" not in vnc_msg
+        agent_msg = format_port_conflict_error([PortConflict(port=8765, label="agent")])
+        assert "GNOME" not in agent_msg


### PR DESCRIPTION
GNOME's built-in Remote Desktop on Ubuntu binds `127.0.0.1:3390` by default, which is winpodx's RDP forward port. The container's bind failure happened inside podman-compose and surfaced as an hour-long boot timeout with zero diagnostics (#754).

- New `core/pod/ports.py`: fast bind-test preflight over the four published host ports (RDP `rdp.port`/3390, VNC `pod.vnc_port`/8007, agent 8765, reverse-open SMB 4445), with a best-effort owning-process hint via `ss -tlnp` and an actionable error: names the port and owner, points at `winpodx config set rdp.port <n>` / `pod.vnc_port <n>` when the conflicting port is configurable, and calls out GNOME Remote Desktop (Settings > Sharing) when 3390 is the one taken.
- `start_pod()` returns `PodStatus(ERROR)` with that message before touching the backend, so the failure is milliseconds instead of an hour. Skipped when the pod is already running/paused (it legitimately holds its own ports). Single choke point covers CLI, GUI, tray, and setup.
- `winpodx doctor` gains the same check (warn, no auto-fixer; ok short-circuit when the pod is running).

Tests: 16 new in `test_pod_ports.py`, start_pod short-circuit + running-skip in `test_backend.py`, doctor class in `test_doctor.py`; touched suites 74 + 99 passed; ruff clean.