### PR TITLE
fix(provision): default provision + migrate CLI to 5 discovery retries (completes #784)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed
 
+- **The `winpodx provision` path (what a fresh `install.sh` actually runs) now also defaults to 5 discovery retries.** The earlier bump covered `winpodx setup` and the `finish_provisioning` default, but the `provision` CLI command kept its own `--retries` default of 2, so a fresh install still gave up after 2 attempts on a slow first boot. All the provisioning entrypoints (setup / provision / migrate / resume) are now consistent at 5.
+
 - **A `--main` upgrade or a purge + reinstall no longer silently keeps old code.** winpodx's version string only changes at release, so the installer kept building `winpodx-<same-version>`; pip's wheel cache (`~/.cache/pip/wheels`) is keyed by name+version and survives `uninstall.sh --purge` (purge clears the install, not pip's cache), so pip would reuse a stale cached wheel and the freshly-cloned source never reached the venv. The installer now builds winpodx with `--no-cache-dir`, forcing a fresh build from the cloned source every time.
 
 - **Discovery retries up to 5 times on a slow first boot instead of 2.** The guest's Start Menu enumeration can exceed the 180s-per-attempt timeout right after Sysprep (Defender scanning, heavy first-boot load), and two attempts weren't always enough, leaving the app menu empty until a manual `winpodx app refresh`. Each retry lands on a progressively idler guest, so more attempts turn a first-boot timeout into a populated menu; a normal boot still succeeds on the first attempt and never waits.

--- a/docs/CHANGELOG.ko.md
+++ b/docs/CHANGELOG.ko.md
@@ -11,6 +11,10 @@
 
 ### Fixed
 
+- **`winpodx provision` 경로(fresh `install.sh`가 실제로 실행)도 discovery 재시도 기본값을 5로.** 앞선 상향은 `winpodx setup`과 `finish_provisioning` 기본값만 커버했고 `provision` CLI 명령의 `--retries` 기본값은 2로 남아 있어서, fresh 설치는 여전히 느린 첫 부팅에서 2회 만에 포기했습니다. 이제 모든 provisioning 진입점(setup / provision / migrate / resume)이 5로 일관됩니다.
+
+- **The `winpodx provision` path (what a fresh `install.sh` actually runs) now also defaults to 5 discovery retries.** The earlier bump covered `winpodx setup` and the `finish_provisioning` default, but the `provision` CLI command kept its own `--retries` default of 2, so a fresh install still gave up after 2 attempts on a slow first boot. All the provisioning entrypoints (setup / provision / migrate / resume) are now consistent at 5.
+
 - **`--main` 업그레이드나 purge 후 재설치가 옛 코드를 조용히 유지하지 않도록 수정.** winpodx 버전 문자열은 릴리스 때만 바뀌므로 설치 프로그램이 계속 `winpodx-<같은 버전>`을 빌드했는데, pip의 wheel 캐시(`~/.cache/pip/wheels`)는 name+version으로 키가 잡히고 `uninstall.sh --purge`에도 살아남습니다(purge는 설치를 지우지 pip 캐시를 안 지웁니다). 그래서 pip이 캐시된 옛 wheel을 재사용하고 새로 clone한 소스가 venv에 도달하지 못했습니다. 이제 설치 프로그램이 winpodx를 `--no-cache-dir`로 빌드해 매번 clone한 소스에서 새로 빌드합니다.
 
 - **느린 첫 부팅에서 discovery를 2회가 아니라 최대 5회 재시도.** Sysprep 직후(Defender 스캔, 첫 부팅 부하) 게스트의 시작 메뉴 열거가 attempt당 180초 타임아웃을 넘길 수 있는데 2회로는 부족해서 앱 메뉴가 빈 채로 남고 수동 `winpodx app refresh`가 필요했습니다. 재시도할수록 게스트가 더 안정되므로, 시도를 늘리면 첫 부팅 타임아웃이 채워진 메뉴로 바뀝니다. 정상 부팅은 여전히 첫 시도에 성공하며 기다리지 않습니다.

--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -779,8 +779,10 @@ def cli(argv: list[str] | None = None) -> None:
     provision_p.add_argument(
         "--retries",
         type=int,
-        default=2,
-        help="Discovery retry attempts with exponential backoff (default 2).",
+        default=5,
+        help="Discovery retry attempts with exponential backoff (default 5). "
+        "A loaded first boot can blow the 180s/attempt budget; each retry "
+        "lands on an idler guest.",
     )
     provision_p.add_argument(
         "--verbose",
@@ -1093,7 +1095,7 @@ def _cmd_provision(args: argparse.Namespace) -> int:
 
     Flags map 1:1 onto the helper parameters. Run with no flags it
     reproduces install.sh's post-create defaults (wait 3600s, soft agent
-    settle, discovery on with 6× retry, reverse-open on when enabled), so
+    settle, discovery on with 5× retry, reverse-open on when enabled), so
     an AppImage first run can simply ``winpodx provision`` for the
     install.sh UX without re-implementing it (item I AppImage parity).
     """
@@ -1146,7 +1148,7 @@ def _cmd_provision(args: argparse.Namespace) -> int:
             require_agent=bool(getattr(args, "require_agent", False)),
             with_reverse_open=with_reverse_open,
             with_discovery=with_discovery,
-            retries=int(getattr(args, "retries", 2)),
+            retries=int(getattr(args, "retries", 5)),
             on_progress=_on_progress,
             wait_fn=_rich_wait,
         )

--- a/src/winpodx/cli/migrate.py
+++ b/src/winpodx/cli/migrate.py
@@ -840,8 +840,8 @@ def _apply_runtime_fixes_to_existing_guest(non_interactive: bool, *, verbose: bo
     #     is purely additive on a fresh install (OEM v22+ already applied
     #     everything), so skipping is strictly safer than racing.
     #
-    #   * with_discovery=True, retries=3 — migrate now folds discovery into
-    #     the chain (previously a separate interactive prompt). retries=3
+    #   * with_discovery=True, retries=5 — migrate now folds discovery into
+    #     the chain (previously a separate interactive prompt). retries=5
     #     rather than install.sh's 6× because migrate runs against an
     #     already-settled agent more often than not.
     #
@@ -879,7 +879,7 @@ def _apply_runtime_fixes_to_existing_guest(non_interactive: bool, *, verbose: bo
             require_agent=True,
             with_reverse_open=getattr(cfg.reverse_open, "enabled", False),
             with_discovery=True,
-            retries=3,
+            retries=5,
             wait_fn=_rich_wait,
         )
     except ProvisionAgentUnavailable:

--- a/tests/test_finish_provisioning.py
+++ b/tests/test_finish_provisioning.py
@@ -836,3 +836,32 @@ def test_discovery_default_retries_is_five() -> None:
     from winpodx.core.provisioner import finish_provisioning
 
     assert inspect.signature(finish_provisioning).parameters["retries"].default == 5
+
+
+def test_provision_cli_retries_default_is_five(monkeypatch) -> None:
+    """install.sh drives a fresh install via `winpodx provision` (not setup),
+    so the provision command's own retries default is the one that matters for
+    first-boot discovery. With no --retries on the args, _cmd_provision must
+    pass 5 to finish_provisioning (a slow first boot blows the 180s/attempt
+    budget; #784 bumped setup + the finish_provisioning default but the
+    provision CLI path defaulted to 2 until this)."""
+    import argparse
+    from types import SimpleNamespace
+
+    from winpodx.cli import main as cli_main
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        "winpodx.core.config.Config.load",
+        classmethod(lambda cls: SimpleNamespace(pod=SimpleNamespace(backend="podman"))),
+    )
+
+    def _fake_finish(cfg, **kwargs):  # noqa: ANN001, ANN003
+        captured.update(kwargs)
+        return {"wait_ready": "ok", "discovery": "3 apps", "reverse_open": "ok"}
+
+    monkeypatch.setattr("winpodx.core.provisioner.finish_provisioning", _fake_finish)
+    # Bare namespace: no `retries` attr -> the getattr fallback / argparse
+    # default is what applies, which must be 5.
+    cli_main._cmd_provision(argparse.Namespace())
+    assert captured["retries"] == 5


### PR DESCRIPTION
**This is why every smoke still showed `scanning guest (up to 2 attempts)` even after #784.** #784 bumped the discovery retry default to 5 for `winpodx setup` and the `finish_provisioning()` signature — but install.sh doesn't use setup's provisioning tail. It runs:

- **fresh install → `winpodx provision`** → `_cmd_provision`, whose argparse `--retries` default was **2** (and its getattr fallback 2)
- **upgrade → `winpodx migrate`**, which passed **3**

So the path users actually hit still capped discovery at 2 attempts. This bumps the `provision` `--retries` default 2 → 5 and `migrate` 3 → 5, making every provisioning entrypoint (setup / provision / migrate / resume) consistent at 5. A slow first boot now retries up to 5 times instead of leaving an empty menu.

Tests: new guard that `_cmd_provision` forwards 5 with no `--retries`; 45 passed on the provisioning suites; ruff clean. After this, a fresh `--main` install shows `up to 5 attempts`.