### PR TITLE
feat(pod): roll the dockur pin to v6.03 and stop forcing rootless user-mode (#735, #770)

### DIFF
--- a/config/oem/VERSIONS.txt
+++ b/config/oem/VERSIONS.txt
@@ -18,7 +18,7 @@
 # describes what winpodx deliberately uses.
 #
 # Format: <key>=<value>
-dockur=v6.02
-dockur-digest=sha256:8cc6f8bc4a60c078141fd3bcf7d2df69ae063a11d98be31a57429afe0dca66da
-dockur-arm=v5.16
-dockur-arm-digest=sha256:ece93263254567c6cd4ce420b1fff793d2326f4535555bdf592f40ab173a7bed
+dockur=v6.03
+dockur-digest=sha256:743847e75b776790c059f33ac6654f84727ba36a6d458a61e37cb2b2f043d168
+dockur-arm=v6.03
+dockur-arm-digest=sha256:f1e9edd9e6ab6a3aee9127fd667b181f783caa8c7d93507755e0f5e081acec06

--- a/src/winpodx/cli/migrate.py
+++ b/src/winpodx/cli/migrate.py
@@ -703,18 +703,22 @@ def _ensure_canonical_image_pin(non_interactive: bool) -> None:
     Idempotent: re-running migrate on an already-pinned config is a
     no-op (string equality check returns False before any rewrite).
     """
-    from winpodx.core.config import DOCKUR_IMAGE_PIN, Config
+    from winpodx.core.config import Config, _default_pod_image
 
     cfg = Config.load()
     if cfg.pod.backend not in ("podman", "docker"):
         return  # the manual backend doesn't use the dockur image / compose
 
-    pin_changed = cfg.pod.image != DOCKUR_IMAGE_PIN
+    # Architecture-aware, like a fresh install: aarch64 hosts get the ARM pin.
+    # This used to hard-code DOCKUR_IMAGE_PIN, so every migrate on an ARM host
+    # silently rewrote the config to the x86 image.
+    canonical_pin = _default_pod_image()
+    pin_changed = cfg.pod.image != canonical_pin
     if pin_changed:
         print("\nAligning container image with this WinPodX version...")
         print(f"  was: {cfg.pod.image}")
-        print(f"  now: {DOCKUR_IMAGE_PIN}")
-        cfg.pod.image = DOCKUR_IMAGE_PIN
+        print(f"  now: {canonical_pin}")
+        cfg.pod.image = canonical_pin
         cfg.save()
 
     # Always regenerate compose.yaml on upgrade — NOT just when the image pin

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -1154,7 +1154,14 @@ _DOWNLOAD_PCT_RE = re.compile(r"([0-9]{1,3})%")
 # printSizeProgress and the growing line is a SIZE chain instead:
 # "512MiB → 1GiB → 1.5GiB → ..." -- no percent tokens at all. Scrape those
 # too so the heartbeat can show "5.5GiB" rather than nothing.
-_DOWNLOAD_SIZE_RE = re.compile(r"([0-9]+(?:\.[0-9]+)?[MG]iB)")
+#
+# dockur v6.03 changed the rendering: progress.sh swapped
+# ``numfmt --to=iec-i --suffix=B`` for ``numfmt --to=iec --suffix=B`` piped
+# through a sed that inserts a space, so the same chain now reads
+# "512 MB -> 1.5 GB". Match both spellings (optional space, optional "i") so
+# the heartbeat keeps working across the pin bump and for anyone still on an
+# older image.
+_DOWNLOAD_SIZE_RE = re.compile(r"([0-9]+(?:\.[0-9]+)?\s?[KMGT]i?B)")
 
 
 class _LineSplitter:

--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -158,13 +158,22 @@ def _validate_device_entry(entry: object) -> str | None:
 # current ``:latest`` digest, paste below. See ``winpodx setup --update
 # -image`` for the runtime equivalent users invoke explicitly.
 #
-# As of 2026-07-18 (dockur/windows v6.02 — QEMU base v7.37, improved
-# download-progress output in the container log (upstream follow-up to the
-# v6.01 buffered-download saga), Windows reinstall detection, QEMU errors
-# surfaced on unexpected exit; requested by @kroese in #735):
+# As of 2026-07-27: the dockur/windows v6.03 release build (dockur revision
+# f6fcb469, QEMU base v7.40). The v6.02 and v6.03 tags point at the same
+# commit — v6.03 is a re-tag — so the version label is cosmetic between them.
+#
+# What matters is that the PREVIOUS pin (sha256:8cc6f8bc…) was not the v6.02
+# release build at all: it was a rolling master build created 2026-07-17
+# 21:26 UTC on QEMU base 7.37. kroese's rootless fix — an OUTPUT-chain DNAT
+# rule so podman's rootlessport, which dials the published port from inside
+# the container's netns and therefore misses PREROUTING, still reaches the
+# guest — landed in the QEMU base at 2026-07-18 13:16 UTC (qemus/qemu
+# ceed7b05c8, first shipped in base v7.37). The old pin predates it by
+# ~16 hours, so #770's root cause was still live in what winpodx shipped.
+# This bump is what actually delivers that fix (#735, #770).
 DOCKUR_IMAGE_PIN = (
     "docker.io/dockurr/windows@sha256:"
-    "8cc6f8bc4a60c078141fd3bcf7d2df69ae063a11d98be31a57429afe0dca66da"
+    "743847e75b776790c059f33ac6654f84727ba36a6d458a61e37cb2b2f043d168"
 )
 
 # Pinned dockur/windows-arm image — used as the default ``cfg.pod.image``
@@ -174,7 +183,14 @@ DOCKUR_IMAGE_PIN = (
 # OCI index, so container runtimes pick the right platform manifest
 # (amd64 or arm64) automatically.
 #
-# As of 2026-06-10 (dockur/windows-arm v5.15, :latest security rebuild):
+# Left where it is deliberately. ARM is exploratory (#141 phase 4/7 open, #140
+# unresolved): nothing here can boot an ARM guest, so rolling this pin forward
+# four minors would ship an unverified image to the users least able to
+# diagnose it. The VERSIONS.txt baseline tracks upstream separately.
+#
+# As of 2026-06-06 — a 5.16-labelled build of dockur/windows-arm (revision
+# 97861800) on QEMU base 7.32. The comment previously said "v5.15", which the
+# image's own OCI metadata contradicts:
 DOCKUR_IMAGE_ARM_PIN = (
     "docker.io/dockurr/windows-arm@sha256:"
     "7c28ddbbe69eb02900bef3b7ab3ad60fbd5fb409524a307a60a3c934f80a9dd5"
@@ -357,6 +373,24 @@ class PodConfig:
     # expanded at use time. Only files under the shared directory are
     # reachable from the guest afterwards (see ``core/rdp.linux_to_unc``).
     home_share: str = ""
+    # #735/#770: how the container reaches the network. Empty (the default)
+    # leaves the choice to dockur, which picks bridge NAT where it works and
+    # falls back to user-mode (passt) otherwise.
+    #
+    # ``"user"`` forces user-mode. That was hard-coded for rootless Podman in
+    # 0.10.3 because rootlessport dials the published port from inside the
+    # container's netns, missing the PREROUTING DNAT rule, so the guest's
+    # NAT-internal address was unreachable and RDP never connected. dockur's
+    # QEMU base ≥ 7.37 adds a matching OUTPUT-chain rule, which the image
+    # pinned from 0.10.5 carries, so the force is no longer applied by
+    # default — but the escape hatch stays: a host where that rule does not
+    # match (rootlessport dialling 127.0.0.1 inside the netns, say) can set
+    # ``network = "user"`` and get the 0.10.3 behaviour back in one command,
+    # rather than being stuck with a pod whose RDP never comes up.
+    #
+    # Sanitised to "" or "user" in ``__post_init__`` -- the value reaches
+    # compose.yaml, so it is never free-form.
+    network: str = ""
     # v0.5.x: Windows installation language/region/keyboard settings.
     # Passed through to dockur's LANGUAGE, REGION, KEYBOARD env vars.
     # Defaults to English (US). Common values for Spanish:
@@ -581,6 +615,12 @@ class PodConfig:
         # config-set time (the user may create it later); note it if missing so
         # a typo doesn't silently hand the guest an empty \\tsclient\home.
         self.home_share = _sanitise_home_share(self.home_share)
+        # network (#735/#770): "" (let dockur choose) or "user" (force passt).
+        # The value is interpolated into compose.yaml, so anything else -- a
+        # hand-edited TOML, a typo -- coerces back to "" rather than reaching
+        # the container as an unknown NETWORK value.
+        _net = self.network.strip().lower() if isinstance(self.network, str) else ""
+        self.network = _net if _net in ("", "user") else ""
         if self.home_share:
             try:
                 _hs_missing = not Path(self.home_share).expanduser().exists()
@@ -940,6 +980,7 @@ class Config:
                 "max_sessions": self.pod.max_sessions,
                 "storage_path": self.pod.storage_path,
                 "home_share": self.pod.home_share,
+                "network": self.pod.network,
                 "language": self.pod.language,
                 "region": self.pod.region,
                 "keyboard": self.pod.keyboard,

--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -836,20 +836,23 @@ def _build_compose_content(cfg: Config) -> str:
     # ("Property 'e1000.host_mtu' not found"). Pinning MTU=1500 makes dockur emit
     # a plain ``-device e1000`` (no host_mtu). Empty MTU for off/balanced keeps
     # dockur's virtio auto-MTU.
-    # Network mode (#770 regression fix): rootless Podman must force dockur's
-    # user-mode (passt) path. Bridge NAT -- what the container auto-picks when
-    # NETWORK is unset -- lands the guest on a NAT-internal 172.x address that
-    # the host's forwarded RDP port never reaches on rootless hosts (the
-    # #269/#387 class). Rootful Podman and Docker keep auto-selection: NAT is
-    # validated there and forwards published ports correctly. USER_PORTS stays
-    # emitted unconditionally -- it is the passt-fallback port list, ignored
-    # under NAT by design, so it is harmless when we don't force user-mode.
+    # Network mode (#735, #770). 0.10.3 forced dockur's user-mode (passt) path
+    # on rootless Podman: bridge NAT put the guest on a NAT-internal address
+    # that the host's forwarded RDP port never reached, because rootlessport
+    # dials the published port from INSIDE the container's netns and so takes
+    # the OUTPUT chain rather than PREROUTING, which dockur's DNAT rule did not
+    # cover. QEMU base >= 7.37 adds the matching OUTPUT rule, and the image
+    # pinned from 0.10.5 carries it, so the force is gone and dockur picks the
+    # mode again.
+    #
+    # ``pod.network`` remains as the escape hatch for a host the upstream fix
+    # misses -- setting it to "user" restores the 0.10.3 behaviour. Already
+    # sanitised to "" or "user" by PodConfig, so it is safe to interpolate.
+    # USER_PORTS stays emitted unconditionally: it is the passt-fallback port
+    # list, ignored under NAT by design.
     network_env = ""
-    if cfg.pod.backend == "podman":
-        from winpodx.backend.podman import is_rootless_podman
-
-        if is_rootless_podman():
-            network_env = '      NETWORK: "user"\n'
+    if cfg.pod.network:
+        network_env = f'      NETWORK: "{cfg.pod.network}"\n'
 
     if cfg.pod.disguise_max:
         disk_type, adapter, vga, mtu = "sata", "e1000", "std", "1500"

--- a/tests/test_compose_network.py
+++ b/tests/test_compose_network.py
@@ -11,14 +11,15 @@ NAT but never forwarded the published ports on to the VM (so the agent port
 hung ``pod wait-ready``). dockur **v6.01** (@kroese) rewrote the rootless-Podman
 NAT port-forwarding, so 0.10.1 stopped forcing the mode (#735).
 
-That regressed rootless hosts the rewrite did not fully cover: the container
-picked bridge NAT, the guest got a NAT-internal ``172.x`` IP, and the host's
-forwarded RDP port never reached it (#770). So winpodx now re-forces
-``NETWORK: "user"`` on **rootless Podman only** -- rootful Podman and Docker,
-where NAT is validated, keep dockur's auto-selection. ``USER_PORTS`` stays
-emitted unconditionally as the passt-fallback path (NAT ignores it by design,
-forwarding every non-``HOST_PORTS`` port to the VM), so it is harmless when we
-do not force user-mode.
+That regressed rootless hosts the rewrite did not fully cover, and 0.10.3
+re-forced user-mode there (#770). The real cause turned out to be that
+podman's rootlessport dials the published port from inside the container's
+netns, so it traverses OUTPUT rather than PREROUTING and dockur's DNAT rule
+never matched. QEMU base >= 7.37 adds the matching OUTPUT rule, and the image
+pinned from 0.10.5 carries it, so the force is gone again -- dockur picks the
+mode, and ``pod.network`` is the escape hatch for a host the upstream fix
+misses. ``USER_PORTS`` stays emitted unconditionally as the passt-fallback
+path (NAT ignores it by design), so it is harmless either way.
 """
 
 from __future__ import annotations
@@ -41,34 +42,63 @@ def _cfg() -> Config:
     return cfg
 
 
-def test_rootless_podman_forces_network_user():
-    # #770: on rootless Podman re-force user-mode (passt); NAT's 172.x guest IP
-    # is unreachable for host-forwarded RDP there.
+def test_no_network_forced_by_default():
+    # 0.10.5: the pinned image carries the OUTPUT-chain DNAT fix, so dockur
+    # picks the mode again on every backend -- rootless included.
     with patch("winpodx.backend.podman.is_rootless_podman", return_value=True):
         content = _build_compose_content(_cfg())
-    assert 'NETWORK: "user"' in content
-    assert "slirp" not in content
+    assert "NETWORK:" not in content
     assert "USER_PORTS:" in content
 
 
 def test_rootful_podman_does_not_force_network():
-    # Rootful Podman keeps dockur's auto-selection (NAT is validated there).
     with patch("winpodx.backend.podman.is_rootless_podman", return_value=False):
         content = _build_compose_content(_cfg())
     assert "NETWORK:" not in content
     assert "USER_PORTS:" in content
 
 
-def test_docker_backend_never_forces_network():
-    # Docker is excluded entirely -- the rootless detector is podman-specific
-    # and must not even be consulted on the docker path.
+def test_docker_backend_does_not_force_network():
     cfg = _cfg()
     cfg.pod.backend = "docker"
-    with patch("winpodx.backend.podman.is_rootless_podman", return_value=True) as detector:
-        content = _build_compose_content(cfg)
+    content = _build_compose_content(cfg)
     assert "NETWORK:" not in content
     assert "USER_PORTS:" in content
-    detector.assert_not_called()
+
+
+def test_pod_network_user_is_the_escape_hatch():
+    # A host the upstream fix misses sets this and gets 0.10.3 behaviour back,
+    # instead of a pod whose RDP never comes up and no way to change it.
+    cfg = _cfg()
+    cfg.pod.network = "user"
+    content = _build_compose_content(cfg)
+    assert 'NETWORK: "user"' in content
+    assert "USER_PORTS:" in content
+
+
+def test_pod_network_applies_on_docker_too():
+    cfg = _cfg()
+    cfg.pod.backend = "docker"
+    cfg.pod.network = "user"
+    content = _build_compose_content(cfg)
+    assert 'NETWORK: "user"' in content
+
+
+def test_pod_network_rejects_unknown_values():
+    # The value is interpolated into compose.yaml, so a hand-edited TOML must
+    # not be able to put arbitrary text there.
+    cfg = _cfg()
+    cfg.pod.network = "bridge; rm -rf /"
+    cfg.pod.__post_init__()
+    assert cfg.pod.network == ""
+    assert "NETWORK:" not in _build_compose_content(cfg)
+
+
+def test_pod_network_normalises_case_and_space():
+    cfg = _cfg()
+    cfg.pod.network = "  USER  "
+    cfg.pod.__post_init__()
+    assert cfg.pod.network == "user"
 
 
 def test_compose_ballooning_off_unconditional():

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -958,3 +958,52 @@ def test_canonical_pin_no_recreate_when_compose_unchanged(tmp_path):
         _ensure_canonical_image_pin(non_interactive=True)
     stop.assert_not_called()
     start.assert_not_called()
+
+
+def test_canonical_pin_is_architecture_aware(tmp_path):
+    """On aarch64 the canonical pin is the ARM image. This used to hard-code
+    DOCKUR_IMAGE_PIN, so every migrate on an ARM host silently rewrote the
+    config to the x86 image."""
+    from winpodx.cli.migrate import _ensure_canonical_image_pin
+    from winpodx.core.config import DOCKUR_IMAGE_ARM_PIN
+    from winpodx.core.pod import PodState
+
+    compose = tmp_path / "compose.yaml"
+    compose.write_text("OLD", encoding="utf-8")
+    cfg = MagicMock()
+    cfg.pod.backend = "podman"
+    cfg.pod.image = "docker.io/dockurr/windows@sha256:something-stale"
+
+    with (
+        patch("winpodx.core.config.Config.load", return_value=cfg),
+        patch("platform.machine", return_value="aarch64"),
+        patch("winpodx.utils.paths.config_dir", return_value=tmp_path),
+        patch("winpodx.core.compose.generate_compose"),
+        patch("winpodx.core.pod.pod_status", return_value=MagicMock(state=PodState.STOPPED)),
+    ):
+        _ensure_canonical_image_pin(non_interactive=True)
+
+    assert cfg.pod.image == DOCKUR_IMAGE_ARM_PIN
+
+
+def test_canonical_pin_uses_x86_image_on_x86(tmp_path):
+    from winpodx.cli.migrate import _ensure_canonical_image_pin
+    from winpodx.core.config import DOCKUR_IMAGE_PIN
+    from winpodx.core.pod import PodState
+
+    compose = tmp_path / "compose.yaml"
+    compose.write_text("OLD", encoding="utf-8")
+    cfg = MagicMock()
+    cfg.pod.backend = "podman"
+    cfg.pod.image = "docker.io/dockurr/windows@sha256:something-stale"
+
+    with (
+        patch("winpodx.core.config.Config.load", return_value=cfg),
+        patch("platform.machine", return_value="x86_64"),
+        patch("winpodx.utils.paths.config_dir", return_value=tmp_path),
+        patch("winpodx.core.compose.generate_compose"),
+        patch("winpodx.core.pod.pod_status", return_value=MagicMock(state=PodState.STOPPED)),
+    ):
+        _ensure_canonical_image_pin(non_interactive=True)
+
+    assert cfg.pod.image == DOCKUR_IMAGE_PIN

--- a/tests/test_wait_ready_eta.py
+++ b/tests/test_wait_ready_eta.py
@@ -270,6 +270,34 @@ def test_size_chain_scraped_when_no_percent() -> None:
     assert lines[0].startswith("❯ Downloading Windows 11")
 
 
+def test_size_chain_scraped_in_v603_format() -> None:
+    """dockur v6.03 renders the same chain as "512 MB -> 1.5 GB": progress.sh
+    swapped `numfmt --to=iec-i` for `--to=iec` piped through a sed that inserts
+    a space. The old MiB/GiB-only pattern stopped matching entirely, so the
+    heartbeat showed nothing on the new image."""
+    import threading
+
+    from winpodx.cli.pod import _iter_container_lines
+
+    class _FakeStream:
+        def __init__(self, chunks):
+            self._chunks = list(chunks)
+
+        def read(self, _n):
+            return self._chunks.pop(0) if self._chunks else b""
+
+    dl_state = {"start": 1.0, "pct": None, "size": None}
+    stream = _FakeStream(
+        [
+            "\u276f Downloading Windows 11...\n512 MB \u2192 1 GB".encode(),
+            " \u2192 1.5 GB \u2192 2 GB".encode(),
+        ]
+    )
+    list(_iter_container_lines(stream, dl_state, threading.Event()))
+    assert dl_state["pct"] is None
+    assert dl_state["size"] == "2 GB"
+
+
 def test_percent_wins_over_size_tokens() -> None:
     import threading
 


### PR DESCRIPTION
@kroese let us know on #771 that v6.03 is out with the rootless networking fix. Checking what our pin actually contained turned up something worth recording.

## The pin was older than we thought

`DOCKUR_IMAGE_PIN` was documented as "v6.02, QEMU base v7.37". Its own OCI metadata says otherwise: a rolling master build (revision `9caf1a9a`) created **2026-07-17 21:26 UTC** on base 7.37.

The OUTPUT-chain DNAT rule lives in the `qemux/qemu` base, not in `dockur/windows` — commit `ceed7b05c8`, **2026-07-18 13:16 UTC**. Our pinned image was built ~16 hours before it existed, so #770's root cause was still live in every install. The bump is what delivers the fix, not the tag name (v6.02 and v6.03 point at the same commit; v6.03 is a re-tag).

New pin: `sha256:743847e7…d168` — the OCI index for `dockurr/windows:6.03`, verified equal to `:latest`, same kind of digest as before so multi-arch resolution is unchanged.

## Dropping the rootless force

With the fix present, the `NETWORK=user` force from 0.10.3 is no longer applied and dockur picks the mode again.

Worth being honest about the residual risk: the upstream rule matches `-d $UPLINK`, the container's own uplink address. A rootlessport that dials `127.0.0.1` inside the netns would not match it, and nothing in `network.sh` sets `route_localnet`. If that happens on someone's host, the symptom is unpleasant — a fresh install sits at `wait-ready` for the full hour and then reports a timeout that never mentions networking, while the web viewer shows a fully booted Windows the whole time; an existing pod restarts the VM on every app launch.

So this adds **`pod.network`** as the escape hatch:

```toml
[pod]
network = "user"
```

That restores exactly the 0.10.3 behaviour in one command instead of leaving a bitten user with no supported way back. Sanitised to `""` or `"user"` — the value is interpolated into `compose.yaml`, so it is never free-form.

## Two things the new image needs

- **Download progress.** v6.03's `progress.sh` swapped `numfmt --to=iec-i` for `--to=iec` piped through a sed that inserts a space, so the size chain renders `512 MB → 1.5 GB` instead of `512MiB → 1.5GiB`. `_DOWNLOAD_SIZE_RE` matched neither the space nor the missing `i`, so the `wait-ready` heartbeat would have gone blank on the new image. Widened to accept both, with a test for each format.
- **migrate on ARM.** `_ensure_canonical_image_pin` hard-coded `DOCKUR_IMAGE_PIN`, so every migrate on an aarch64 host silently rewrote the config to the **x86** image. Now uses `_default_pod_image()`.

## ARM pin stays put

Rolled the `VERSIONS.txt` baseline to v6.03 (that is what the weekly checker reads) but left `DOCKUR_IMAGE_ARM_PIN` alone. Nothing here can boot an ARM guest — #141 phases 4 and 7 are open, #140 is unresolved — so rolling it four minors would ship an unverified image to the users least able to diagnose it. Its comment claimed "v5.15"; the image says 5.16-era, revision `97861800`, base 7.32. Corrected.

## Tests

`tests/test_compose_network.py` rewritten for the new behaviour (no force by default on any backend, the escape hatch on both podman and docker, and rejection of a hand-edited value). Plus the v6.03 size format and two architecture-aware migrate cases. 2296 passed.

## What to test on rootless Podman

This is the part code reading cannot settle. After `install.sh --main`:

```
podman exec winpodx-windows iptables -t nat -S OUTPUT   # expect a DNAT jump
winpodx pod logs | grep -i "Mode:"                      # expect NAT, not User (passt)
nc -z 127.0.0.1 3390 && echo "RDP reachable"
```

Then launch an app. If RDP never connects, `network = "user"` under `[pod]` plus `winpodx pod restart` puts it back.