### PR TITLE
fix(desktop): file PNG icons under their real hicolor size, and log the window helper (#702)

### DIFF
--- a/src/winpodx/core/rdp.py
+++ b/src/winpodx/core/rdp.py
@@ -10,6 +10,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -1136,6 +1137,31 @@ def _redact_cmd_for_log(cmd: list[str]) -> str:
     return " ".join(out)
 
 
+def _drain_window_setup_log(helper: subprocess.Popen) -> None:
+    """Forward the detached window-setup helper's output into our log (#702).
+
+    The helper injects ``_NET_WM_ICON`` onto the RAIL window and re-lists UWP
+    windows in the taskbar. It outlives the launcher, so its output used to go
+    to DEVNULL — which meant a failure left no trace anywhere and the reporter
+    and I had nothing to compare. A non-zero exit is a warning; everything else
+    is debug, since this runs on every RemoteApp launch.
+    """
+    try:
+        output, _ = helper.communicate(timeout=120)
+    except subprocess.TimeoutExpired:
+        log.debug("window_setup helper still running after 120s; leaving it")
+        return
+    except OSError as e:  # pragma: no cover - defensive
+        log.debug("window_setup helper output unreadable: %s", e)
+        return
+
+    text = (output or "").strip()
+    if helper.returncode:
+        log.warning("window_setup helper exited %s: %s", helper.returncode, text or "(no output)")
+    elif text:
+        log.debug("window_setup helper: %s", text)
+
+
 def _spawn_detached(session: RDPSession, cmd: list[str]) -> RDPSession:
     """Acquire the PID lock and spawn a detached FreeRDP client for ``session``.
 
@@ -1575,7 +1601,6 @@ def launch_app(
     to :func:`build_rdp_command` as overrides. ``None`` / empty leaves every
     launch byte-for-byte unchanged.
     """
-    import threading
 
     # #692: fold the per-app RDP overrides in. The dict is already validated by
     # app.parse_rdp_overrides, but keep light type guards so a direct caller
@@ -1782,15 +1807,23 @@ def launch_app(
             setup_args += ["--icon", app_icon]
         if launch_uri is not None:
             setup_args += ["--uwp"]
+        # Route the helper's output into our log rather than DEVNULL: when the
+        # icon injection does not take, there was previously nothing at all to
+        # look at, which is how #702 stayed undiagnosable across two releases.
+        # A separate thread drains it so the short-lived launcher can still
+        # exit immediately.
         try:
-            subprocess.Popen(
+            helper = subprocess.Popen(
                 setup_args,
                 start_new_session=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
             )
         except OSError as e:
             log.debug("window_setup helper spawn failed: %s", e)
+        else:
+            threading.Thread(target=_drain_window_setup_log, args=(helper,), daemon=True).start()
 
     return session
 

--- a/src/winpodx/desktop/entry.py
+++ b/src/winpodx/desktop/entry.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import struct
 import sys
 from pathlib import Path
 
@@ -318,11 +319,68 @@ def remove_desktop_entry(app_name: str) -> None:
         log.warning("Could not update winpodx menu folder definition: %s", e)
 
 
+# hicolor's fixed-size directories. A PNG goes in the one closest to its real
+# dimensions: the directory name is a declaration about the file, so putting an
+# 88x88 UWP logo in 32x32/apps means anything asking the theme for a 32px icon
+# is handed something nearly three times that (#702).
+_HICOLOR_SIZES = (16, 22, 24, 32, 48, 64, 128, 256)
+_DEFAULT_PNG_SIZE = 32
+
+
+def _png_dimensions(path: Path) -> tuple[int, int] | None:
+    """Read a PNG's pixel dimensions from its IHDR, or None if unreadable.
+
+    Parsed by hand rather than through an image library: winpodx is stdlib-only
+    on 3.11+, and the first 24 bytes are all this needs.
+    """
+    try:
+        with path.open("rb") as fh:
+            header = fh.read(24)
+    except OSError:
+        return None
+    if len(header) < 24 or header[:8] != b"\x89PNG\r\n\x1a\n":
+        return None
+    try:
+        width, height = struct.unpack(">II", header[16:24])
+    except struct.error:
+        return None
+    if not (0 < width <= 1 << 16) or not (0 < height <= 1 << 16):
+        return None
+    return width, height
+
+
+def _hicolor_bucket(path: Path) -> int:
+    """Pick the hicolor size directory a PNG belongs in.
+
+    Uses the larger edge, so a non-square icon is not filed under a size it
+    overflows. Falls back to 32 when the file is not a readable PNG — the same
+    directory everything used to land in, so a malformed file behaves as before
+    rather than disappearing somewhere unexpected.
+    """
+    dims = _png_dimensions(path)
+    if dims is None:
+        return _DEFAULT_PNG_SIZE
+    largest = max(dims)
+    return min(_HICOLOR_SIZES, key=lambda size: (abs(size - largest), size))
+
+
+def _remove_stale_icon_copies(icon_name: str, *, keep: Path) -> None:
+    """Delete this icon from every sized hicolor directory except ``keep``."""
+    for size_dir in icons_dir().glob("*x*/apps"):
+        stale = size_dir / f"{icon_name}.png"
+        if stale == keep:
+            continue
+        try:
+            stale.unlink(missing_ok=True)
+        except OSError as e:  # pragma: no cover - a stale copy is not worth failing over
+            log.debug("could not remove stale icon %s: %s", stale, e)
+
+
 def _install_icon(app: AppInfo) -> str:
     """Install app icon into the hicolor icon theme. Returns the icon name.
 
-    SVG icons go to scalable/apps/, PNG icons to 32x32/apps/ per hicolor spec.
-    Other formats fall back to the default winpodx icon.
+    SVG icons go to scalable/apps/; a PNG goes to the sized directory matching
+    its real dimensions. Other formats fall back to the default winpodx icon.
     """
     icon_name = f"winpodx-{app.name}"
 
@@ -339,9 +397,16 @@ def _install_icon(app: AppInfo) -> str:
         dest_dir = icons_dir() / "scalable" / "apps"
         dest = dest_dir / f"{icon_name}.svg"
     elif suffix == ".png":
-        # Discovered apps often only have PNG from extracted Windows resources.
-        dest_dir = icons_dir() / "32x32" / "apps"
+        # Discovered apps often only have PNG from extracted Windows resources,
+        # and those come at whatever size the resource happened to be — UWP
+        # logos are commonly 44x44 or 88x88, not 32x32.
+        bucket = _hicolor_bucket(src)
+        dest_dir = icons_dir() / f"{bucket}x{bucket}" / "apps"
         dest = dest_dir / f"{icon_name}.png"
+        # An upgrade can move an icon between buckets (everything used to land
+        # in 32x32). Drop the old copies first, or the theme keeps serving a
+        # stale one from whichever directory it searches first.
+        _remove_stale_icon_copies(icon_name, keep=dest)
     else:
         log.warning(
             "Icon %s for app %s is not SVG or PNG (%s); "

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -1044,3 +1044,87 @@ def test_installed_entry_has_absolute_exec(tmp_path, monkeypatch):
 
     exec_line = next(line for line in written.read_text().splitlines() if line.startswith("Exec="))
     assert exec_line == f"Exec={launcher} app run notepad %u"
+
+
+# --- #702: a PNG belongs in the hicolor directory matching its real size -----
+
+
+def _write_png(path: Path, width: int, height: int) -> Path:
+    # Minimal PNG: signature + IHDR header. Only the first 24 bytes are read.
+    import struct as _struct
+    import zlib
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ihdr = _struct.pack(">II", width, height) + bytes([8, 6, 0, 0, 0])
+    chunk = _struct.pack(">I", len(ihdr)) + b"IHDR" + ihdr
+    chunk += _struct.pack(">I", zlib.crc32(b"IHDR" + ihdr) & 0xFFFFFFFF)
+    path.write_bytes(b"\x89PNG\r\n\x1a\n" + chunk)
+    return path
+
+
+@pytest.mark.parametrize(
+    ("size", "expected"),
+    [
+        (16, 16),
+        (32, 32),
+        (48, 48),
+        (256, 256),
+        (44, 48),  # UWP small logo -> nearest bucket
+        (88, 64),  # UWP large logo, closer to 64 than 128
+    ],
+)
+def test_png_lands_in_matching_hicolor_bucket(tmp_path, monkeypatch, size, expected):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    icon = _write_png(tmp_path / "src" / "icon.png", size, size)
+
+    app = AppInfo(
+        name=f"sized{size}", full_name="Sized", executable="C:\\x.exe", icon_path=str(icon)
+    )
+    install_desktop_entry(app)
+
+    landed = tmp_path / "data" / "icons" / "hicolor" / f"{expected}x{expected}" / "apps"
+    assert (landed / f"winpodx-sized{size}.png").exists()
+
+
+def test_non_square_png_uses_its_larger_edge(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    icon = _write_png(tmp_path / "src" / "wide.png", 128, 32)
+
+    app = AppInfo(name="wide", full_name="Wide", executable="C:\\x.exe", icon_path=str(icon))
+    install_desktop_entry(app)
+
+    hicolor = tmp_path / "data" / "icons" / "hicolor"
+    assert (hicolor / "128x128" / "apps" / "winpodx-wide.png").exists()
+    assert not (hicolor / "32x32" / "apps" / "winpodx-wide.png").exists()
+
+
+def test_unreadable_png_falls_back_to_32(tmp_path, monkeypatch):
+    # A truncated / non-PNG file keeps the historical destination rather than
+    # vanishing into an unexpected directory.
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    bogus = tmp_path / "src" / "bogus.png"
+    bogus.parent.mkdir(parents=True, exist_ok=True)
+    bogus.write_bytes(b"not a png at all")
+
+    app = AppInfo(name="bogus", full_name="Bogus", executable="C:\\x.exe", icon_path=str(bogus))
+    install_desktop_entry(app)
+
+    landed = tmp_path / "data" / "icons" / "hicolor" / "32x32" / "apps"
+    assert (landed / "winpodx-bogus.png").exists()
+
+
+def test_rebucketing_removes_the_stale_copy(tmp_path, monkeypatch):
+    # Upgrade path: every PNG used to land in 32x32, so an icon that now
+    # belongs elsewhere must not be served from both places.
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    hicolor = tmp_path / "data" / "icons" / "hicolor"
+    old = hicolor / "32x32" / "apps" / "winpodx-moved.png"
+    old.parent.mkdir(parents=True, exist_ok=True)
+    old.write_bytes(b"stale")
+
+    icon = _write_png(tmp_path / "src" / "moved.png", 88, 88)
+    app = AppInfo(name="moved", full_name="Moved", executable="C:\\x.exe", icon_path=str(icon))
+    install_desktop_entry(app)
+
+    assert (hicolor / "64x64" / "apps" / "winpodx-moved.png").exists()
+    assert not old.exists()


### PR DESCRIPTION
Two things found while looking into why #702's reporter still sees the FreeRDP icon after the v0.10.1 fix.

## Icons were filed under a size they are not

`_install_icon` sent every discovered PNG to `hicolor/32x32/apps`, whatever the image actually measured. UWP logos are copied at the size the Windows resource happened to be, so on this machine:

```
  32x32 -> 32x32      22
  32x32 -> 44x44       6
  32x32 -> 88x88      21
```

27 of 49 installed icons were in a directory that declares a size they are not. In hicolor the directory name is a statement about the file, so anything asking the theme for a 32px icon was handed something up to three times that.

PNGs now go to the bucket nearest their larger edge (16/22/24/32/48/64/128/256), read from the IHDR header with `struct` — no image library, keeping the stdlib-only rule on 3.11+. A file that is not a readable PNG still lands in 32x32, the historical destination, so a malformed icon behaves as it did rather than turning up somewhere unexpected.

Install also clears the icon from the other size directories first. Everything used to land in 32x32, so an upgrade moves icons between buckets, and without that the theme keeps serving whichever copy it finds first.

## The helper that injects the icon was silent

The detached `window_setup` helper — the one that writes `_NET_WM_ICON` onto the RAIL window and re-lists UWP windows — had `stdout` and `stderr` pointed at `DEVNULL`. When the icon does not appear there was nothing anywhere to look at, which is a large part of why #702 has stayed undiagnosable across two releases. Output now goes to the log (warning on a non-zero exit, debug otherwise), drained on a daemon thread so a short-lived `winpodx app run` still exits immediately.

## Honest scope

I could not reproduce the icon-cache corruption this was suspected of causing: `gtk-update-icon-cache -f -t ~/.local/share/icons/hicolor` succeeds here with the misplaced files in place. So the misplacement is a real spec violation worth fixing, but it is **not established** as the cause of the reported symptom. The helper logging is the part most likely to actually move #702 forward, by giving the reporter and me something to compare.

## Tests

Nine cases in `tests/test_desktop.py`: each standard size lands in its own bucket, 44 → 48 and 88 → 64, a non-square PNG uses its larger edge, an unreadable file falls back to 32, and re-installing an icon that changed bucket removes the stale copy. 2323 passed.