### PR TITLE
fix(reverse-open): route URLs clicked in the guest to the host app (#694)

### DIFF
--- a/src/winpodx/reverse_open/listener.py
+++ b/src/winpodx/reverse_open/listener.py
@@ -93,6 +93,39 @@ _POD_ID_RE = re.compile(r"^[a-z0-9-]+$")
 # ``\\tsclient\…`` prefix check.
 _GUEST_PATH_RE = re.compile(r"^[A-Za-z]:\\")
 
+# Schemes refused specifically on the guest → host direction, on top of the
+# shared ``DANGEROUS_SCHEMES`` denylist (#694). These open an authenticated
+# outbound session from the host rather than displaying a document, so a
+# compromised guest could use one to make the host connect somewhere and
+# offer up the user's stored credentials. The host→guest direction is
+# unaffected: routing ``ssh://`` to a Windows client is the user's own
+# explicit action, whereas here the request originates in the guest.
+#
+# Deliberately narrow. Everything else a browser or mail client understands
+# — http/https, mailto, and vendor deep links (slack, zoommtg, spotify, …) —
+# still routes, because displaying a link is the entire point of #694.
+_GUEST_ORIGIN_DENIED_SCHEMES: frozenset[str] = frozenset(
+    {
+        "ssh",
+        "sftp",
+        "telnet",
+        "rdp",
+        "vnc",
+        "spice",
+        "spice+tls",
+        "spice+unix",
+        "smb",
+        "cifs",
+        "nfs",
+        "afp",
+    }
+)
+
+# Control characters are rejected outright in a URL: a CR/ESC payload in a
+# request would otherwise reach the daemon log (and any terminal tailing it)
+# verbatim. NUL is already refused for every path shape.
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
+
 
 @dataclass
 class ListenerStats:
@@ -105,6 +138,7 @@ class ListenerStats:
     rejected_unknown_app: int = 0
     rejected_path: int = 0
     rejected_guest_unsupported: int = 0
+    rejected_url_scheme: int = 0
     rejected_replay: int = 0
     rejected_in_flight: int = 0
     janitor_removed: int = 0
@@ -310,6 +344,15 @@ class Listener:
             self._handle_guest_request(path, slug, app, data["path"])
             return
 
+        # A link clicked in the guest (#694). The shim can't tell a URL from a
+        # host path, so both arrive as origin "host"; the schema check already
+        # confirmed this one is a routable URL. Handled before safe_open_unc,
+        # which would reject it a second time for not resolving under a share
+        # root.
+        if _url_reject_reason(data["path"]) is None:
+            self._handle_url_request(path, slug, app, data["path"])
+            return
+
         unc = data["path"]
         try:
             with safe_open_unc(unc, self._cfg.share_roots) as safe:
@@ -375,6 +418,60 @@ class Listener:
         except OSError as exc:
             self._stats.spawn_errors += 1
             log.warning("listener: launch spawn failed for %s: %s", slug, exc)
+            _safe_unlink(path)
+            return
+
+        self._seen.add(uuid)
+        self._stats.accepted += 1
+        _safe_unlink(path)
+
+    def _handle_url_request(self, path: Path, slug: str, app: object, url: str) -> None:
+        """Open a URL the guest handed us in a host app (origin="host", #694).
+
+        The user clicked a link inside Windows — in Outlook, say — and the
+        per-app shim registered as that scheme's handler forwarded it. There
+        is no filesystem path to resolve, so this skips ``safe_open_unc``
+        entirely and substitutes the URL into the app's argv as a single slot.
+
+        Two guards beyond the scheme policy already applied in
+        ``_url_reject_reason``:
+
+        * the target app must itself declare the scheme (an
+          ``x-scheme-handler/<scheme>`` entry in its ``.desktop``). That stops
+          scheme confusion — handing ``zoommtg://…`` to an app that treats
+          argv as a filename — though it is not an allowlist in its own
+          right, since a remote-desktop client legitimately declares plenty of
+          schemes. The direction-specific denylist is what covers that case;
+        * the spawn is ``shell=False`` with the URL in exactly one argv slot,
+          so nothing in the string can become a separate word or a shell
+          token.
+
+        The UUID is recorded only after the spawn fires, so a failed launch
+        can be retried from the guest.
+        """
+        uuid = path.stem
+        from winpodx.core.url_schemes import url_scheme_of
+
+        scheme = url_scheme_of(url)
+        declared = f"x-scheme-handler/{scheme}"
+        if declared not in getattr(app, "mime_types", []):
+            self._stats.rejected_url_scheme += 1
+            log.warning(
+                "listener: app %s does not declare %s — refusing url request %s",
+                slug,
+                declared,
+                path.name,
+            )
+            _safe_unlink(path)
+            return
+
+        argv = substitute_path(app.exec_argv, url)  # type: ignore[attr-defined]
+        log.info("listener: spawning (url) slug=%s scheme=%s argv=%r", slug, scheme, argv)
+        try:
+            self._spawn(argv, {})
+        except OSError as exc:
+            self._stats.spawn_errors += 1
+            log.warning("listener: url spawn failed for %s: %s", slug, exc)
             _safe_unlink(path)
             return
 
@@ -542,7 +639,15 @@ def _validate_schema(data: object) -> str | None:
         # Accept both Windows backslash form and forward-slash form
         # (Go's filepath.ToSlash leaves the latter when the shim
         # rendering pipeline doubles back through cross-platform Path).
-        return "path must start with \\\\tsclient\\"
+        #
+        # Not a UNC path — it may still be a URL. The guest shim classifies
+        # anything that is neither ``\\…`` nor a drive path as origin "host"
+        # (config/oem/reverse-open/shim/src/main.rs), so a browser link
+        # clicked in the guest arrives here verbatim. Checking UNC first
+        # means a real UNC path can never be reinterpreted as a URL (#694).
+        url_problem = _url_reject_reason(path)
+        if url_problem is not None:
+            return url_problem
     ts = data.get("ts")
     if not isinstance(ts, str) or not ts:
         return "ts field missing or not a string"
@@ -550,6 +655,37 @@ def _validate_schema(data: object) -> str | None:
     if pod_id is not None:
         if not isinstance(pod_id, str) or not _POD_ID_RE.fullmatch(pod_id):
             return "pod_id must be null or a slug"
+    return None
+
+
+def _url_reject_reason(path: str) -> str | None:
+    """Return why ``path`` is unacceptable as a guest-originated URL, or None.
+
+    ``None`` means the string is a URL this listener is willing to hand to a
+    host app (#694). The checks, in order:
+
+    * a routable scheme — ``winpodx.core.url_schemes.url_scheme_of`` applies
+      the shared syntax rule and the ``DANGEROUS_SCHEMES`` denylist, so
+      ``file:``, ``javascript:``, ``data:`` and friends never get here. That
+      matters most for ``file:``: it would otherwise walk straight around the
+      share-root confinement that ``safe_open_unc`` exists to enforce;
+    * no control characters, so nothing in the request can rewrite a log line;
+    * not a remote-session scheme (see ``_GUEST_ORIGIN_DENIED_SCHEMES``).
+
+    The syntax rule also guarantees the URL starts with a letter, so the
+    string can never be mistaken for an option when it lands in the app's
+    argv.
+    """
+    from winpodx.core.url_schemes import url_scheme_of
+
+    scheme = url_scheme_of(path)
+    if scheme is None:
+        # Neither a UNC path (checked first by the caller) nor a URL we route.
+        return "path must start with \\\\tsclient\\ or be a routable URL"
+    if _CONTROL_CHARS_RE.search(path):
+        return "url contains control characters"
+    if scheme in _GUEST_ORIGIN_DENIED_SCHEMES:
+        return f"url scheme {scheme!r} is not routable from the guest"
     return None
 
 

--- a/tests/test_reverse_open_listener.py
+++ b/tests/test_reverse_open_listener.py
@@ -674,3 +674,138 @@ def test_filemode_permission_helper() -> None:
     # Self-check: stat.filemode formatting matches what we expect to
     # surface in the PermissionError message.
     assert stat.filemode(0o775).endswith("xrwxr-x")
+
+
+# --- #694: URLs clicked in the guest ----------------------------------------
+
+
+def _apps_db_with_schemes(slug: str, exec_argv: list[str], schemes: list[str]) -> AppsDatabase:
+    entry = AppEntry(
+        slug=slug,
+        name="Browser",
+        comment="",
+        exec_argv=exec_argv,
+        icon_name="",
+        mime_types=["text/html"] + [f"x-scheme-handler/{s}" for s in schemes],
+        desktop_file="/browser.desktop",
+    )
+    return AppsDatabase({slug: entry}, "2026-07-27T00:00:00Z")
+
+
+def _url_request(url: str, app: str = "brave") -> dict:
+    # The guest shim classifies anything that is neither \\… nor a drive path
+    # as origin "host", so a clicked link arrives with the URL in `path`.
+    return {
+        "version": 2,
+        "app": app,
+        "path": url,
+        "origin": "host",
+        "ts": "2026-07-27T00:00:00Z",
+        "pod_id": None,
+    }
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/a?b=1,2&c=%20d",
+        "http://example.com/",
+        "mailto:someone@example.com?subject=hi",
+        "slack://channel?id=C123",
+    ],
+)
+def test_schema_accepts_routable_urls(url: str) -> None:
+    assert _validate_schema(_url_request(url)) is None
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:///etc/shadow",
+        "javascript:alert(1)",
+        "data:text/html;base64,PHNjcmlwdD4=",
+        "vbscript:msgbox",
+    ],
+)
+def test_schema_rejects_dangerous_url_schemes(url: str) -> None:
+    # file: in particular would walk straight around the share-root
+    # confinement that safe_open_unc exists to enforce.
+    assert _validate_schema(_url_request(url)) is not None
+
+
+@pytest.mark.parametrize("url", ["ssh://host", "vnc://host:1", "smb://host/share"])
+def test_schema_rejects_remote_session_schemes_from_guest(url: str) -> None:
+    # Routable in general, but a guest must not be able to make the host open
+    # an authenticated outbound session.
+    assert _validate_schema(_url_request(url)) is not None
+
+
+def test_schema_rejects_url_with_control_characters() -> None:
+    assert _validate_schema(_url_request("https://example.com/\x1b[2Kfake")) is not None
+
+
+def test_schema_still_rejects_non_url_host_path() -> None:
+    # A bare relative path is neither a UNC path nor a URL.
+    assert _validate_schema(_url_request("some/relative/path")) is not None
+
+
+def test_unc_path_is_not_reinterpreted_as_url() -> None:
+    # UNC is checked first; a share named like a scheme must not change that.
+    body = _url_request("\\\\tsclient\\home\\notes.txt")
+    assert _validate_schema(body) is None
+
+
+def test_listener_spawns_app_with_url(tmp_path: Path, spawn_capture) -> None:
+    captured, spawn = spawn_capture
+    inc = _incoming(tmp_path)
+    inc.chmod(0o700)
+    cfg = ListenerConfig(incoming_dir=inc, share_roots={})
+    db = _apps_db_with_schemes("brave", ["/usr/bin/brave", "%u"], ["http", "https"])
+    listener = Listener(cfg, db, _seen(tmp_path), spawn=spawn)
+
+    url = "https://example.com/a?b=1,2"
+    _write_request(inc, _url_request(url))
+    listener.process_pending()
+
+    assert len(captured) == 1
+    argv, popen_kwargs = captured[0]
+    # The URL occupies exactly one argv slot, verbatim -- no shell, no split.
+    assert argv == ["/usr/bin/brave", url]
+    assert popen_kwargs == {}
+    assert listener.stats_snapshot().accepted == 1
+    assert list(inc.iterdir()) == []
+
+
+def test_listener_refuses_url_scheme_the_app_does_not_declare(
+    tmp_path: Path, spawn_capture
+) -> None:
+    captured, spawn = spawn_capture
+    inc = _incoming(tmp_path)
+    inc.chmod(0o700)
+    cfg = ListenerConfig(incoming_dir=inc, share_roots={})
+    # Declares http/https only -- a zoommtg: link must not be handed to it.
+    db = _apps_db_with_schemes("brave", ["/usr/bin/brave", "%u"], ["http", "https"])
+    listener = Listener(cfg, db, _seen(tmp_path), spawn=spawn)
+
+    _write_request(inc, _url_request("zoommtg://zoom.us/join?confno=1"))
+    listener.process_pending()
+
+    assert captured == []
+    assert listener.stats_snapshot().rejected_url_scheme == 1
+    assert list(inc.iterdir()) == []
+
+
+def test_listener_drops_request_for_dangerous_url(tmp_path: Path, spawn_capture) -> None:
+    captured, spawn = spawn_capture
+    inc = _incoming(tmp_path)
+    inc.chmod(0o700)
+    cfg = ListenerConfig(incoming_dir=inc, share_roots={})
+    db = _apps_db_with_schemes("brave", ["/usr/bin/brave", "%u"], ["http", "https", "file"])
+    listener = Listener(cfg, db, _seen(tmp_path), spawn=spawn)
+
+    _write_request(inc, _url_request("file:///etc/shadow"))
+    listener.process_pending()
+
+    assert captured == []
+    assert listener.stats_snapshot().rejected_schema == 1
+    assert list(inc.iterdir()) == []


