### PR TITLE
fix(pod): stop the image's install.bat lint report from looking like a failure

### DIFF
--- a/config/oem/install.bat
+++ b/config/oem/install.bat
@@ -42,7 +42,7 @@ REM container recreate) just re-asserts the exclusion silently.
 REM C:\Users\Public\winpodx is where register-apps.ps1 stages the
 REM reverse-open shim + its per-slug .exe copies (#425). That tiny,
 REM stripped, unsigned Rust binary trips Defender's ML heuristic
-REM (Trojan:Win32/Rafvartar!rfn -- a false positive), so it gets
+REM (a Trojan:Win32/Rafvartar variant -- a false positive), so it gets
 REM quarantined and reverse-open silently breaks. Exclude the path (and
 REM the shim process) here, first-step, so the exclusion is in place
 REM before per-user logon stages the files. Add-MpPreference accepts a

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -1041,6 +1041,20 @@ _WGET_PROGRESS_RE = re.compile(r"(\d{1,3})%\s+(\d+\.?\d*[KMG]?)(=)?\s*(\S*)\s*$"
 # actionable -- suppressed in the clean (non-verbose) drain.
 _CONTAINER_NOISE = ("BdsDxe:", "mknod: /dev/net/tun")
 
+# dockur v6.03 runs a static checker over the OEM install.bat and prints a
+# multi-screen report — severity headings, a "SECURITY LEVEL ISSUES" section,
+# and a "Found N critical error" banner. It is advisory (the install proceeds
+# either way) and its findings are about deliberate choices in our own script:
+# `-ExecutionPolicy Bypass` on scripts we ship, %VAR% used in commands, mkdir
+# without an errorlevel check. Printed verbatim mid-install it reads like the
+# install is failing, so the clean drain collapses it to one line. `--verbose`
+# still shows every line.
+_LINT_BLOCK_START = "possible issues were detected in your install.bat"
+_LINT_BLOCK_SUMMARY = (
+    "install.bat lint notices from the container image (advisory) "
+    "— re-run with --verbose to read them"
+)
+
 
 def _format_wget_progress(line: str) -> tuple[int, str] | None:
     """Parse a dockur/wget progress line into ``(percent, clean_text)``.
@@ -1479,6 +1493,10 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
                 "pct": None,
                 "size": None,
             }
+            # Whether the clean drain is inside the image's install.bat lint
+            # report (see _LINT_BLOCK_START). A list so the nested drain can
+            # mutate it, matching _last_pct below.
+            _in_lint_block = [False]
 
             def _drain(stream) -> None:  # type: ignore[no-untyped-def]
                 if stream is None:
@@ -1535,6 +1553,19 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
                             if pct >= _last_pct[0] + 3 or pct >= 100:
                                 print(text)
                                 _last_pct[0] = pct
+                        continue
+                    # Collapse the image's install.bat lint report (v6.03+).
+                    # The block is bounded by the next real dockur milestone,
+                    # which is the only thing that starts with the marker glyph.
+                    if _in_lint_block[0]:
+                        if line.lstrip().startswith("❯"):
+                            _in_lint_block[0] = False
+                        else:
+                            continue
+                    if _LINT_BLOCK_START in line:
+                        _in_lint_block[0] = True
+                        _live.clear()
+                        print(f"       [container] {_LINT_BLOCK_SUMMARY}")
                         continue
                     if any(noise in line for noise in _CONTAINER_NOISE):
                         # UEFI boot-loader / tun spam: keep a transient

--- a/tests/test_wait_ready_eta.py
+++ b/tests/test_wait_ready_eta.py
@@ -340,3 +340,41 @@ def test_complete_line_tokens_scraped_during_download() -> None:
     # Percent seen on a complete line sticks; the later size-only line does
     # not clear it (percent wins).
     assert dl_state["pct"] == 45
+
+
+# --- dockur v6.03 install.bat lint report ------------------------------------
+
+
+def test_lint_block_markers_bound_the_report() -> None:
+    """The collapse relies on two things: the start marker appearing in the
+    image's report, and the block ending at the next milestone glyph. Guard
+    both so a reworded marker upstream shows up as a test failure rather than
+    a wall of text in the installer output."""
+    from winpodx.cli.pod import _LINT_BLOCK_START, _LINT_BLOCK_SUMMARY
+
+    report_first_line = "❯ Warning: possible issues were detected in your install.bat file:"
+    assert _LINT_BLOCK_START in report_first_line
+    # The summary must not itself look like a dockur milestone, or the block
+    # would re-open on its own output.
+    assert not _LINT_BLOCK_SUMMARY.lstrip().startswith("❯")
+
+
+def test_install_bat_has_no_bare_delayed_expansion_marker() -> None:
+    """A lone `!` makes the image's static checker report a critical error
+    mid-install, which reads like the install is broken. The script never
+    enables delayed expansion, so the `!` is literal and the fix is textual --
+    but keep it out so the banner stays gone."""
+    from pathlib import Path
+
+    install_bat = Path(__file__).resolve().parent.parent / "config" / "oem" / "install.bat"
+    source = install_bat.read_text(encoding="utf-8", errors="replace")
+    assert "setlocal enabledelayedexpansion" not in source.lower(), (
+        "delayed expansion is now on -- a bare ! is no longer literal, "
+        "so every ! in the script needs auditing"
+    )
+    offenders = [
+        (n, line)
+        for n, line in enumerate(source.splitlines(), 1)
+        if line.lstrip().upper().startswith("REM") and "!" in line
+    ]
+    assert offenders == [], f"bare ! in a REM comment trips the image linter: {offenders}"


### PR DESCRIPTION
Found while smoke-testing #799 on openSUSE Tumbleweed / rootless Podman.

## What users now see

dockur v6.03 runs a static checker over the OEM `install.bat` during image build. The report lands in the middle of a fresh install:

```
❯ Warning: possible issues were detected in your install.bat file:
ERROR LEVEL ISSUES:
Line 45: Invalid variable expansion syntax (E011)
...
SECURITY LEVEL ISSUES:
Line 381, 514, 551, ...: PowerShell execution policy bypass (SEC009)
...
Error: 1 issue
  Critical issues that will cause script failure or incorrect behavior.
Security: 23 issues
WARNING  Found 1 critical error that must be fixed.
```

Provisioning completed fine right after it (51 apps, 7/7 fixes), but a wall of red-flag text saying a critical error "must be fixed" reads like the install is failing.

## The reported error is a false positive

Line 45 was:

```bat
REM (Trojan:Win32/Rafvartar!rfn -- a false positive), so it gets
```

The checker reads that `!` as a mismatched delayed-expansion delimiter. `install.bat` never runs `setlocal enabledelayedexpansion`, so `!` is literal throughout — and the same checker does not flag the `!` on line 675, so it is not even self-consistent. Nothing is broken; the banner is just noise. Rewording the comment retires it.

A test pins both halves: no `REM` line carries a bare `!`, and delayed expansion stays off (if that ever changes, every `!` in the script needs auditing and the test says so).

## The rest gets collapsed, not hidden

The remaining findings are about deliberate choices in our own script: `-ExecutionPolicy Bypass` on scripts we ship ourselves, `%VAR%` used in commands, `mkdir` without an errorlevel check. Nothing actionable, and nothing a user can act on.

So the clean `wait-ready` drain collapses the block to one line:

```
       [container] install.bat lint notices from the container image (advisory) — re-run with --verbose to read them
```

The block is bounded by the next dockur milestone (the only lines starting with `❯`), so a reworded report upstream cannot swallow real output. `--verbose` prints every line unchanged.

## Smoke notes from the same run (#799 / #735)

Worth recording since they answer the open question on #735:

- The pin bump landed: `❯ Starting Windows for Podman v6.03`.
- With the force removed, the generated compose carries no `NETWORK` key and `pod.network` is `""` — yet the container still reports `Mode: User (passt)`, and `iptables -t nat -S` inside it shows empty `PREROUTING`/`OUTPUT` chains. **dockur v6.03 selects user-mode on rootless Podman by itself.** So dropping the force is safe because upstream now makes the same choice we were forcing, not because bridge NAT started working there.
- RDP on 3390 reachable, full provisioning green.
- The v6.03 log string change (`Adding OEM folder` → `Adding OEM files`) did not disturb milestone tracking.

## Tests

2314 passed.