### PR TITLE
fix(discovery): make low-resource provisioning reliable

### DIFF
--- a/src/winpodx/cli/main.py
+++ b/src/winpodx/cli/main.py
@@ -10,6 +10,16 @@ from winpodx import __version__
 from winpodx.core.i18n import tr
 
 
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError("must be a positive integer") from e
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
 def cli(argv: list[str] | None = None) -> None:
     """winpodx CLI entry point."""
     from winpodx.utils.logging import setup_logging
@@ -57,7 +67,7 @@ def cli(argv: list[str] | None = None) -> None:
 
     refresh_p.add_argument(
         "--timeout",
-        type=int,
+        type=_positive_int,
         default=DEFAULT_DISCOVERY_TIMEOUT,
         help=(
             "Discovery timeout in seconds "
@@ -780,9 +790,10 @@ def cli(argv: list[str] | None = None) -> None:
         "--retries",
         type=int,
         default=5,
-        help="Discovery retry attempts with exponential backoff (default 5). "
-        "A loaded first boot can blow the 180s/attempt budget; each retry "
-        "lands on an idler guest.",
+        help=(
+            "Discovery retry attempts for transient channel/session failures "
+            "with exponential backoff (default 5). Terminal timeouts are not retried."
+        ),
     )
     provision_p.add_argument(
         "--verbose",
@@ -1095,7 +1106,8 @@ def _cmd_provision(args: argparse.Namespace) -> int:
 
     Flags map 1:1 onto the helper parameters. Run with no flags it
     reproduces install.sh's post-create defaults (wait 3600s, soft agent
-    settle, discovery on with 5× retry, reverse-open on when enabled), so
+    settle, discovery on with five retries for non-timeout transient failures,
+    reverse-open on when enabled), so
     an AppImage first run can simply ``winpodx provision`` for the
     install.sh UX without re-implementing it (item I AppImage parity).
     """
@@ -1169,8 +1181,25 @@ def _cmd_provision(args: argparse.Namespace) -> int:
         )
         return 4
 
-    print(tr("Provisioning complete."))
+    discovery_status = results.get("discovery")
+    discovery_failed = (
+        with_discovery
+        and isinstance(discovery_status, str)
+        and discovery_status.startswith("failed:")
+    )
+    if discovery_failed:
+        print(
+            tr(
+                "provision deferred: Windows app discovery did not complete; "
+                "leaving pending setup for the next retry."
+            ),
+            file=sys.stderr,
+        )
+    else:
+        print(tr("Provisioning complete."))
+
     for stage, status in results.items():
+        output = sys.stderr if discovery_failed and stage == "discovery" else sys.stdout
         if isinstance(status, dict):
             # apply_fixes carries a {helper: status_str} map; render it as a
             # compact "N/N fixes OK" when every helper succeeded, else a joined
@@ -1182,10 +1211,10 @@ def _cmd_provision(args: argparse.Namespace) -> int:
                 rendered = f"{ok_count}/{total} fixes OK"
             else:
                 rendered = ", ".join(f"{k}: {v}" for k, v in status.items())
-            print(f"  {stage}: {rendered}")
+            print(f"  {stage}: {rendered}", file=output)
         else:
-            print(f"  {stage}: {status}")
-    return 0
+            print(f"  {stage}: {status}", file=output)
+    return 5 if discovery_failed else 0
 
 
 def _cmd_language(code: str | None) -> None:

--- a/src/winpodx/cli/setup_cmd.py
+++ b/src/winpodx/cli/setup_cmd.py
@@ -712,7 +712,8 @@ def _run_full_provision(cfg: Config) -> None:
     reverse-open — moved into the helper, parameter-gated. We pass the same
     parameters the old inline code used: 3600s wait, soft agent settle
     (require_agent=False so a slow first boot doesn't crash setup), discovery
-    with 6× retry, reverse-open gated on cfg.reverse_open.enabled.
+    with five retries for non-timeout transient failures, reverse-open gated
+    on cfg.reverse_open.enabled.
 
     Skipped for non-podman/docker backends (the helper short-circuits too).
     """

--- a/src/winpodx/core/agent.py
+++ b/src/winpodx/core/agent.py
@@ -44,6 +44,7 @@ log = logging.getLogger(__name__)
 # documented as the paired second SoT (PowerShell can't import a Python
 # constant). Changing the port means editing here AND those PS1/BAT files.
 AGENT_PORT = 8765
