### PR TITLE
fix(setup): make an ignored --storage-path/--win-iso impossible to miss (#767)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed
+
+- **`winpodx setup --storage-path` / `--win-iso` were silently ignored when a leftover podman volume from an earlier attempt still existed** (#767, thanks @realahmed7777). Deleting `winpodx.toml` does not remove the named volume, so setup found an existing install, kept the VM on the old disk, and skipped staging the custom ISO — and the only signal was a one-line note that scrolled off before the "Setup Complete" banner (dockur then logged a "BTRFS filesystem for /storage" warning on what the user expected to be their roomier ext4 path, and Windows downloaded anyway). Setup now surfaces a prominent, framed warning that names the requested path, the location still in use, and how to relocate (`winpodx setup --migrate-storage --migrate-storage-target <path>`) or start fresh (remove the old volume / `winpodx uninstall --purge`), and re-prints it right before the final banner so it survives scrollback. The storage-decision behaviour is unchanged — relocating an existing install still requires `--migrate-storage`; this only makes the ignore impossible to miss.
+
 ## [0.10.3] - 2026-07-21
 
 ### Fixed

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **이전 시도에서 남은 podman 볼륨이 그대로 있을 때 `winpodx setup --storage-path` / `--win-iso`가 조용히 무시되던 문제를 수정** (#767, @realahmed7777 감사). `winpodx.toml`을 지워도 named 볼륨은 제거되지 않으므로, setup이 기존 설치를 발견해 VM을 이전 디스크에 그대로 두고 커스텀 ISO 스테이징도 건너뛰었습니다 — 게다가 유일한 신호는 "Setup Complete" 배너 전에 스크롤로 밀려 사라지는 한 줄짜리 안내뿐이었습니다(그 결과 dockur는 사용자가 더 넓은 ext4 경로로 기대한 위치에 "BTRFS filesystem for /storage" 경고를 남기고, Windows는 그대로 다운로드했습니다). 이제 setup은 요청한 경로, 여전히 사용 중인 위치, 그리고 재배치 방법(`winpodx setup --migrate-storage --migrate-storage-target <path>`) 또는 완전히 새로 시작하는 방법(이전 볼륨 제거 / `winpodx uninstall --purge`)을 명시한 눈에 띄는 프레임 경고를 표시하고, 스크롤로 사라지지 않도록 최종 배너 직전에 다시 출력합니다. 스토리지 결정 동작 자체는 그대로입니다 — 기존 설치를 재배치하려면 여전히 `--migrate-storage`가 필요하며, 이번 변경은 무시 사실을 놓칠 수 없게 만들 뿐입니다.
+
 ## [0.10.3] - 2026-07-21
 
 ### Fixed

--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -207,9 +207,66 @@ def _update_image_pin() -> int:
     return 0
 
 
+# --- #767: make an ignored --storage-path / --win-iso impossible to miss ------
+#
+# Root cause of #767: a user who deletes winpodx.toml but leaves the leftover
+# podman named volume from an earlier attempt lands in Case 2 below, where the
+# explicit --storage-path can't be honoured (relocating an existing install is
+# --migrate-storage's job). The old one-line note scrolled off before the
+# "Setup Complete" banner, so the VM silently stayed on the old disk and a
+# custom --win-iso was ignored. These helpers escalate the ignore to a framed
+# banner; handle_setup also re-prints it right before the final banner so it
+# survives scrollback. They change VISIBILITY only -- the storage-decision
+# semantics (relocation still needs --migrate-storage) are unchanged.
+
+
+def _print_prominent_warning(lines: list[str]) -> None:
+    """Print a framed, hard-to-miss warning block (blank line + '!' bars)."""
+    bar = "!" * 64
+    print()
+    print(bar)
+    for line in lines:
+        print(line)
+    print(bar)
+    print()
+
+
+def _storage_ignored_warning(requested: Path | str, current: str) -> list[str]:
+    """Warning body for an explicit --storage-path that could not be applied (#767)."""
+    return [
+        tr("WARNING: --storage-path was NOT applied."),
+        tr("  Requested:    {path}").format(path=requested),
+        tr("  Still in use: {current}").format(current=current),
+        tr(
+            "  An existing winpodx install was found. Deleting winpodx.toml does "
+            "not move existing storage or remove a leftover podman volume."
+        ),
+        tr(
+            "  To relocate it, run: winpodx setup --migrate-storage --migrate-storage-target {path}"
+        ).format(path=requested),
+        tr(
+            "  For a genuinely fresh start, remove the old volume first "
+            "(or `winpodx uninstall --purge`)."
+        ),
+    ]
+
+
+def _win_iso_skipped_warning(iso_path: Path | str) -> list[str]:
+    """Warning body for an explicit --win-iso that could not be staged (#767)."""
+    return [
+        tr("WARNING: --win-iso was NOT staged; Windows will download instead."),
+        tr("  ISO: {path}").format(path=iso_path),
+        tr(
+            "  Staging needs the bind-mount storage layout, but this install is "
+            "on the legacy named volume (no host directory to copy the ISO into)."
+        ),
+        tr("  Run `winpodx setup --migrate-storage` first, then re-pass --win-iso."),
+    ]
+
+
 def _decide_storage_mode(
     cfg: Config, *, non_interactive: bool, explicit_target: Path | None = None
-) -> None:
+) -> list[str] | None:
     """Resolve ``cfg.pod.storage_path`` for the about-to-be-generated compose.
 
     See the call site in ``handle_setup`` for the three-case decision.
@@ -220,21 +277,33 @@ def _decide_storage_mode(
     install — e.g. a roomier partition. It gets the same fresh-target prep
     (mkdir + btrfs NoCoW + SSD emulation) as the default path. Relocating an
     *existing* install is out of scope here — that's ``--migrate-storage``.
+
+    ``non_interactive`` is accepted for call-site symmetry with the rest of the
+    setup helpers but is not consulted here; the decision is the same batch or
+    interactive. Returns the framed-warning body (for handle_setup to re-print
+    before the final banner, #767) when an explicit target had to be ignored,
+    else ``None``.
     """
     if cfg.pod.backend not in ("podman", "docker"):
-        return
+        return None
 
-    # Case 1: already set explicitly. Trust the user.
+    # Case 1: already set explicitly. Trust the user. If they passed a
+    # --storage-path that differs from the configured location, it can't be
+    # honoured here (that's --migrate-storage) -- surface it loudly (#767).
     if cfg.pod.storage_path:
         if explicit_target is not None:
-            print(
-                tr(
-                    "  Note: storage is already configured ({path}); ignoring "
-                    "--storage-path. To relocate an existing install, use "
-                    "`winpodx setup --migrate-storage --migrate-storage-target`."
-                ).format(path=cfg.pod.storage_path)
-            )
-        return
+            try:
+                same = (
+                    Path(cfg.pod.storage_path).expanduser().resolve()
+                    == explicit_target.expanduser().resolve()
+                )
+            except OSError:
+                same = str(explicit_target) == cfg.pod.storage_path
+            if not same:
+                warning = _storage_ignored_warning(explicit_target, cfg.pod.storage_path)
+                _print_prominent_warning(warning)
+                return warning
+        return None
 
     from winpodx.core.storage_migration import (
         default_target_path,
@@ -252,14 +321,13 @@ def _decide_storage_mode(
     resolved = resolve_named_volume(cfg.pod.backend)
     if resolved is not None:
         if explicit_target is not None:
-            print(
-                tr(
-                    "  Note: an existing {volume} volume was found; ignoring "
-                    "--storage-path. To move the install to {target}, use "
-                    "`winpodx setup --migrate-storage --migrate-storage-target {target}`."
-                ).format(volume=repr(resolved), target=explicit_target)
+            # The existing location IS the named volume, so any explicit target
+            # "differs" -- always surface the ignore prominently (#767).
+            warning = _storage_ignored_warning(
+                explicit_target, tr("existing {volume} volume").format(volume=repr(resolved))
             )
-            return
+            _print_prominent_warning(warning)
+            return warning
         mp = get_volume_mountpoint(cfg.pod.backend, resolved)
         if mp is not None and detect_path_fs(mp) == "btrfs":
             print()
@@ -273,7 +341,7 @@ def _decide_storage_mode(
             print("        winpodx setup --migrate-storage")
             print(tr("    (~5-10 min, preserves the Windows install)"))
             print()
-        return
+        return None
 
     # Case 3: fresh install. Pick the bind-mount path (the user's
     # --storage-path if given, else the per-user default), create the
@@ -290,7 +358,7 @@ def _decide_storage_mode(
                 path=target, error=e
             )
         )
-        return
+        return None
 
     fs = detect_path_fs(target)
     if fs == "btrfs":
@@ -318,8 +386,10 @@ def _decide_storage_mode(
         cfg.pod.ssd = True
         print(tr("  Host storage is an SSD — the Windows disk will emulate SSD (TRIM, no defrag)."))
 
+    return None
 
-def _stage_win_iso(cfg: Config, iso_path: str | None) -> None:
+
+def _stage_win_iso(cfg: Config, iso_path: str | None) -> list[str] | None:
     """Stage a user-provided Windows ISO as dockur's ``<storage>/custom.iso`` (#647).
 
     MUST run after :func:`_decide_storage_mode` (so ``storage_path`` is
@@ -329,33 +399,34 @@ def _stage_win_iso(cfg: Config, iso_path: str | None) -> None:
     (the #647 bug: install.sh staged it *after* the container had started).
 
     Reflink-copies where the filesystem supports it (btrfs/xfs → instant, no
-    extra space). No-op on the legacy named-volume layout (no host storage dir).
+    extra space). No-op on the legacy named-volume layout (no host storage dir);
+    when the user *explicitly* passed ``--win-iso`` on that layout the skip is
+    surfaced as a framed warning (#767) and returned so handle_setup can
+    re-print it before the final banner.
     """
     if not iso_path:
-        return
+        return None
     import shutil
     import subprocess
 
     src = Path(iso_path).expanduser()
     if not src.is_file():
         print(tr("--win-iso: no such file: {path}").format(path=src))
-        return
+        return None
     storage = (cfg.pod.storage_path or "").strip()
     if not storage:
-        print(
-            tr(
-                "--win-iso: needs the bind-mount storage layout — the legacy named "
-                "volume has no host directory to stage into. Run "
-                "`winpodx setup --migrate-storage` first. Skipping (Windows will download)."
-            )
-        )
-        return
+        # #767: --win-iso was explicitly passed (iso_path is truthy) but staging
+        # can't happen without the bind-mount layout. Make it impossible to miss
+        # rather than a one-line note that scrolls off before the banner.
+        warning = _win_iso_skipped_warning(src)
+        _print_prominent_warning(warning)
+        return warning
     storage_dir = Path(storage).expanduser()
     storage_dir.mkdir(parents=True, exist_ok=True)
     dst = storage_dir / "custom.iso"
     if src.resolve() == dst.resolve():
         print(tr("--win-iso: already staged at {dst}").format(dst=dst))
-        return
+        return None
     print(tr("Staging local ISO → {dst} (dockur installs from it; no download)…").format(dst=dst))
     try:
         # reflink where supported (btrfs/xfs); falls back to a full copy.
@@ -364,6 +435,7 @@ def _stage_win_iso(cfg: Config, iso_path: str | None) -> None:
         shutil.copyfile(src, dst)
     gib = dst.stat().st_size / (1024**3)
     print(tr("  Local ISO staged ({gib:.1f} GB).").format(gib=gib))
+    return None
 
 
 def _handle_migrate_storage(args: argparse.Namespace) -> int:
@@ -784,6 +856,35 @@ def handle_setup(args: argparse.Namespace) -> None:
                 changed = True
             if changed:
                 cfg.save()
+            # #767: unlike --freerdp-source / --multimon (applied just above),
+            # --storage-path / --win-iso can't take effect on this existing-
+            # config skip path -- they only apply to a fresh install / compose
+            # regen. Passing them here used to be fully silent, leaving the VM
+            # on the old disk with no signal. Surface it prominently.
+            _storage_arg = getattr(args, "storage_path", None)
+            _iso_arg = getattr(args, "win_iso", None)
+            if _storage_arg or _iso_arg:
+                lines = [tr("WARNING: an existing winpodx config was found; setup was skipped.")]
+                if _storage_arg:
+                    lines.append(
+                        tr("  --storage-path {path} was NOT applied.").format(path=_storage_arg)
+                    )
+                    lines.append(
+                        tr("  Deleting winpodx.toml does not move existing storage. To relocate:")
+                    )
+                    lines.append(
+                        tr(
+                            "    winpodx setup --migrate-storage --migrate-storage-target {path}"
+                        ).format(path=_storage_arg)
+                    )
+                if _iso_arg:
+                    lines.append(
+                        tr(
+                            "  --win-iso {path} was NOT staged; the existing install keeps "
+                            "its disk."
+                        ).format(path=_iso_arg)
+                    )
+                _print_prominent_warning(lines)
             _ensure_oem_token_staged()
             # Half-uninstalled detection. If cfg points at a podman/docker
             # pod but the container is gone (user did `uninstall.sh`
@@ -856,6 +957,12 @@ def handle_setup(args: argparse.Namespace) -> None:
         cfg.rdp.__post_init__()
 
     _resolve_credentials(cfg, non_interactive=non_interactive, config_existed=config_existed)
+
+    # #767: framed warnings for an explicitly-passed --storage-path / --win-iso
+    # that had to be ignored. Collected from the storage/ISO helpers below and
+    # re-printed right before the "Setup Complete" banner so they survive
+    # scrollback (the mid-stream note used to be the only signal).
+    _deferred_ignore_warnings: list[list[str]] = []
 
     if cfg.pod.backend in ("podman", "docker"):
         # v0.2.1: detect host specs and pick a tier preset (low/mid/high)
@@ -946,15 +1053,19 @@ def handle_setup(args: argparse.Namespace) -> None:
         #      Windows raw disk image inherits NoCoW from day one.
         _storage_path_arg = getattr(args, "storage_path", None)
         _explicit_storage = Path(_storage_path_arg).expanduser() if _storage_path_arg else None
-        _decide_storage_mode(
+        _w = _decide_storage_mode(
             cfg, non_interactive=non_interactive, explicit_target=_explicit_storage
         )
+        if _w:
+            _deferred_ignore_warnings.append(_w)
 
         # Stage a user-provided ISO into <storage>/custom.iso BEFORE compose up
         # so dockur picks it up instead of downloading Windows (#647). Must come
         # after _decide_storage_mode (storage_path resolved) + before
         # _recreate_container below.
-        _stage_win_iso(cfg, getattr(args, "win_iso", None))
+        _w = _stage_win_iso(cfg, getattr(args, "win_iso", None))
+        if _w:
+            _deferred_ignore_warnings.append(_w)
 
         # #395: bail out with an actionable message if the selected backend's
         # daemon isn't reachable, rather than letting compose fail with a
@@ -1038,6 +1149,12 @@ def handle_setup(args: argparse.Namespace) -> None:
     # provisioner.ensure_ready). Until the user's first launch, only the
     # winpodx GUI itself appears in the menu.
     _register_all_desktop_entries()
+
+    # #767: re-surface any ignored --storage-path / --win-iso right before the
+    # final banner so it doesn't scroll off. Already printed once at the
+    # decision point; this repeat is the one that survives a long install log.
+    for _warn in _deferred_ignore_warnings:
+        _print_prominent_warning(_warn)
 
     print("\n" + "=" * 40)
     print(tr(" Setup Complete"))

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -195,6 +195,58 @@ class TestHalfUninstalledGuard:
 
         assert Config.load().rdp.freerdp_source == "flatpak"
 
+    def test_storage_flag_note_on_existing_config_skip(self, tmp_path, monkeypatch, capsys):
+        """#767: --storage-path / --win-iso on the existing-config skip path used to
+        be fully silent. It must now surface a prominent, actionable note."""
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr("sys.stdin", MagicMock(isatty=lambda: False))
+        _make_existing_config(tmp_path)
+
+        args = _setup_args(non_interactive=True)
+        args.storage_path = str(tmp_path / "roomy")
+        args.win_iso = str(tmp_path / "win.iso")
+
+        with (
+            patch("winpodx.cli.setup_cmd.check_all", return_value=_mock_freerdp_ok()),
+            patch("winpodx.cli.setup_cmd.import_winapps_config", return_value=None),
+            patch("winpodx.cli.setup_cmd._ensure_oem_token_staged"),
+            patch(
+                "winpodx.cli.setup_cmd._container_exists_on_backend",
+                return_value=True,
+            ),
+        ):
+            from winpodx.cli.setup_cmd import handle_setup
+
+            handle_setup(args)
+
+        out = capsys.readouterr().out
+        assert "an existing winpodx config was found" in out
+        assert str(tmp_path / "roomy") in out  # names the requested storage path
+        assert "--win-iso" in out  # notes the ignored ISO too
+        assert "--migrate-storage" in out  # points at the actual relocate path
+
+    def test_no_storage_note_when_flags_absent(self, tmp_path, monkeypatch, capsys):
+        """No false positive: the plain existing-config skip stays quiet about storage."""
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr("sys.stdin", MagicMock(isatty=lambda: False))
+        _make_existing_config(tmp_path)
+
+        with (
+            patch("winpodx.cli.setup_cmd.check_all", return_value=_mock_freerdp_ok()),
+            patch("winpodx.cli.setup_cmd.import_winapps_config", return_value=None),
+            patch("winpodx.cli.setup_cmd._ensure_oem_token_staged"),
+            patch(
+                "winpodx.cli.setup_cmd._container_exists_on_backend",
+                return_value=True,
+            ),
+        ):
+            from winpodx.cli.setup_cmd import handle_setup
+
+            handle_setup(_setup_args(non_interactive=True))
+
+        out = capsys.readouterr().out
+        assert "WARNING: an existing winpodx config was found" not in out
+
     def test_calls_ensure_ready_when_container_missing(self, tmp_path, monkeypatch):
         """Half-uninstalled: config present, container gone → ensure_ready
         is called to recreate the container from compose.yaml."""
@@ -559,6 +611,89 @@ class TestDecideStorageModeExplicitTarget:
         # An already-configured install isn't relocated here (that's --migrate-storage).
         assert cfg.pod.storage_path == "/existing/storage"
 
+    def test_case2_named_volume_explicit_target_warns(self, tmp_path, capsys):
+        """#767: a leftover named volume + explicit --storage-path must surface a
+        framed, hard-to-miss warning (not a mid-stream note) and NOT relocate."""
+        from pathlib import Path
+
+        from winpodx.cli.setup_cmd import _decide_storage_mode
+        from winpodx.core.config import Config
+
+        cfg = Config()
+        cfg.pod.backend = "podman"
+        cfg.pod.storage_path = ""  # legacy named-volume layout
+        with patch(
+            "winpodx.core.storage_migration.resolve_named_volume",
+            return_value="winpodx-data",
+        ):
+            result = _decide_storage_mode(
+                cfg, non_interactive=True, explicit_target=Path(tmp_path / "roomy")
+            )
+        out = capsys.readouterr().out
+        assert "WARNING: --storage-path was NOT applied." in out
+        assert "!" * 64 in out  # framed banner marker
+        assert "winpodx-data" in out
+        assert "--migrate-storage" in out
+        # semantics unchanged: still named-volume (storage_path stays empty)
+        assert cfg.pod.storage_path == ""
+        assert result is not None  # returned so handle_setup re-prints before banner
+
+    def test_case1_configured_explicit_differs_warns(self, tmp_path, capsys):
+        """#767: --storage-path differing from an already-configured location warns."""
+        from pathlib import Path
+
+        from winpodx.cli.setup_cmd import _decide_storage_mode
+        from winpodx.core.config import Config
+
+        cfg = Config()
+        cfg.pod.backend = "podman"
+        cfg.pod.storage_path = "/existing/storage"
+        result = _decide_storage_mode(
+            cfg, non_interactive=True, explicit_target=Path(tmp_path / "other")
+        )
+        out = capsys.readouterr().out
+        assert "WARNING: --storage-path was NOT applied." in out
+        assert cfg.pod.storage_path == "/existing/storage"  # not relocated
+        assert result is not None
+
+    def test_case1_configured_same_path_no_warning(self, tmp_path, capsys):
+        """No false positive: passing the path already in use is a no-op, no warning."""
+        from pathlib import Path
+
+        from winpodx.cli.setup_cmd import _decide_storage_mode
+        from winpodx.core.config import Config
+
+        storage = tmp_path / "storage"
+        cfg = Config()
+        cfg.pod.backend = "podman"
+        cfg.pod.storage_path = str(storage)
+        result = _decide_storage_mode(cfg, non_interactive=True, explicit_target=Path(storage))
+        out = capsys.readouterr().out
+        assert "WARNING" not in out
+        assert result is None
+
+    def test_fresh_install_explicit_target_no_warning(self, tmp_path, capsys):
+        """No false positive: a genuinely fresh install honors --storage-path silently."""
+        from pathlib import Path
+
+        from winpodx.cli.setup_cmd import _decide_storage_mode
+        from winpodx.core.config import Config
+
+        target = tmp_path / "roomy" / "winpodx"
+        cfg = Config()
+        cfg.pod.backend = "podman"
+        cfg.pod.storage_path = ""
+        with (
+            patch("winpodx.core.storage_migration.resolve_named_volume", return_value=None),
+            patch("winpodx.utils.btrfs.detect_path_fs", return_value="ext4"),
+            patch("winpodx.utils.btrfs.host_storage_is_ssd", return_value=False),
+        ):
+            result = _decide_storage_mode(cfg, non_interactive=True, explicit_target=Path(target))
+        out = capsys.readouterr().out
+        assert "WARNING" not in out
+        assert cfg.pod.storage_path == str(target)  # honored
+        assert result is None
+
 
 class TestStageWinIso:
     """`_stage_win_iso` — #647: stage <storage>/custom.iso before compose-up."""
@@ -602,6 +737,22 @@ class TestStageWinIso:
         cfg.pod.storage_path = ""  # legacy named-volume → no host dir
         _stage_win_iso(cfg, str(iso))  # must not raise
         # nothing to assert beyond "no crash"; named-volume has no host dir
+
+    def test_no_storage_path_emits_prominent_warning(self, tmp_path, capsys):
+        """#767: an explicit --win-iso on the legacy named-volume layout can't be
+        staged — surface a framed warning (not a mid-stream note) and don't stage."""
+        from winpodx.cli.setup_cmd import _stage_win_iso
+        from winpodx.core.config import Config
+
+        iso = self._iso(tmp_path)
+        cfg = Config()
+        cfg.pod.storage_path = ""  # legacy named-volume → no host dir
+        result = _stage_win_iso(cfg, str(iso))
+        out = capsys.readouterr().out
+        assert "WARNING: --win-iso was NOT staged" in out
+        assert "!" * 64 in out  # framed banner marker
+        assert "--migrate-storage" in out
+        assert result is not None  # returned so handle_setup re-prints before banner
 
     def test_missing_iso_skips(self, tmp_path):
         from winpodx.cli.setup_cmd import _stage_win_iso


### PR DESCRIPTION
Reported in #767 (@realahmed7777, Bazzite): `winpodx setup --storage-path <ext4>` put nothing on the chosen disk (dockur logged the BTRFS `/storage` warning on what should have been ext4) and `--win-iso` downloaded from Microsoft anyway.

**Root cause:** the reporter deleted `winpodx.toml` but not the leftover podman named volume from an earlier attempt, so `_decide_storage_mode` hit its existing-volume case, kept the old location, and ignored `--storage-path` — printing only a mid-stream note that scrolled off before the `Setup Complete` banner. The same empty `storage_path` made `_stage_win_iso` skip the ISO. A third path (`config_existed and non_interactive`) was fully silent.

**This PR does not change storage-decision semantics** — relocating an existing install still requires `--migrate-storage`. It only makes the ignore impossible to miss:
- A prominent framed `WARNING` block names the requested path, the current location, and how to relocate (`--migrate-storage --migrate-storage-target`) or start fresh (remove the old volume / `uninstall --purge`). Printed at the decision point AND re-printed right before `Setup Complete` so it survives scrollback.
- Same treatment for a skipped `--win-iso`.
- The previously-silent `config_existed + non_interactive` early return now prints the note when `--storage-path`/`--win-iso` were passed.
- Fresh install (no leftover volume) still honors `--storage-path` with no warning (false-positive guarded + tested).

Other #767 sub-items are handled separately: the winpodx.org `--storage-dir` vs `--storage-path` doc mismatch is a homepage fix, and the count-up download display (expected v6.02 size-chain) + the Microsoft IP-block are upstream/expected (reply on the issue).

Tests: 7 new in test_setup.py (each case warns / no false positive on fresh); 72 + 99 passed on touched + consumer suites; ruff clean.