### PR TITLE
fix(config): let an empty install locale mean autodetect (#791 follow-up)

### DIFF
--- a/src/winpodx/core/config.py
+++ b/src/winpodx/core/config.py
@@ -644,23 +644,29 @@ class PodConfig:
                     self.home_share,
                 )
         # language, region, keyboard: sanitize to prevent YAML injection.
-        # Default to English (US) if the value contains dangerous chars.
-        for field_name, default_val in [
-            ("language", "English"),
-            ("region", "en-001"),
-            ("keyboard", "en-US"),
-        ]:
-            val = getattr(self, field_name, default_val)
+        #
+        # Empty is a meaningful value here, not a missing one: it means "detect
+        # from the host at compose time" (#791). This used to coerce empty back
+        # to English / en-001 / en-US, which made the field unreachable — the
+        # autodetect branch in compose could never run because the value was
+        # never empty by the time it looked.
+        #
+        # A value carrying YAML-reserved characters still gets rejected, and
+        # rejecting it to empty rather than to English means a hand-edited
+        # config falls back to the user's own locale. Detection only ever
+        # returns values from winpodx's own tables, so that stays injection-safe.
+        for field_name in ("language", "region", "keyboard"):
+            val = getattr(self, field_name, "")
             if not isinstance(val, str) or not val.strip():
-                setattr(self, field_name, default_val)
+                setattr(self, field_name, "")
             elif any(ch in _DANGEROUS_YAML_CHARS for ch in val):
                 logging.getLogger(__name__).warning(
-                    "%s=%r contains characters reserved by YAML / shell; coercing to default %r",
+                    "%s=%r contains characters reserved by YAML / shell; "
+                    "falling back to the host-detected locale",
                     field_name,
                     val,
-                    default_val,
                 )
-                setattr(self, field_name, default_val)
+                setattr(self, field_name, "")
             else:
                 setattr(self, field_name, val.strip())
         # timezone (#254): free-form string with the same YAML-injection

--- a/tests/test_compose_network.py
+++ b/tests/test_compose_network.py
@@ -121,6 +121,32 @@ def test_compose_never_sets_disk_io_iouring():
 # --- #791: install locale detected from the host -----------------------------
 
 
+def test_default_config_detects_locale_from_the_host(monkeypatch):
+    # Goes through PodConfig() rather than assigning after construction: the
+    # sanitiser in __post_init__ used to coerce the empty default back to
+    # English, which made the autodetect branch unreachable in real use while
+    # a test that set the attribute afterwards still passed.
+    monkeypatch.setenv("LANG", "ko_KR.UTF-8")
+    cfg = _cfg()
+
+    assert cfg.pod.language == ""  # empty survives __post_init__
+    content = _build_compose_content(cfg)
+
+    assert 'LANGUAGE: "Korean"' in content
+    assert 'REGION: "ko-KR"' in content
+    assert 'KEYBOARD: "ko-KR"' in content
+
+
+def test_yaml_dangerous_locale_falls_back_to_detection(monkeypatch):
+    monkeypatch.setenv("LANG", "de_DE.UTF-8")
+    cfg = _cfg()
+    cfg.pod.language = 'English"\ninjected: "x'
+    cfg.pod.__post_init__()
+
+    assert cfg.pod.language == ""
+    assert 'LANGUAGE: "German"' in _build_compose_content(cfg)
+
+
 def test_empty_locale_fields_are_detected_from_the_host(monkeypatch):
     monkeypatch.setenv("LANG", "ko_KR.UTF-8")
     cfg = _cfg()

--- a/tests/test_setup_wizard_prompts.py
+++ b/tests/test_setup_wizard_prompts.py
@@ -44,26 +44,22 @@ def test_wizard_prompts_set_all_locale_edition_tuning_fields() -> None:
 
 
 def test_wizard_prompts_enter_keeps_defaults() -> None:
-    """Empty input (Enter) keeps the existing cfg defaults."""
+    """Empty input (Enter) keeps whatever the prompt displayed as the default."""
+    from winpodx.utils.locale import detect_install_locale
+
     cfg = _cfg()
-    before = (
-        cfg.pod.win_version,
-        cfg.pod.language,
-        cfg.pod.region,
-        cfg.pod.keyboard,
-        cfg.pod.tuning_profile,
-    )
+    before_edition = cfg.pod.win_version
+    before_tuning = cfg.pod.tuning_profile
+
     with patch("builtins.input", lambda _prompt: ""):
         _prompt_edition_locale_tuning(cfg)
 
-    after = (
-        cfg.pod.win_version,
-        cfg.pod.language,
-        cfg.pod.region,
-        cfg.pod.keyboard,
-        cfg.pod.tuning_profile,
-    )
-    assert before == after
+    assert cfg.pod.win_version == before_edition
+    assert cfg.pod.tuning_profile == before_tuning
+    # The locale fields default to empty meaning "detect from the host", so
+    # what Enter accepts is the detected value the prompt showed -- and it is
+    # stored, so it cannot change later under a different host locale (#791).
+    assert (cfg.pod.language, cfg.pod.region, cfg.pod.keyboard) == detect_install_locale()
 
 
 def test_wizard_rejects_unknown_tuning_profile_keeps_default() -> None:


### PR DESCRIPTION
Follow-up to #804, which does not currently work.

## What went wrong

#804 changed `pod.language` / `region` / `keyboard` to default to empty, meaning "detect from the host at compose time". But `PodConfig.__post_init__` has had a sanitiser since v0.5.x that treats empty as *missing* and coerces it back:

```python
if not isinstance(val, str) or not val.strip():
    setattr(self, field_name, default_val)   # "English" / "en-001" / "en-US"
```

So the value compose reads is never empty, and `_resolve_install_locale`'s detection branch is dead code. On a Korean host:

```
$ LANG=ko_KR.UTF-8 python -c "from winpodx.core.config import PodConfig; print(PodConfig().language)"
English
```

## Why the tests passed anyway

The compose test assigned the empty value **after** construction:

```python
cfg = _cfg()
cfg.pod.language = ""      # bypasses __post_init__
```

That asserts a state the real code cannot reach. A test that goes through the constructor would have failed immediately.

## Change

Empty is preserved through `__post_init__` — it is a meaningful value here, not a missing one.

A value carrying YAML-reserved characters is still rejected, but now to empty rather than to English. A hand-edited config then falls back to the user's own locale instead of silently becoming English, and detection only ever returns values from winpodx's own tables, so that stays injection-safe. `_yaml_escape` still runs on the resolved value.

Verified against the real path:

```
$ LANG=ko_KR.UTF-8 … PodConfig()   -> language='' region='' keyboard=''
                      detect_install_locale() -> ('Korean', 'ko-KR', 'ko-KR')
$ LANG=C            detect_install_locale() -> ('English', 'en-001', 'en-US')
```

## Tests

The compose cases now construct `PodConfig()` and assert the empty default survives before checking the rendered output, plus a case for a YAML-dangerous value falling back to detection.

`test_wizard_prompts_enter_keeps_defaults` was asserting `before == after`, which only held because of the coercion — its failure here is the signal that the fix works. It now asserts the actual contract: Enter accepts the detected value the prompt displayed, and stores it so it cannot change later under a different host locale.

2356 passed.