### PR TITLE
fix(install): announce the two multi-minute silent stretches (#789)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1558,6 +1558,12 @@ if [ -n "$WINPODX_NO_GUI" ]; then
     log "Headless install (--no-gui): PySide6 skipped."
 else
     # Full: winpodx core + reverse-open + GUI.
+    #
+    # PySide6 is a ~100 MB wheel and pip is running --quiet, so this is a
+    # multi-minute stretch with nothing on screen. People read that as a hang
+    # and Ctrl-C out of it, which is how half-installed states get created
+    # (#789).
+    log "  Downloading the Qt GUI toolkit (PySide6, ~100 MB) — this can take a few minutes."
     "$WORK_VENV_PY" -m pip install --quiet --no-cache-dir "${WORK_DIR}[gui,reverse-open]"
 fi
 
@@ -1727,11 +1733,22 @@ else
     # "installed" banner at the bottom still claimed everything worked. Capture
     # the output instead and check the exit code so a failure is visible and
     # the closing banner reflects reality.
+    # #789: setup pulls the ~2 GB container image on a fresh host. Redirecting
+    # its output to a file made that a silent multi-minute stretch, so tee it:
+    # the user sees the pull progress live, and the file is still there to
+    # quote from if setup fails.
     SETUP_OUT="$(mktemp)"
-    if WINPODX_NO_PROVISION=1 "$VENV_PY" -m winpodx setup "${SETUP_ARGS[@]}" >"$SETUP_OUT" 2>&1; then
+    log "  Preparing the Windows container (first run pulls a ~2 GB image)..."
+    # `set -o pipefail` is on (line 3), so the pipeline's status is setup's
+    # status even though tee and sed run after it -- the exit-code check that
+    # #716 added keeps working unchanged.
+    if WINPODX_NO_PROVISION=1 "$VENV_PY" -m winpodx setup "${SETUP_ARGS[@]}" 2>&1 |
+        tee "$SETUP_OUT" | sed 's/^/    /'; then
         SETUP_OK=1
     else
         SETUP_OK=0
+    fi
+    if [ "$SETUP_OK" -eq 0 ]; then
         err "winpodx setup failed. Last output:"
         tail -n 20 "$SETUP_OUT" | sed 's/^/    /' >&2
         warn "Setup did not finish -- run \`winpodx setup\` manually to retry (or see the full error above)."

--- a/tests/test_install_sh_provision.py
+++ b/tests/test_install_sh_provision.py
@@ -241,3 +241,33 @@ def test_no_inline_chain_steps_survive(script: str) -> None:
     )
     for cmd in forbidden:
         assert cmd not in script, f"inline bash chain step still present: {cmd!r}"
+
+
+# --- #789: the two multi-minute stretches that used to be silent -------------
+
+
+def test_pyside6_download_is_announced(script: str) -> None:
+    """A ~100 MB wheel under `pip --quiet` looks like a hang, and people
+    Ctrl-C out of it — which is how half-installed states get created."""
+    active = _strip_comments(script)
+    assert "PySide6, ~100 MB" in active
+
+
+def test_setup_output_is_teed_not_swallowed(script: str) -> None:
+    """Redirecting setup straight to a file hid the container image pull.
+    It must reach the terminal as well as the capture file."""
+    active = _strip_comments(script)
+
+    assert 'tee "$SETUP_OUT"' in active
+    # The old form sent everything to the file and showed nothing.
+    assert '-m winpodx setup "${SETUP_ARGS[@]}" >"$SETUP_OUT" 2>&1' not in active
+
+
+def test_setup_failure_detection_survives_the_pipe(script: str) -> None:
+    """Piping through tee would report tee's status instead of setup's without
+    pipefail, silently turning a failed setup into a successful install."""
+    assert "set -euo pipefail" in script
+
+    active = _strip_comments(script)
+    assert "SETUP_OK=0" in active
+    assert 'tail -n 20 "$SETUP_OUT"' in active


### PR DESCRIPTION
Two places in `install.sh` sit for minutes with nothing on screen, and both are places people report the installer as hung:

- the GUI install pulls **PySide6**, a ~100 MB wheel, under `pip --quiet`;
- `winpodx setup` had its entire output redirected to a temp file, so the **container image pull** (~2 GB on a fresh host) was invisible.

The first now says what it is downloading and that it takes a while. The second is teed rather than swallowed: output reaches the terminal, indented, and the capture file is still there for the failure path #716 added.

`set -o pipefail` is already on at line 3, so piping through `tee` does not cost the exit-code check — verified rather than assumed:

```
$ (echo "some output"; exit 3) 2>&1 | tee "$T" | sed "s/^/    /"
    some output
RESULT: reported failure (correct)
```

## Why it matters beyond tidiness

Aborting a silent stretch is how half-installed states get created, and that is the shape of several install-failure reports on the tracker. Showing the pull also means the next person who hits a slow or blocked download can see *what* is slow, instead of filing "install hangs".

## Tests

Three guards in `tests/test_install_sh_provision.py`: the PySide6 notice is present, setup output is teed rather than redirected straight to the file, and the failure detection that depends on `pipefail` is intact. 25 passed.