### PR TITLE
fix: rootless network regression (#770) + Homebrew podman-compose detection (#765)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed
+
+- **Rootless Podman re-forces dockur's user-mode (passt) networking, fixing RDP that never connected on some hosts after 0.10.1** (#770, thanks @vrvy-live). Dropping the forced `NETWORK=user` in 0.10.1 (#735) let the container auto-pick bridge NAT, but on rootless Podman hosts the NAT rewrite did not fully cover, the guest then landed on a NAT-internal `172.x` address that the host's forwarded RDP port (`127.0.0.1:3390`) could never reach — the container booted and QEMU came up on the web viewer, but RDP never connected. winpodx now re-forces `NETWORK: "user"` on rootless Podman only, restoring the known-good passt path (#269/#387 class); rootful Podman and Docker, where dockur's NAT port-forwarding is validated, keep dockur's auto-selection. `USER_PORTS` is unchanged.
+- **`podman-compose` installed via Homebrew is now detected even when brew's bin is off the session PATH** (#765, #725, thanks @realahmed7777). On immutable distros like Bazzite, Homebrew is the usual way to install `podman-compose`, but winpodx probed for it with `shutil.which`, which only searches `$PATH` -- and a desktop/tray session's `$PATH` often omits brew's bin. So `winpodx setup`, `winpodx doctor`, and the tray Pod > Start (a separate path in `PodmanBackend`) all reported "podman-compose not found" and silently no-oped even though it was installed. The probe now also checks the known Homebrew bin dirs (`/home/linuxbrew/.linuxbrew/bin`, `~/.linuxbrew/bin`, `/opt/homebrew/bin`) and `~/.local/bin`, and uses the resolved absolute path so the pod-start subprocess finds it regardless of the inherited `PATH`.
+
 ## [0.10.2] - 2026-07-20
 
 ### Changed

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **rootless Podman에서 dockur의 user-mode(passt) 네트워킹을 다시 강제하여, 0.10.1 이후 일부 호스트에서 RDP가 연결되지 않던 문제를 수정** (#770, @vrvy-live 감사). 0.10.1(#735)에서 강제 `NETWORK=user`를 제거하면서 컨테이너가 bridge NAT를 자동 선택하게 됐는데, NAT 재작성이 완전히 커버하지 못한 rootless Podman 호스트에서는 게스트가 NAT 내부 `172.x` 주소를 받아 호스트가 포워딩한 RDP 포트(`127.0.0.1:3390`)로는 절대 도달할 수 없었습니다 — 컨테이너는 부팅되고 QEMU도 웹 뷰어에 떴지만 RDP만 연결되지 않았습니다. 이제 winpodx는 rootless Podman에서만 `NETWORK: "user"`를 다시 강제해 검증된 passt 경로(#269/#387 계열)를 복원하며, dockur의 NAT 포트 포워딩이 검증된 rootful Podman과 Docker는 dockur의 자동 선택을 그대로 둡니다. `USER_PORTS`는 변경 없습니다.
+- **Homebrew로 설치한 `podman-compose`를 brew의 bin이 세션 PATH에 없어도 감지** (#765, #725, @realahmed7777 감사). Bazzite 같은 불변 배포판에서는 Homebrew가 `podman-compose` 설치의 일반적인 방법인데, winpodx는 `shutil.which`로만 탐색해서 `$PATH`만 검색했고 데스크톱/트레이 세션의 `$PATH`에는 brew의 bin이 빠져 있는 경우가 많았습니다. 그래서 `winpodx setup`, `winpodx doctor`, 트레이 Pod > Start(`PodmanBackend`의 별도 경로) 모두 설치돼 있는데도 "podman-compose not found"로 조용히 no-op이 됐습니다. 이제 알려진 Homebrew bin 디렉토리(`/home/linuxbrew/.linuxbrew/bin`, `~/.linuxbrew/bin`, `/opt/homebrew/bin`)와 `~/.local/bin`도 확인하고, 상속된 `PATH`와 무관하게 pod-start 서브프로세스가 찾을 수 있도록 해석된 절대 경로를 사용합니다.
+
 ## [0.10.2] - 2026-07-20
 
 ### Changed

--- a/src/winpodx/backend/podman.py
+++ b/src/winpodx/backend/podman.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import functools
 import logging
+import os
 import subprocess
 import time
 
@@ -12,6 +14,43 @@ from winpodx.backend.base import Backend, _container_uptime_secs
 from winpodx.utils.paths import config_dir
 
 log = logging.getLogger(__name__)
+
+
+@functools.lru_cache(maxsize=1)
+def is_rootless_podman() -> bool:
+    """Return True when the host runs Podman in rootless mode.
+
+    Rootless Podman is the case that still needs winpodx to force dockur's
+    ``NETWORK: "user"`` (passt) path. Dropping that force in 0.10.1 (#735)
+    let the container pick bridge NAT, which on rootless hosts lands the
+    guest on a NAT-internal ``172.x`` address that the host's forwarded RDP
+    port never reaches -- the #269/#387 class the forced user-mode used to
+    route around, resurfaced in the field as #770. dockur v6.01's rootless
+    NAT port-forwarding rewrite covers some hosts but not all, so winpodx
+    re-forces user-mode on rootless Podman only.
+
+    Primary signal is ``podman info``'s ``Host.Security.Rootless`` field
+    ("true"/"false"). If that call fails (podman missing or erroring) we
+    fall back to the effective-UID heuristic: a non-zero euid means the
+    daemonless podman is running rootless. The result cannot change within
+    a single winpodx run, so it is cached.
+    """
+    try:
+        result = subprocess.run(
+            ["podman", "info", "--format", "{{.Host.Security.Rootless}}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=host_env(),
+        )
+        out = result.stdout.strip().lower()
+        if result.returncode == 0 and out in ("true", "false"):
+            return out == "true"
+    except (OSError, subprocess.SubprocessError):
+        pass
+    # Fallback when `podman info` is unavailable: on POSIX a non-root
+    # effective UID means the daemonless podman runs rootless.
+    return getattr(os, "geteuid", lambda: 1)() != 0
 
 
 class PodmanBackend(Backend):
@@ -32,19 +71,33 @@ class PodmanBackend(Backend):
         # Thin AppImage (#357 root-cause fix, 0.6.0 item A): podman-
         # compose is no longer bundled, so the standard ``shutil.which``
         # finds the host copy directly -- no host-first dance needed.
-        import shutil
+        #
+        # #765 / #725: this is the code path `start()`/`stop()` use, which
+        # is what the tray's Pod>Start button calls via
+        # `core.pod.start_pod` -- so a PATH-only probe here is what made
+        # a Homebrew-installed podman-compose (off PATH by default on
+        # immutable distros like Bazzite) silently no-op the tray button.
+        # `find_podman_compose` also probes known Homebrew bin dirs and
+        # returns an absolute path, which we must use verbatim: this
+        # subprocess only inherits *our* PATH, not whatever shell found
+        # brew's shim.
+        from winpodx.utils.deps import find_podman_compose
 
-        if shutil.which("podman-compose"):
-            return ["podman-compose", "-f", self._compose_file()]
+        podman_compose = find_podman_compose()
+        if podman_compose:
+            return [podman_compose, "-f", self._compose_file()]
         raise RuntimeError(
-            "podman-compose not found on PATH. WinPodX requires podman-compose "
+            "podman-compose not found. WinPodX requires podman-compose "
             "(not the `podman compose` subcommand, which delegates to "
             "docker-compose and breaks our keep-groups extension -- see #288). "
             "Install it with your package manager: "
             "Fedora/Nobara: `sudo dnf install podman-compose`, "
             "Debian/Ubuntu: `sudo apt install podman-compose`, "
             "Arch: `sudo pacman -S podman-compose`, "
-            "openSUSE: `sudo zypper install podman-compose`."
+            "openSUSE: `sudo zypper install podman-compose`. "
+            "Homebrew installs are auto-detected even off PATH; if you already "
+            'installed it via brew and still see this, run `eval "$(brew shellenv)"` '
+            "before launching winpodx."
         )
 
     def start(self) -> None:

--- a/src/winpodx/cli/doctor.py
+++ b/src/winpodx/cli/doctor.py
@@ -33,6 +33,7 @@ probe has a short timeout, and the network never gets touched.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import shutil
 import subprocess
@@ -342,8 +343,10 @@ def _check_compose_provider() -> Finding | None:
     plugin) ships separately from ``podman`` itself. Without one, container
     creation silently no-ops and the failure only surfaces later as a cryptic
     ``no such container "winpodx-windows"`` from `pod wait-ready` (#753).
-    Mirrors the exact probe ``setup_cmd._recreate_container`` uses so
-    doctor's verdict matches what setup will actually do. Only relevant for
+    Shares ``utils.deps.find_podman_compose`` with ``setup_cmd``'s and
+    ``backend.podman``'s probes so doctor's verdict matches what setup and
+    pod start will actually do -- including finding a Homebrew-installed
+    ``podman-compose`` that's off ``$PATH`` (#765, #725). Only relevant for
     the podman backend; the docker backend's ``docker compose`` plugin ships
     with the docker CLI and isn't separately probed by setup_cmd either, so
     it's skipped (``None``) here too.
@@ -356,8 +359,19 @@ def _check_compose_provider() -> Finding | None:
     except Exception:  # noqa: BLE001 — config issues are reported by their own check
         return None
 
-    if shutil.which("podman-compose"):
-        return Finding("ok", "compose provider: podman-compose")
+    from winpodx.utils.deps import find_podman_compose
+
+    podman_compose = find_podman_compose()
+    if podman_compose:
+        if shutil.which("podman-compose"):
+            return Finding("ok", "compose provider: podman-compose")
+        # Found off PATH (e.g. a Homebrew install on an immutable distro like
+        # Bazzite) -- say where, so a user debugging the tray Pod>Start
+        # no-op (#725) can see it was found via a non-PATH probe (#765).
+        return Finding(
+            "ok",
+            f"compose provider: podman-compose ({os.path.dirname(podman_compose)})",
+        )
 
     try:
         subprocess.run(
@@ -382,6 +396,8 @@ def _check_compose_provider() -> Finding | None:
             "Debian/Ubuntu: sudo apt install podman-compose | "
             "Fedora: sudo dnf install podman-compose | "
             "openSUSE: sudo zypper install podman-compose | "
+            "already installed via Homebrew? put its bin dir on PATH "
+            '(`eval "$(brew shellenv)"`) | '
             "fallback: pipx install podman-compose"
         ),
     )

--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -21,7 +21,7 @@ from winpodx.core.config import Config
 from winpodx.core.i18n import tr
 from winpodx.utils.agent_token import ensure_agent_token, stage_token_to_oem
 from winpodx.utils.compat import import_winapps_config
-from winpodx.utils.deps import check_all
+from winpodx.utils.deps import check_all, find_podman_compose
 from winpodx.utils.paths import config_dir
 
 COMPOSE_TIMEOUT_DEFAULT_SECS = 1800
@@ -1108,8 +1108,12 @@ def _recreate_container(cfg: Config) -> None:
 
     compose_cmd: list[str] | None = None
     if backend == "podman":
-        if shutil.which("podman-compose"):
-            compose_cmd = ["podman-compose"]
+        podman_compose = find_podman_compose()
+        if podman_compose:
+            # Absolute path when resolved off-PATH (e.g. Homebrew) -- a bare
+            # "podman-compose" would fail to exec once this subprocess's own
+            # (minimal) PATH is used (#765, #725).
+            compose_cmd = [podman_compose]
         else:
             try:
                 sp.run(
@@ -1148,7 +1152,11 @@ def _recreate_container(cfg: Config) -> None:
                 "    Debian/Ubuntu:  sudo apt install podman-compose\n"
                 "    Fedora:         sudo dnf install podman-compose\n"
                 "    openSUSE:       sudo zypper install podman-compose\n"
-                "    (fallback:      pipx install podman-compose)"
+                "    (fallback:      pipx install podman-compose)\n"
+                "  Homebrew installs (common on immutable distros like Bazzite) "
+                "are auto-detected even off PATH; if you already installed it via "
+                "`brew install podman-compose` and still see this, make sure "
+                'brew\'s bin dir is on PATH (`eval "$(brew shellenv)"`).'
             )
             print(tr(msg))
             raise RuntimeError("no compose provider found for the podman backend")

--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -63,7 +63,7 @@ name: "winpodx"
       REGION: "{region}"
       KEYBOARD: "{keyboard}"
       TZ: "{timezone}"
-      ADAPTER: "{adapter}"
+{network_env}      ADAPTER: "{adapter}"
       MTU: "{mtu}"
 {usb_env}      VGA: "{vga}"
       CPU_FLAGS: "{cpu_flags}"
@@ -836,6 +836,21 @@ def _build_compose_content(cfg: Config) -> str:
     # ("Property 'e1000.host_mtu' not found"). Pinning MTU=1500 makes dockur emit
     # a plain ``-device e1000`` (no host_mtu). Empty MTU for off/balanced keeps
     # dockur's virtio auto-MTU.
+    # Network mode (#770 regression fix): rootless Podman must force dockur's
+    # user-mode (passt) path. Bridge NAT -- what the container auto-picks when
+    # NETWORK is unset -- lands the guest on a NAT-internal 172.x address that
+    # the host's forwarded RDP port never reaches on rootless hosts (the
+    # #269/#387 class). Rootful Podman and Docker keep auto-selection: NAT is
+    # validated there and forwards published ports correctly. USER_PORTS stays
+    # emitted unconditionally -- it is the passt-fallback port list, ignored
+    # under NAT by design, so it is harmless when we don't force user-mode.
+    network_env = ""
+    if cfg.pod.backend == "podman":
+        from winpodx.backend.podman import is_rootless_podman
+
+        if is_rootless_podman():
+            network_env = '      NETWORK: "user"\n'
+
     if cfg.pod.disguise_max:
         disk_type, adapter, vga, mtu = "sata", "e1000", "std", "1500"
         # Swap dockur's default qemu-xhci (VEN_1B36, Red Hat) for nec-usb-xhci
@@ -857,6 +872,7 @@ def _build_compose_content(cfg: Config) -> str:
         adapter=adapter,
         mtu=mtu,
         usb_env=usb_env,
+        network_env=network_env,
         vga=vga,
         hv=hv,
         user=_yaml_escape(cfg.rdp.user),

--- a/src/winpodx/utils/deps.py
+++ b/src/winpodx/utils/deps.py
@@ -15,6 +15,7 @@ duplicate. Every other surface in the project consumes this module.
 
 from __future__ import annotations
 
+import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
@@ -153,6 +154,47 @@ def check_all(probe_daemons: bool = False) -> dict[str, DepCheck]:
         checks[cmd] = dep
     checks["kvm"] = check_kvm()
     return checks
+
+
+# Homebrew-on-Linux install prefixes for `podman-compose` (#765, #725).
+# Homebrew is the standard way to get CLI tools on immutable distros
+# (Bazzite, Fedora Silverblue) where there's no system package manager to
+# `apt`/`dnf install` into. None of these are reliably on `$PATH`: brew only
+# adds itself via `eval "$(brew shellenv)"` in the user's shell rc, which an
+# interactive terminal sources but a desktop-session-launched process (the
+# tray / GUI autostart entry in particular) never does — so `shutil.which`
+# alone false-negatives even though the binary is genuinely installed.
+_BREW_COMPOSE_DIRS = (
+    "/home/linuxbrew/.linuxbrew/bin",
+    "~/.linuxbrew/bin",
+    "/opt/homebrew/bin",
+    "~/.local/bin",
+)
+
+
+def find_podman_compose() -> str | None:
+    """Locate the ``podman-compose`` binary: PATH first, then known off-PATH dirs.
+
+    Falls back to probing Homebrew's install prefixes (see
+    ``_BREW_COMPOSE_DIRS``) when ``shutil.which`` misses, so a
+    Homebrew-installed ``podman-compose`` is still found even when brew's
+    bin dir isn't on the caller's ``$PATH`` (#765, #725).
+
+    Always returns an ABSOLUTE path (never the bare ``"podman-compose"``
+    string). Callers MUST use that absolute path in subprocess argv rather
+    than re-deriving the name — a spawned subprocess only inherits the
+    *current* process's ``$PATH``, not whatever this function used to find
+    the binary, so a bare name would fail at exec time even after being
+    "found" here.
+    """
+    found = shutil.which("podman-compose")
+    if found:
+        return found
+    for raw_dir in _BREW_COMPOSE_DIRS:
+        candidate = Path(raw_dir).expanduser() / "podman-compose"
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None
 
 
 def podman_major_version() -> int | None:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -117,6 +117,52 @@ def test_start_pod_skips_port_check_when_pod_already_running():
     assert status.state == PodState.RUNNING
 
 
+class TestPodmanComposeCmdBrewOffPath:
+    """#765/#725: `_compose_cmd` is the code path `start()`/`stop()` use --
+    i.e. what the tray's Pod>Start button actually calls via
+    `core.pod.start_pod`. A PATH-only `podman-compose` probe here silently
+    no-ops the tray button for a Homebrew install (common on immutable
+    distros like Bazzite) whose bin dir isn't on the desktop session's
+    $PATH."""
+
+    def test_on_path_unchanged(self, monkeypatch):
+        from winpodx.backend.podman import PodmanBackend
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/podman-compose")
+        backend = PodmanBackend(Config())
+        cmd = backend._compose_cmd()
+        assert cmd[0] == "/usr/bin/podman-compose"
+
+    def test_found_via_brew_dir_uses_absolute_path(self, monkeypatch, tmp_path):
+        from winpodx.backend.podman import PodmanBackend
+
+        brew_dir = tmp_path / "linuxbrew" / "bin"
+        brew_dir.mkdir(parents=True)
+        compose_bin = brew_dir / "podman-compose"
+        compose_bin.write_text("#!/bin/sh\n")
+        compose_bin.chmod(0o755)
+
+        monkeypatch.setattr("shutil.which", lambda name: None)
+        monkeypatch.setattr("winpodx.utils.deps._BREW_COMPOSE_DIRS", (str(brew_dir),))
+
+        backend = PodmanBackend(Config())
+        cmd = backend._compose_cmd()
+        assert cmd[0] == str(compose_bin)
+
+    def test_raises_when_truly_absent(self, monkeypatch, tmp_path):
+        from winpodx.backend.podman import PodmanBackend
+
+        monkeypatch.setattr("shutil.which", lambda name: None)
+        monkeypatch.setattr("winpodx.utils.deps._BREW_COMPOSE_DIRS", (str(tmp_path / "nowhere"),))
+
+        backend = PodmanBackend(Config())
+        try:
+            backend._compose_cmd()
+            raise AssertionError("expected RuntimeError")
+        except RuntimeError as e:
+            assert "podman-compose" in str(e)
+
+
 def test_podman_backend_is_running_uses_configured_container_name():
     from winpodx.backend.podman import PodmanBackend
 

--- a/tests/test_cli_issues.py
+++ b/tests/test_cli_issues.py
@@ -573,11 +573,12 @@ class TestComposeBackendSpecificKeys:
 
 
 class TestComposeNetworkKey:
-    def test_network_mode_not_forced_and_never_slirp(self, tmp_path, monkeypatch):
-        # #735: dockur v6.01 fixed rootless-Podman NAT port-forwarding, so the
-        # compose no longer forces NETWORK=user -- the container picks NAT and
-        # falls back to passt itself. We must never request "slirp" (dockur's
-        # last-resort fallback), and must not pin a NETWORK mode at all.
+    def test_rootful_podman_not_forced_and_never_slirp(self, tmp_path, monkeypatch):
+        # #770: NETWORK=user is re-forced on ROOTLESS Podman only (dropping it in
+        # 0.10.1 let the container pick NAT, whose 172.x guest IP was unreachable
+        # for host-forwarded RDP). On rootful Podman (and Docker) winpodx leaves
+        # NETWORK unset so dockur auto-picks bridge NAT. It must never request
+        # "slirp" (dockur's last-resort fallback) in either case.
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
         from winpodx.core.config import Config
 
@@ -588,7 +589,8 @@ class TestComposeNetworkKey:
 
         from winpodx.cli.setup_cmd import _generate_compose
 
-        _generate_compose(cfg)
+        with patch("winpodx.backend.podman.is_rootless_podman", return_value=False):
+            _generate_compose(cfg)
         content = (tmp_path / "winpodx" / "compose.yaml").read_text()
         assert "NETWORK:" not in content
         assert "slirp" not in content

--- a/tests/test_compose_network.py
+++ b/tests/test_compose_network.py
@@ -9,13 +9,21 @@ Historically the compose pinned ``NETWORK: "user"`` to force user-mode
 (passt), a workaround for #269 / #387 where dockur's bridge-NAT path set up
 NAT but never forwarded the published ports on to the VM (so the agent port
 hung ``pod wait-ready``). dockur **v6.01** (@kroese) rewrote the rootless-Podman
-NAT port-forwarding to fix exactly that, so we no longer force the mode (#735):
-the container picks NAT when it can and falls back to passt itself. ``USER_PORTS``
-stays as the passt-fallback path (NAT ignores it by design, forwarding every
-non-``HOST_PORTS`` port to the VM).
+NAT port-forwarding, so 0.10.1 stopped forcing the mode (#735).
+
+That regressed rootless hosts the rewrite did not fully cover: the container
+picked bridge NAT, the guest got a NAT-internal ``172.x`` IP, and the host's
+forwarded RDP port never reached it (#770). So winpodx now re-forces
+``NETWORK: "user"`` on **rootless Podman only** -- rootful Podman and Docker,
+where NAT is validated, keep dockur's auto-selection. ``USER_PORTS`` stays
+emitted unconditionally as the passt-fallback path (NAT ignores it by design,
+forwarding every non-``HOST_PORTS`` port to the VM), so it is harmless when we
+do not force user-mode.
 """
 
 from __future__ import annotations
+
+from unittest.mock import patch
 
 from winpodx.core.config import Config
 from winpodx.core.pod.compose import _build_compose_content
@@ -33,17 +41,34 @@ def _cfg() -> Config:
     return cfg
 
 
-def test_compose_does_not_force_network_mode():
-    # #735: don't force NETWORK=user -- let dockur v6.01 pick NAT (with its
-    # rootless port-forwarding fix) and fall back to passt on its own.
-    content = _build_compose_content(_cfg())
-    assert "NETWORK:" not in content
-
-
-def test_compose_user_ports_present():
-    # USER_PORTS stays as the passt-fallback path (ignored under NAT by design).
-    content = _build_compose_content(_cfg())
+def test_rootless_podman_forces_network_user():
+    # #770: on rootless Podman re-force user-mode (passt); NAT's 172.x guest IP
+    # is unreachable for host-forwarded RDP there.
+    with patch("winpodx.backend.podman.is_rootless_podman", return_value=True):
+        content = _build_compose_content(_cfg())
+    assert 'NETWORK: "user"' in content
+    assert "slirp" not in content
     assert "USER_PORTS:" in content
+
+
+def test_rootful_podman_does_not_force_network():
+    # Rootful Podman keeps dockur's auto-selection (NAT is validated there).
+    with patch("winpodx.backend.podman.is_rootless_podman", return_value=False):
+        content = _build_compose_content(_cfg())
+    assert "NETWORK:" not in content
+    assert "USER_PORTS:" in content
+
+
+def test_docker_backend_never_forces_network():
+    # Docker is excluded entirely -- the rootless detector is podman-specific
+    # and must not even be consulted on the docker path.
+    cfg = _cfg()
+    cfg.pod.backend = "docker"
+    with patch("winpodx.backend.podman.is_rootless_podman", return_value=True) as detector:
+        content = _build_compose_content(cfg)
+    assert "NETWORK:" not in content
+    assert "USER_PORTS:" in content
+    detector.assert_not_called()
 
 
 def test_compose_ballooning_off_unconditional():

--- a/tests/test_deps_unified.py
+++ b/tests/test_deps_unified.py
@@ -14,6 +14,7 @@ for these tests.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -236,3 +237,60 @@ def test_check_all_default_does_not_probe(monkeypatch):
     deps = D.check_all()
     assert deps["docker"].daemon_reachable is None
     assert deps["podman"].daemon_reachable is None
+
+
+# ---- find_podman_compose (#765, #725: Homebrew off-PATH detection) -------
+
+
+def test_find_podman_compose_on_path(monkeypatch):
+    import winpodx.utils.deps as D
+
+    monkeypatch.setattr(D.shutil, "which", lambda name: "/usr/bin/podman-compose")
+    assert D.find_podman_compose() == "/usr/bin/podman-compose"
+
+
+def test_find_podman_compose_found_in_brew_dir_when_path_misses(monkeypatch, tmp_path):
+    # Simulate a Homebrew install whose bin dir isn't on $PATH (the tray/GUI
+    # session PATH case, #765/#725): shutil.which misses, but the binary
+    # exists (and is executable) under one of the known brew prefixes.
+    import winpodx.utils.deps as D
+
+    brew_dir = tmp_path / "linuxbrew" / "bin"
+    brew_dir.mkdir(parents=True)
+    compose_bin = brew_dir / "podman-compose"
+    compose_bin.write_text("#!/bin/sh\n")
+    compose_bin.chmod(0o755)
+
+    monkeypatch.setattr(D.shutil, "which", lambda name: None)
+    monkeypatch.setattr(D, "_BREW_COMPOSE_DIRS", (str(brew_dir),))
+
+    found = D.find_podman_compose()
+    assert found == str(compose_bin)
+    assert os.path.isabs(found)
+
+
+def test_find_podman_compose_none_when_truly_absent(monkeypatch, tmp_path):
+    import winpodx.utils.deps as D
+
+    missing_dir = tmp_path / "nowhere"
+    monkeypatch.setattr(D.shutil, "which", lambda name: None)
+    monkeypatch.setattr(D, "_BREW_COMPOSE_DIRS", (str(missing_dir),))
+
+    assert D.find_podman_compose() is None
+
+
+def test_find_podman_compose_skips_non_executable_brew_candidate(monkeypatch, tmp_path):
+    # A file that exists but isn't executable (e.g. a stray non-executable
+    # download) must not be reported as found.
+    import winpodx.utils.deps as D
+
+    brew_dir = tmp_path / "brew_bin"
+    brew_dir.mkdir()
+    compose_bin = brew_dir / "podman-compose"
+    compose_bin.write_text("not executable")
+    compose_bin.chmod(0o644)
+
+    monkeypatch.setattr(D.shutil, "which", lambda name: None)
+    monkeypatch.setattr(D, "_BREW_COMPOSE_DIRS", (str(brew_dir),))
+
+    assert D.find_podman_compose() is None

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -233,6 +233,20 @@ class TestCheckComposeProvider:
         assert f.severity == "ok"
         assert "podman-compose" in f.title
 
+    def test_ok_and_notes_location_when_found_off_path(self, monkeypatch):
+        # #765/#725: a Homebrew-installed podman-compose off $PATH must still
+        # be an "ok" Finding, and must say *where* it was found so a user
+        # debugging the tray Pod>Start no-op sees it wasn't a plain PATH hit.
+        monkeypatch.setattr("shutil.which", lambda _name: None)
+        monkeypatch.setattr(
+            "winpodx.utils.deps.find_podman_compose",
+            lambda: "/home/linuxbrew/.linuxbrew/bin/podman-compose",
+        )
+        f = self._run(monkeypatch)
+        assert f.severity == "ok"
+        assert "podman-compose" in f.title
+        assert "/home/linuxbrew/.linuxbrew/bin" in f.title
+
     def test_ok_when_podman_compose_plugin_available(self, monkeypatch):
         monkeypatch.setattr("shutil.which", lambda _name: None)
         monkeypatch.setattr("subprocess.run", lambda *a, **k: SimpleNamespace(returncode=0))

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -12,7 +12,9 @@ and the user would have to do a ``--purge`` reinstall to recover.
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -363,6 +365,9 @@ class TestRecreateContainerNoComposeProvider:
         cfg.pod.backend = "podman"
 
         monkeypatch.setattr("shutil.which", lambda _name: None)
+        # Hermetic against a real Homebrew install on the runner (#765): point
+        # the off-PATH probe dirs at a directory that can't contain one.
+        monkeypatch.setattr("winpodx.utils.deps._BREW_COMPOSE_DIRS", (str(tmp_path / "nowhere"),))
         with patch("subprocess.run", side_effect=FileNotFoundError("podman not found")):
             with pytest.raises(RuntimeError, match="compose provider"):
                 _recreate_container(cfg)
@@ -370,6 +375,45 @@ class TestRecreateContainerNoComposeProvider:
         out = capsys.readouterr().out
         assert "ERROR: no compose provider found" in out
         assert "podman-compose" in out
+        assert "Homebrew" in out
+
+
+class TestRecreateContainerBrewComposeOffPath:
+    """#765/#725: a Homebrew-installed podman-compose off $PATH must still be
+    used to create the container -- and via its ABSOLUTE path, since the
+    compose subprocess only inherits this process's own (possibly brew-less)
+    PATH, not whatever found the binary here."""
+
+    def test_uses_absolute_path_from_brew_dir(self, tmp_path, monkeypatch):
+        from winpodx.cli.setup_cmd import _recreate_container
+        from winpodx.core.config import Config
+
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        cfg = Config()
+        cfg.pod.backend = "podman"
+
+        brew_dir = tmp_path / "linuxbrew" / "bin"
+        brew_dir.mkdir(parents=True)
+        compose_bin = brew_dir / "podman-compose"
+        compose_bin.write_text("#!/bin/sh\n")
+        compose_bin.chmod(0o755)
+
+        monkeypatch.setattr("shutil.which", lambda _name: None)
+        monkeypatch.setattr("winpodx.utils.deps._BREW_COMPOSE_DIRS", (str(brew_dir),))
+
+        calls: list[list[str]] = []
+
+        def _fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=_fake_run):
+            _recreate_container(cfg)
+
+        assert calls, "expected at least one compose subprocess call"
+        for cmd in calls:
+            assert cmd[0] == str(compose_bin)
+            assert os.path.isabs(cmd[0])
 
 
 class TestResolveCredentials:


### PR DESCRIPTION
Two P0s found in the field right after 0.10.2, both from recent releases. Bundled as one hotfix branch (shared working tree, disjoint concerns).

### #770 — rootless RDP never connects (regression from #735)
Dropping the forced `NETWORK=user` in 0.10.1 let the container auto-pick bridge NAT. On **rootless Podman** the guest then landed on a NAT-internal `172.x` address that the host's forwarded `127.0.0.1:3390` could never reach, so RDP never connected even though the container booted and QEMU was up on the web viewer (reporter @vrvy-live, CachyOS; gist showed `Mode: NAT`). Re-force `NETWORK: "user"` on **rootless Podman only** via a new `is_rootless_podman()` detector (`podman info` Rootless field, `geteuid` fallback); rootful Podman and Docker keep dockur's auto-selection where its NAT forwarding is validated. `USER_PORTS` unchanged.

### #765 / #725 — Homebrew podman-compose invisible (gap in #753)
On immutable distros like Bazzite, `podman-compose` is installed via Homebrew, but winpodx probed with `shutil.which` (`/home/kernalix7/Desktop/00_Personal_Project/00G_winpodx/.venv/bin:/home/kernalix7/Desktop/00_Personal_Project/00G_winpodx/.venv/bin:/home/kernalix7/.opencode/bin:/home/kernalix7/.local/bin:/home/kernalix7/.npm-global/bin:/home/kernalix7/.rd/bin:/home/kernalix7/flutter/bin:/home/kernalix7/.config/Code/User/globalStorage/github.copilot-chat/debugCommand:/home/kernalix7/.config/Code/User/globalStorage/github.copilot-chat/copilotCli:/home/kernalix7/.local/share/../bin:/home/kernalix7/.opencode/bin:/home/kernalix7/.local/bin:/home/kernalix7/.npm-global/bin:/home/kernalix7/.rd/bin:/home/kernalix7/flutter/bin:/home/kernalix7/.nix-profile/bin:/home/kernalix7/.nix-profile/bin:/var/lib/nix/nix/profiles/default/bin:/home/kernalix7/.local/bin:/usr/local/bin:/usr/bin:/bin:/home/kernalix7/.vscode/extensions/ms-python.debugpy-2026.6.0-linux-x64/bundled/scripts/noConfigScripts:/home/kernalix7/.claude/plugins/cache/AIPS/AIPS/7.1.6/bin:/home/kernalix7/.claude/plugins/cache/openai-codex/codex/1.0.4/bin:/home/kernalix7/.claude/plugins/cache/claude-plugins-official/rust-analyzer-lsp/1.0.0/bin` only) and a desktop/tray session's `/home/kernalix7/Desktop/00_Personal_Project/00G_winpodx/.venv/bin:/home/kernalix7/Desktop/00_Personal_Project/00G_winpodx/.venv/bin:/home/kernalix7/.opencode/bin:/home/kernalix7/.local/bin:/home/kernalix7/.npm-global/bin:/home/kernalix7/.rd/bin:/home/kernalix7/flutter/bin:/home/kernalix7/.config/Code/User/globalStorage/github.copilot-chat/debugCommand:/home/kernalix7/.config/Code/User/globalStorage/github.copilot-chat/copilotCli:/home/kernalix7/.local/share/../bin:/home/kernalix7/.opencode/bin:/home/kernalix7/.local/bin:/home/kernalix7/.npm-global/bin:/home/kernalix7/.rd/bin:/home/kernalix7/flutter/bin:/home/kernalix7/.nix-profile/bin:/home/kernalix7/.nix-profile/bin:/var/lib/nix/nix/profiles/default/bin:/home/kernalix7/.local/bin:/usr/local/bin:/usr/bin:/bin:/home/kernalix7/.vscode/extensions/ms-python.debugpy-2026.6.0-linux-x64/bundled/scripts/noConfigScripts:/home/kernalix7/.claude/plugins/cache/AIPS/AIPS/7.1.6/bin:/home/kernalix7/.claude/plugins/cache/openai-codex/codex/1.0.4/bin:/home/kernalix7/.claude/plugins/cache/claude-plugins-official/rust-analyzer-lsp/1.0.0/bin` omits brew's bin. So `setup`, `doctor`, and the tray Pod > Start (a separate `PodmanBackend._compose_cmd` path, which is the real #725 no-op) all reported "not found" despite it being installed (reporter @realahmed7777). New `find_podman_compose()` also probes the Homebrew bin dirs + `~/.local/bin` and returns an **absolute path** so the pod-start subprocess finds it regardless of inherited `PATH`. Fixed all three call sites.

Gates: targeted suites 154 + 21 passed; ruff + format clean. Ships in the 0.10.3 release (version bump + 5-team gate to follow on merge).