### PR TITLE
fix(agent): heal a drifted guest token from every caller, not just doctor (#730)

### DIFF
--- a/src/winpodx/core/agent_resync.py
+++ b/src/winpodx/core/agent_resync.py
@@ -20,6 +20,7 @@ and so still works while the agent is 401. It rewrites
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from pathlib import Path
 
@@ -69,6 +70,65 @@ def _resync_payload(token: str) -> str:
             "}",
         ]
     )
+
+
+# Shared heal state (#730). A 401 means the guest's baked token drifted from
+# the host's, which never clears on its own, so several independent callers can
+# hit it at the same moment: the tray keepalive, the reverse-open sync, a
+# foreground command, `winpodx doctor`. resync_token drives a real FreeRDP
+# session and takes tens of seconds, so they must not each push their own.
+#
+# ``generation`` lets a caller that lost the race skip straight to its retry:
+# it captures the value before its call and, if the value moved while it waited
+# on the lock, somebody else already healed. ``failed_at`` stops a permanently
+# broken setup from spending a FreeRDP session on every single exec.
+_HEAL_LOCK = threading.Lock()
+_HEAL_GENERATION = 0
+_HEAL_FAILED_AT = 0.0
+HEAL_FAILURE_COOLDOWN = 300.0
+
+
+def heal_generation() -> int:
+    """Current token-heal generation, to be captured before an agent call."""
+    return _HEAL_GENERATION
+
+
+def heal_token_once(cfg, *, seen_generation: int) -> tuple[bool, str]:
+    """Resync the guest token at most once across all callers (#730).
+
+    ``seen_generation`` is the value :func:`heal_generation` returned before
+    the call that got the 401. Returns ``(ok, detail)``; ``ok`` means the
+    caller should retry, either because this call healed or because another
+    one did while this caller waited for the lock.
+
+    Never raises — :func:`resync_token` is already best-effort, and a failure
+    to heal has to surface as the original auth error, not as a new one.
+    """
+    global _HEAL_GENERATION, _HEAL_FAILED_AT
+
+    with _HEAL_LOCK:
+        if _HEAL_GENERATION != seen_generation:
+            return True, "already healed by another caller"
+
+        now = time.monotonic()
+        if _HEAL_FAILED_AT and now - _HEAL_FAILED_AT < HEAL_FAILURE_COOLDOWN:
+            waited = int(now - _HEAL_FAILED_AT)
+            return False, f"resync failed {waited}s ago; in cooldown"
+
+        try:
+            ok, detail = resync_token(cfg)
+        except Exception as e:  # noqa: BLE001 -- healing must not add a new failure mode
+            _HEAL_FAILED_AT = now
+            log.warning("agent token heal raised unexpectedly: %s", e)
+            return False, f"resync raised: {e}"
+
+        if not ok:
+            _HEAL_FAILED_AT = now
+            return False, detail
+
+        _HEAL_GENERATION += 1
+        _HEAL_FAILED_AT = 0.0
+        return True, detail
 
 
 def resync_token(cfg, *, verify_timeout: float = 25.0) -> tuple[bool, str]:

--- a/src/winpodx/core/checks.py
+++ b/src/winpodx/core/checks.py
@@ -142,6 +142,9 @@ def probe_guest_exec(cfg: Config) -> Probe:
         except Exception:  # noqa: BLE001
             return "skip", "pod state unknown"
 
+        from winpodx.core.agent_resync import heal_generation, heal_token_once
+
+        generation = heal_generation()
         client = AgentClient(cfg)
         healed = False
         try:
@@ -149,10 +152,11 @@ def probe_guest_exec(cfg: Config) -> Probe:
         except AgentAuthError:
             # 401 = the guest's baked token drifted from the host's (#615).
             # This is config drift, not a transient blip, so it never clears
