### PR TITLE
fix(desktop): resolve an absolute winpodx path for Exec= lines (#779)

### DIFF
--- a/src/winpodx/cli/doctor.py
+++ b/src/winpodx/cli/doctor.py
@@ -699,16 +699,67 @@ def _apps_missing_desktop_entries() -> list:
 
 
 def _desktop_shortcut_missing() -> bool:
-    """True if the "Windows Desktop" launcher shortcut (#769) isn't installed."""
-    from winpodx.desktop.entry import DESKTOP_SHORTCUT_STEM
+    """True if the "Windows Desktop" launcher shortcut (#769) needs installing.
+
+    Either it isn't there, or it carries a bare ``Exec=winpodx …`` a
+    stripped-PATH launcher can't resolve (#779) — re-installing fixes both.
+    """
+    from winpodx.desktop.entry import DESKTOP_SHORTCUT_STEM, _winpodx_exe
     from winpodx.utils.paths import applications_dir
 
-    return not (applications_dir() / f"{DESKTOP_SHORTCUT_STEM}.desktop").exists()
+    shortcut = applications_dir() / f"{DESKTOP_SHORTCUT_STEM}.desktop"
+    if not shortcut.exists():
+        return True
+    if not _winpodx_exe().startswith("/"):
+        return False
+    program = _entry_exec_program(shortcut)
+    return bool(program) and not program.startswith("/")
+
+
+def _entry_exec_program(entry_path) -> str:
+    """First token of an installed entry's ``Exec=`` line ("" when unreadable)."""
+    try:
+        for line in entry_path.read_text(encoding="utf-8", errors="replace").splitlines():
+            if line.startswith("Exec="):
+                parts = line[len("Exec=") :].strip().split()
+                return parts[0] if parts else ""
+    except OSError:
+        return ""
+    return ""
+
+
+def _apps_with_bare_exec() -> list:
+    """Return apps whose installed entry launches a bare, non-absolute command.
+
+    A DE that runs launchers as systemd transient units strips PATH, so an
+    ``Exec=winpodx …`` entry dies with "Could not find the program 'winpodx'"
+    (#779). Entries written before the fix carry that bare name; re-installing
+    them stamps the absolute path in. Only reported when we can actually
+    resolve an absolute path now, so there is nothing to churn otherwise.
+    """
+    from winpodx.core.app import list_available_apps
+    from winpodx.desktop.entry import _winpodx_exe
+
+    if not _winpodx_exe().startswith("/"):
+        return []
+    stale = []
+    for app in list_available_apps():
+        if getattr(app, "hidden", False):
+            continue
+        entry = _desktop_entry_path(app)
+        if not entry.exists():
+            continue  # counted by _apps_missing_desktop_entries instead
+        program = _entry_exec_program(entry)
+        if program and not program.startswith("/"):
+            stale.append(app)
+    return stale
 
 
 def _check_missing_desktop_entries() -> Finding:
     """Apps in the index with no installed ``.desktop`` file, plus the
-    "Windows Desktop" launcher shortcut (#769) if it's missing.
+    "Windows Desktop" launcher shortcut (#769) if it's missing, plus entries
+    whose ``Exec=`` is a bare command a stripped-PATH launcher can't find
+    (#779).
 
     Host-only -- unit-testable. Auto-fixable via ``missing_desktop_entries``.
     """
@@ -716,18 +767,24 @@ def _check_missing_desktop_entries() -> Finding:
         missing = _apps_missing_desktop_entries()
     except Exception as e:  # noqa: BLE001
         return Finding("warn", "could not enumerate apps", detail=str(e))
+    try:
+        stale = _apps_with_bare_exec()
+    except Exception:  # noqa: BLE001 -- advisory only, never fail the check
+        stale = []
     shortcut_missing = _desktop_shortcut_missing()
-    if not missing and not shortcut_missing:
+    if not missing and not stale and not shortcut_missing:
         return Finding("ok", "all registered apps have desktop entries")
     parts = []
     if missing:
         parts.append(f"{len(missing)} app(s) missing a desktop entry")
+    if stale:
+        parts.append(f"{len(stale)} entry(s) with a non-absolute Exec")
     if shortcut_missing:
         parts.append("desktop shortcut missing")
     return Finding(
         "warn",
         ", ".join(parts),
-        detail=", ".join(a.name for a in missing),
+        detail=", ".join(a.name for a in (missing + stale)),
         suggestion="Run `winpodx doctor --fix` (or `winpodx app install <name>`) to re-register.",
         fix_id="missing_desktop_entries",
     )
@@ -869,8 +926,12 @@ def _fix_missing_desktop_entries() -> tuple[bool, str]:
         missing = _apps_missing_desktop_entries()
     except Exception as e:  # noqa: BLE001
         return False, f"could not enumerate apps: {e}"
+    try:
+        stale = _apps_with_bare_exec()
+    except Exception:  # noqa: BLE001 -- best-effort repair, never block the fix
+        stale = []
     shortcut_missing = _desktop_shortcut_missing()
-    if not missing and not shortcut_missing:
+    if not missing and not stale and not shortcut_missing:
         return True, "no missing desktop entries"
 
     from winpodx.desktop.entry import install_desktop_entry, install_desktop_shortcut
@@ -879,7 +940,7 @@ def _fix_missing_desktop_entries() -> tuple[bool, str]:
 
     registered = 0
     failed: list[str] = []
-    for app in missing:
+    for app in missing + stale:
         try:
             install_desktop_entry(app)
             if app.mime_types:

--- a/src/winpodx/desktop/entry.py
+++ b/src/winpodx/desktop/entry.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import logging
+import os
 import shutil
+import sys
 from pathlib import Path
 
 from winpodx.core.app import AppInfo
@@ -90,10 +92,51 @@ def _winpodx_exe() -> str:
 
     Desktop entries must use an absolute path so they work when launched by
     desktop environments that run apps as systemd transient units with a
-    stripped PATH (e.g. Deepin's dde-application-manager).  Falls back to the
-    bare name when shutil.which() can't resolve it (e.g. during tests).
+    stripped PATH (e.g. Deepin's dde-application-manager, KDE on Fedora
+    Kinoite).  A bare ``winpodx`` there fails with "Could not find the program
+    'winpodx'" (#779).
+
+    ``shutil.which`` only sees the PATH of whatever process writes the entry,
+    and that is not always the user's interactive PATH: ``install.sh`` runs
+    provisioning through the absolute ``~/.local/bin/winpodx`` symlink, so a
+    shell that has not picked up ``~/.local/bin`` yet resolves nothing.  Fall
+    back through the locations we actually install launchers to before giving
+    up on the bare name (still the last resort, e.g. during tests).
     """
-    return shutil.which("winpodx") or "winpodx"
+    # Inside an AppImage the console script lives on an ephemeral mount
+    # (/tmp/.mount_*) that disappears when the process exits, so writing it
+    # into Exec= yields entries that break on the next boot. $APPIMAGE is the
+    # stable path to the image itself and forwards argv to the entrypoint.
+    appimage = os.environ.get("APPIMAGE", "")
+    if appimage and _is_executable_file(Path(appimage)):
+        return appimage
+
+    found = shutil.which("winpodx")
+    if found:
+        return found
+
+    for candidate in (
+        # Same prefix as the running interpreter — a pip/venv install puts the
+        # console script next to python (covers `python -m winpodx` in a venv).
+        Path(sys.executable).parent / "winpodx",
+        # The symlink install.sh creates; the usual answer on #779 hosts.
+        Path.home() / ".local" / "bin" / "winpodx",
+        # Distro / system-wide installs (RPM, DEB, AUR).
+        Path("/usr/local/bin/winpodx"),
+        Path("/usr/bin/winpodx"),
+    ):
+        if _is_executable_file(candidate):
+            return str(candidate)
+
+    return "winpodx"
+
+
+def _is_executable_file(path: Path) -> bool:
+    """True when ``path`` is an existing file we are allowed to execute."""
+    try:
+        return path.is_file() and os.access(path, os.X_OK)
+    except OSError:
+        return False
 
 
 def install_desktop_entry(app: AppInfo) -> Path:

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -703,9 +703,12 @@ def test_install_desktop_entry_uses_absolute_exec_path(tmp_path, monkeypatch):
 
 def test_winpodx_exe_falls_back_to_bare_name(monkeypatch):
     # shutil.which returns None when winpodx isn't on PATH (e.g. running from a
-    # checkout); the bare name keeps the .desktop entry valid for PATH-based
-    # launchers rather than emitting ``Exec=None``.
+    # checkout). Once the known install locations come up empty too (#779), the
+    # bare name keeps the .desktop entry valid for PATH-based launchers rather
+    # than emitting ``Exec=None``.
     monkeypatch.setattr(entry_mod.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(entry_mod, "_is_executable_file", lambda _p: False)
+    monkeypatch.delenv("APPIMAGE", raising=False)
     assert entry_mod._winpodx_exe() == "winpodx"
 
 
@@ -983,3 +986,61 @@ def test_remove_desktop_shortcut_missing_file_is_noop(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     remove_desktop_shortcut()  # must not raise
+
+
+# --- #779: desktop entries must carry an absolute Exec path ------------------
+
+
+def _make_exe(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\n")
+    path.chmod(0o755)
+    return path
+
+
+def test_winpodx_exe_prefers_path_lookup(tmp_path, monkeypatch):
+    found = _make_exe(tmp_path / "somewhere" / "winpodx")
+    monkeypatch.setattr(entry_mod.shutil, "which", lambda name: str(found))
+    monkeypatch.delenv("APPIMAGE", raising=False)
+
+    assert entry_mod._winpodx_exe() == str(found)
+
+
+def test_winpodx_exe_falls_back_to_local_bin_when_path_is_stripped(tmp_path, monkeypatch):
+    # install.sh drops the launcher in ~/.local/bin, but the process writing
+    # the entry may have a PATH that doesn't include it yet (#779).
+    home = tmp_path / "home"
+    launcher = _make_exe(home / ".local" / "bin" / "winpodx")
+    monkeypatch.setattr(entry_mod.shutil, "which", lambda name: None)
+    monkeypatch.setattr(entry_mod.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(entry_mod.sys, "executable", str(tmp_path / "nonexistent" / "python3"))
+    monkeypatch.delenv("APPIMAGE", raising=False)
+
+    assert entry_mod._winpodx_exe() == str(launcher)
+
+
+def test_winpodx_exe_prefers_appimage_over_ephemeral_mount(tmp_path, monkeypatch):
+    # Inside an AppImage the console script lives on a mount that vanishes at
+    # exit, so $APPIMAGE (the stable path) must win over which().
+    appimage = _make_exe(tmp_path / "WinPodX.AppImage")
+    monkeypatch.setenv("APPIMAGE", str(appimage))
+    monkeypatch.setattr(entry_mod.shutil, "which", lambda name: "/tmp/.mount_abc/usr/bin/winpodx")
+
+    assert entry_mod._winpodx_exe() == str(appimage)
+
+
+def test_installed_entry_has_absolute_exec(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    launcher = _make_exe(home / ".local" / "bin" / "winpodx")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.setattr(entry_mod.shutil, "which", lambda name: None)
+    monkeypatch.setattr(entry_mod.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(entry_mod.sys, "executable", str(tmp_path / "nonexistent" / "python3"))
+    monkeypatch.delenv("APPIMAGE", raising=False)
+
+    app = AppInfo(name="notepad", full_name="Notepad", executable="C:\\notepad.exe")
+    written = install_desktop_entry(app)
+
+    exec_line = next(line for line in written.read_text().splitlines() if line.startswith("Exec="))
+    assert exec_line == f"Exec={launcher} app run notepad %u"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -513,6 +513,63 @@ class TestMissingDesktopEntryFixer:
     # #769: the "Windows Desktop" launcher shortcut is tracked by the same
     # check/fixer pair, independent of per-app entries.
 
+    # #779: an entry written before the fix carries a bare ``Exec=winpodx``
+    # that stripped-PATH launchers can't resolve. Same check/fixer repairs it.
+
+    def test_detects_bare_exec_entry(self, tmp_path, monkeypatch):
+        entries = {}
+        for name, program in (("alpha", "/home/u/.local/bin/winpodx"), ("beta", "winpodx")):
+            f = tmp_path / f"winpodx-{name}.desktop"
+            f.write_text(f"[Desktop Entry]\nExec={program} app run {name} %u\n")
+            entries[name] = f
+        monkeypatch.setattr(
+            "winpodx.core.app.list_available_apps", lambda: [_FakeApp("alpha"), _FakeApp("beta")]
+        )
+        monkeypatch.setattr(doctor, "_desktop_entry_path", lambda app: entries[app.name])
+        monkeypatch.setattr("winpodx.desktop.entry._winpodx_exe", lambda: "/usr/bin/winpodx")
+
+        stale = doctor._apps_with_bare_exec()
+        assert [a.name for a in stale] == ["beta"]
+
+    def test_bare_exec_not_flagged_when_no_absolute_path_available(self, tmp_path, monkeypatch):
+        # Nothing to upgrade to -> don't nag about an entry we can't improve.
+        f = tmp_path / "winpodx-beta.desktop"
+        f.write_text("[Desktop Entry]\nExec=winpodx app run beta %u\n")
+        monkeypatch.setattr("winpodx.core.app.list_available_apps", lambda: [_FakeApp("beta")])
+        monkeypatch.setattr(doctor, "_desktop_entry_path", lambda app: f)
+        monkeypatch.setattr("winpodx.desktop.entry._winpodx_exe", lambda: "winpodx")
+
+        assert doctor._apps_with_bare_exec() == []
+
+    def test_fix_rewrites_bare_exec_entry(self, monkeypatch):
+        monkeypatch.setattr(doctor, "_apps_missing_desktop_entries", lambda: [])
+        monkeypatch.setattr(doctor, "_apps_with_bare_exec", lambda: [_FakeApp("beta")])
+        monkeypatch.setattr(doctor, "_desktop_shortcut_missing", lambda: False)
+        installed = []
+        monkeypatch.setattr(
+            "winpodx.desktop.entry.install_desktop_entry",
+            lambda app: installed.append(app.name),
+        )
+        monkeypatch.setattr("winpodx.desktop.mime.register_mime_types", lambda app: None)
+        monkeypatch.setattr("winpodx.desktop.icons.update_icon_cache", lambda: None)
+
+        ok, msg = doctor._fix_missing_desktop_entries()
+        assert ok
+        assert installed == ["beta"]
+
+    def test_shortcut_with_bare_exec_needs_install(self, tmp_path, monkeypatch):
+        from winpodx.desktop.entry import DESKTOP_SHORTCUT_STEM
+
+        apps_dir = tmp_path / "applications"
+        apps_dir.mkdir()
+        (apps_dir / f"{DESKTOP_SHORTCUT_STEM}.desktop").write_text(
+            "[Desktop Entry]\nExec=winpodx app run desktop\n"
+        )
+        monkeypatch.setattr("winpodx.utils.paths.applications_dir", lambda: apps_dir)
+        monkeypatch.setattr("winpodx.desktop.entry._winpodx_exe", lambda: "/usr/bin/winpodx")
+
+        assert doctor._desktop_shortcut_missing() is True
+
     def test_check_flags_shortcut_missing_alone(self, monkeypatch):
         # No apps missing, but the shortcut itself is gone -> still a warn.
         monkeypatch.setattr(doctor, "_apps_missing_desktop_entries", lambda: [])


### PR DESCRIPTION
Desktop entries launched from the application menu die with "Could not find the program 'winpodx'" on desktops that run launchers as systemd transient units with a stripped PATH (reported on Fedora Kinoite / KDE Plasma, #779).

## Cause

`_winpodx_exe()` only consulted `shutil.which("winpodx")`, which sees the PATH of whatever process writes the entry. `install.sh` runs provisioning through the absolute `~/.local/bin/winpodx` symlink, so a shell that has not picked up `~/.local/bin` yet resolves nothing and the template falls through to the bare name.

## Change

- `_winpodx_exe()` falls back through the locations we actually install launchers to (venv sibling, `~/.local/bin`, `/usr/local/bin`, `/usr/bin`) before the bare name.
- `$APPIMAGE` now wins over `which()`: inside an AppImage the console script lives on an ephemeral `/tmp/.mount_*` path that would be stale in a written entry.
- `winpodx doctor` flags installed entries (and the #769 desktop shortcut) whose `Exec=` is non-absolute and repairs them via `--fix`, so existing installs recover without a manual refresh. Only reported when an absolute path is actually resolvable, so there is nothing to churn otherwise.

## Tests

Nine new cases across `tests/test_desktop.py` and `tests/test_doctor.py` covering the fallback chain, the AppImage preference, the bare-name last resort, the written `Exec=` line, and the doctor detect/repair path. The pre-existing `test_winpodx_exe_falls_back_to_bare_name` was pinning the old behaviour and now isolates the candidate lookup instead.