### PR TITLE
feat(pod): install Windows in the host's language by default (#791, #790)

### DIFF
--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -639,25 +639,37 @@ def _prompt_edition_locale_tuning(cfg: Config) -> None:
     )
     cfg.pod.win_version = edition
 
+    # These three default to empty in the config, meaning "detect from the
+    # host at compose time" (#791). Show what that detection produces rather
+    # than an empty bracket, so the user confirms a real value — and store it,
+    # since a value they were shown and accepted should not later change
+    # because they logged in under a different locale.
+    from winpodx.utils.locale import detect_install_locale
+
+    detected_language, detected_region, detected_keyboard = detect_install_locale()
+
     # UI language (dockur LANGUAGE env). Full English name, e.g. "English",
     # "German", "Korean". dockur maps it to the matching ISO at download.
+    language_default = cfg.pod.language or detected_language
     cfg.pod.language = _ask(
-        tr("Windows UI language [{default}]: ").format(default=cfg.pod.language),
-        default=cfg.pod.language,
+        tr("Windows UI language [{default}]: ").format(default=language_default),
+        default=language_default,
     )
 
     # Regional format (dockur REGION env). BCP-47, e.g. en-US, en-GB,
-    # ko-KR. Default en-001 = "English (World)"; suggest the more common
-    # en-US for US date / number formatting (#293).
+    # ko-KR. en-001 = "English (World)", the fallback when the host locale
+    # is not one dockur accepts.
+    region_default = cfg.pod.region or detected_region
     cfg.pod.region = _ask(
-        tr("Regional format (BCP-47, e.g. en-US) [{default}]: ").format(default=cfg.pod.region),
-        default=cfg.pod.region,
+        tr("Regional format (BCP-47, e.g. en-US) [{default}]: ").format(default=region_default),
+        default=region_default,
     )
 
     # Keyboard layout (dockur KEYBOARD env). BCP-47, e.g. en-US, de-DE.
+    keyboard_default = cfg.pod.keyboard or detected_keyboard
     cfg.pod.keyboard = _ask(
-        tr("Keyboard layout (BCP-47, e.g. en-US) [{default}]: ").format(default=cfg.pod.keyboard),
-        default=cfg.pod.keyboard,
+        tr("Keyboard layout (BCP-47, e.g. en-US) [{default}]: ").format(default=keyboard_default),
+        default=keyboard_default,
     )
 
     # Host tuning profile (#215 / #245). auto = detect + apply every safe

--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -393,11 +393,22 @@ class PodConfig:
     network: str = ""
     # v0.5.x: Windows installation language/region/keyboard settings.
     # Passed through to dockur's LANGUAGE, REGION, KEYBOARD env vars.
-    # Defaults to English (US). Common values for Spanish:
-    # language="Spanish", region="es-ES", keyboard="es-ES"
-    language: str = "English"
-    region: str = "en-001"
-    keyboard: str = "en-US"
+    #
+    # Empty (the default since #791) means "detect from the host at compose
+    # time", the same convention ``timezone`` already uses — someone on a
+    # Korean or Chinese desktop should not have to know these fields exist to
+    # avoid an English Windows. A non-empty value is passed through verbatim.
+    #
+    # These only take effect at FIRST BOOT: dockur bakes them into the Sysprep
+    # answer file, so changing them later does not re-language an installed
+    # guest. Existing installs are unaffected either way, since their config
+    # already has the explicit values that were written when they were set up.
+    #
+    # Common values for Spanish: language="Spanish", region="es-ES",
+    # keyboard="es-ES".
+    language: str = ""
+    region: str = ""
+    keyboard: str = ""
     # v0.5.7+: Windows guest timezone (#254). Empty string = autodetect
     # from the host at compose time (timedatectl / /etc/localtime /
     # /etc/timezone fallback chain in ``utils/locale.py``). IANA name

--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -589,6 +589,34 @@ def _resolve_timezone_for_compose(cfg: Config) -> str:
     return detect_timezone()
 
 
