### PR TITLE
fix(wait-ready): scrape dockur's size-mode download chain + PATH-shadow false positive (#735/#752 follow-ups)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1654,7 +1654,14 @@ fi
 # version that silently never changes (see uninstall.sh's find_winpodx_bin
 # for the same PATH-precedence concern on the removal side).
 RESOLVED_WINPODX="$(command -v winpodx 2>/dev/null || true)"
-if [ -n "$RESOLVED_WINPODX" ] && [ "$RESOLVED_WINPODX" != "$SYMLINK" ]; then
+# Normalize both sides before comparing: PATH entries like
+# ~/.local/share/../bin make `command -v` return an unnormalized string
+# for the SAME file, which false-positived this warning on the first
+# smoke run (#752 follow-up). realpath also resolves the symlink itself,
+# so compare the symlink's own resolved path too.
+if [ -n "$RESOLVED_WINPODX" ] \
+   && [ "$(realpath -m "$RESOLVED_WINPODX" 2>/dev/null || echo "$RESOLVED_WINPODX")" \
+        != "$(realpath -m "$SYMLINK" 2>/dev/null || echo "$SYMLINK")" ]; then
     warn "PATH resolves 'winpodx' to $RESOLVED_WINPODX, not $SYMLINK (the copy this run just installed/updated)."
     warn "That other copy is what actually runs. Remove it, or reorder PATH so $HOME/.local/bin comes first, for this install to take effect."
 fi

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -1149,6 +1149,12 @@ class _LiveLine:
 # percentage is needed -- unlike v6.01's wget meter there's no speed/ETA
 # mid-line, just the running chain of milestones.
 _DOWNLOAD_PCT_RE = re.compile(r"([0-9]{1,3})%")
+# ...but when the download server doesn't report a total size (the smoke run
+# against the Microsoft CDN hit exactly this), progress.sh falls back to
+# printSizeProgress and the growing line is a SIZE chain instead:
+# "512MiB → 1GiB → 1.5GiB → ..." -- no percent tokens at all. Scrape those
+# too so the heartbeat can show "5.5GiB" rather than nothing.
+_DOWNLOAD_SIZE_RE = re.compile(r"([0-9]+(?:\.[0-9]+)?[MG]iB)")
 
 
 class _LineSplitter:
@@ -1229,6 +1235,12 @@ def _iter_container_lines(stream, dl_state: dict, stop: threading.Event):  # typ
             matches = _DOWNLOAD_PCT_RE.findall(splitter.partial)
             if matches:
                 dl_state["pct"] = min(int(matches[-1]), 100)
+            else:
+                # Size-mode chain (no total known upstream): keep the latest
+                # "5.5GiB"-style token instead. pct wins when both ever match.
+                sizes = _DOWNLOAD_SIZE_RE.findall(splitter.partial)
+                if sizes:
+                    dl_state["size"] = sizes[-1]
     tail = splitter.flush()
     if tail:
         yield tail
@@ -1444,7 +1456,11 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
             # (_DOWNLOAD_PCT_RE / _iter_container_lines above), so "pct" carries the
             # latest value scraped off that growing line; it's cleared alongside
             # "start" so a stale percentage from a prior download can't linger.
-            dl_state: dict[str, float | int | None] = {"start": None, "pct": None}
+            dl_state: dict[str, float | int | str | None] = {
+                "start": None,
+                "pct": None,
+                "size": None,
+            }
 
             def _drain(stream) -> None:  # type: ignore[no-untyped-def]
                 if stream is None:
@@ -1474,12 +1490,14 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
                     if "Downloading Windows" in line:
                         dl_state["start"] = _time.monotonic()
                         dl_state["pct"] = None
+                        dl_state["size"] = None
                     elif dl_state["start"] is not None and any(
                         m in line
                         for m in ("Extracting", "Adding", "Building", "Creating", "Booting")
                     ):
                         dl_state["start"] = None
                         dl_state["pct"] = None
+                        dl_state["size"] = None
 
                     if verbose:
                         # --verbose: raw, every container line, permanent.
@@ -1534,17 +1552,23 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
                         el = int(_time.monotonic() - dl)
                         clock = f"{el // 60}m {el % 60:02d}s"
                         pct = dl_state.get("pct")
