### PR TITLE
fix(oem): leave the search indexer alone unless the user opts in (#570)

### DIFF
--- a/config/oem/install.bat
+++ b/config/oem/install.bat
@@ -1,7 +1,7 @@
 @echo off
 REM First-boot OEM setup for winpodx Windows guest. Runs once during dockur's unattended install. Every action must stay idempotent - there is no guest-side re-run channel in 0.1.6 (push/exec bridge planned for a later release).
 
-set WINPODX_OEM_VERSION=29
+set WINPODX_OEM_VERSION=30
 
 echo [WinPodX] Starting post-install configuration (version %WINPODX_OEM_VERSION%)...
 
@@ -150,8 +150,15 @@ reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Windows Search" /v AllowCortan
 
 reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\DataCollection" /v AllowTelemetry /t REG_DWORD /d 0 /f
 
-sc config WSearch start= disabled
-net stop WSearch 2>nul
+REM WSearch is deliberately NOT disabled here (#570). Turning it off is the
+REM `search_indexing` debloat item, which the catalogue marks risk=high and
+REM describes as making Start-menu search fall back to a file-system walk.
+REM Doing it unconditionally at install time applied a high-risk opt-in to
+REM everyone, and the visible result was the Start-menu / Explorer search bar
+REM spinning forever in a full-desktop session. Users who want the indexer
+REM off can choose it in `winpodx debloat`; guests that already had it
+REM disabled by an earlier OEM version are re-enabled by that item's undo
+REM script (scripts/windows/debloat/undo/search_indexing.ps1).
 
 sc config SysMain start= disabled
 net stop SysMain 2>nul

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -76,7 +76,7 @@ def test_bundled_oem_version_matches_install_bat_marker(monkeypatch):
     Force the install.bat fallback by nulling the .txt stamp reader.
     """
     monkeypatch.setattr("winpodx.core.info._read_text_file", lambda *a, **k: None)
-    assert _bundled_oem_version() == "29"
+    assert _bundled_oem_version() == "30"
 
 
 def test_bundled_oem_version_falls_back_to_unknown(monkeypatch, tmp_path):

--- a/tests/test_oem_install_bat.py
+++ b/tests/test_oem_install_bat.py
@@ -43,7 +43,7 @@ def test_install_bat_does_not_self_lock_setup_log() -> None:
 
 def test_install_bat_oem_version_matches_expected_setup_contract() -> None:
     text = INSTALL_BAT.read_text(encoding="utf-8")
-    assert "set WINPODX_OEM_VERSION=29" in text
+    assert "set WINPODX_OEM_VERSION=30" in text
     assert "(echo %WINPODX_OEM_VERSION%)>C:\\winpodx\\oem_version.txt" in text
 
 
@@ -104,3 +104,33 @@ def test_install_bat_defender_excludes_reverse_open_shim_path() -> None:
     assert "Add-MpPreference -ExclusionPath" in text
     assert r"C:\Users\Public\winpodx" in text
     assert "winpodx-reverse-open-shim.exe" in text
+
+
+def test_install_bat_does_not_disable_wsearch_unconditionally() -> None:
+    """#570: turning the indexer off is the `search_indexing` debloat item,
+    which the catalogue marks risk=high. Applying it to every install made the
+    Start-menu search bar spin forever in a full-desktop session."""
+    text = INSTALL_BAT.read_text(encoding="utf-8")
+    active = "\n".join(_active_lines(text)).casefold()
+
+    assert "sc config wsearch" not in active
+    assert "net stop wsearch" not in active
+
+
+def test_search_indexing_is_an_optin_debloat_item() -> None:
+    # The other half of the contract: if the item ever stopped existing, the
+    # removal above would leave no way to disable the indexer at all.
+    import sys
+    from pathlib import Path
+
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:  # pragma: no cover - 3.9 / 3.10 back-fill
+        import tomli as tomllib
+
+    items_toml = Path(__file__).resolve().parent.parent / "data" / "debloat" / "items.toml"
+    data = tomllib.loads(items_toml.read_text(encoding="utf-8"))
+    item = data["items"]["search_indexing"]
+
+    assert item["risk"] == "high"
+    assert item["undo_script"] == "undo/search_indexing.ps1"


### PR DESCRIPTION
> **Needs a real-Windows smoke test before merge** — this changes the guest OEM install.

`install.bat` ran this on every install:

```bat
sc config WSearch start= disabled
net stop WSearch 2>nul
```

The same action is the `search_indexing` item in the debloat catalogue, where it is marked **`risk = "high"`** and described as *"Disable the WSearch service. Tradeoff: Start menu search becomes file-system-walk slow."*

So the default install was silently applying a high-risk opt-in to everyone. What #570's reporter saw is the direct consequence: the Start-menu / Explorer search bar in a full-desktop session spins forever and never returns a result. It works over noVNC because that is a different session, not because search works.

## Change

Removed from `install.bat`, with a comment naming the debloat item that owns the behaviour so the next person does not re-add it. Users who want the indexer off choose it in `winpodx debloat`; guests an earlier OEM version already disabled it on are recovered by that item's existing undo script (`scripts/windows/debloat/undo/search_indexing.ps1`).

OEM version bumped 29 → 30 so provisioned guests pick the change up, with the three version-contract assertions updated to match.

## Scope

`AllowCortana` on the adjacent line is the same pattern — a debloat item (`web_search`) applied unconditionally — but it is `risk = "low"` and is not what stops search returning results. Left alone rather than widening this change; worth its own look later.

`SysMain` is disabled unconditionally too, same story. Also left alone.

## Tests

Two static assertions in `tests/test_oem_install_bat.py`: install.bat no longer disables WSearch, and the `search_indexing` item still exists with `risk = "high"` and its undo script — so removing the unconditional call cannot leave users with no way to disable the indexer at all. 2316 passed.

## Smoke checklist

1. Fresh install, then in a full-desktop session type into the Start-menu search box — results should appear rather than the bar spinning.
2. `winpodx debloat` → pick **Search indexing service** → confirm search goes slow / stops indexing.
3. On a guest provisioned by OEM ≤ 29 (search already dead): run the undo for that item and confirm the service comes back Automatic and search works.