### PR TITLE
fix(agent): stop the guest console code page mangling /exec output

### DIFF
--- a/config/oem/agent/agent.ps1
+++ b/config/oem/agent/agent.ps1
@@ -154,8 +154,26 @@ function Invoke-ExecScript([string]$scriptB64, [int]$timeoutSec) {
             return @{ error = 'bad_base64'; detail = $_.Exception.Message }
         }
         $hash = Get-BytesHash $bytes
+        # Hash the caller's bytes BEFORE the preamble, so the value the host
+        # compares against stays the hash of what it sent.
+        #
+        # The preamble forces the child to write UTF-8. Without it the child
+        # encodes stdout with the console's OEM code page, and any character
+        # that code page lacks goes through Windows' best-fit mapping on the
+        # way out -- which silently turned "Microsoft(R) Drive Optimizer" into
+        # "Microsoftr Drive Optimizer" in discovery output. The characters are
+        # gone by the time the bytes reach the pipe, so nothing downstream can
+        # recover them.
+        #
+        # Assigning [Console]::OutputEncoding throws on some hosts when stdout
+        # is redirected, hence the try/catch: a child that cannot set it is no
+        # worse off than before this preamble existed.
+        $preamble = [Text.Encoding]::UTF8.GetBytes(
+            "try { [Console]::OutputEncoding = New-Object Text.UTF8Encoding `$false } catch { }`r`n" +
+            "`$OutputEncoding = New-Object Text.UTF8Encoding `$false`r`n"
+        )
         try {
-            [IO.File]::WriteAllBytes($tempFile, $bytes)
+            [IO.File]::WriteAllBytes($tempFile, ($preamble + $bytes))
         } catch {
             return @{ error = 'temp_write_failed'; detail = $_.Exception.Message; hash = $hash }
         }