### PR DESCRIPTION
Clicking an `http`/`https` link in a guest app registered against the reverse-open shim did nothing, while opening a `.htm` **file** with the same shim worked. #694.

## Cause

The guest shim classifies its argument by shape (`config/oem/reverse-open/shim/src/main.rs:135-145`): a leading `\\` is a host UNC path, `X:\` is a guest-local path, and everything else falls through to the catch-all `(file, "host")`. A URL takes the catch-all, so it reaches the host verbatim with `origin: "host"` — the shim itself is fine.

The host then rejects it twice:

1. `_validate_schema` requires an `origin="host"` path to start with `\\tsclient\` (`listener.py`), so the request is counted as `rejected_schema`, logged once, and unlinked. Nothing is spawned and nothing surfaces to the user.
2. Even past that, `safe_open_unc` would refuse it for not resolving under a share root.

A `.htm` file works because it arrives as `origin="guest"`, which has a fully implemented branch.

## Change

The listener now recognises a routable URL on `origin="host"` and dispatches it to the app with the URL substituted into a single argv slot, before the `safe_open_unc` call. **No guest change** — an already-installed shim delivers the URL intact, so the binary is untouched and there is no new antivirus exposure.

### Scheme policy, guest → host

- The shared `DANGEROUS_SCHEMES` denylist applies. `file:` is the load-bearing one: it would otherwise walk around the share-root confinement that `safe_open_unc` exists to enforce. `javascript:`, `data:`, `vbscript:` and the rest are receiver-side code-execution vectors.
- Control characters are refused, so nothing in a request can rewrite a log line.
- Remote-session schemes (`ssh`, `sftp`, `telnet`, `rdp`, `vnc`, `spice*`, `smb`, `cifs`, `nfs`, `afp`) are refused **on this direction only**. Displaying a link is the use case; letting a compromised guest make the host open an authenticated outbound session is not.
- The target app must declare the scheme (`x-scheme-handler/<scheme>` in its `.desktop`). This prevents scheme confusion — handing `zoommtg://` to an app that treats argv as a filename. It is deliberately **not** described as an allowlist: a remote-desktop client legitimately declares `ssh`/`rdp`/`vnc`/`spice`, which is exactly why the direction-specific denylist above exists.
- Spawning stays `shell=False` with the URL in exactly one argv slot, and the scheme syntax rule guarantees the string starts with a letter, so it can never be read as an option.

A new `rejected_url_scheme` counter makes a refusal visible in `stats_snapshot()`.

## Tests

14 new cases in `tests/test_reverse_open_listener.py`: routable schemes accepted (including a URL with a comma and percent-encoding), dangerous and remote-session schemes rejected, control characters rejected, UNC paths not reinterpreted as URLs, end-to-end spawn with the URL in one argv slot, and the undeclared-scheme refusal. 410 reverse-open / url-scheme / host-open tests pass.

## Follow-up (not in this PR)

The reporter had to hand-write registry keys because the guest registration script drops `x-scheme-handler/*` MIME entries. Adding scheme registration there is a `.ps1`-only change (no shim rebuild) and belongs in its own PR, with the Windows constraint documented: UserChoice is hash-protected, so we can only make the app a selectable candidate — the user still confirms it in Settings.