-            # on its own — auto-heal once over FreeRDP, then re-probe.
-            from winpodx.core.agent_resync import resync_token
-
-            ok, detail = resync_token(cfg)
+            # on its own — auto-heal once over FreeRDP, then re-probe. Shared
+            # with the agent transport (#730) so a doctor run and a background
+            # keepalive that both hit the 401 push once between them, not
+            # twice: each resync drives a real FreeRDP session.
+            ok, detail = heal_token_once(cfg, seen_generation=generation)
             if not ok:
                 return "fail", f"auth 401 (token drift); auto-resync failed: {detail}"
             healed = True

--- a/src/winpodx/core/transport/agent.py
+++ b/src/winpodx/core/transport/agent.py
@@ -15,6 +15,7 @@ agent yet (Phase 4 of the agent-v2 spec); ``stream()`` raises
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 
 from winpodx.core.agent import (
@@ -37,6 +38,8 @@ from winpodx.core.transport.base import (
 )
 
 assert SPEC_VERSION == 1, "AgentTransport built against Transport spec v1"
+
+log = logging.getLogger(__name__)
 
 
 class AgentTransport(Transport):
@@ -96,6 +99,34 @@ class AgentTransport(Transport):
         with FreerdpTransport.
         """
         del description  # unused — agent /exec has no task-name field
+        from winpodx.core.agent_resync import heal_generation, heal_token_once
+
+        generation = heal_generation()
+        try:
+            return self._exec_once(script, timeout)
+        except TransportAuthError:
+            # A 401 here is token drift, not a transient blip: a non-purge
+            # reinstall regenerates the host token while the guest disk (and
+            # its baked copy) survives. /health is unauthenticated so it keeps
+            # returning OK, which is why this used to look like a dead feature
+            # rather than an auth problem — apply-fixes, discovery,
+            # reverse-open sync and the keepalive all stayed broken until
+            # someone happened to run `winpodx doctor`, the one caller that
+            # healed (#730). Heal here instead, once, then retry.
+            ok, detail = heal_token_once(self.cfg, seen_generation=generation)
+            if not ok:
+                log.warning("agent auth failed and token heal did not run: %s", detail)
+                raise
+            # resync_token may have minted a fresh host token, so drop the
+            # client holding the old cached bearer.
+            self._client = AgentClient(self.cfg)
+
+        # Outside the handler on purpose: a second 401 propagates as-is
+        # instead of re-entering the heal path.
+        return self._exec_once(script, timeout)
+
+    def _exec_once(self, script: str, timeout: int) -> ExecResult:
+        """One /exec round trip with the Agent -> Transport exception mapping."""
         try:
             agent_result = self._client.exec(script, timeout=float(timeout))
         except AgentAuthError as e:

--- a/tests/test_agent_resync.py
+++ b/tests/test_agent_resync.py
@@ -172,3 +172,78 @@ def test_doctor_guest_exec_reports_failed_resync(monkeypatch):
     probe = checks.probe_guest_exec(SimpleNamespace())
     assert probe.status == "fail"
     assert "auto-resync failed" in probe.detail
+
+
+# --- #730: the heal must run once across all callers, not once per caller ----
+
+
+@pytest.fixture(autouse=True)
+def _reset_heal_state(monkeypatch):
+    # Module-level generation/cooldown would otherwise leak between tests.
+    monkeypatch.setattr(agent_resync, "_HEAL_GENERATION", 0, raising=False)
+    monkeypatch.setattr(agent_resync, "_HEAL_FAILED_AT", 0.0, raising=False)
+
+
+def test_heal_runs_resync_and_bumps_generation(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        agent_resync, "resync_token", lambda cfg: (calls.append(1), (True, "ok"))[1]
+    )
+    gen = agent_resync.heal_generation()
+
+    ok, _ = agent_resync.heal_token_once(object(), seen_generation=gen)
+
+    assert ok
+    assert calls == [1]
+    assert agent_resync.heal_generation() == gen + 1
+
+
+def test_heal_skips_when_another_caller_already_healed(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        agent_resync, "resync_token", lambda cfg: (calls.append(1), (True, "ok"))[1]
+    )
+    stale_generation = agent_resync.heal_generation()
+    agent_resync.heal_token_once(object(), seen_generation=stale_generation)
+
+    # A second caller that captured the pre-heal generation must not push again.
+    ok, detail = agent_resync.heal_token_once(object(), seen_generation=stale_generation)
+
+    assert ok
+    assert "another caller" in detail
+    assert calls == [1]
+
+
+def test_failed_heal_enters_cooldown(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        agent_resync, "resync_token", lambda cfg: (calls.append(1), (False, "no freerdp"))[1]
+    )
+    now = [1000.0]
+    monkeypatch.setattr(agent_resync.time, "monotonic", lambda: now[0])
+
+    ok, detail = agent_resync.heal_token_once(object(), seen_generation=0)
+    assert not ok and "no freerdp" in detail
+
+    # A broken setup must not spend a FreeRDP session on every exec.
+    now[0] += 10.0
+    ok, detail = agent_resync.heal_token_once(object(), seen_generation=0)
+    assert not ok and "cooldown" in detail
+    assert calls == [1]
+
+    # ...but it must recover once the cooldown lapses.
+    now[0] += agent_resync.HEAL_FAILURE_COOLDOWN
+    agent_resync.heal_token_once(object(), seen_generation=0)
+    assert calls == [1, 1]
+
+
+def test_heal_never_raises(monkeypatch):
+    def _boom(cfg):
+        raise RuntimeError("freerdp exploded")
+
+    monkeypatch.setattr(agent_resync, "resync_token", _boom)
+
+    ok, detail = agent_resync.heal_token_once(object(), seen_generation=0)
+
+    assert not ok
+    assert "freerdp exploded" in detail

--- a/tests/test_transport/test_agent.py
+++ b/tests/test_transport/test_agent.py
@@ -118,10 +118,18 @@ class TestExec:
         assert result.ok
 
     def test_auth_error_maps_to_transport_auth_error(self, transport):
-        with patch.object(
-            type(transport._client),
-            "exec",
-            side_effect=AgentAuthError("/exec auth failed (401)"),
+        # Heal stubbed out so this stays a pure mapping test; the heal path
+        # has its own cases below.
+        with (
+            patch(
+                "winpodx.core.agent_resync.heal_token_once",
+                return_value=(False, "stubbed"),
+            ),
+            patch.object(
+                type(transport._client),
+                "exec",
+                side_effect=AgentAuthError("/exec auth failed (401)"),
+            ),
         ):
             with pytest.raises(TransportAuthError):
                 transport.exec("anything")
@@ -166,3 +174,92 @@ class TestStream:
     def test_stream_raises_transport_unavailable(self, transport):
         with pytest.raises(TransportUnavailable):
             transport.stream("Get-Process", lambda _line: None)
+
+
+class TestExecTokenSelfHeal:
+    """#730: a 401 is token drift and never clears on its own, so exec heals
+    once and retries instead of leaving every agent-backed feature dead until
+    someone runs `winpodx doctor`."""
+
+    def test_heals_once_then_succeeds_on_retry(self, transport):
+        attempts = []
+
+        def _exec(_self, script, timeout=None):
+            attempts.append(script)
+            if len(attempts) == 1:
+                raise AgentAuthError("/exec returned 401")
+            return AgentExecResult(rc=0, stdout="healed", stderr="")
+
+        with (
+            patch("winpodx.core.agent_resync.heal_token_once", return_value=(True, "ok")) as heal,
+            patch.object(type(transport._client), "exec", _exec),
+        ):
+            result = transport.exec("Write-Output hi")
+
+        assert result == ExecResult(rc=0, stdout="healed", stderr="")
+        assert len(attempts) == 2
+        heal.assert_called_once()
+
+    def test_raises_without_retry_when_heal_fails(self, transport):
+        attempts = []
+
+        def _exec(_self, script, timeout=None):
+            attempts.append(script)
+            raise AgentAuthError("/exec returned 401")
+
+        with (
+            patch(
+                "winpodx.core.agent_resync.heal_token_once",
+                return_value=(False, "no freerdp"),
+            ),
+            patch.object(type(transport._client), "exec", _exec),
+        ):
+            with pytest.raises(TransportAuthError):
+                transport.exec("Write-Output hi")
+
+        assert len(attempts) == 1
+
+    def test_second_401_after_heal_does_not_loop(self, transport):
+        attempts = []
+
+        def _exec(_self, script, timeout=None):
+            attempts.append(script)
+            raise AgentAuthError("/exec returned 401")
+
+        with (
+            patch("winpodx.core.agent_resync.heal_token_once", return_value=(True, "ok")) as heal,
+            patch.object(type(transport._client), "exec", _exec),
+        ):
+            with pytest.raises(TransportAuthError):
+                transport.exec("Write-Output hi")
+
+        # Healed once, retried once, then gave up — no third attempt.
+        assert len(attempts) == 2
+        heal.assert_called_once()
+
+    def test_successful_call_never_heals(self, transport):
+        with (
+            patch("winpodx.core.agent_resync.heal_token_once") as heal,
+            patch.object(
+                type(transport._client),
+                "exec",
+                return_value=AgentExecResult(rc=0, stdout="ok", stderr=""),
+            ),
+        ):
+            transport.exec("Write-Output hi")
+
+        heal.assert_not_called()
+
+    def test_non_auth_errors_do_not_heal(self, transport):
+        with (
+            patch("winpodx.core.agent_resync.heal_token_once") as heal,
+            patch.object(
+                type(transport._client),
+                "exec",
+                side_effect=AgentTimeoutError("timed out"),
+            ),
+        ):
+            with pytest.raises(TransportTimeoutError):
+                transport.exec("Write-Output hi")
+
+        heal.assert_not_called()


### PR DESCRIPTION
A 401 from the guest agent means its baked token no longer matches the host's. That happens on a non-purge reinstall: the host token is regenerated while the guest disk, and the copy staged into it, survives. It never clears on its own.

What made it hard to recognise is that `/health` is unauthenticated, so it keeps returning OK. The agent looks alive, and what the user sees is a set of features that quietly do nothing.

## What was already there, and what was missing

`resync_token()` exists, and a heal-then-retry around it existed too — wired into exactly one caller, the `winpodx doctor` agent probe. Everywhere else `AgentTransport.exec` mapped `AgentAuthError` straight to `TransportAuthError` with no retry, so apply-fixes, discovery, reverse-open sync and the tray keepalive all stayed dead until the user happened to run doctor.

## Change

`AgentTransport.exec` now heals once and retries once:

- the retry sits **outside** the `except` block, so a second 401 propagates rather than re-entering the heal path — there is no loop to get into;
- the exception mapping moved into `_exec_once` so the retry does not duplicate it;
- the client is rebuilt after a successful heal, because `ensure_agent_token()` may have minted a new host token that the existing instance has already cached.

The guard itself lives in `agent_resync` so `doctor` uses the same one. Several callers can hit the same 401 in the same moment — keepalive, reverse-open sync, a foreground command, a doctor run — and each `resync_token()` drives a real FreeRDP session that takes tens of seconds. So:

- a lock serialises them;
- a **generation counter** lets a caller that lost the race skip its own push entirely and go straight to its retry, since somebody else already healed;
- a **300 s cooldown** after a failed resync stops a permanently broken setup from spending a FreeRDP session on every single exec.

`heal_token_once` never raises: a failure to heal has to surface as the original auth error, not as a new one.

## Tests

Nine cases across `tests/test_agent_resync.py` and `tests/test_transport/test_agent.py`: heal runs once and bumps the generation, a racing caller skips the push, a failed heal enters and later leaves the cooldown, an exception inside resync is swallowed, exec heals then succeeds on retry, a failed heal raises without retrying, a second 401 does not loop, a successful call never heals, and a non-auth error never heals. The existing auth-mapping test now stubs the heal so it stays a pure mapping test.

2323 passed.

## Note on the issue body

The issue says `--wipe-storage` is the only recovery. That has not been true since the doctor self-heal landed, and after this it is not the recovery path at all. Worth editing when this merges.