@@ -174,6 +192,11 @@ function Invoke-ExecScript([string]$scriptB64, [int]$timeoutSec) {
             $psi.CreateNoWindow         = $true
             $psi.RedirectStandardOutput = $true
             $psi.RedirectStandardError  = $true
+            # Decode the child's bytes as UTF-8, matching the preamble written
+            # into its script. Left unset, .NET decodes with the console's OEM
+            # code page and mangles anything outside it.
+            $psi.StandardOutputEncoding = New-Object Text.UTF8Encoding $false
+            $psi.StandardErrorEncoding  = New-Object Text.UTF8Encoding $false
             $proc = New-Object System.Diagnostics.Process
             $proc.StartInfo = $psi
             [void]$proc.Start()

--- a/config/oem/install.bat
+++ b/config/oem/install.bat
@@ -1,7 +1,7 @@
 @echo off
 REM First-boot OEM setup for winpodx Windows guest. Runs once during dockur's unattended install. Every action must stay idempotent - there is no guest-side re-run channel in 0.1.6 (push/exec bridge planned for a later release).
 
-set WINPODX_OEM_VERSION=30
+set WINPODX_OEM_VERSION=31
 
 echo [WinPodX] Starting post-install configuration (version %WINPODX_OEM_VERSION%)...
 

--- a/tests/test_agent_ps1_syntax.py
+++ b/tests/test_agent_ps1_syntax.py
@@ -266,3 +266,32 @@ def test_agent_ps1_braces_balanced(agent_source: str):
     opens = body.count("{")
     closes = body.count("}")
     assert opens == closes, f"unbalanced braces: {opens} '{{' vs {closes} '}}'"
+
+
+# --- guest /exec must not lose characters to the console code page ----------
+
+
+def test_exec_child_stdio_is_decoded_as_utf8(agent_source: str):
+    """Left unset, .NET decodes a redirected child's output with the console's
+    OEM code page, which mangles anything that page lacks."""
+    assert "$psi.StandardOutputEncoding = New-Object Text.UTF8Encoding $false" in agent_source
+    assert "$psi.StandardErrorEncoding  = New-Object Text.UTF8Encoding $false" in agent_source
+
+
+def test_exec_child_is_told_to_emit_utf8(agent_source: str):
+    """Decoding as UTF-8 only helps if the child encodes as UTF-8. Otherwise
+    Windows' best-fit mapping has already replaced the characters -- that is
+    how "Microsoft(R) Drive Optimizer" reached the host as "Microsoftr ...".
+    """
+    assert "[Console]::OutputEncoding = New-Object Text.UTF8Encoding" in agent_source
+    assert "$OutputEncoding = New-Object Text.UTF8Encoding" in agent_source
+
+
+def test_exec_hashes_the_callers_bytes_not_the_preamble(agent_source: str):
+    """The host compares the returned hash against what it sent, so the
+    preamble must be added after hashing."""
+    hash_at = agent_source.index("$hash = Get-BytesHash $bytes")
+    preamble_at = agent_source.index("$preamble = [Text.Encoding]::UTF8.GetBytes(")
+    write_at = agent_source.index("[IO.File]::WriteAllBytes($tempFile, ($preamble + $bytes))")
+
+    assert hash_at < preamble_at < write_at

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -76,7 +76,7 @@ def test_bundled_oem_version_matches_install_bat_marker(monkeypatch):
     Force the install.bat fallback by nulling the .txt stamp reader.
     """
     monkeypatch.setattr("winpodx.core.info._read_text_file", lambda *a, **k: None)
-    assert _bundled_oem_version() == "30"
+    assert _bundled_oem_version() == "31"
 
 
 def test_bundled_oem_version_falls_back_to_unknown(monkeypatch, tmp_path):

--- a/tests/test_oem_install_bat.py
+++ b/tests/test_oem_install_bat.py
@@ -43,7 +43,7 @@ def test_install_bat_does_not_self_lock_setup_log() -> None:
 
 def test_install_bat_oem_version_matches_expected_setup_contract() -> None:
     text = INSTALL_BAT.read_text(encoding="utf-8")
-    assert "set WINPODX_OEM_VERSION=30" in text
+    assert "set WINPODX_OEM_VERSION=31" in text
     assert "(echo %WINPODX_OEM_VERSION%)>C:\\winpodx\\oem_version.txt" in text
 
 


### PR DESCRIPTION
> **Needs a real-Windows smoke test before merge** — this changes `agent.ps1`, which runs in the guest.

Found while smoke-testing main: discovery registered an app as **`Microsoftr Drive Optimizer`**. It should be `Microsoft® Drive Optimizer`, and it was on an earlier run.

## Where it breaks

The name is already wrong in `app.toml`, so the loss happens in the guest, before anything the host controls. And `®` → `r` is not a random substitution — it is Windows' **best-fit character mapping**, what `WideCharToMultiByte` does when asked to encode a character the target code page does not have.

`agent.ps1` redirects the `/exec` child's stdout without specifying an encoding:

```powershell
$psi.RedirectStandardOutput = $true
$psi.RedirectStandardError  = $true
```

So the child PowerShell encodes its output with the console's OEM code page, and .NET decodes with the same one. By the time the bytes reach the pipe the characters are gone, which is why nothing downstream could recover them.

## Fix

Both halves are needed, and either alone is useless:

- the **parent** sets `StandardOutputEncoding` / `StandardErrorEncoding` to UTF-8, so .NET decodes the child's bytes correctly;
- a **preamble** prepended to the temp script sets `[Console]::OutputEncoding` and `$OutputEncoding` to UTF-8, so the child emits UTF-8 in the first place. Fixing only the parent would decode already-mangled bytes very accurately.

Two details:

- The preamble is added **after** `Get-BytesHash`, so the hash the host compares against still covers exactly the bytes it sent. A test pins that ordering, since getting it wrong would break every `/exec` with a hash mismatch rather than anything obvious.
- Assigning `[Console]::OutputEncoding` throws on some hosts when stdout is redirected, so that line is wrapped — a child that cannot set it is no worse off than before this existed.

## The FreeRDP path is fine

Worth stating since it is the other exec transport: it captures output into a PowerShell variable and writes the result with `Out-File -Encoding utf8`, never crossing a console encoding. Only the agent path was lossy, and the agent is what discovery used on the run that produced this.

## Tests

Three static assertions in `tests/test_agent_ps1_syntax.py`: the child's stdio is decoded as UTF-8, the child is told to emit UTF-8, and the hash is taken before the preamble. The pwsh AST parse in the same file covers syntax in CI. 2364 passed.

OEM version bumped 30 → 31 so provisioned guests pick up the new agent.

## Smoke

Reinstall, then check the discovered name:

```
grep full_name ~/.local/share/winpodx/discovered/*drive-optimizer*/app.toml
```

Expect `Microsoft® Drive Optimizer`. A CJK-named app (#553) should keep working — that path already survived, so this must not regress it.