### PR TITLE
feat(reverse-open): register Linux apps as Windows URL-scheme handlers (#694)

### DIFF
--- a/config/oem/reverse-open/register-apps.ps1
+++ b/config/oem/reverse-open/register-apps.ps1
@@ -150,6 +150,33 @@ function Resolve-MimeExtensions([string]$Mime) {
     return @()
 }
 
+# Schemes we never register a Linux app as a Windows handler for: code-exec,
+# local-file and settings vectors. Coarse guest-side guard mirroring
+# discover_apps.ps1; core/url_schemes.py owns the authoritative denylist --
+# keep the three in lockstep.
+$script:SchemeDeny = [System.Collections.Generic.HashSet[string]]::new(
+    [string[]]@('file', 'javascript', 'vbscript', 'data', 'about', 'shell', 'res',
+        'chrome', 'chrome-extension', 'ms-settings', 'ms-msdt', 'ms-search',
+        'search-ms', 'hcp', 'its', 'mk', 'ldap', 'help', 'wscript', 'cscript',
+        'view-source'))
+
+function Resolve-MimeScheme([string]$Mime) {
+    <#
+        Return the URL scheme an `x-scheme-handler/<scheme>` MIME names, or ''.
+
+        Resolve-MimeExtensions cannot do this: its `^[a-z]+/(.+)$` pattern does
+        not match `x-scheme-handler` (the dashes), so scheme MIME entries used
+        to fall through and be silently dropped. Users then had to hand-write
+        the registry keys to make a Linux browser handle guest links (#694).
+    #>
+    if ($Mime -notmatch '^x-scheme-handler/(.+)$') { return '' }
+    $s = $matches[1].ToLower().Trim().TrimEnd(':')
+    # RFC 3986 scheme syntax, length-bounded (mirrors core/url_schemes.py).
+    if ($s -notmatch '^[a-z][a-z0-9+.\-]{0,31}$') { return '' }
+    if ($script:SchemeDeny.Contains($s)) { return '' }
+    return $s
+}
+
 # --- main -----------------------------------------------------------------
 
 Write-LogLine 'INFO' "reading apps from $AppsJson"
@@ -329,6 +356,68 @@ foreach ($app in $manifest.apps) {
             }
         }
     }
