### PR TITLE
feat(desktop): add a 'Windows Desktop' launcher entry (#769)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
+- **A "Windows Desktop" launcher entry now appears alongside your Windows apps** (#769, thanks @jltorres60). It opens the full Windows desktop (the equivalent of `winpodx app run desktop`), so it's one click from the app menu instead of a terminal command. The entry lands in the same winpodx menu group as the per-app shortcuts, is installed by `winpodx setup` and `winpodx app refresh`, and is re-created by `winpodx doctor --fix` if it goes missing.
 - **The telemetry / ads / widgets debloat presets cover more privacy surface** (#696, thanks @GameSoul7Eugene). The three registry-tweak scripts pick up additional opt-outs, each with a matching restore in its undo sibling: activity history / timeline upload, handwriting and inking error/data collection, online speech recognition, typing-insights (implicit ink & text) collection, Windows feedback frequency (Siuf), cloud-search history (MSA / AAD / device), the "let websites access my language list" opt-out, and the Windows-10 taskbar Feeds (News and interests) keys alongside the existing Windows-11 widgets policy. The more aggressive entries from the original PR were intentionally left out of this subset — a `CompatTelRunner.exe` image-file-execution hijack, turning SafeSearch off, blocking Store app auto-updates, disabling the location sensor and the Connected Devices Platform service, and the cloud settings-sync toggles — as out of scope or an app-compat risk for a throwaway VM.
 
 ### Fixed

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -11,6 +11,7 @@
 
 ### Added
 
+- **Windows 앱 목록 옆에 "Windows 데스크톱" 실행 항목이 추가됩니다** (#769, @jltorres60 감사). `winpodx app run desktop`과 동일하게 전체 Windows 데스크톱을 엽니다 — 터미널 명령 대신 앱 메뉴에서 클릭 한 번으로 실행할 수 있습니다. 이 항목은 개별 앱 바로가기와 같은 winpodx 메뉴 그룹에 위치하며, `winpodx setup`과 `winpodx app refresh`에서 함께 설치되고, 사라진 경우 `winpodx doctor --fix`로 다시 생성됩니다.
 - **telemetry / ads / widgets 디블로트 프리셋의 개인정보 대응 범위를 확장** (#696, @GameSoul7Eugene 감사). 세 개의 레지스트리 조정 스크립트에 추가 옵트아웃 항목이 더해졌고, 각 항목은 undo 스크립트에 대응되는 복원 항목을 함께 갖습니다: 활동 기록 / 타임라인 업로드, 손글씨·잉킹 오류/데이터 수집, 온라인 음성 인식, 입력 인사이트(암묵적 잉크·텍스트) 수집, Windows 피드백 빈도(Siuf), 클라우드 검색 기록(MSA / AAD / 장치), "웹사이트의 언어 목록 접근" 옵트아웃, 그리고 기존 Windows 11 위젯 정책과 함께 Windows 10 작업 표시줄 Feeds(뉴스 및 관심 콘텐츠) 키가 포함됩니다. 원본 PR의 더 공격적인 항목들 — `CompatTelRunner.exe` 이미지 파일 실행(IFEO) 하이재킹, SafeSearch 끄기, Store 앱 자동 업데이트 차단, 위치 센서 및 Connected Devices Platform 서비스 비활성화, 클라우드 설정 동기화 토글 — 은 일회용 VM에서 범위를 벗어나거나 앱 호환성 위험이 있어 이 서브셋에서 의도적으로 제외했습니다.
 
 ### Fixed

--- a/src/winpodx/cli/app.py
+++ b/src/winpodx/cli/app.py
@@ -206,7 +206,12 @@ def _register_desktop_entries(discovered) -> None:
     entries (under ~/.local/share/winpodx/apps/) are preserved.
     """
     from winpodx.core.app import list_available_apps
-    from winpodx.desktop.entry import install_desktop_entry, remove_desktop_entry
+    from winpodx.desktop.entry import (
+        DESKTOP_SHORTCUT_STEM,
+        install_desktop_entry,
+        install_desktop_shortcut,
+        remove_desktop_entry,
+    )
     from winpodx.desktop.icons import update_icon_cache
     from winpodx.utils.paths import applications_dir
 
@@ -231,19 +236,32 @@ def _register_desktop_entries(discovered) -> None:
                 file=sys.stderr,
             )
 
+    # #769: keep the "Windows Desktop" launcher shortcut present across
+    # refreshes too -- it isn't tied to any discovered app, so nothing else
+    # would re-create it if a user (or a stale profile) deleted it.
+    try:
+        install_desktop_shortcut()
+    except Exception as e:  # noqa: BLE001
+        print(
+            tr("  warning: could not install desktop shortcut: {error}").format(error=e),
+            file=sys.stderr,
+        )
+
     # v0.2.0.9: prune any winpodx-*.desktop file whose slug is not in the
     # current AppInfo set (covers both vanished discoveries and old
     # bundled / removed entries).
     removed = 0
     apps_dir = applications_dir()
+    shortcut_slug = DESKTOP_SHORTCUT_STEM[len("winpodx-") :]
     if apps_dir.exists():
         for entry in apps_dir.glob("winpodx-*.desktop"):
             stem = entry.stem  # winpodx-<slug>
             if not stem.startswith("winpodx-"):
                 continue
             slug = stem[len("winpodx-") :]
-            # Don't touch the GUI launcher itself or any winpodx-internal entry.
-            if slug in {"", "gui", "launcher"}:
+            # Don't touch the GUI launcher, the full-desktop shortcut (#769),
+            # or any other winpodx-internal entry.
+            if slug in {"", "gui", "launcher", shortcut_slug}:
                 continue
             if slug in available_slugs:
                 continue

--- a/src/winpodx/cli/doctor.py
+++ b/src/winpodx/cli/doctor.py
@@ -698,8 +698,17 @@ def _apps_missing_desktop_entries() -> list:
     return missing
 
 
+def _desktop_shortcut_missing() -> bool:
+    """True if the "Windows Desktop" launcher shortcut (#769) isn't installed."""
+    from winpodx.desktop.entry import DESKTOP_SHORTCUT_STEM
+    from winpodx.utils.paths import applications_dir
+
+    return not (applications_dir() / f"{DESKTOP_SHORTCUT_STEM}.desktop").exists()
+
+
 def _check_missing_desktop_entries() -> Finding:
-    """Apps in the index with no installed ``.desktop`` file.
+    """Apps in the index with no installed ``.desktop`` file, plus the
+    "Windows Desktop" launcher shortcut (#769) if it's missing.
 
     Host-only -- unit-testable. Auto-fixable via ``missing_desktop_entries``.
     """
@@ -707,11 +716,17 @@ def _check_missing_desktop_entries() -> Finding:
         missing = _apps_missing_desktop_entries()
     except Exception as e:  # noqa: BLE001
         return Finding("warn", "could not enumerate apps", detail=str(e))
-    if not missing:
+    shortcut_missing = _desktop_shortcut_missing()
+    if not missing and not shortcut_missing:
         return Finding("ok", "all registered apps have desktop entries")
+    parts = []
+    if missing:
+        parts.append(f"{len(missing)} app(s) missing a desktop entry")
+    if shortcut_missing:
+        parts.append("desktop shortcut missing")
     return Finding(
         "warn",
-        f"{len(missing)} app(s) missing a desktop entry",
+        ", ".join(parts),
         detail=", ".join(a.name for a in missing),
         suggestion="Run `winpodx doctor --fix` (or `winpodx app install <name>`) to re-register.",
         fix_id="missing_desktop_entries",
@@ -840,7 +855,9 @@ def _fix_stale_locks() -> tuple[bool, str]:
 
 
 def _fix_missing_desktop_entries() -> tuple[bool, str]:
-    """Re-register desktop entries for apps that are missing one. Host-only.
+    """Re-register desktop entries for apps that are missing one, and
+    re-install the "Windows Desktop" launcher shortcut (#769) if it's
+    missing too. Host-only.
 
     Reuses the existing desktop-entry install path
     (``desktop.entry.install_desktop_entry`` + icon + MIME), the same one
@@ -852,10 +869,11 @@ def _fix_missing_desktop_entries() -> tuple[bool, str]:
         missing = _apps_missing_desktop_entries()
     except Exception as e:  # noqa: BLE001
         return False, f"could not enumerate apps: {e}"
-    if not missing:
+    shortcut_missing = _desktop_shortcut_missing()
+    if not missing and not shortcut_missing:
         return True, "no missing desktop entries"
 
-    from winpodx.desktop.entry import install_desktop_entry
+    from winpodx.desktop.entry import install_desktop_entry, install_desktop_shortcut
     from winpodx.desktop.icons import update_icon_cache
     from winpodx.desktop.mime import register_mime_types
 
@@ -869,6 +887,11 @@ def _fix_missing_desktop_entries() -> tuple[bool, str]:
             registered += 1
         except Exception as e:  # noqa: BLE001
             failed.append(f"{app.name} ({e})")
+    if shortcut_missing:
+        try:
+            install_desktop_shortcut()
+        except Exception as e:  # noqa: BLE001
+            failed.append(f"desktop shortcut ({e})")
     # Refresh the icon cache once after the batch (cheap, idempotent).
     try:
         update_icon_cache()
@@ -876,7 +899,8 @@ def _fix_missing_desktop_entries() -> tuple[bool, str]:
         pass
     if failed:
         return False, f"re-registered {registered}, failed: {', '.join(failed)}"
-    return True, f"re-registered {registered} desktop entry(ies)"
+    suffix = " + desktop shortcut" if shortcut_missing else ""
+    return True, f"re-registered {registered} desktop entry(ies){suffix}"
 
 
 # PowerShell: start the keep-alive watchdog task now. The task itself is

--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -1387,7 +1387,7 @@ def handle_rotate_password(args: argparse.Namespace) -> None:
 def _register_all_desktop_entries() -> None:
     """Register all app definitions as .desktop entries."""
     from winpodx.core.app import list_available_apps
-    from winpodx.desktop.entry import install_desktop_entry
+    from winpodx.desktop.entry import install_desktop_entry, install_desktop_shortcut
     from winpodx.desktop.icons import (
         install_gui_launcher_desktop,
         install_winpodx_icon,
@@ -1407,6 +1407,11 @@ def _register_all_desktop_entries() -> None:
     apps = list_available_apps()
     for app_info in apps:
         install_desktop_entry(app_info)
+
+    # #769: "Windows Desktop" launcher, independent of whether any apps have
+    # been discovered yet -- always available so users aren't stuck needing a
+    # terminal for `winpodx app run desktop`.
+    install_desktop_shortcut()
 
     if apps:
         update_icon_cache()

--- a/src/winpodx/desktop/entry.py
+++ b/src/winpodx/desktop/entry.py
@@ -39,6 +39,29 @@ StartupWMClass={wm_class}
 # Comment field non-empty for menu tooltips and file managers.
 _DEFAULT_COMMENT = "Windows application via WinPodX"
 
+# #769: reserved filename stem for the "full Windows desktop" launcher
+# shortcut (equivalent to `winpodx app run desktop`). It lives alongside the
+# per-app winpodx-<slug>.desktop entries (same "winpodx-" prefix, same menu
+# folder) so it shows up in the same DE menu group -- but it is NOT an app
+# entry, and slug is never a discovered AppInfo.name. Callers that prune
+# stale winpodx-*.desktop files by slug (cli/app.py, gui/workers.py) must
+# skip this stem explicitly.
+DESKTOP_SHORTCUT_STEM = "winpodx-full-desktop"
+
+_DESKTOP_SHORTCUT_TEMPLATE = """\
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Windows Desktop
+Comment=Full Windows desktop session via WinPodX
+Exec={winpodx_exe} app run desktop
+Icon=winpodx
+Categories={categories}
+Keywords=windows;winpodx;rdp;desktop;
+Terminal=false
+StartupNotify=true
+"""
+
 
 def update_desktop_database() -> None:
     """Rebuild the applications ``mimeinfo.cache`` so ``MimeType=`` lines take
@@ -161,6 +184,56 @@ def install_desktop_entry(app: AppInfo) -> Path:
         update_desktop_database()
 
     return desktop_path
+
+
+def install_desktop_shortcut() -> Path:
+    """Create and install the "Windows Desktop" launcher .desktop file (#769).
+
+    Equivalent to ``winpodx app run desktop`` -- opens the full Windows
+    desktop (no RemoteApp), so users don't need a terminal for it. Lands
+    under the same winpodx menu folder as the per-app entries, reusing the
+    shared winpodx icon (no per-entry icon to install/clean up).
+    """
+    dest_dir = applications_dir()
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    content = _DESKTOP_SHORTCUT_TEMPLATE.format(
+        winpodx_exe=_winpodx_exe(),
+        categories=f"{category_for_folder('')};",
+    )
+
+    desktop_path = dest_dir / f"{DESKTOP_SHORTCUT_STEM}.desktop"
+    desktop_path.write_text(content, encoding="utf-8")
+    desktop_path.chmod(0o644)
+
+    # Same best-effort folder bootstrap as install_desktop_entry: guarantees
+    # the winpodx menu category resolves even if this is the very first
+    # winpodx entry ever installed (e.g. before any app has been discovered).
+    try:
+        install_menu_folder()
+    except OSError as e:
+        log.warning("Could not write winpodx menu folder definition: %s", e)
+
+    return desktop_path
+
+
+def remove_desktop_shortcut() -> None:
+    """Remove the "Windows Desktop" launcher .desktop file (#769).
+
+    No per-entry icon to clean up -- it uses the shared winpodx icon. Mirrors
+    remove_desktop_entry's rebuild-or-tear-down of the menu folder so an
+    emptied folder is still pruned correctly.
+    """
+    apps_dir = applications_dir()
+    (apps_dir / f"{DESKTOP_SHORTCUT_STEM}.desktop").unlink(missing_ok=True)
+
+    try:
+        if apps_dir.exists() and any(apps_dir.glob("winpodx-*.desktop")):
+            install_menu_folder()
+        else:
+            remove_menu_folder()
+    except OSError as e:  # pragma: no cover - defensive, never blocks removal
+        log.warning("Could not update winpodx menu folder definition: %s", e)
 
 
 def remove_desktop_entry(app_name: str) -> None:

--- a/src/winpodx/gui/workers.py
+++ b/src/winpodx/gui/workers.py
@@ -106,7 +106,12 @@ class InfoWorker(QObject):
 def sync_desktop_entries(discovered) -> None:
     """Bidirectionally sync .desktop entries after GUI discovery."""
     from winpodx.core.app import list_available_apps
-    from winpodx.desktop.entry import install_desktop_entry, remove_desktop_entry
+    from winpodx.desktop.entry import (
+        DESKTOP_SHORTCUT_STEM,
+        install_desktop_entry,
+        install_desktop_shortcut,
+        remove_desktop_entry,
+    )
     from winpodx.utils.paths import applications_dir
 
     discovered_slugs = {d.slug or d.name for d in discovered}
@@ -119,14 +124,22 @@ def sync_desktop_entries(discovered) -> None:
             except Exception:  # noqa: BLE001
                 log.debug("install_desktop_entry failed for %s", slug, exc_info=True)
 
+    # #769: keep the "Windows Desktop" launcher shortcut present across GUI
+    # refreshes too, same as the CLI's _register_desktop_entries.
+    try:
+        install_desktop_shortcut()
+    except Exception:  # noqa: BLE001
+        log.debug("install_desktop_shortcut failed", exc_info=True)
+
     apps_dir = applications_dir()
+    shortcut_slug = DESKTOP_SHORTCUT_STEM[len("winpodx-") :]
     if apps_dir.exists():
         for entry in apps_dir.glob("winpodx-*.desktop"):
             stem = entry.stem
             if not stem.startswith("winpodx-"):
                 continue
             slug = stem[len("winpodx-") :]
-            if slug in {"", "gui", "launcher"}:
+            if slug in {"", "gui", "launcher", shortcut_slug}:
                 continue
             if slug in available:
                 continue

--- a/tests/test_cli_issues.py
+++ b/tests/test_cli_issues.py
@@ -742,3 +742,33 @@ class TestRefreshAppsCli:
         assert data[0]["slug"] == "myapp"
         assert data[0]["icon_path"].endswith("winpodx-myapp.png")
         assert "discovered 1 app" in captured.err
+
+
+class TestDesktopShortcutSurvivesRefreshPrune:
+    """#769: `_register_desktop_entries` prunes stale winpodx-*.desktop files
+    whose slug isn't a discovered/available app. The "Windows Desktop"
+    launcher shortcut isn't tied to any app slug and must survive that prune,
+    while genuinely stale per-app entries still get removed."""
+
+    def test_shortcut_survives_prune_stale_app_removed(self, tmp_path, monkeypatch):
+        from winpodx.cli.app import _register_desktop_entries
+        from winpodx.desktop.entry import DESKTOP_SHORTCUT_STEM
+
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr("winpodx.core.app.list_available_apps", lambda: [])
+
+        apps_dir = tmp_path / "applications"
+        apps_dir.mkdir(parents=True)
+        shortcut_path = apps_dir / f"{DESKTOP_SHORTCUT_STEM}.desktop"
+        shortcut_path.write_text("[Desktop Entry]\nName=stale placeholder\n", encoding="utf-8")
+        stale_app = apps_dir / "winpodx-vanished.desktop"
+        stale_app.write_text("[Desktop Entry]\nName=Vanished\n", encoding="utf-8")
+
+        _register_desktop_entries([])  # nothing discovered this refresh
+
+        assert shortcut_path.exists(), "shortcut must survive the slug-based prune"
+        assert "Windows Desktop" in shortcut_path.read_text(encoding="utf-8"), (
+            "refresh must also re-create it with real content, not leave the stale stub"
+        )
+        assert not stale_app.exists(), "a genuinely stale per-app entry must still be pruned"

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -918,3 +918,68 @@ def test_top_level_windows_folder_does_not_clobber_root(tmp_path, monkeypatch):
     # The "Windows" subfolder lives under the namespaced name with its own label.
     sub = (dirs / "winpodx-folder-windows.directory").read_text(encoding="utf-8")
     assert "Name=Windows" in sub
+
+
+# #769: "Windows Desktop" launcher shortcut (equivalent to
+# `winpodx app run desktop`), installed alongside the per-app entries.
+
+
+def test_install_desktop_shortcut_writes_expected_fields(tmp_path, monkeypatch):
+    from winpodx.desktop.entry import DESKTOP_SHORTCUT_STEM, install_desktop_shortcut
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(entry_mod, "_winpodx_exe", lambda: "winpodx")
+
+    desktop_path = install_desktop_shortcut()
+
+    assert desktop_path == tmp_path / "applications" / f"{DESKTOP_SHORTCUT_STEM}.desktop"
+    content = desktop_path.read_text(encoding="utf-8")
+    assert "Name=Windows Desktop" in content
+    exec_lines = [ln for ln in content.splitlines() if ln.startswith("Exec=")]
+    # No %u -- the full desktop session takes no file argument.
+    assert exec_lines == ["Exec=winpodx app run desktop"]
+    assert "Icon=winpodx" in content
+    assert "Categories=X-winpodx;" in content
+
+
+def test_install_desktop_shortcut_joins_winpodx_menu_folder(tmp_path, monkeypatch):
+    # It must land in the same nested menu tree as the per-app entries, not
+    # some separate ungrouped location.
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(entry_mod, "_winpodx_exe", lambda: "winpodx")
+
+    from winpodx.desktop.entry import install_desktop_shortcut
+
+    install_desktop_shortcut()
+
+    directory, fragment = _menu_paths(tmp_path)
+    assert directory.exists()
+    assert fragment.exists()
+    assert "<Category>X-winpodx</Category>" in fragment.read_text(encoding="utf-8")
+
+
+def test_remove_desktop_shortcut_unlinks_file(tmp_path, monkeypatch):
+    from winpodx.desktop.entry import install_desktop_shortcut, remove_desktop_shortcut
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(entry_mod, "_winpodx_exe", lambda: "winpodx")
+
+    desktop_path = install_desktop_shortcut()
+    assert desktop_path.exists()
+
+    remove_desktop_shortcut()
+
+    assert not desktop_path.exists()
+
+
+def test_remove_desktop_shortcut_missing_file_is_noop(tmp_path, monkeypatch):
+    # Uninstall cleanup must not raise if it was already removed / never installed.
+    from winpodx.desktop.entry import remove_desktop_shortcut
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    remove_desktop_shortcut()  # must not raise

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -476,6 +476,7 @@ class TestMissingDesktopEntryFixer:
         apps = [_FakeApp("beta", mime_types=["text/plain"])]
         monkeypatch.setattr("winpodx.core.app.list_available_apps", lambda: apps)
         monkeypatch.setattr(doctor, "_desktop_entry_path", lambda app: _ExistsPath(False))
+        monkeypatch.setattr(doctor, "_desktop_shortcut_missing", lambda: False)
         installed = []
         monkeypatch.setattr(
             "winpodx.desktop.entry.install_desktop_entry",
@@ -491,6 +492,7 @@ class TestMissingDesktopEntryFixer:
     def test_fix_noop_when_all_present(self, monkeypatch):
         monkeypatch.setattr("winpodx.core.app.list_available_apps", lambda: [_FakeApp("alpha")])
         monkeypatch.setattr(doctor, "_desktop_entry_path", lambda app: _ExistsPath(True))
+        monkeypatch.setattr(doctor, "_desktop_shortcut_missing", lambda: False)
         called = []
         monkeypatch.setattr(
             "winpodx.desktop.entry.install_desktop_entry",
@@ -503,9 +505,44 @@ class TestMissingDesktopEntryFixer:
 
     def test_check_flags_with_fix_id(self, monkeypatch):
         monkeypatch.setattr(doctor, "_apps_missing_desktop_entries", lambda: [_FakeApp("beta")])
+        monkeypatch.setattr(doctor, "_desktop_shortcut_missing", lambda: False)
         f = doctor._check_missing_desktop_entries()
         assert f.severity == "warn"
         assert f.fix_id == "missing_desktop_entries"
+
+    # #769: the "Windows Desktop" launcher shortcut is tracked by the same
+    # check/fixer pair, independent of per-app entries.
+
+    def test_check_flags_shortcut_missing_alone(self, monkeypatch):
+        # No apps missing, but the shortcut itself is gone -> still a warn.
+        monkeypatch.setattr(doctor, "_apps_missing_desktop_entries", lambda: [])
+        monkeypatch.setattr(doctor, "_desktop_shortcut_missing", lambda: True)
+        f = doctor._check_missing_desktop_entries()
+        assert f.severity == "warn"
+        assert f.fix_id == "missing_desktop_entries"
+        assert "shortcut" in f.title
+
+    def test_check_ok_when_apps_and_shortcut_present(self, monkeypatch):
+        monkeypatch.setattr(doctor, "_apps_missing_desktop_entries", lambda: [])
+        monkeypatch.setattr(doctor, "_desktop_shortcut_missing", lambda: False)
+        f = doctor._check_missing_desktop_entries()
+        assert f.severity == "ok"
+
+    def test_fix_installs_missing_shortcut(self, monkeypatch):
+        # All app entries present, only the shortcut needs re-installing.
+        monkeypatch.setattr("winpodx.core.app.list_available_apps", lambda: [_FakeApp("alpha")])
+        monkeypatch.setattr(doctor, "_desktop_entry_path", lambda app: _ExistsPath(True))
+        monkeypatch.setattr(doctor, "_desktop_shortcut_missing", lambda: True)
+        shortcut_calls = []
+        monkeypatch.setattr(
+            "winpodx.desktop.entry.install_desktop_shortcut",
+            lambda: shortcut_calls.append(1),
+        )
+        monkeypatch.setattr("winpodx.desktop.icons.update_icon_cache", lambda: None)
+        ok, msg = doctor._fix_missing_desktop_entries()
+        assert ok
+        assert shortcut_calls == [1]
+        assert "desktop shortcut" in msg
 
 
 class TestDeadAgentFixer:


### PR DESCRIPTION
Requested by @jltorres60 (#769): a launcher for the full Windows desktop (`winpodx app run desktop`) alongside the per-app entries, so it's one click from the app menu instead of a terminal command. Default-on.

- New `install_desktop_shortcut()` / `remove_desktop_shortcut()` in `desktop/entry.py` writing `winpodx-full-desktop.desktop` (`Exec = app run desktop`, shared winpodx icon, same winpodx menu folder as the apps; no RAIL wm-class since the full desktop isn't a RemoteApp window).
- Wired into the setup provision loop, the CLI and GUI refresh paths, and `doctor --fix` (which now detects a missing shortcut on its own, not only missing app entries).
- **Excluded the reserved stem from the refresh prune in BOTH sync paths** — `cli/app.py` and the near-identical duplicate in `gui/workers.py` — so a refresh no longer silently deletes it (the GUI copy had the same latent bug).

Tests: 8 new (entry write/remove, prune-survival, doctor detect/fix); 139 passed on touched suites; ruff clean. The 1 full-suite failure (test_storage_migration happy-path) is pre-existing on main, unrelated.