### PR TITLE
fix(rdp): share one FreeRDP version probe and warn about old RAIL at launch (#785)

### DIFF
--- a/src/winpodx/cli/doctor.py
+++ b/src/winpodx/cli/doctor.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -46,7 +45,9 @@ from winpodx.core.i18n import tr
 # Oldest FreeRDP 3.x without the RemoteApp/RAIL window-mapping bugs that leave
 # an app connected but its window never shown (#546). 3.5.x and earlier are
 # affected; warn (not fail) below this, since the binary still works otherwise.
-_FREERDP_RAIL_FLOOR = (3, 6, 0)
+# The value itself lives in ``winpodx.core.rdp`` (imported lazily at the check,
+# matching this module's style) so the launcher warning (#785) and this check
+# can never disagree about where the floor sits.
 
 
 @dataclass(frozen=True)
@@ -220,23 +221,15 @@ def _check_freerdp() -> Finding:
         # Best-effort version string for the human reader; a failure to run
         # --version doesn't downgrade the finding (binary exists, that's the
         # signal we care about for doctor).
-        version_line = ""
-        ver: tuple[int, int, int] | None = None
-        try:
-            result = subprocess.run(
-                [dep.path, "--version"],
-                capture_output=True,
-                text=True,
-                timeout=3,
-                check=False,
-            )
-            blob = (result.stdout or "") + (result.stderr or "")
-            version_line = result.stdout.splitlines()[0] if result.stdout else ""
-            m = re.search(r"FreeRDP version\s+(\d+)\.(\d+)\.(\d+)", blob)
-            if m:
-                ver = (int(m.group(1)), int(m.group(2)), int(m.group(3)))
-        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-            pass
+        # Shared with the launcher (winpodx.core.rdp) so both agree and the
+        # probe runs once. Doing it here meant splitting a Flatpak launcher
+        # string wrong, so no version was ever detected on Flatpak hosts and
+        # the RAIL warning below never fired (#785).
+        from winpodx.core.rdp import FREERDP_RAIL_FLOOR as _FREERDP_RAIL_FLOOR
+        from winpodx.core.rdp import freerdp_version
+
+        ver = freerdp_version()
+        version_line = f"FreeRDP version {'.'.join(str(p) for p in ver)}" if ver else ""
         # Old FreeRDP 3.x RAIL: 3.5.x and earlier have window-ordering bugs that
         # leave a RemoteApp connected but its window never mapped (only
         # "xf_Pointer: Invalid appWindow" spam) -- see #546 (Ubuntu/Budgie 24.04

--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -191,13 +191,88 @@ def _media_redirect_base() -> Path:
 # Success-only cache, keyed by preference; a miss is not cached so a
 # mid-session install is picked up.
 _FREERDP_CACHE: dict[str, tuple[str, str]] = {}
-_FREERDP_MAJOR_CACHE: int | None = None
+# Sentinel distinguishes "not probed yet" from "probed, no version found":
+# a failed probe must not re-run --version on every call.
+_UNPROBED = object()
+_FREERDP_VERSION_CACHE: object = _UNPROBED
+
+# FreeRDP 3.5.x and earlier have RAIL window-ordering bugs that leave a
+# RemoteApp connected with its window never mapped, or painted with the stale
+# logon framebuffer (#546, #332, #733, #785). Advisory only: the same binary
+# drives full-desktop sessions and plenty of apps fine.
+FREERDP_RAIL_FLOOR = (3, 6, 0)
+
+
+def freerdp_version() -> tuple[int, int, int] | None:
+    """Return the installed FreeRDP version, or ``None`` if undetectable.
+
+    One probe for the whole process, shared by the launcher and ``doctor``:
+    the launcher path must know the major version to pick the right ``/app:``
+    syntax, and doctor reports the full triple. Probing twice meant doctor
+    re-implemented the lookup and got the Flatpak case wrong — ``find_freerdp``
+    can return a whole ``flatpak run … com.freerdp.FreeRDP`` command line, and
+    running that as a single argv element raises ``FileNotFoundError``, so no
+    version was ever detected on Flatpak hosts and the RAIL warning silently
+    never fired.
+    """
+    global _FREERDP_VERSION_CACHE
+    if _FREERDP_VERSION_CACHE is not _UNPROBED:
+        return _FREERDP_VERSION_CACHE  # type: ignore[return-value]
+
+    _FREERDP_VERSION_CACHE = None
+    found = find_freerdp()
+    if found is None:
+        return None
+
+    path, _kind = found
+    # The launcher string may be a full command ("flatpak run …"), so split it
+    # rather than treating it as one executable path.
+    cmd = shlex.split(path) + ["--version"]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=5, check=False)
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+
+    # FreeRDP --version prints "This is FreeRDP version <major>.<minor>.<patch>".
+    # Be forgiving about which stream it lands on and what surrounds it.
+    blob = (result.stdout or "") + (result.stderr or "")
+    match = re.search(r"FreeRDP version\s+(\d+)\.(\d+)\.(\d+)", blob)
+    if match is None:
+        # Some builds print only "<major>.<minor>"; the major is what the
+        # launcher gates on, so accept that shape too.
+        match = re.search(r"FreeRDP version\s+(\d+)\.(\d+)", blob)
+        if match is None:
+            return None
+        _FREERDP_VERSION_CACHE = (int(match.group(1)), int(match.group(2)), 0)
+        return _FREERDP_VERSION_CACHE  # type: ignore[return-value]
+
+    _FREERDP_VERSION_CACHE = (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+    return _FREERDP_VERSION_CACHE  # type: ignore[return-value]
+
+
+def freerdp_rail_warning() -> str | None:
+    """Human-readable warning when the installed FreeRDP predates working RAIL.
+
+    ``None`` when the version is fine, undetectable, or not FreeRDP 3 — an
+    unknown version must not produce a scary message on a working setup.
+    """
+    ver = freerdp_version()
+    if ver is None or ver[0] != 3 or ver >= FREERDP_RAIL_FLOOR:
+        return None
+    shown = ".".join(str(p) for p in ver)
+    floor = ".".join(str(p) for p in FREERDP_RAIL_FLOOR)
+    return (
+        f"FreeRDP {shown} is older than {floor} and has known RemoteApp window bugs: "
+        "the app may connect without ever showing a window, or show one still painted "
+        "with the Windows logon screen. Upgrading FreeRDP (newer distro package, or the "
+        "winpodx AppImage, which bundles its own) is the fix."
+    )
 
 
 def freerdp_major_version() -> int:
     """Return the FreeRDP major version (2 or 3), or 3 on detection failure.
 
-    Result is cached in ``_FREERDP_MAJOR_CACHE``. We default to 3 when
+    Thin wrapper over :func:`freerdp_version` (one shared probe). Defaults to 3 when
     the version probe can't run cleanly because: (a) winpodx targets
     FreeRDP 3+ anyway, (b) the combined ``/app:program:X,name:Y,cmd:Z``
     syntax is FreeRDP 3-only and is what most users hit, (c) on
@@ -212,36 +287,10 @@ def freerdp_major_version() -> int:
     parses the entire combined string as a literal path and lands on
     the Store fallback (#158).
     """
-    global _FREERDP_MAJOR_CACHE
-    if _FREERDP_MAJOR_CACHE is not None:
-        return _FREERDP_MAJOR_CACHE
-
-    found = find_freerdp()
-    if found is None:
-        _FREERDP_MAJOR_CACHE = 3  # safest default; later code paths gate on this
-        return _FREERDP_MAJOR_CACHE
-
-    path, _kind = found
-    # ``flatpak run ...`` returns the inner FreeRDP version too; the
-    # caller passes the whole launcher string so shlex it.
-    cmd = shlex.split(path) + ["--version"]
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
-        _FREERDP_MAJOR_CACHE = 3
-        return _FREERDP_MAJOR_CACHE
-    # FreeRDP --version prints "This is FreeRDP version <major>.<minor>.<patch>"
-    # on stdout. Be forgiving about stream choice and surrounding text.
-    blob = (result.stdout or "") + (result.stderr or "")
-    match = re.search(r"FreeRDP version\s+(\d+)\.", blob)
-    if not match:
-        _FREERDP_MAJOR_CACHE = 3
-        return _FREERDP_MAJOR_CACHE
-    try:
-        _FREERDP_MAJOR_CACHE = int(match.group(1))
-    except ValueError:
-        _FREERDP_MAJOR_CACHE = 3
-    return _FREERDP_MAJOR_CACHE
+    ver = freerdp_version()
+    # 3 is the safest default: winpodx targets FreeRDP 3+, and the combined
+    # ``/app:`` syntax the launcher builds is FreeRDP-3-only.
+    return ver[0] if ver is not None else 3
 
 
 def _find_native_freerdp() -> tuple[str, str] | None:
@@ -1629,6 +1678,16 @@ def launch_app(
     # spam. Wait (best-effort, agent-only) until the desktop is interactive.
     if is_remoteapp and cfg.pod.backend in ("podman", "docker"):
         _wait_session_interactive(cfg, timeout=_INTERACTIVE_WAIT_TIMEOUT)
+
+    # Same advisory `winpodx doctor` gives, surfaced where the symptom appears
+    # (#785). The wait above only helps when the guest agent answers; on an old
+    # FreeRDP the window can still come up blank or painted with the logon
+    # screen, and users hit that long before they think to run doctor.
+    if is_remoteapp:
+        rail_warning = freerdp_rail_warning()
+        if rail_warning:
+            log.warning("%s", rail_warning)
+            print(f"warning: {rail_warning}", file=sys.stderr)
 
     log.info("Launching RDP: %s", _redact_cmd_for_log(cmd))
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -138,12 +138,10 @@ class TestCheckFreerdp:
             "winpodx.utils.deps.check_freerdp",
             lambda: DepCheck(name="xfreerdp", found=found, path="/usr/bin/xfreerdp3"),
         )
-
-        class _Res:
-            stdout = f"This is FreeRDP version {version} (...)\n" if version else ""
-            stderr = ""
-
-        monkeypatch.setattr(doctor.subprocess, "run", lambda *a, **k: _Res())
+        # doctor consumes the launcher's single shared probe (#785), so stub
+        # that rather than re-stubbing subprocess here.
+        parsed = tuple(int(p) for p in version.split(".")) if version else None
+        monkeypatch.setattr("winpodx.core.rdp.freerdp_version", lambda: parsed)
 
     def test_old_3x_warns(self, monkeypatch):
         self._patch(monkeypatch, version="3.5.1")

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -1607,3 +1607,92 @@ class TestKeyboardLayoutPropagation:
         cmd, _ = build_rdp_command(cfg)
         kbd_flags = [c for c in cmd if c.startswith("/kbd")]
         assert kbd_flags == ["/kbd:layout:0x00000409"]  # only the user's, no auto
+
+
+# --- #785: one shared FreeRDP version probe + RAIL warning -------------------
+
+
+class TestFreerdpVersionProbe:
+    """The launcher and doctor must share one probe, and it must handle the
+    Flatpak launcher string (a whole command, not a single executable)."""
+
+    def _reset(self, monkeypatch):
+        import winpodx.core.rdp as rdp_mod
+
+        monkeypatch.setattr(rdp_mod, "_FREERDP_VERSION_CACHE", rdp_mod._UNPROBED)
+        return rdp_mod
+
+    def test_parses_version_triple(self, monkeypatch):
+        rdp_mod = self._reset(monkeypatch)
+        monkeypatch.setattr(
+            rdp_mod, "find_freerdp", lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp")
+        )
+
+        class _Res:
+            stdout = "This is FreeRDP version 3.5.1 (release)\n"
+            stderr = ""
+
+        monkeypatch.setattr(rdp_mod.subprocess, "run", lambda *a, **k: _Res())
+        assert rdp_mod.freerdp_version() == (3, 5, 1)
+
+    def test_flatpak_launcher_string_is_split(self, monkeypatch):
+        # Regression: running the whole "flatpak run ..." string as one argv
+        # element raised FileNotFoundError, so no version was ever detected on
+        # Flatpak hosts and the RAIL warning silently never fired.
+        rdp_mod = self._reset(monkeypatch)
+        launcher = "flatpak run --branch=stable com.freerdp.FreeRDP"
+        monkeypatch.setattr(rdp_mod, "find_freerdp", lambda *a, **k: (launcher, "flatpak"))
+        seen: list[list[str]] = []
+
+        class _Res:
+            stdout = "This is FreeRDP version 3.7.0\n"
+            stderr = ""
+
+        def _run(cmd, *a, **k):
+            seen.append(cmd)
+            return _Res()
+
+        monkeypatch.setattr(rdp_mod.subprocess, "run", _run)
+        assert rdp_mod.freerdp_version() == (3, 7, 0)
+        assert seen[0] == ["flatpak", "run", "--branch=stable", "com.freerdp.FreeRDP", "--version"]
+
+    def test_failed_probe_is_cached(self, monkeypatch):
+        rdp_mod = self._reset(monkeypatch)
+        monkeypatch.setattr(rdp_mod, "find_freerdp", lambda *a, **k: None)
+        calls = []
+        monkeypatch.setattr(rdp_mod, "find_freerdp", lambda *a, **k: (calls.append(1), None)[1])
+        assert rdp_mod.freerdp_version() is None
+        assert rdp_mod.freerdp_version() is None
+        assert len(calls) == 1  # not re-probed
+
+    def test_major_version_delegates(self, monkeypatch):
+        rdp_mod = self._reset(monkeypatch)
+        monkeypatch.setattr(rdp_mod, "freerdp_version", lambda: (3, 9, 2))
+        assert rdp_mod.freerdp_major_version() == 3
+
+    def test_major_version_defaults_to_3_when_unknown(self, monkeypatch):
+        rdp_mod = self._reset(monkeypatch)
+        monkeypatch.setattr(rdp_mod, "freerdp_version", lambda: None)
+        assert rdp_mod.freerdp_major_version() == 3
+
+
+class TestFreerdpRailWarning:
+    def test_warns_below_floor(self, monkeypatch):
+        import winpodx.core.rdp as rdp_mod
+
+        monkeypatch.setattr(rdp_mod, "freerdp_version", lambda: (3, 5, 1))
+        msg = rdp_mod.freerdp_rail_warning()
+        assert msg is not None and "3.5.1" in msg and "3.6.0" in msg
+
+    def test_silent_at_floor(self, monkeypatch):
+        import winpodx.core.rdp as rdp_mod
+
+        monkeypatch.setattr(rdp_mod, "freerdp_version", lambda: (3, 6, 0))
+        assert rdp_mod.freerdp_rail_warning() is None
+
+    def test_silent_when_version_unknown(self, monkeypatch):
+        # An undetectable version must not produce a scary message.
+        import winpodx.core.rdp as rdp_mod
+
+        monkeypatch.setattr(rdp_mod, "freerdp_version", lambda: None)
+        assert rdp_mod.freerdp_rail_warning() is None


### PR DESCRIPTION
Follow-up from triaging #785 / #781 (LightWave 3D on Mint / Cinnamon / FreeRDP 3.5.1). The reporter's screenshots show the RemoteApp window arriving with the correct caption but still painted with the Windows logon framebuffer — the #332 / #733 pattern, which old FreeRDP 3.x RAIL is prone to. While checking whether `winpodx doctor` would have told them, I found the warning could not fire at all on some installs.

## Bug

`_check_freerdp` ran its own probe:

```python
subprocess.run([dep.path, "--version"], ...)
```

For a Flatpak FreeRDP, `find_freerdp()` returns a whole command line — `flatpak run --branch=stable com.freerdp.FreeRDP` — not an executable path. Passing that as a single argv element raises `FileNotFoundError`, which the surrounding `except` swallows, so `ver` stayed `None`, the RAIL check was skipped, and doctor reported a plain OK. `core.rdp.freerdp_major_version()` already handled this correctly with `shlex.split`, so the two probes disagreed.

## Change

- New `freerdp_version() -> tuple[int, int, int] | None` in `core.rdp`, behind a single process-wide cache with a sentinel so a failed probe is not retried on every call. It splits the launcher string, so Flatpak works.
- `freerdp_major_version()` becomes a thin wrapper over it — one probe for the whole process, no second implementation.
- `doctor` consumes it instead of rolling its own, which fixes the Flatpak blind spot.
- The 3.6.0 RAIL floor moves to `core.rdp` as `FREERDP_RAIL_FLOOR`, so the launcher warning and the doctor check cannot drift apart.
- A RemoteApp launch now emits the same advisory to stderr and the log when the installed FreeRDP is below the floor. Users hit the symptom (blank window, or one showing the logon screen) well before they think to run doctor. Silent when the version is undetectable or not FreeRDP 3, so an unknown build never produces a scary message on a working setup.

## Tests

10 new cases in `tests/test_rdp.py`: version parsing, the Flatpak launcher split (asserting the exact argv), failed-probe caching, `freerdp_major_version` delegation and its default, and the warning boundary at 3.5.1 / 3.6.0 / unknown. `tests/test_doctor.py`'s `TestCheckFreerdp` now stubs the shared probe rather than re-stubbing `subprocess`. Full suite: 2297 passed.

Does not fix #785 itself — that is the FreeRDP-version / RAIL-timing issue, pending the reporter confirming whether non-LightWave apps behave the same. It does mean the diagnosis reaches them.