### PR TITLE
fix(install): build winpodx with --no-cache-dir so --main/reinstall gets fresh code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed
 
+- **A `--main` upgrade or a purge + reinstall no longer silently keeps old code.** winpodx's version string only changes at release, so the installer kept building `winpodx-<same-version>`; pip's wheel cache (`~/.cache/pip/wheels`) is keyed by name+version and survives `uninstall.sh --purge` (purge clears the install, not pip's cache), so pip would reuse a stale cached wheel and the freshly-cloned source never reached the venv. The installer now builds winpodx with `--no-cache-dir`, forcing a fresh build from the cloned source every time.
+
 - **Discovery retries up to 5 times on a slow first boot instead of 2.** The guest's Start Menu enumeration can exceed the 180s-per-attempt timeout right after Sysprep (Defender scanning, heavy first-boot load), and two attempts weren't always enough, leaving the app menu empty until a manual `winpodx app refresh`. Each retry lands on a progressively idler guest, so more attempts turn a first-boot timeout into a populated menu; a normal boot still succeeds on the first attempt and never waits.
 
 - **The winpodx.org homepage now actually shows its non-English translations.** The site loads a generated `web/lang/translations.js` bundle (not the per-language JSON), and there was no committed generator, so catalog edits (the recent `--storage-dir`/`--storage-path` clarification and this release's update note) never reached the live site in German/French/Italian/Japanese/Korean/Chinese. Added `scripts/gen_web_i18n.py` (run it after any `web/lang/*.json` edit) and regenerated the bundle.

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -11,6 +11,8 @@
 
 ### Fixed
 
+- **`--main` 업그레이드나 purge 후 재설치가 옛 코드를 조용히 유지하지 않도록 수정.** winpodx 버전 문자열은 릴리스 때만 바뀌므로 설치 프로그램이 계속 `winpodx-<같은 버전>`을 빌드했는데, pip의 wheel 캐시(`~/.cache/pip/wheels`)는 name+version으로 키가 잡히고 `uninstall.sh --purge`에도 살아남습니다(purge는 설치를 지우지 pip 캐시를 안 지웁니다). 그래서 pip이 캐시된 옛 wheel을 재사용하고 새로 clone한 소스가 venv에 도달하지 못했습니다. 이제 설치 프로그램이 winpodx를 `--no-cache-dir`로 빌드해 매번 clone한 소스에서 새로 빌드합니다.
+
 - **느린 첫 부팅에서 discovery를 2회가 아니라 최대 5회 재시도.** Sysprep 직후(Defender 스캔, 첫 부팅 부하) 게스트의 시작 메뉴 열거가 attempt당 180초 타임아웃을 넘길 수 있는데 2회로는 부족해서 앱 메뉴가 빈 채로 남고 수동 `winpodx app refresh`가 필요했습니다. 재시도할수록 게스트가 더 안정되므로, 시도를 늘리면 첫 부팅 타임아웃이 채워진 메뉴로 바뀝니다. 정상 부팅은 여전히 첫 시도에 성공하며 기다리지 않습니다.
 
 ### Added

--- a/install.sh
+++ b/install.sh
@@ -1542,14 +1542,23 @@ fi
 # python_version marker) from pyproject. We then add the reverse-open
 # icon deps (cairosvg + pyxdg) and, unless --no-gui, PySide6 — pinned to
 # the same ranges pyproject declares so we don't invent versions.
+#
+# --no-cache-dir on the winpodx source install: the version string only
+# bumps at release, so a `--main` / same-version reinstall keeps building
+# winpodx-<same-version>. pip's wheel cache (~/.cache/pip/wheels) is keyed
+# by name+version and SURVIVES an `uninstall.sh --purge` (purge clears the
+# install, not pip's cache), so pip would silently reuse a stale cached
+# wheel from an earlier build and the freshly-cloned source never reaches
+# the venv -- a `--main` upgrade or a purge+reinstall would run OLD code.
+# Building without the cache forces a fresh build from the cloned WORK_DIR.
 log "Installing WinPodX into the venv (pip install '$WORK_DIR')..."
 if [ -n "$WINPODX_NO_GUI" ]; then
     # Headless: winpodx core + reverse-open icon quality, no PySide6.
-    "$WORK_VENV_PY" -m pip install --quiet "${WORK_DIR}[reverse-open]"
+    "$WORK_VENV_PY" -m pip install --quiet --no-cache-dir "${WORK_DIR}[reverse-open]"
     log "Headless install (--no-gui): PySide6 skipped."
 else
     # Full: winpodx core + reverse-open + GUI.
-    "$WORK_VENV_PY" -m pip install --quiet "${WORK_DIR}[gui,reverse-open]"
+    "$WORK_VENV_PY" -m pip install --quiet --no-cache-dir "${WORK_DIR}[gui,reverse-open]"
 fi
 
 # Belt-and-suspenders: ensure cairosvg + pyxdg are present even if a


### PR DESCRIPTION
**Root cause of "I reinstalled (even with `--purge`) but the code is still old":** winpodx's version string only bumps at release, so the installer keeps building `winpodx-<same-version>`. pip's wheel cache (`~/.cache/pip/wheels`) is keyed by name+version and **survives `uninstall.sh --purge`** (purge clears the install, not pip's cache). So on a `--main` upgrade — or a purge + reinstall — at the same version, pip reuses the stale cached wheel and the freshly-cloned source never reaches the venv. The venv runs OLD code even though `git clone` fetched the new source.

Fix: build the winpodx source install with `--no-cache-dir`, forcing a fresh build from the cloned `WORK_DIR` every time (both the GUI and headless paths). Versioned deps are untouched.

Validation: `bash -n` clean, shellcheck baseline unchanged, `test_install_sh_provision.py` 22 passed.