+_EXEC_RESPONSE_GRACE = 5.0
 
 
 class AgentError(RuntimeError):
@@ -235,10 +236,10 @@ class AgentClient:
         """POST /exec — run ``script`` as PowerShell on the guest.
 
         ``script`` is the raw PowerShell source; this method base64-encodes
-        it before sending. ``timeout`` is the per-call client budget in
-        seconds; we pass ``timeout-1`` to urlopen so the server-side cap
-        has room to fire and respond before the client gives up. A
-        client-side socket timeout becomes ``AgentTimeoutError``.
+        it before sending. ``timeout`` is the guest's per-call execution
+        budget in seconds; urllib waits for that server timeout plus a
+        private five-second cleanup/response grace period before giving up.
+        A client-side socket timeout becomes ``AgentTimeoutError``.
 
         Returns ``ExecResult`` even when the script's rc is non-zero —
         that's a script-level outcome, not a transport-level error.
@@ -258,7 +259,7 @@ class AgentClient:
             with_auth=True,
             extra_headers={"Content-Type": "application/json"},
         )
-        urlopen_timeout = float(max(1, timeout - 1))
+        urlopen_timeout = float(timeout) + _EXEC_RESPONSE_GRACE
         try:
             with urllib_request.urlopen(req, timeout=urlopen_timeout) as resp:
                 status = resp.status

--- a/src/winpodx/core/discovery/__init__.py
+++ b/src/winpodx/core/discovery/__init__.py
@@ -598,7 +598,7 @@ def _classify_channel_error(exc: Exception) -> str:
     dialog on a perfectly running pod (kernalix7 hit this 2026-05-03
     after a fresh install).
 
-    The new logic separates three states:
+    The new logic separates four states:
 
     1. ``pod_not_running`` — connection refused / connect transport
        failed / agent unavailable. Pod is genuinely down or still
@@ -607,7 +607,8 @@ def _classify_channel_error(exc: Exception) -> str:
        the session terminated (LOGOFF_BY_USER, RPC_INITIATED_DISCONNECT,
        common during multi-session mid-activation). Retry usually
        works.
-    3. ``script_failed`` — anything else (script crash, malformed
+    3. ``timeout`` — the transport or guest command exceeded its deadline.
+    4. ``script_failed`` — anything else (script crash, malformed
        output, etc.).
     """
     msg = str(exc).lower()
@@ -636,6 +637,8 @@ def _classify_channel_error(exc: Exception) -> str:
     # match. Caller can route this to the sync-password rescue path.
     if "auth" in msg or "logon_failure" in msg or "0xc000006d" in msg:
         return "pod_not_running"
+    if "timeout" in msg or "timed out" in msg:
+        return "timeout"
     return "script_failed"
 
 
