### PR TITLE
fix(agent): run /exec scripts through a UTF-8 launcher

### DIFF
--- a/config/oem/agent/agent.ps1
+++ b/config/oem/agent/agent.ps1
@@ -145,8 +145,9 @@ function Send-Json($resp, [int]$code, $obj) {
 # because Start-Process does not support -EncodedCommand cleanly with
 # stdout/stderr redirection; the temp file is cleaned up after the run.
 function Invoke-ExecScript([string]$scriptB64, [int]$timeoutSec) {
-    $tempBase  = Join-Path $script:RunsDir ([Guid]::NewGuid().ToString('N'))
-    $tempFile  = "$tempBase.ps1"
+    $tempBase   = Join-Path $script:RunsDir ([Guid]::NewGuid().ToString('N'))
+    $tempFile   = "$tempBase.ps1"
+    $launchFile = "$tempBase.launch.ps1"
     try {
         try {
             $bytes = [Convert]::FromBase64String($scriptB64)
@@ -156,6 +157,37 @@ function Invoke-ExecScript([string]$scriptB64, [int]$timeoutSec) {
         $hash = Get-BytesHash $bytes
         try {
             [IO.File]::WriteAllBytes($tempFile, $bytes)
+        } catch {
+            return @{ error = 'temp_write_failed'; detail = $_.Exception.Message; hash = $hash }
+        }
+        # Run the caller's script through a launcher that sets UTF-8 first.
+        #
+        # Without it the child encodes stdout with the console's OEM code page,
+        # and any character that page lacks goes through Windows' best-fit
+        # mapping on the way out -- which turned "Microsoft(R) Drive Optimizer"
+        # into "Microsoftr Drive Optimizer" in discovery output. The characters
+        # are gone by the time the bytes reach the pipe, so nothing downstream
+        # can recover them.
+        #
+        # It has to be a separate FILE, not a preamble prepended to the
+        # caller's script: PowerShell requires param() and [CmdletBinding()] to
+        # be the first statement in their file, and discover_apps.ps1 opens
+        # with both. Prepending anything executable makes it unparseable
+        # ("Unexpected attribute 'CmdletBinding'").
+        #
+        # `exit $rc` keeps -File's exit-code semantics: & leaves the called
+        # script's exit code in $LASTEXITCODE, which is $null when the script
+        # returns without ever running a native command.
+        $launcher = @"
+try { [Console]::OutputEncoding = New-Object Text.UTF8Encoding `$false } catch { }
+`$OutputEncoding = New-Object Text.UTF8Encoding `$false
+& '$tempFile'
+`$rc = `$LASTEXITCODE
+if (`$null -eq `$rc) { `$rc = 0 }
+exit `$rc
+"@
+        try {
+            [IO.File]::WriteAllText($launchFile, $launcher, (New-Object Text.UTF8Encoding $false))
         } catch {
             return @{ error = 'temp_write_failed'; detail = $_.Exception.Message; hash = $hash }
         }
@@ -169,11 +201,16 @@ function Invoke-ExecScript([string]$scriptB64, [int]$timeoutSec) {
         try {
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName               = 'powershell.exe'
-            $psi.Arguments              = '-NoProfile -ExecutionPolicy Bypass -File "' + $tempFile + '"'
+            $psi.Arguments              = '-NoProfile -ExecutionPolicy Bypass -File "' + $launchFile + '"'
             $psi.UseShellExecute        = $false
             $psi.CreateNoWindow         = $true
             $psi.RedirectStandardOutput = $true
             $psi.RedirectStandardError  = $true
+            # Decode the child's bytes as UTF-8, matching what the launcher
+            # tells it to emit. Left unset, .NET decodes with the console's OEM
+            # code page and undoes the launcher's work.
+            $psi.StandardOutputEncoding = New-Object Text.UTF8Encoding $false
+            $psi.StandardErrorEncoding  = New-Object Text.UTF8Encoding $false
             $proc = New-Object System.Diagnostics.Process
             $proc.StartInfo = $psi
             [void]$proc.Start()
@@ -216,8 +253,10 @@ function Invoke-ExecScript([string]$scriptB64, [int]$timeoutSec) {
             timedOut = $timedOut
         }
     } finally {
-        if ($tempFile -and (Test-Path $tempFile)) {
-            try { Remove-Item -LiteralPath $tempFile -Force -ErrorAction SilentlyContinue } catch { }
+        foreach ($f in @($tempFile, $launchFile)) {
+            if ($f -and (Test-Path $f)) {
+                try { Remove-Item -LiteralPath $f -Force -ErrorAction SilentlyContinue } catch { }
+            }
         }
     }
 }

--- a/config/oem/install.bat
+++ b/config/oem/install.bat
@@ -1,7 +1,7 @@
 @echo off
 REM First-boot OEM setup for winpodx Windows guest. Runs once during dockur's unattended install. Every action must stay idempotent - there is no guest-side re-run channel in 0.1.6 (push/exec bridge planned for a later release).
 
-set WINPODX_OEM_VERSION=30
+set WINPODX_OEM_VERSION=31
 
 echo [WinPodX] Starting post-install configuration (version %WINPODX_OEM_VERSION%)...
 

--- a/tests/test_agent_ps1_syntax.py
+++ b/tests/test_agent_ps1_syntax.py
@@ -266,3 +266,114 @@ def test_agent_ps1_braces_balanced(agent_source: str):
     opens = body.count("{")
     closes = body.count("}")
     assert opens == closes, f"unbalanced braces: {opens} '{{' vs {closes} '}}'"
+
+
+# --- guest /exec must not lose characters to the console code page ----------
+#
+# The first attempt at this prepended an encoding preamble to the caller's
+# script. That made every /exec unparseable, because PowerShell requires
+# param() and [CmdletBinding()] to be the first statement in their file and
+# discover_apps.ps1 opens with both. Parsing agent.ps1 alone did not catch it:
+# what breaks is the script agent.ps1 ASSEMBLES at runtime. These tests build
+# that artifact and parse it.
+
+
+def _render_launcher(agent_source: str, script_path: str) -> str:
+    """Reproduce the launcher agent.ps1 writes, for a given inner script."""
+    import re
+
+    m = re.search(r'\$launcher = @"\n(.*?)\n"@', agent_source, re.S)
+    assert m, "launcher here-string not found in agent.ps1"
+    body = m.group(1)
+    # PowerShell here-strings use ` to escape $; the only interpolation left
+    # is the script path.
+    return body.replace("`$", "$").replace("$tempFile", script_path)
+
+
+def test_launcher_is_a_separate_file_not_a_preamble(agent_source: str):
+    assert "$launchFile = " in agent_source
+    assert '-File "' + "' + $launchFile + '" in agent_source
+    # The caller's bytes must reach disk untouched.
+    assert "[IO.File]::WriteAllBytes($tempFile, $bytes)" in agent_source
+
+
+def test_exec_child_stdio_is_decoded_as_utf8(agent_source: str):
+    assert "$psi.StandardOutputEncoding = New-Object Text.UTF8Encoding $false" in agent_source
+    assert "$psi.StandardErrorEncoding  = New-Object Text.UTF8Encoding $false" in agent_source
+
+
+def test_both_temp_files_are_cleaned_up(agent_source: str):
+    assert "foreach ($f in @($tempFile, $launchFile))" in agent_source
+
+
+def test_assembled_launcher_parses(agent_source: str, tmp_path):
+    """Parse the launcher agent.ps1 actually writes — the check that would
+    have caught the preamble regression."""
+    pwsh = shutil.which("pwsh")
+    if not pwsh:
+        pytest.skip("pwsh not installed on this host")
+
+    launcher = tmp_path / "launch.ps1"
+    launcher.write_text(
+        _render_launcher(agent_source, str(tmp_path / "inner.ps1")), encoding="utf-8"
+    )
+
+    result = subprocess.run(
+        [
+            pwsh,
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            (
+                "$errors = $null; "
+                f"[void][System.Management.Automation.Language.Parser]::ParseFile('{launcher}', "
+                "[ref]$null, [ref]$errors); "
+                "if ($errors -and $errors.Count -gt 0) { "
+                "  $errors | ForEach-Object { Write-Error $_.ToString() }; exit 1 "
+                "}"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"launcher does not parse:\n{result.stderr}"
+
+
+def test_discovery_script_still_parses_when_launched_this_way(agent_source: str, tmp_path):
+    """The real inner script keeps its param()/[CmdletBinding()] first, which
+    is the property the preamble approach destroyed."""
+    pwsh = shutil.which("pwsh")
+    if not pwsh:
+        pytest.skip("pwsh not installed on this host")
+
+    discover = REPO_ROOT / "scripts" / "windows" / "discover_apps.ps1"
+    inner = tmp_path / "inner.ps1"
+    # agent.ps1 writes the caller's bytes verbatim -- so this is byte-identical
+    # to what the guest would run.
+    inner.write_bytes(discover.read_bytes())
+
+    launcher = tmp_path / "launch.ps1"
+    launcher.write_text(_render_launcher(agent_source, str(inner)), encoding="utf-8")
+
+    for target in (inner, launcher):
+        result = subprocess.run(
+            [
+                pwsh,
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                (
+                    "$errors = $null; "
+                    f"[void][System.Management.Automation.Language.Parser]::ParseFile('{target}', "
+                    "[ref]$null, [ref]$errors); "
+                    "if ($errors -and $errors.Count -gt 0) { "
+                    "  $errors | ForEach-Object { Write-Error $_.ToString() }; exit 1 "
+                    "}"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"{target.name} does not parse:\n{result.stderr}"

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -76,7 +76,7 @@ def test_bundled_oem_version_matches_install_bat_marker(monkeypatch):
     Force the install.bat fallback by nulling the .txt stamp reader.
     """
     monkeypatch.setattr("winpodx.core.info._read_text_file", lambda *a, **k: None)
-    assert _bundled_oem_version() == "30"
+    assert _bundled_oem_version() == "31"
 
 
 def test_bundled_oem_version_falls_back_to_unknown(monkeypatch, tmp_path):

--- a/tests/test_oem_install_bat.py
+++ b/tests/test_oem_install_bat.py
@@ -43,7 +43,7 @@ def test_install_bat_does_not_self_lock_setup_log() -> None:
 
 def test_install_bat_oem_version_matches_expected_setup_contract() -> None:
     text = INSTALL_BAT.read_text(encoding="utf-8")
-    assert "set WINPODX_OEM_VERSION=30" in text
+    assert "set WINPODX_OEM_VERSION=31" in text
     assert "(echo %WINPODX_OEM_VERSION%)>C:\\winpodx\\oem_version.txt" in text
 
 


### PR DESCRIPTION
> **Needs a real-Windows smoke test before merge** — changes `agent.ps1`, which runs in the guest.

Second attempt at the console-code-page fix. The first one (#808, reverted in `6112ddc`) broke discovery completely, so this PR is as much about the testing gap as the encoding.

## What the first attempt got wrong

It prepended an encoding preamble to the caller's script. PowerShell requires `param()` and `[CmdletBinding()]` to be the **first statement in their file**, and `discover_apps.ps1` opens with both. Every `/exec` became unparseable:

```
At C:\OEM\agent-runs\8159a9fe....ps1:49 char:1
+ [CmdletBinding()]
+ ~~~~~~~~~~~~~~~~~
Unexpected attribute 'CmdletBinding'.
```

Discovery failed all five attempts and the install registered zero apps.

## Why CI did not catch it

The pwsh AST test parses `agent.ps1`, and `agent.ps1` was syntactically fine. What broke was **the script agent.ps1 assembles at runtime**, which nothing parsed. The static string assertions checked that the preamble was present — not that the result was valid PowerShell.

## The fix

The caller's bytes go to disk untouched. A separate launcher file invokes them:

```powershell
try { [Console]::OutputEncoding = New-Object Text.UTF8Encoding $false } catch { }
$OutputEncoding = New-Object Text.UTF8Encoding $false
& 'C:\OEM\agent-runs\<guid>.ps1'
$rc = $LASTEXITCODE
if ($null -eq $rc) { $rc = 0 }
exit $rc
```

`param()` keeps its position because it is still the first statement of its own file. `-File` semantics are unchanged, and `exit $rc` preserves the exit code — `$LASTEXITCODE` is `$null` when a script returns without ever running a native command, which would otherwise become a spurious failure. Both temp files are cleaned up.

The parent still sets `StandardOutputEncoding` / `StandardErrorEncoding` to UTF-8. Decoding correctly only helps if the child encodes correctly, and the reverse — both halves are needed.

## Verification, not assumption

Run against a real pwsh in a container before opening this:

```
OK   agent.ps1
OK   launch.ps1          (the assembled launcher)
OK   inner.ps1           (the real discover_apps.ps1, byte-identical)
```

and re-creating the preamble approach reproduces the exact guest failure:

```
FAIL — Unexpected attribute 'CmdletBinding'.
       Unexpected token 'param' in expression or statement.
```

## Tests

The new cases build the assembled artifact and parse it — the check that was missing. `test_assembled_launcher_parses` renders the launcher from `agent.ps1`'s own here-string; `test_discovery_script_still_parses_when_launched_this_way` writes the real `discover_apps.ps1` as the inner script and parses both files. They skip where pwsh is absent and run in CI. 2364 passed.

OEM version bumped 30 → 31 so provisioned guests pick up the new agent.

## Smoke

```
grep full_name ~/.local/share/winpodx/discovered/*drive-optimizer*/app.toml
```

Expect `Microsoft® Drive Optimizer`. **First check discovery works at all** — app count should be back to ~54, not 0. A CJK-named app (#553) must keep working.