+    # --- URL schemes (#694) ----------------------------------------------
+    # A Linux app that declares x-scheme-handler/<scheme> should be reachable
+    # when a guest app opens a link of that scheme -- clicking an http link in
+    # Outlook and having it land in the Linux browser is the whole point.
+    #
+    # Two pieces are needed. The ProgID becomes a legal protocol-handler target
+    # by carrying an empty "URL Protocol" value (its shell\open\command is
+    # already `"<exe>" "%1"`, which is exactly what a protocol handler needs).
+    # Then a Capabilities block plus a RegisteredApplications entry makes
+    # Windows list the app in Settings -> Default apps.
+    #
+    # Everything is under HKCU, so no elevation, matching the rest of this
+    # script. Note Windows protects the UserChoice default with a hash: we can
+    # only make the app a SELECTABLE candidate, and the user confirms it in
+    # Settings. That happens to match winpodx's own rule of never silently
+    # seizing a default handler.
+    $schemes = New-Object System.Collections.Generic.HashSet[string]
+    foreach ($mime in $mimes) {
+        $s = Resolve-MimeScheme $mime
+        if ($s) { [void]$schemes.Add($s) }
+    }
+
+    if ($schemes.Count -gt 0) {
+        # Marks the existing ProgID as a protocol handler. Empty string value
+        # is the documented convention.
+        Set-NamedValue $progIdRoot 'URL Protocol' ''
+
+        # Apps claiming http/https must live under StartMenuInternet to appear
+        # in Settings -> Default apps -> Web browser. Anything else (mailto,
+        # vendor schemes) only needs a plain Capabilities key.
+        $isBrowser = $schemes.Contains('http') -or $schemes.Contains('https')
+        if ($isBrowser) {
+            $appCapRoot = "HKCU:\Software\Clients\StartMenuInternet\winpodx-$slug"
+            Set-DefaultValue $appCapRoot $friendly
+            Set-DefaultValue (Join-Path $appCapRoot 'shell\open\command') "`"$exePath`""
+        }
+        else {
+            $appCapRoot = "HKCU:\Software\winpodx\$slug"
+        }
+
+        $capKey = Join-Path $appCapRoot 'Capabilities'
+        Set-NamedValue $capKey 'ApplicationName' $friendly
+        Set-NamedValue $capKey 'ApplicationDescription' $friendly
+
+        $urlAssoc = Join-Path $capKey 'URLAssociations'
+        if (-not (Test-Path -LiteralPath $urlAssoc)) {
+            New-Item -Path $urlAssoc -Force | Out-Null
+        }
+        foreach ($s in $schemes) {
+            New-ItemProperty -Path $urlAssoc -Name $s -Value "winpodx-$slug" `
+                -PropertyType String -Force | Out-Null
+        }
+
+        # RegisteredApplications points Windows at the Capabilities key. The
+        # value data is a registry path relative to HKCU\Software.
+        $capRelative = $appCapRoot -replace '^HKCU:\\Software\\', ''
+        Set-NamedValue 'HKCU:\Software\RegisteredApplications' "winpodx-$slug" `
+            "$capRelative\Capabilities"
+
+        Write-LogLine 'INFO' "registered $slug for scheme(s): $($schemes -join ', ')"
+    }
+
     Write-LogLine 'INFO' "registered $slug (exe=$exeName) for $($exts.Count) extension(s)"
     $registered++
 }

--- a/config/oem/reverse-open/unregister-apps.ps1
+++ b/config/oem/reverse-open/unregister-apps.ps1
@@ -112,6 +112,70 @@ foreach ($appName in $apps) {
     }
 }
 
+# --- URL-scheme registration (#694) ---------------------------------------
+# Mirrors register-apps.ps1: the Capabilities keys that make a Linux app
+# selectable as a Windows protocol handler, and the RegisteredApplications
+# values pointing at them. The per-slug ProgID (which carries the "URL
+# Protocol" marker) is already removed above.
+$removedSchemeReg = 0
+$regAppsKey = 'HKCU:\Software\RegisteredApplications'
+if (Test-Path -LiteralPath $regAppsKey) {
+    try {
+        $props = Get-ItemProperty -LiteralPath $regAppsKey -ErrorAction Stop
+        foreach ($prop in $props.PSObject.Properties) {
+            if ($prop.Name -notlike 'winpodx-*') { continue }
+            if ($DryRun) {
+                Write-LogLine 'INFO' "[dry-run] would remove RegisteredApplications\$($prop.Name)"
+                $removedSchemeReg++
+                continue
+            }
+            try {
+                Remove-ItemProperty -LiteralPath $regAppsKey -Name $prop.Name -Force -ErrorAction Stop
+                Write-LogLine 'INFO' "removed RegisteredApplications\$($prop.Name)"
+                $removedSchemeReg++
+            } catch {
+                Write-LogLine 'WARN' "could not remove RegisteredApplications\$($prop.Name): $($_.Exception.Message)"
+            }
+        }
+    } catch {
+        Write-LogLine 'WARN' "enumerate RegisteredApplications failed: $($_.Exception.Message)"
+    }
+}
+
+# Capabilities live in one of two places depending on whether the app claimed
+# http/https (browsers must sit under StartMenuInternet to show up in
+# Settings -> Default apps -> Web browser).
+$capRoots = @()
+$smiRoot = 'HKCU:\Software\Clients\StartMenuInternet'
+if (Test-Path -LiteralPath $smiRoot) {
+    try {
+        $capRoots += Get-ChildItem -LiteralPath $smiRoot -ErrorAction Stop |
+            Where-Object { $_.PSChildName -like 'winpodx-*' } |
+            Select-Object -ExpandProperty PSPath
+    } catch {
+        Write-LogLine 'WARN' "enumerate StartMenuInternet failed: $($_.Exception.Message)"
+    }
+}
+# Non-browser apps get HKCU\Software\winpodx\<slug>; the whole subtree is ours.
+$winpodxCapRoot = 'HKCU:\Software\winpodx'
+if (Test-Path -LiteralPath $winpodxCapRoot) {
+    $capRoots += $winpodxCapRoot
+}
+foreach ($capPath in $capRoots) {
+    if ($DryRun) {
+        Write-LogLine 'INFO' "[dry-run] would remove $capPath"
+        $removedSchemeReg++
+        continue
+    }
+    try {
+        Remove-Item -LiteralPath $capPath -Recurse -Force -ErrorAction Stop
+        Write-LogLine 'INFO' "removed $capPath"
+        $removedSchemeReg++
+    } catch {
+        Write-LogLine 'WARN' "could not remove ${capPath}: $($_.Exception.Message)"
+    }
+}
+
 # --- per-ext OpenWithList sub-keys + legacy values + OpenWithProgids ---
 # Current scheme: OpenWithList\winpodx-<slug>.exe SUB-KEYS (this is the
 # Windows convention). Pre-fix builds wrote VALUES under OpenWithList

--- a/src/winpodx/cli/doctor.py
+++ b/src/winpodx/cli/doctor.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -46,7 +45,9 @@ from winpodx.core.i18n import tr
 # Oldest FreeRDP 3.x without the RemoteApp/RAIL window-mapping bugs that leave
 # an app connected but its window never shown (#546). 3.5.x and earlier are
 # affected; warn (not fail) below this, since the binary still works otherwise.
-_FREERDP_RAIL_FLOOR = (3, 6, 0)
+# The value itself lives in ``winpodx.core.rdp`` (imported lazily at the check,
+# matching this module's style) so the launcher warning (#785) and this check
+# can never disagree about where the floor sits.
 
 
 @dataclass(frozen=True)
@@ -220,23 +221,15 @@ def _check_freerdp() -> Finding:
         # Best-effort version string for the human reader; a failure to run
         # --version doesn't downgrade the finding (binary exists, that's the
         # signal we care about for doctor).
-        version_line = ""
-        ver: tuple[int, int, int] | None = None
-        try:
-            result = subprocess.run(
-                [dep.path, "--version"],
-                capture_output=True,
-                text=True,
-                timeout=3,
-                check=False,
-            )
-            blob = (result.stdout or "") + (result.stderr or "")
-            version_line = result.stdout.splitlines()[0] if result.stdout else ""
-            m = re.search(r"FreeRDP version\s+(\d+)\.(\d+)\.(\d+)", blob)
-            if m:
-                ver = (int(m.group(1)), int(m.group(2)), int(m.group(3)))
-        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-            pass
+        # Shared with the launcher (winpodx.core.rdp) so both agree and the
+        # probe runs once. Doing it here meant splitting a Flatpak launcher
+        # string wrong, so no version was ever detected on Flatpak hosts and
+        # the RAIL warning below never fired (#785).
+        from winpodx.core.rdp import FREERDP_RAIL_FLOOR as _FREERDP_RAIL_FLOOR
+        from winpodx.core.rdp import freerdp_version
+
+        ver = freerdp_version()
+        version_line = f"FreeRDP version {'.'.join(str(p) for p in ver)}" if ver else ""
         # Old FreeRDP 3.x RAIL: 3.5.x and earlier have window-ordering bugs that
         # leave a RemoteApp connected but its window never mapped (only
         # "xf_Pointer: Invalid appWindow" spam) -- see #546 (Ubuntu/Budgie 24.04

--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -191,13 +191,88 @@ def _media_redirect_base() -> Path:
 # Success-only cache, keyed by preference; a miss is not cached so a
 # mid-session install is picked up.
 _FREERDP_CACHE: dict[str, tuple[str, str]] = {}
-_FREERDP_MAJOR_CACHE: int | None = None
+# Sentinel distinguishes "not probed yet" from "probed, no version found":
+# a failed probe must not re-run --version on every call.
+_UNPROBED = object()
+_FREERDP_VERSION_CACHE: object = _UNPROBED
+
+# FreeRDP 3.5.x and earlier have RAIL window-ordering bugs that leave a
+# RemoteApp connected with its window never mapped, or painted with the stale
+# logon framebuffer (#546, #332, #733, #785). Advisory only: the same binary
+# drives full-desktop sessions and plenty of apps fine.
+FREERDP_RAIL_FLOOR = (3, 6, 0)
+
+
+def freerdp_version() -> tuple[int, int, int] | None:
+    """Return the installed FreeRDP version, or ``None`` if undetectable.
+
+    One probe for the whole process, shared by the launcher and ``doctor``:
+    the launcher path must know the major version to pick the right ``/app:``
+    syntax, and doctor reports the full triple. Probing twice meant doctor
+    re-implemented the lookup and got the Flatpak case wrong — ``find_freerdp``
+    can return a whole ``flatpak run … com.freerdp.FreeRDP`` command line, and
+    running that as a single argv element raises ``FileNotFoundError``, so no
+    version was ever detected on Flatpak hosts and the RAIL warning silently
+    never fired.
+    """
+    global _FREERDP_VERSION_CACHE
+    if _FREERDP_VERSION_CACHE is not _UNPROBED:
+        return _FREERDP_VERSION_CACHE  # type: ignore[return-value]
+
+    _FREERDP_VERSION_CACHE = None
+    found = find_freerdp()
+    if found is None:
+        return None
+
+    path, _kind = found
+    # The launcher string may be a full command ("flatpak run …"), so split it
+    # rather than treating it as one executable path.
+    cmd = shlex.split(path) + ["--version"]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=5, check=False)
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+
+    # FreeRDP --version prints "This is FreeRDP version <major>.<minor>.<patch>".
+    # Be forgiving about which stream it lands on and what surrounds it.
+    blob = (result.stdout or "") + (result.stderr or "")
+    match = re.search(r"FreeRDP version\s+(\d+)\.(\d+)\.(\d+)", blob)
+    if match is None:
+        # Some builds print only "<major>.<minor>"; the major is what the
+        # launcher gates on, so accept that shape too.
+        match = re.search(r"FreeRDP version\s+(\d+)\.(\d+)", blob)
+        if match is None:
+            return None
+        _FREERDP_VERSION_CACHE = (int(match.group(1)), int(match.group(2)), 0)
+        return _FREERDP_VERSION_CACHE  # type: ignore[return-value]
+
+    _FREERDP_VERSION_CACHE = (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+    return _FREERDP_VERSION_CACHE  # type: ignore[return-value]
+
+
+def freerdp_rail_warning() -> str | None:
+    """Human-readable warning when the installed FreeRDP predates working RAIL.
+
+    ``None`` when the version is fine, undetectable, or not FreeRDP 3 — an
+    unknown version must not produce a scary message on a working setup.
+    """
+    ver = freerdp_version()
+    if ver is None or ver[0] != 3 or ver >= FREERDP_RAIL_FLOOR:
+        return None
+    shown = ".".join(str(p) for p in ver)
+    floor = ".".join(str(p) for p in FREERDP_RAIL_FLOOR)
+    return (
+        f"FreeRDP {shown} is older than {floor} and has known RemoteApp window bugs: "
+        "the app may connect without ever showing a window, or show one still painted "
+        "with the Windows logon screen. Upgrading FreeRDP (newer distro package, or the "
+        "winpodx AppImage, which bundles its own) is the fix."
+    )
 
 
 def freerdp_major_version() -> int:
     """Return the FreeRDP major version (2 or 3), or 3 on detection failure.
 
-    Result is cached in ``_FREERDP_MAJOR_CACHE``. We default to 3 when
+    Thin wrapper over :func:`freerdp_version` (one shared probe). Defaults to 3 when
     the version probe can't run cleanly because: (a) winpodx targets
     FreeRDP 3+ anyway, (b) the combined ``/app:program:X,name:Y,cmd:Z``
     syntax is FreeRDP 3-only and is what most users hit, (c) on
@@ -212,36 +287,10 @@ def freerdp_major_version() -> int:
     parses the entire combined string as a literal path and lands on
     the Store fallback (#158).
     """
-    global _FREERDP_MAJOR_CACHE
-    if _FREERDP_MAJOR_CACHE is not None:
-        return _FREERDP_MAJOR_CACHE
-
-    found = find_freerdp()
-    if found is None:
-        _FREERDP_MAJOR_CACHE = 3  # safest default; later code paths gate on this
-        return _FREERDP_MAJOR_CACHE
-
-    path, _kind = found
-    # ``flatpak run ...`` returns the inner FreeRDP version too; the
-    # caller passes the whole launcher string so shlex it.
-    cmd = shlex.split(path) + ["--version"]
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
-        _FREERDP_MAJOR_CACHE = 3
-        return _FREERDP_MAJOR_CACHE
-    # FreeRDP --version prints "This is FreeRDP version <major>.<minor>.<patch>"
-    # on stdout. Be forgiving about stream choice and surrounding text.
-    blob = (result.stdout or "") + (result.stderr or "")
-    match = re.search(r"FreeRDP version\s+(\d+)\.", blob)
-    if not match:
-        _FREERDP_MAJOR_CACHE = 3
-        return _FREERDP_MAJOR_CACHE
-    try:
-        _FREERDP_MAJOR_CACHE = int(match.group(1))
-    except ValueError:
-        _FREERDP_MAJOR_CACHE = 3
-    return _FREERDP_MAJOR_CACHE
+    ver = freerdp_version()
+    # 3 is the safest default: winpodx targets FreeRDP 3+, and the combined
+    # ``/app:`` syntax the launcher builds is FreeRDP-3-only.
+    return ver[0] if ver is not None else 3
 
 
 def _find_native_freerdp() -> tuple[str, str] | None:
@@ -1629,6 +1678,16 @@ def launch_app(
     # spam. Wait (best-effort, agent-only) until the desktop is interactive.
     if is_remoteapp and cfg.pod.backend in ("podman", "docker"):
         _wait_session_interactive(cfg, timeout=_INTERACTIVE_WAIT_TIMEOUT)
+
+    # Same advisory `winpodx doctor` gives, surfaced where the symptom appears
+    # (#785). The wait above only helps when the guest agent answers; on an old
+    # FreeRDP the window can still come up blank or painted with the logon
+    # screen, and users hit that long before they think to run doctor.
+    if is_remoteapp:
+        rail_warning = freerdp_rail_warning()
+        if rail_warning:
+            log.warning("%s", rail_warning)
+            print(f"warning: {rail_warning}", file=sys.stderr)
 
     log.info("Launching RDP: %s", _redact_cmd_for_log(cmd))
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -138,12 +138,10 @@ class TestCheckFreerdp:
             "winpodx.utils.deps.check_freerdp",
             lambda: DepCheck(name="xfreerdp", found=found, path="/usr/bin/xfreerdp3"),
         )
-
-        class _Res:
-            stdout = f"This is FreeRDP version {version} (...)\n" if version else ""
-            stderr = ""
-
-        monkeypatch.setattr(doctor.subprocess, "run", lambda *a, **k: _Res())
+        # doctor consumes the launcher's single shared probe (#785), so stub
+        # that rather than re-stubbing subprocess here.
+        parsed = tuple(int(p) for p in version.split(".")) if version else None
+        monkeypatch.setattr("winpodx.core.rdp.freerdp_version", lambda: parsed)
 
     def test_old_3x_warns(self, monkeypatch):
         self._patch(monkeypatch, version="3.5.1")

--- a/tests/test_rdp.py
+++ b/tests/test_rdp.py
@@ -1607,3 +1607,92 @@ class TestKeyboardLayoutPropagation:
         cmd, _ = build_rdp_command(cfg)
         kbd_flags = [c for c in cmd if c.startswith("/kbd")]
         assert kbd_flags == ["/kbd:layout:0x00000409"]  # only the user's, no auto
+
+
+# --- #785: one shared FreeRDP version probe + RAIL warning -------------------
+
+
+class TestFreerdpVersionProbe:
+    """The launcher and doctor must share one probe, and it must handle the
+    Flatpak launcher string (a whole command, not a single executable)."""
+
+    def _reset(self, monkeypatch):
+        import winpodx.core.rdp as rdp_mod
+
+        monkeypatch.setattr(rdp_mod, "_FREERDP_VERSION_CACHE", rdp_mod._UNPROBED)
+        return rdp_mod
+
+    def test_parses_version_triple(self, monkeypatch):
+        rdp_mod = self._reset(monkeypatch)
+        monkeypatch.setattr(
+            rdp_mod, "find_freerdp", lambda *a, **k: ("/usr/bin/xfreerdp3", "xfreerdp")
+        )
+
+        class _Res:
+            stdout = "This is FreeRDP version 3.5.1 (release)\n"
+            stderr = ""
+
+        monkeypatch.setattr(rdp_mod.subprocess, "run", lambda *a, **k: _Res())
+        assert rdp_mod.freerdp_version() == (3, 5, 1)
+
+    def test_flatpak_launcher_string_is_split(self, monkeypatch):
+        # Regression: running the whole "flatpak run ..." string as one argv
+        # element raised FileNotFoundError, so no version was ever detected on
+        # Flatpak hosts and the RAIL warning silently never fired.
+        rdp_mod = self._reset(monkeypatch)
+        launcher = "flatpak run --branch=stable com.freerdp.FreeRDP"
+        monkeypatch.setattr(rdp_mod, "find_freerdp", lambda *a, **k: (launcher, "flatpak"))
+        seen: list[list[str]] = []
+
+        class _Res:
+            stdout = "This is FreeRDP version 3.7.0\n"
+            stderr = ""
+
+        def _run(cmd, *a, **k):
+            seen.append(cmd)
+            return _Res()
+
+        monkeypatch.setattr(rdp_mod.subprocess, "run", _run)
+        assert rdp_mod.freerdp_version() == (3, 7, 0)
+        assert seen[0] == ["flatpak", "run", "--branch=stable", "com.freerdp.FreeRDP", "--version"]
+
+    def test_failed_probe_is_cached(self, monkeypatch):
+        rdp_mod = self._reset(monkeypatch)
+        monkeypatch.setattr(rdp_mod, "find_freerdp", lambda *a, **k: None)
+        calls = []
+        monkeypatch.setattr(rdp_mod, "find_freerdp", lambda *a, **k: (calls.append(1), None)[1])
+        assert rdp_mod.freerdp_version() is None
+        assert rdp_mod.freerdp_version() is None
+        assert len(calls) == 1  # not re-probed
+
+    def test_major_version_delegates(self, monkeypatch):
+        rdp_mod = self._reset(monkeypatch)
+        monkeypatch.setattr(rdp_mod, "freerdp_version", lambda: (3, 9, 2))
+        assert rdp_mod.freerdp_major_version() == 3
+
+    def test_major_version_defaults_to_3_when_unknown(self, monkeypatch):
+        rdp_mod = self._reset(monkeypatch)
+        monkeypatch.setattr(rdp_mod, "freerdp_version", lambda: None)
+        assert rdp_mod.freerdp_major_version() == 3
+
+
+class TestFreerdpRailWarning:
+    def test_warns_below_floor(self, monkeypatch):
+        import winpodx.core.rdp as rdp_mod
+
+        monkeypatch.setattr(rdp_mod, "freerdp_version", lambda: (3, 5, 1))
+        msg = rdp_mod.freerdp_rail_warning()
+        assert msg is not None and "3.5.1" in msg and "3.6.0" in msg
+
+    def test_silent_at_floor(self, monkeypatch):
+        import winpodx.core.rdp as rdp_mod
+
+        monkeypatch.setattr(rdp_mod, "freerdp_version", lambda: (3, 6, 0))
+        assert rdp_mod.freerdp_rail_warning() is None
+
+    def test_silent_when_version_unknown(self, monkeypatch):
+        # An undetectable version must not produce a scary message.
+        import winpodx.core.rdp as rdp_mod
+
+        monkeypatch.setattr(rdp_mod, "freerdp_version", lambda: None)
+        assert rdp_mod.freerdp_rail_warning() is None

--- a/tests/test_reverse_open_register_ps1.py
+++ b/tests/test_reverse_open_register_ps1.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: MIT
+"""Sanity checks for the reverse-open guest registration scripts.
+
+Both .ps1 files run inside the Windows guest, so CI can't exercise them end to
+end. These checks (a) pwsh-AST-parse them when pwsh is on PATH (CI has it;
+skipped on the dev box) so a syntax error can't merge silently, and (b)
+statically assert the URL-scheme registration invariants (#694): the scheme
+denylist stays in lockstep with the host's, the ProgID is marked as a protocol
+handler, and everything the register script writes is torn down again.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REVERSE_OPEN_DIR = REPO_ROOT / "config" / "oem" / "reverse-open"
+REGISTER_PS1 = REVERSE_OPEN_DIR / "register-apps.ps1"
+UNREGISTER_PS1 = REVERSE_OPEN_DIR / "unregister-apps.ps1"
+
+
+@pytest.fixture(scope="module")
+def register_source() -> str:
+    assert REGISTER_PS1.is_file(), f"register-apps.ps1 missing at {REGISTER_PS1}"
+    return REGISTER_PS1.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def unregister_source() -> str:
+    assert UNREGISTER_PS1.is_file(), f"unregister-apps.ps1 missing at {UNREGISTER_PS1}"
+    return UNREGISTER_PS1.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("script", [REGISTER_PS1, UNREGISTER_PS1], ids=lambda p: p.name)
+def test_pwsh_parse(script: Path) -> None:
+    """If pwsh is on PATH, the script must parse without errors."""
+    pwsh = shutil.which("pwsh")
+    if not pwsh:
+        pytest.skip("pwsh not installed on this host")
+    cmd = [
+        pwsh,
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        (
+            "$errors = $null; "
+            f"[void][System.Management.Automation.Language.Parser]::ParseFile('{script}', "
+            "[ref]$null, [ref]$errors); "
+            "if ($errors -and $errors.Count -gt 0) { "
+            "  $errors | ForEach-Object { Write-Error $_.ToString() }; exit 1 "
+            "}"
+        ),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, (
+        f"pwsh parse failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+
+
+def test_scheme_denylist_matches_the_host(register_source: str) -> None:
+    """The guest-side guard is coarse, but it must not permit anything the
+    host's authoritative denylist refuses -- otherwise a scheme could be
+    registered on the guest that the listener will always reject."""
+    from winpodx.core.url_schemes import DANGEROUS_SCHEMES
+
+    for scheme in DANGEROUS_SCHEMES:
+        assert f"'{scheme}'" in register_source, f"{scheme} missing from guest denylist"
+
+
+def test_scheme_mime_is_recognised(register_source: str) -> None:
+    """Resolve-MimeExtensions can't match x-scheme-handler/* (its pattern has
+    no dashes), which is why scheme MIMEs used to be dropped silently."""
+    assert "Resolve-MimeScheme" in register_source
+    assert "^x-scheme-handler/(.+)$" in register_source
+
+
+def test_scheme_syntax_rule_mirrors_the_host(register_source: str) -> None:
+    from winpodx.core.url_schemes import SAFE_SCHEME_RE
+
+    # Same shape as core/url_schemes.py's SAFE_SCHEME_RE, in PowerShell form.
+    assert r"^[a-z][a-z0-9+.\-]{0,31}$" in register_source
+    assert SAFE_SCHEME_RE.pattern == r"^[a-z][a-z0-9+.\-]{0,31}$"
+
+
+def test_progid_is_marked_as_protocol_handler(register_source: str) -> None:
+    """Without an (empty) "URL Protocol" value the ProgID is not a legal
+    protocol-handler target and Windows ignores it for links."""
+    assert "'URL Protocol'" in register_source
+
+
+def test_browser_schemes_register_under_start_menu_internet(register_source: str) -> None:
+    """An app claiming http/https only appears in Settings -> Default apps ->
+    Web browser if it lives under StartMenuInternet."""
+    assert "StartMenuInternet" in register_source
+    assert "Contains('http')" in register_source
+
+
+def test_registered_applications_entry_is_written(register_source: str) -> None:
+    assert "RegisteredApplications" in register_source
+    assert "URLAssociations" in register_source
+
+
+def test_unregister_removes_everything_register_writes(unregister_source: str) -> None:
+    """Every scheme-registration surface must be torn down, or a reinstall
+    leaves dangling handlers pointing at a shim that no longer exists."""
+    for surface in (
+        "RegisteredApplications",
+        "StartMenuInternet",
+        r"HKCU:\Software\winpodx",
+    ):
+        assert surface in unregister_source, f"{surface} not cleaned up"
+
+
+def test_unregister_honours_dry_run_for_scheme_keys(unregister_source: str) -> None:
+    """The script's --DryRun contract: report, never mutate."""
+    scheme_section = unregister_source.split("URL-scheme registration")[1]
+    scheme_section = scheme_section.split("per-ext OpenWithList")[0]
+    assert "[dry-run] would remove RegisteredApplications" in scheme_section
+    assert scheme_section.count("if ($DryRun)") >= 2


### PR DESCRIPTION
> **Needs a real-Windows smoke test before merge** — this changes guest-side registry writes, which pwsh-on-Linux parsing cannot validate.

Second half of #694. #796 taught the host listener to accept a URL from the guest; this makes the guest actually send one without the user hand-writing registry keys.

## Cause

`register-apps.ps1` resolves a MIME type to file extensions with `Resolve-MimeExtensions`, whose pattern is `^[a-z]+/(.+)$`. That cannot match `x-scheme-handler` — the dashes — so every scheme MIME fell through and was silently dropped. Nothing on the guest ever knew a Linux app could handle `http`, `mailto`, or a vendor scheme, which is why the reporter had to write `StartMenuInternet` / `RegisteredApplications` keys by hand.

## Change

`register-apps.ps1` extracts schemes from the app's MIME list and registers them:

- The existing per-slug ProgID gets an empty `URL Protocol` value, which is what makes it a legal protocol-handler target. Its `shell\open\command` was already `"<exe>" "%1"`, exactly the shape a protocol handler needs.
- A `Capabilities` block with `URLAssociations`, plus a `RegisteredApplications` entry pointing at it, so Windows lists the app in Settings → Default apps. Apps claiming `http`/`https` are written under `Clients\StartMenuInternet\winpodx-<slug>` (required to appear as a Web browser choice); everything else uses a plain `HKCU\Software\winpodx\<slug>`.

`unregister-apps.ps1` removes every surface the register side writes, honouring `-DryRun`.

### Constraints worth stating

- **All HKCU**, so no elevation — consistent with the rest of the script.
- **We can only make the app selectable.** Windows protects the `UserChoice` default with a hash, so nothing here silently becomes the default handler; the user confirms in Settings. That happens to match winpodx's existing rule about never seizing `http`/`https`.
- **No shim rebuild.** The Rust binary is untouched, so there is no new antivirus exposure (#425).

### Scheme guard

Mirrors `discover_apps.ps1` and `core/url_schemes.py`: RFC 3986 syntax, length-bounded, minus the code-exec / local-file / settings denylist (`file`, `javascript`, `data`, `ms-settings`, …). A test asserts the guest denylist covers every entry in the host's `DANGEROUS_SCHEMES`, so the two cannot drift.

## Tests

New `tests/test_reverse_open_register_ps1.py`: pwsh AST parse of both scripts (runs in CI, skipped where pwsh is absent), denylist parity with the host, the syntax rule matching `SAFE_SCHEME_RE`, the `URL Protocol` marker, the StartMenuInternet branch for browsers, and that unregister tears down each surface and respects `-DryRun`. 409 reverse-open / sync / OEM tests pass.

## Smoke checklist for the guest

1. `winpodx host-open refresh` on a host where a browser declares `x-scheme-handler/http`.
2. In Windows: Settings → Apps → Default apps — the Linux browser should be listed and selectable.
3. Select it, then click an `http` link in a guest app: it should open on the Linux side.
4. `winpodx host-open unregister-guest`, then confirm `HKCU\Software\RegisteredApplications` has no `winpodx-*` values left.