@@ -760,7 +763,7 @@ def discover_apps(
             if tresult.rc != 0:
                 raise DiscoveryError(
                     f"Discovery script failed (rc={tresult.rc}): {tresult.stderr.strip()}",
-                    kind="script_failed",
+                    kind="timeout" if tresult.rc == 124 else "script_failed",
                 )
             return _parse_discovery_output(tresult.stdout)
 
@@ -808,7 +811,7 @@ def discover_apps(
         if result.rc != 0:
             raise DiscoveryError(
                 f"Discovery script failed (rc={result.rc}): {result.stderr.strip()}",
-                kind="script_failed",
+                kind="timeout" if result.rc == 124 else "script_failed",
             )
 
         return _parse_discovery_output(result.stdout)

--- a/src/winpodx/core/provisioner.py
+++ b/src/winpodx/core/provisioner.py
@@ -435,14 +435,12 @@ def finish_provisioning(
       first boot.
     * ``with_discovery`` — run the shared discovery path (discover_apps +
       persist_discovered + _register_desktop_entries) with ``retries``
-      attempts and exponential backoff. Defaults to 5: the guest's Start
-      Menu enumeration can blow the 180s-per-attempt budget on a heavily
-      loaded first boot (Sysprep just finished, Defender scanning), and
-      each retry lands on a progressively idler guest — so a few extra
-      attempts turn a first-boot timeout into a populated menu instead of
-      an empty one the user has to fix with ``app refresh``. Each attempt
-      only costs its 180s budget when it actually times out; a normal boot
-      succeeds on attempt 1 and never waits.
+      attempts and exponential backoff. Defaults to 5 so transient channel
+      and session failures on a heavily loaded first boot (Sysprep just
+      finished, Defender scanning) can land on a progressively idler guest.
+      A discovery deadline uses ``DEFAULT_DISCOVERY_TIMEOUT`` and surfaces
+      immediately instead of repeating an expensive operation on an already
+      resource-constrained guest.
     * ``with_reverse_open`` — run the host-open listener-start + manifest
       refresh, gated additionally on ``cfg.reverse_open.enabled``.
     * ``on_progress(stage, detail)`` — optional callback so a GUI can mirror
@@ -642,11 +640,11 @@ def _run_discovery_with_retry(
     entries``). install.sh's old ``app refresh`` and pending.resume's
     ``discover_apps + persist + register`` both collapse onto this.
 
-    Retries up to ``retries`` attempts with exponential backoff (2, 4, 8…s,
-    capped at 30 s) to ride out the agent's transient "responsive but not
-    yet stable" window right after install.bat's final TermService cycle —
-    install.sh used a fixed 6× / 10 s loop; the backoff here is gentler at
-    the start and bounded above.
+    Retries non-timeout failures up to ``retries`` attempts with exponential
+    backoff (2, 4, 8…s, capped at 30 s) to ride out the agent's transient
+    "responsive but not yet stable" window right after install.bat's final
+    TermService cycle. A timeout is terminal because immediately repeating a
+    full-length scan compounds pressure on a resource-constrained guest.
 
     ``require_agent`` mirrors the chain-level flag: with ``WINPODX_REQUIRE_AGENT
     =1`` exported (which ``finish_provisioning`` does for the agent-first
@@ -663,7 +661,12 @@ def _run_discovery_with_retry(
     lazy-import pattern is used by ``utils.pending.resume``.
     """
     from winpodx.cli.app import _register_desktop_entries
-    from winpodx.core.discovery import DiscoveryError, discover_apps, persist_discovered
+    from winpodx.core.discovery import (
+        DEFAULT_DISCOVERY_TIMEOUT,
+        DiscoveryError,
+        discover_apps,
+        persist_discovered,
+    )
     from winpodx.core.transport.agent import AgentTransport
 
     transport = AgentTransport(cfg)
@@ -671,13 +674,15 @@ def _run_discovery_with_retry(
     attempt = 0
     while True:
         try:
-            apps = discover_apps(cfg, timeout=180)
+            apps = discover_apps(cfg, timeout=DEFAULT_DISCOVERY_TIMEOUT)
             persist_discovered(apps)
             if apps:
                 _register_desktop_entries(apps)
             return len(apps)
         except Exception as e:  # noqa: BLE001 — retry on any discovery failure
             last_exc = e
+            if isinstance(e, DiscoveryError) and e.kind == "timeout":
+                raise
             agent_unavailable = (
                 isinstance(e, DiscoveryError) and getattr(e, "kind", "") == "agent_unavailable"
             )

--- a/src/winpodx/utils/pending.py
+++ b/src/winpodx/utils/pending.py
@@ -146,9 +146,9 @@ def resume(printer=print) -> None:
     #                   agent.ps1 / OEM scripts in the guest)
     #   * discovery   ← results["discovery"]
     # Parameters preserve the old behaviour: 300s wait (NOT 3600), soft
-    # agent settle (require_agent=False), no reverse-open, discovery with a
-    # 3× retry. Discovery always runs in the helper; we only clear the
-    # discovery marker when it was actually pending.
+    # agent settle (require_agent=False), no reverse-open, and discovery with
+    # five retries for non-timeout transient failures. Discovery always runs
+    # in the helper; we only clear the discovery marker when it was pending.
     def _on_progress(stage: str, detail: str) -> None:
         printer(f"[WinPodX] {stage}: {detail}")
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -249,7 +249,7 @@ class TestExec:
         assert result.ok is True
         assert captured["url"] == "http://127.0.0.1:8765/exec"
         assert captured["method"] == "POST"
-        assert captured["timeout"] == 14.0  # timeout - 1
+        assert captured["timeout"] == 20.0  # timeout + five-second response grace
         # Authorization header present.
         header_keys = {k.lower(): v for k, v in captured["headers"].items()}
         assert header_keys["authorization"] == "Bearer " + "cafebabe" * 8
@@ -257,6 +257,28 @@ class TestExec:
         sent = json.loads(captured["body"].decode("utf-8"))
         assert sent["timeout_sec"] == 15
         assert base64.b64decode(sent["script"]).decode("utf-8") == "Write-Output ok"
+
+    def test_exec_deadline_allows_response_grace_at_minimum_timeout(
+        self, monkeypatch, authed_client
+    ):
+        # Given: a successful guest response and the minimum valid timeout.
+        body = json.dumps({"rc": 0, "stdout": "", "stderr": ""}).encode("utf-8")
+        captured: dict = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured["timeout"] = timeout
+            captured["body"] = req.data
+            return _FakeResponse(body, status=200)
+
+        _patch_urlopen(monkeypatch, fake_urlopen)
+
+        # When: the client executes the script.
+        authed_client.exec("Write-Output ok", timeout=1)
+
+        # Then: the guest gets the requested timeout and the client keeps five seconds of grace.
+        sent = json.loads(captured["body"].decode("utf-8"))
+        assert sent["timeout_sec"] == 1
+        assert captured["timeout"] == 6.0
 
     def test_exec_token_rejected(self, monkeypatch, authed_client):
         def fake_urlopen(req, timeout=None):

--- a/tests/test_cli_issues.py
+++ b/tests/test_cli_issues.py
@@ -647,6 +647,21 @@ class TestRefreshAppsCli:
             _args, kwargs = mock_da.call_args
             assert kwargs.get("timeout") == DEFAULT_DISCOVERY_TIMEOUT
 
+    @pytest.mark.parametrize("timeout", [0, -1])
+    def test_refresh_rejects_non_positive_timeout_before_discovery(
+        self, timeout: int, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from winpodx.cli.main import cli as cli_entry
+
+        discovery = MagicMock(return_value=[])
+        monkeypatch.setattr("winpodx.core.discovery.discover_apps", discovery)
+
+        with pytest.raises(SystemExit) as excinfo:
+            cli_entry(["app", "refresh", "--timeout", str(timeout)])
+
+        assert excinfo.value.code == 2
+        discovery.assert_not_called()
+
     def test_refresh_pod_not_running_exits_2(self):
         from winpodx.core.config import Config
         from winpodx.core.discovery import DiscoveryError

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -582,6 +582,26 @@ class TestProvision:
         assert result == 5
         assert "provision deferred: agent offline" in capsys.readouterr().err
 
+    def test_discovery_failure_returns_deferred_exit_without_success_banner(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from winpodx.core import provisioner
+
+        _patch_config(monkeypatch, SimpleNamespace(pod=SimpleNamespace(backend="podman")))
+        monkeypatch.setattr(
+            provisioner,
+            "finish_provisioning",
+            lambda cfg, **kwargs: {"wait_ready": "ok", "discovery": "failed: guest channel closed"},
+        )
+
+        result = main._cmd_provision(self._args())
+
+        output = capsys.readouterr()
+        assert result == 5
+        assert "provision deferred" in output.err
+        assert "discovery: failed: guest channel closed" in output.err
+        assert "Provisioning complete." not in output.out
+
     def test_wait_timeout_returns_retryable_exit(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/test_discovery/test_discovery.py
+++ b/tests/test_discovery/test_discovery.py
@@ -973,6 +973,21 @@ def test_discover_nonzero_exit_raises(tmp_path, monkeypatch):
         assert excinfo.value.kind == "script_failed"
 
 
+def test_discover_timeout_exit_is_classified_as_timeout(tmp_path, monkeypatch):
+    cfg = _make_cfg(backend="podman")
+    script = tmp_path / "discover_apps.ps1"
+    script.write_text("# stub")
+
+    _stub_run_in_windows(monkeypatch, rc=124, stderr="guest command timed out")
+    with (
+        patch("winpodx.core.discovery.shutil.which", return_value="/usr/bin/podman"),
+        patch("winpodx.core.discovery._ps_script_path", return_value=script),
+    ):
+        with pytest.raises(DiscoveryError, match="rc=124") as excinfo:
+            discover_apps(cfg)
+        assert excinfo.value.kind == "timeout"
+
+
 def test_discover_uses_windows_exec_channel(tmp_path, monkeypatch):
     """v0.1.9.5: the discover_apps.ps1 body is forwarded to windows_exec, NOT
     sent through podman exec (which only reaches the Linux container)."""
@@ -1155,9 +1170,7 @@ def test_discover_surfaces_timeout(tmp_path, monkeypatch):
     ):
         with pytest.raises(DiscoveryError, match="channel failure") as excinfo:
             discover_apps(cfg, timeout=1)
-        # Timeout is a channel-level failure; classifies as script_failed
-        # since the script never got a chance to actually fail.
-        assert excinfo.value.kind == "script_failed"
+        assert excinfo.value.kind == "timeout"
 
 
 # --- Hybrid filter: essentials allowlist + noise denylist ------------------
@@ -1618,6 +1631,23 @@ def test_discover_agent_nonzero_and_transport_failure(tmp_path, monkeypatch):
     assert disconnected.value.kind == "session_disconnected"
 
 
+def test_discover_agent_timeout_exit_is_classified_as_timeout(tmp_path, monkeypatch):
+    cfg = _make_cfg()
+    script = tmp_path / "discover_apps.ps1"
+    script.write_text("# agent script")
+    transport = MagicMock()
+    transport.name = "agent"
+    transport.exec.return_value = MagicMock(rc=124, stdout="", stderr="guest command timed out")
+    monkeypatch.setattr("winpodx.core.transport.dispatch", lambda _cfg: transport)
+    monkeypatch.setattr("winpodx.core.discovery.shutil.which", lambda _runtime: "/usr/bin/podman")
+    monkeypatch.setattr("winpodx.core.discovery._ps_script_path", lambda: script)
+
+    with pytest.raises(DiscoveryError, match="rc=124") as excinfo:
+        discover_apps(cfg)
+
+    assert excinfo.value.kind == "timeout"
+
+
 def test_discover_require_agent_rejects_freerdp_fallback(tmp_path, monkeypatch):
     cfg = _make_cfg()
     script = tmp_path / "discover_apps.ps1"
@@ -1637,6 +1667,7 @@ def test_discover_require_agent_rejects_freerdp_fallback(tmp_path, monkeypatch):
     "message,expected",
     [
         ("connection refused", "pod_not_running"),
+        ("ERRCONNECT_ACTIVATION_TIMEOUT", "pod_not_running"),
         ("ERRINFO_RPC_INITIATED_DISCONNECT", "session_disconnected"),
         ("LOGON_FAILURE 0xc000006d", "pod_not_running"),
         ("PowerShell syntax error", "script_failed"),

--- a/tests/test_finish_provisioning.py
+++ b/tests/test_finish_provisioning.py
@@ -16,6 +16,7 @@ import pytest
 
 from winpodx.core import provisioner
 from winpodx.core.config import Config
+from winpodx.core.discovery import DEFAULT_DISCOVERY_TIMEOUT, DiscoveryError
 from winpodx.core.provisioner import (
     ProvisionAgentUnavailable,
     finish_provisioning,
@@ -279,7 +280,7 @@ def test_on_progress_exception_is_swallowed(monkeypatch):
     assert results["wait_ready"] == "ok"
 
 
-# --- discovery retry helper (the 6× behaviour) ---------------------------
+# --- discovery retry helper (non-timeout transient failures) --------------
 
 
 def test_discovery_retry_succeeds_after_transient_failures(monkeypatch):
@@ -312,6 +313,81 @@ def test_discovery_retry_raises_after_exhausting(monkeypatch):
 
     with pytest.raises(RuntimeError, match="never settles"):
         provisioner._run_discovery_with_retry(_cfg(), retries=3)
+
+
+def test_discovery_retry_uses_default_discovery_timeout(monkeypatch):
+    timeouts: list[int] = []
+
+    def discover(cfg, *, timeout):
+        timeouts.append(timeout)
+        return []
+
+    monkeypatch.setattr("winpodx.core.discovery.discover_apps", discover)
+    monkeypatch.setattr("winpodx.core.discovery.persist_discovered", lambda apps: None)
+    monkeypatch.setattr("winpodx.cli.app._register_desktop_entries", lambda apps: None)
+
+    assert provisioner._run_discovery_with_retry(_cfg(), retries=5) == 0
+    assert timeouts == [DEFAULT_DISCOVERY_TIMEOUT]
+
+
+def test_discovery_retry_does_not_retry_timeout(monkeypatch):
+    attempts = 0
+    sleeps: list[int] = []
+    persisted = 0
+    registered = 0
+
+    def timeout(cfg, *, timeout):
+        nonlocal attempts
+        attempts += 1
+        raise DiscoveryError("guest channel timed out", kind="timeout")
+
+    def persist(apps):
+        nonlocal persisted
+        persisted += 1
+
+    def register(apps):
+        nonlocal registered
+        registered += 1
+
+    monkeypatch.setattr("winpodx.core.discovery.discover_apps", timeout)
+    monkeypatch.setattr("winpodx.core.discovery.persist_discovered", persist)
+    monkeypatch.setattr("winpodx.cli.app._register_desktop_entries", register)
+    monkeypatch.setattr(provisioner.time, "sleep", sleeps.append)
+
+    with pytest.raises(DiscoveryError, match="guest channel timed out"):
+        provisioner._run_discovery_with_retry(_cfg(), retries=5)
+
+    assert (attempts, sleeps, persisted, registered) == (1, [], 0, 0)
+
+
+def test_discovery_retry_retries_non_timeout_transient_five_times(monkeypatch):
+    attempts = 0
+    sleeps: list[int] = []
+    persisted = 0
+    registered = 0
+
+    def transient(cfg, *, timeout):
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("guest is still starting")
+
+    def persist(apps):
+        nonlocal persisted
+        persisted += 1
+
+    def register(apps):
+        nonlocal registered
+        registered += 1
+
+    monkeypatch.setattr("winpodx.core.discovery.discover_apps", transient)
+    monkeypatch.setattr("winpodx.core.discovery.persist_discovered", persist)
+    monkeypatch.setattr("winpodx.cli.app._register_desktop_entries", register)
+    monkeypatch.setattr(provisioner.time, "sleep", sleeps.append)
+
+    with pytest.raises(RuntimeError, match="guest is still starting"):
+        provisioner._run_discovery_with_retry(_cfg(), retries=5)
+
+    assert (attempts, sleeps, persisted, registered) == (5, [2, 4, 8, 16], 0, 0)
 
 
 # --- _apply_via_transport transient retry (agent_keepalive hardening) ----
@@ -827,10 +903,9 @@ def test_discovery_with_retry_reraises_other_errors_even_with_require_agent(monk
 
 
 def test_discovery_default_retries_is_five() -> None:
-    """First-boot discovery can time out on the 180s/attempt budget under a
-    loaded guest; the default retry count is 5 so a slow first boot ends with a
-    populated menu instead of an empty one (regression guard against a revert
-    to the old 2)."""
+    """Five retries cover transient guest channel/session failures; terminal
+    discovery timeouts return immediately (regression guard against a revert
+    to the old retry count of 2)."""
     import inspect
 
     from winpodx.core.provisioner import finish_provisioning
@@ -842,8 +917,8 @@ def test_provision_cli_retries_default_is_five(monkeypatch) -> None:
     """install.sh drives a fresh install via `winpodx provision` (not setup),
     so the provision command's own retries default is the one that matters for
     first-boot discovery. With no --retries on the args, _cmd_provision must
-    pass 5 to finish_provisioning (a slow first boot blows the 180s/attempt
-    budget; #784 bumped setup + the finish_provisioning default but the
+    pass 5 to finish_provisioning for non-timeout transient channel/session
+    failures (#784 bumped setup + the finish_provisioning default but the
     provision CLI path defaulted to 2 until this)."""
     import argparse
     from types import SimpleNamespace


### PR DESCRIPTION
## Summary
- give guest discovery its full 300-second budget plus HTTP response grace
- stop retrying terminal timeouts while preserving transient recovery backoff
- defer failed provisioning discovery through the existing pending exit path
- reject nonpositive refresh timeout values

## Verification
- 355 affected tests passed
- Ruff check and format passed
- version stamps consistent
- live app refresh exited 0, discovered 54 apps, registered 52 entries
- five review lanes passed