+                        size = dl_state.get("size")
+                        # Percent when the server reported a total, size chain
+                        # when it didn't, bare clock before either arrives.
+                        progress = f"{pct}%" if pct is not None else size
                         if verbose:
                             now = _time.monotonic()
                             if now - last_verbose[0] >= 15:
-                                if pct is not None:
-                                    print(f"       (downloading Windows ISO... {pct}%, {clock})")
+                                if progress is not None:
+                                    print(
+                                        f"       (downloading Windows ISO... {progress}, {clock})"
+                                    )
                                 else:
                                     print(f"       (downloading Windows ISO... {clock})")
                                 last_verbose[0] = now
                         elif _live.usable:
-                            if pct is not None:
-                                _live.set(f"  Downloading Windows ISO... {pct}% ({clock})")
+                            if progress is not None:
+                                _live.set(f"  Downloading Windows ISO... {progress} ({clock})")
                             else:
                                 _live.set(f"  Downloading Windows ISO...  ({clock})")
                     else:

--- a/tests/test_wait_ready_eta.py
+++ b/tests/test_wait_ready_eta.py
@@ -240,3 +240,50 @@ def test_iter_container_lines_tracks_pct_and_yields_lines_end_to_end() -> None:
         "Extracting Windows image",
     ]
     assert dl_state["pct"] == 100
+
+
+def test_size_chain_scraped_when_no_percent() -> None:
+    """dockur v6.02 size-mode chain (server sent no total): the partial tail
+    has GiB/MiB tokens but no percents -- latest size lands on dl_state."""
+    import threading
+
+    from winpodx.cli.pod import _iter_container_lines
+
+    class _FakeStream:
+        def __init__(self, chunks):
+            self._chunks = list(chunks)
+
+        def read(self, _n):
+            return self._chunks.pop(0) if self._chunks else b""
+
+    dl_state = {"start": 1.0, "pct": None, "size": None}
+    stream = _FakeStream(
+        [
+            "❯ Downloading Windows 11...\n512MiB → 1GiB".encode(),
+            " → 1.5GiB → 2GiB".encode(),
+        ]
+    )
+    lines = list(_iter_container_lines(stream, dl_state, threading.Event()))
+    assert dl_state["pct"] is None
+    assert dl_state["size"] == "2GiB"
+    # The completed milestone line still came through; the tail flushed at EOF.
+    assert lines[0].startswith("❯ Downloading Windows 11")
+
+
+def test_percent_wins_over_size_tokens() -> None:
+    import threading
+
+    from winpodx.cli.pod import _iter_container_lines
+
+    class _FakeStream:
+        def __init__(self, chunks):
+            self._chunks = list(chunks)
+
+        def read(self, _n):
+            return self._chunks.pop(0) if self._chunks else b""
+
+    dl_state = {"start": 1.0, "pct": None, "size": None}
+    stream = _FakeStream([b"header\n10% \xe2\x86\x92 20%"])
+    list(_iter_container_lines(stream, dl_state, threading.Event()))
+    assert dl_state["pct"] == 20
+    assert dl_state["size"] is None


### PR DESCRIPTION
Two follow-ups from the first fresh-install smoke on dockur v6.02:

- **Size-mode download progress.** When the download server doesn't report a total size (the Microsoft CDN did exactly this), dockur's progress.sh emits a growing size chain (`512MiB -> 1GiB -> ...`) instead of percentages, so the new live-progress relay showed only the elapsed clock. The scraper now also picks up the latest size token and the heartbeat renders `Downloading Windows ISO... 5.5GiB (3m 10s)`; percent still wins when the server does report a total. Both values reset on the download-window edges as before.
- **PATH-shadow warning false positive.** The #752 warning compared `command -v winpodx` against the installed symlink as raw strings, so an unnormalized PATH entry (`~/.local/share/../bin`) triggered it for the very same file on the smoke run. Both sides are realpath-normalized now.

Tests: 2 new scraper tests (size chain scraped when no percents + percent-wins precedence); touched suites 72 passed; ruff + format clean; `bash -n` clean.