+def _resolve_install_locale(cfg: Config) -> tuple[str, str, str]:
+    """Resolve the LANGUAGE / REGION / KEYBOARD values dockur installs with.
+
+    Each field is independent: an empty one is detected from the host, a set
+    one passes through. That matters for the common half-configured case —
+    someone who picked a keyboard layout but never touched the language should
+    keep their layout and still get a guest in their own language (#791).
+
+    Detection is all-or-nothing per :func:`utils.locale.detect_install_locale`,
+    which falls back to English when the host locale is missing or outside the
+    set dockur accepts.
+    """
+    from winpodx.utils.locale import detect_install_locale
+
+    language = (cfg.pod.language or "").strip()
+    region = (cfg.pod.region or "").strip()
+    keyboard = (cfg.pod.keyboard or "").strip()
+    if language and region and keyboard:
+        return language, region, keyboard
+
+    detected_language, detected_region, detected_keyboard = detect_install_locale()
+    return (
+        language or detected_language,
+        region or detected_region,
+        keyboard or detected_keyboard,
+    )
+
+
 def _device_nodes_block(cfg: Config) -> str:
     """Build the indented YAML ``devices:`` list body.
 
@@ -854,6 +882,8 @@ def _build_compose_content(cfg: Config) -> str:
     if cfg.pod.network:
         network_env = f'      NETWORK: "{cfg.pod.network}"\n'
 
+    install_language, install_region, install_keyboard = _resolve_install_locale(cfg)
+
     if cfg.pod.disguise_max:
         disk_type, adapter, vga, mtu = "sata", "e1000", "std", "1500"
         # Swap dockur's default qemu-xhci (VEN_1B36, Red Hat) for nec-usb-xhci
@@ -882,9 +912,9 @@ def _build_compose_content(cfg: Config) -> str:
         password=_yaml_escape(password),
         home=str(Path.home()),
         win_version=_yaml_escape(cfg.pod.win_version),
-        language=_yaml_escape(cfg.pod.language),
-        region=_yaml_escape(cfg.pod.region),
-        keyboard=_yaml_escape(cfg.pod.keyboard),
+        language=_yaml_escape(install_language),
+        region=_yaml_escape(install_region),
+        keyboard=_yaml_escape(install_keyboard),
         timezone=_yaml_escape(_resolve_timezone_for_compose(cfg)),
         rdp_port=cfg.rdp.port,
         vnc_port=cfg.pod.vnc_port,

--- a/src/winpodx/utils/locale.py
+++ b/src/winpodx/utils/locale.py
@@ -183,3 +183,151 @@ def resolve_timezone_for_oem(configured: str) -> str:
         return iana_to_windows(raw)
     # Already a Windows TZ ID (no slash, e.g. "Korea Standard Time").
     return raw
+
+
+# Windows installation locale, detected from the host (#791, #790).
+#
+# dockur takes three separate values and bakes them into the Sysprep answer
+# file at FIRST BOOT: LANGUAGE (the UI language pack), REGION (the BCP 47 tag
+# behind date/number/currency formatting) and KEYBOARD (the input layout).
+# They are not applied again afterwards, so the defaults matter more than most
+# — a guest installed as English/en-001 stays that way until it is reinstalled.
+#
+# The names on the left of _DOCKUR_LANGUAGE_BY_TAG are what dockur's own
+# language list accepts; they are not BCP 47 and not interchangeable with the
+# region tags. Kept in sync with the picker in gui/_main_window_settings.py.
+_DOCKUR_LANGUAGE_BY_TAG: dict[str, str] = {
+    "ar": "Arabic",
+    "bg": "Bulgarian",
+    "cs": "Czech",
+    "da": "Danish",
+    "de": "German",
+    "el": "Greek",
+    "en": "English",
+    "es": "Spanish",
+    "et": "Estonian",
+    "fi": "Finnish",
+    "fr": "French",
+    "he": "Hebrew",
+    "hr": "Croatian",
+    "hu": "Hungarian",
+    "it": "Italian",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "lt": "Lithuanian",
+    "lv": "Latvian",
+    "nb": "Norwegian",
+    "nl": "Dutch",
+    "no": "Norwegian",
+    "pl": "Polish",
+    "pt": "Portuguese",
+    "ro": "Romanian",
+    "ru": "Russian",
+    "sk": "Slovak",
+    "sl": "Slovenian",
+    "sr": "Serbian",
+    "sv": "Swedish",
+    "th": "Thai",
+    "tr": "Turkish",
+    "uk": "Ukrainian",
+    "zh": "Chinese",
+}
+
+# Territory changes which language pack dockur installs, not just the region:
+# Traditional and Simplified Chinese are different packs, and so are the two
+# Portuguese and two Spanish variants.
+_DOCKUR_LANGUAGE_BY_LOCALE: dict[str, str] = {
+    "zh-TW": "Traditional Chinese",
+    "zh-HK": "Traditional Chinese",
+    "zh-MO": "Traditional Chinese",
+    "pt-BR": "Brazilian Portuguese",
+    "es-MX": "Mexican Spanish",
+}
+
+# Region / keyboard tags dockur accepts. A host locale outside this set keeps
+# the English default rather than handing dockur a tag it will reject at
+# install time, which would be a much worse failure than the wrong language.
+_DOCKUR_REGION_TAGS: frozenset[str] = frozenset(
+    {
+        "ar-SA",
+        "cs-CZ",
+        "da-DK",
+        "de-DE",
+        "el-GR",
+        "en-001",
+        "en-GB",
+        "en-US",
+        "es-ES",
+        "es-MX",
+        "fi-FI",
+        "fr-FR",
+        "he-IL",
+        "hu-HU",
+        "it-IT",
+        "ja-JP",
+        "ko-KR",
+        "nb-NO",
+        "nl-NL",
+        "pl-PL",
+        "pt-BR",
+        "pt-PT",
+        "ru-RU",
+        "sv-SE",
+        "th-TH",
+        "tr-TR",
+        "uk-UA",
+        "zh-CN",
+        "zh-TW",
+    }
+)
+
+DEFAULT_INSTALL_LOCALE = ("English", "en-001", "en-US")
+
+
+def _posix_locale_from_env() -> str | None:
+    """Return the host's ``ll_CC`` locale from the environment, or None.
+
+    Reads the POSIX precedence order. ``C`` and ``POSIX`` mean "no locale
+    configured" and give None, so a stripped-down shell environment falls back
+    to the English default rather than being read as a preference.
+    """
+    for var in ("LC_ALL", "LC_MESSAGES", "LANG"):
+        raw = (os.environ.get(var) or "").strip()
+        if not raw:
+            continue
+        # Strip the codeset and any @modifier: "sr_RS.UTF-8@latin" -> "sr_RS".
+        value = raw.split(".", 1)[0].split("@", 1)[0]
+        if value.upper() in ("C", "POSIX", ""):
+            continue
+        return value
+    return None
+
+
+def detect_install_locale() -> tuple[str, str, str]:
+    """Detect ``(language, region, keyboard)`` for the Windows install.
+
+    Falls back to :data:`DEFAULT_INSTALL_LOCALE` whenever the host locale is
+    absent, malformed, or outside the set dockur accepts — a wrong-language
+    guest is recoverable, an install that aborts on a rejected tag is not.
+
+    Never raises.
+    """
+    posix = _posix_locale_from_env()
+    if not posix or "_" not in posix:
+        return DEFAULT_INSTALL_LOCALE
+
+    lang, _, territory = posix.partition("_")
+    lang = lang.lower()
+    tag = f"{lang}-{territory.upper()}"
+
+    if tag not in _DOCKUR_REGION_TAGS:
+        return DEFAULT_INSTALL_LOCALE
+
+    language = _DOCKUR_LANGUAGE_BY_LOCALE.get(tag) or _DOCKUR_LANGUAGE_BY_TAG.get(lang)
+    if language is None:
+        return DEFAULT_INSTALL_LOCALE
+
+    # Keyboard follows the region: dockur's keyboard list is the same set of
+    # tags, and a layout that does not match the language is rarely what
+    # someone wants from an autodetected default.
+    return language, tag, tag

--- a/tests/test_compose_network.py
+++ b/tests/test_compose_network.py
@@ -116,3 +116,49 @@ def test_compose_never_sets_disk_io_iouring():
     # default DISK_IO. (See the v6.00 roll-forward follow-up.)
     content = _build_compose_content(_cfg())
     assert "DISK_IO:" not in content
+
+
+# --- #791: install locale detected from the host -----------------------------
+
+
+def test_empty_locale_fields_are_detected_from_the_host(monkeypatch):
+    monkeypatch.setenv("LANG", "ko_KR.UTF-8")
+    cfg = _cfg()
+    cfg.pod.language = ""
+    cfg.pod.region = ""
+    cfg.pod.keyboard = ""
+
+    content = _build_compose_content(cfg)
+
+    assert 'LANGUAGE: "Korean"' in content
+    assert 'REGION: "ko-KR"' in content
+    assert 'KEYBOARD: "ko-KR"' in content
+
+
+def test_configured_locale_is_not_overridden(monkeypatch):
+    # Someone who set these explicitly keeps them whatever the host says.
+    monkeypatch.setenv("LANG", "ko_KR.UTF-8")
+    cfg = _cfg()
+    cfg.pod.language = "German"
+    cfg.pod.region = "de-DE"
+    cfg.pod.keyboard = "de-DE"
+
+    content = _build_compose_content(cfg)
+
+    assert 'LANGUAGE: "German"' in content
+    assert 'REGION: "de-DE"' in content
+
+
+def test_partially_configured_locale_fills_only_the_gaps(monkeypatch):
+    # A user who picked a keyboard but never touched the language should keep
+    # the layout and still get a guest in their own language.
+    monkeypatch.setenv("LANG", "ko_KR.UTF-8")
+    cfg = _cfg()
+    cfg.pod.language = ""
+    cfg.pod.region = ""
+    cfg.pod.keyboard = "en-US"
+
+    content = _build_compose_content(cfg)
+
+    assert 'LANGUAGE: "Korean"' in content
+    assert 'KEYBOARD: "en-US"' in content

--- a/tests/test_locale.py
+++ b/tests/test_locale.py
@@ -173,3 +173,74 @@ class TestResolveTimezoneForOem:
 
     def test_unknown_iana_falls_back_to_utc(self):
         assert resolve_timezone_for_oem("Made/Up/Zone") == "UTC"
+
+
+# --- #791 / #790: Windows install locale detected from the host --------------
+
+
+class TestDetectInstallLocale:
+    def _env(self, monkeypatch, value):
+        for var in ("LC_ALL", "LC_MESSAGES", "LANG"):
+            monkeypatch.delenv(var, raising=False)
+        if value is not None:
+            monkeypatch.setenv("LANG", value)
+
+    @pytest.mark.parametrize(
+        ("lang_env", "expected"),
+        [
+            ("ko_KR.UTF-8", ("Korean", "ko-KR", "ko-KR")),
+            ("de_DE.UTF-8", ("German", "de-DE", "de-DE")),
+            ("ja_JP.UTF-8", ("Japanese", "ja-JP", "ja-JP")),
+            ("en_GB.UTF-8", ("English", "en-GB", "en-GB")),
+            ("fr_FR", ("French", "fr-FR", "fr-FR")),
+        ],
+    )
+    def test_maps_common_host_locales(self, monkeypatch, lang_env, expected):
+        from winpodx.utils.locale import detect_install_locale
+
+        self._env(monkeypatch, lang_env)
+        assert detect_install_locale() == expected
+
+    @pytest.mark.parametrize(
+        ("lang_env", "expected_language"),
+        [
+            ("zh_CN.UTF-8", "Chinese"),
+            ("zh_TW.UTF-8", "Traditional Chinese"),
+            ("pt_BR.UTF-8", "Brazilian Portuguese"),
+            ("pt_PT.UTF-8", "Portuguese"),
+            ("es_MX.UTF-8", "Mexican Spanish"),
+            ("es_ES.UTF-8", "Spanish"),
+        ],
+    )
+    def test_territory_picks_the_right_language_pack(
+        self, monkeypatch, lang_env, expected_language
+    ):
+        # Traditional vs Simplified Chinese, and the pt/es variants, are
+        # separate dockur language packs -- the territory decides, not the
+        # language subtag.
+        from winpodx.utils.locale import detect_install_locale
+
+        self._env(monkeypatch, lang_env)
+        assert detect_install_locale()[0] == expected_language
+
+    @pytest.mark.parametrize("lang_env", [None, "C", "POSIX", "", "garbage", "xx_YY.UTF-8"])
+    def test_falls_back_to_english_when_unusable(self, monkeypatch, lang_env):
+        # A tag dockur would reject aborts the install, which is far worse
+        # than the wrong UI language.
+        from winpodx.utils.locale import DEFAULT_INSTALL_LOCALE, detect_install_locale
+
+        self._env(monkeypatch, lang_env)
+        assert detect_install_locale() == DEFAULT_INSTALL_LOCALE
+
+    def test_lc_all_wins_over_lang(self, monkeypatch):
+        from winpodx.utils.locale import detect_install_locale
+
+        monkeypatch.setenv("LANG", "de_DE.UTF-8")
+        monkeypatch.setenv("LC_ALL", "ko_KR.UTF-8")
+        assert detect_install_locale()[1] == "ko-KR"
+
+    def test_modifier_is_stripped(self, monkeypatch):
+        from winpodx.utils.locale import detect_install_locale
+
+        self._env(monkeypatch, "de_DE.UTF-8@euro")
+        assert detect_install_locale() == ("German", "de-DE", "de-DE")


### PR DESCRIPTION
Two reporters asked for the same thing from different angles: @zkitefly for the UI language (#791), @ismikes for Region and Regional format (#790).

## Why it never happened by itself

`pod.language` / `region` / `keyboard` were hard-coded to `English` / `en-001` / `en-US`, and the only prompt that changes them lives inside `_prompt_edition_locale_tuning`, which is behind `--customize`. The default setup flow never reaches it. So everyone got an English Windows with "English (World)" formatting no matter what their desktop was set to, and both reporters had to go find fields they did not know existed.

`en-001` is worth calling out on its own: it is literally Windows' *World* region, which is why @ismikes saw dates and numbers in a format matching nowhere in particular.

## Change

The three fields now default to empty, meaning **detect from the host at compose time** — the convention `pod.timezone` already uses. `detect_install_locale()` reads `LC_ALL` / `LC_MESSAGES` / `LANG` in POSIX precedence order and maps the locale to the three values dockur wants.

Two details that decide whether this is right or subtly wrong:

- **Territory picks the language pack, not the language subtag.** `zh_TW` is Traditional Chinese, not Chinese; `pt_BR` is Brazilian Portuguese, not Portuguese; `es_MX` is Mexican Spanish. Mapping on the subtag alone installs the wrong pack for each of those.
- **An unrecognised locale falls back to English rather than being passed through.** A tag dockur rejects aborts the install; a guest in the wrong language is merely annoying. `C`, `POSIX` and an empty environment all count as "no preference" and take the fallback too.

Each field resolves independently, so someone who set a keyboard layout but never touched the language keeps their layout and still gets a guest in their own language.

**Existing installs are unaffected.** Their `winpodx.toml` already carries the explicit values written when they were set up, and a non-empty value always passes through.

The setup wizard shows the detected value as the prompt default rather than an empty bracket, and stores whatever the user accepts — a value someone was shown and confirmed should not silently change later because they logged in under a different locale.

## Scope

`#790`'s second half — applying the regional format to an **already-installed** guest with `Set-Culture` / `Set-WinHomeLocation` — is a guest-side change on the apply-fixes path and needs a real-Windows smoke test, so it is not in here. This PR covers the fresh-install half both issues share.

## Tests

15 cases: five common host locales end to end, the six territory-sensitive language packs, six unusable inputs falling back (unset, `C`, `POSIX`, empty, garbage, an unsupported tag), `LC_ALL` winning over `LANG`, `@modifier` stripping, and three compose integrations covering empty, fully configured and partially configured fields. 2336 passed.