### PR TITLE
fix(readme): repair the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,11 +303,11 @@ For security issues, follow the process in [SECURITY.md](SECURITY.md).
 
 ## Star History
 
-<a href="https://star-history.com/#kernalix7/winpodx&Date">
+<a href="https://star-history.dera.page/#kernalix7/winpodx&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=kernalix7/winpodx&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=kernalix7/winpodx&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=kernalix7/winpodx&type=Date" />
   </picture>
 </a>
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -299,11 +299,11 @@ pytest tests/ -n auto --cov=winpodx --cov-report=term-missing:skip-covered --cov
 
 ## Star History
 
-<a href="https://star-history.com/#kernalix7/winpodx&Date">
+<a href="https://star-history.dera.page/#kernalix7/winpodx&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=kernalix7/winpodx&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=kernalix7/winpodx&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=kernalix7/winpodx&type=Date" />
   </picture>
 </a>
 


### PR DESCRIPTION
<!-- recovery-replacement-for-pr-835 -->
## Recovery notice

This PR replaces [#835](https://github.com/kernalix7/winpodx/pull/835), originally opened by @FaintFlower from `FaintFlower:fix/star-history-chart`. During a repository-history cleanup, I force-pushed `main`; GitHub closed the original PR and retained a stale rewritten base SHA, so it could not be reopened even after the affected branches were rolled back exactly. I apologize to @FaintFlower for the disruption.

The original contributor branch is used directly here. Its commit and author metadata are unchanged:

- `ee0cf20d9c1d3b09d19fe918391f971fca4fc110` — fix(readme): repair the broken star history chart

Original metadata: opened `2026-08-19T11:45:34Z`; assignee @kernalix7; no labels or milestone; no comments or reviews were recorded before recovery; the closed PR currently exposes no check-rollup entries. Review state and checks cannot be transferred by GitHub.

## Original description

<details>
<summary>Verbatim description from #835</summary>

The star history chart in the README is broken and no longer renders, so readers of the project no longer see its growth at a glance. This changes the chart link and image sources in the English and Korean READMEs to a working chart service, restoring the feature without affecting any other badges or links. Please take a look when you get a chance.

</details>

## Original discussion and reviews

_No issue comments or reviews were recorded on #835 before recovery._

The original PR remains the canonical historical record; this replacement exists only because GitHub will not reopen it after the force-push rollback.

