### PR TITLE
fix(tuning): stop dockur granting +invtsc on hosts whose kernel rejected the TSC

### DIFF
--- a/src/winpodx/core/pod/compose.py
+++ b/src/winpodx/core/pod/compose.py
@@ -162,8 +162,38 @@ def _cpu_flags_for_host(cfg: Config | None = None) -> str:
     cap = detect_tuning_capability(vm_cpu_cores=cfg.pod.cpu_cores, vm_ram_gb=cfg.pod.ram_gb)
     profile = recommend_tuning_profile(cap, user_pref=cfg.pod.tuning_profile)
 
-    if profile.apply_invtsc:
-        sub_flags.append("+invtsc")
+    if cap.invtsc:
+        # Host capability (incl. our clocksource cross-check) says invtsc is
+        # genuinely safe here. Whether *we* emit `+invtsc` is still gated on
+        # the user's tuning_profile (`profile.apply_invtsc`) -- but if the
+        # user profile suppresses it (e.g. "off"), we deliberately do NOT
+        # override dockur's own `+invtsc` (see below): the host is fine, so
+        # there's nothing to correct.
+        if profile.apply_invtsc:
+            sub_flags.append("+invtsc")
+    else:
+        # cap.invtsc is False -- either the CPU genuinely lacks invariant
+        # TSC, or (the dangerous case this guards against) the kernel's own
+        # boot-time cross-core sync check already rejected the TSC despite
+        # CPUID reporting constant_tsc/nonstop_tsc (see
+        # detect_tuning_capability's clocksource cross-check). Either way,
+        # profile.apply_invtsc is always False too here (recommend_tuning_profile
+        # gates it on cap.invtsc), so this is unconditional, not profile-gated.
+        #
+        # dockur's base image (qemus/qemu's proc.sh, configureKvmAmdFeatures /
+        # configureKvmIntelFeatures) independently adds its own `+invtsc` to
+        # CPU_FEATURES whenever the host reports `tsc_scale` (AMD) /
+        # `tsc_scaling` (Intel) -- a check that never cross-checks the
+        # kernel's clocksource verdict either, so it can (and on the host
+        # that motivated this fix, does) add `+invtsc` regardless of our own
+        # verdict. dockur assembles `-cpu $CPU_MODEL,$CPU_FEATURES,$CPU_FLAGS`,
+        # so our CPU_FLAGS always lands after dockur's own CPU_FEATURES in the
+        # final string, and QEMU applies `-cpu` sub-flags left-to-right with
+        # the last occurrence of a feature winning -- so merely omitting our
+        # own `+invtsc` is not enough to stop the guest from getting one
+        # anyway. Explicitly emitting `-invtsc` overrides it. Harmless no-op
+        # on hosts where dockur didn't add it either.
+        sub_flags.append("-invtsc")
 
     # Bare-metal compatibility mode (#246): hide the KVM/QEMU hypervisor
     # signature from the guest so software that refuses to run under a detected

--- a/src/winpodx/utils/specs.py
+++ b/src/winpodx/utils/specs.py
@@ -190,6 +190,33 @@ def _read_cpuinfo_flags() -> set[str]:
     return set()
 
 
+def _host_clocksource_is_tsc() -> bool:
+    """Whether the host kernel's own boot-time TSC sync check passed.
+
+    `constant_tsc`/`nonstop_tsc` in /proc/cpuinfo are static CPUID bits --
+    they say the hardware is *capable* of an invariant TSC, not that this
+    kernel's cross-core synchronization check at boot actually accepted it.
+    On boards where that check fails, the kernel falls back its own
+    clocksource away from "tsc" (typically to "hpet"/"acpi_pm") while the
+    CPUID bits stay set regardless. Handing the guest `+invtsc` in that case
+    tells it to trust a clock the host itself just rejected -- observed to
+    produce a UEFI/DXE-stage boot hang (RDTSC-calibrated delay loop never
+    converges, vCPU spins at 100% host/kernel time, 0% guest time).
+
+    Missing/unreadable sysfs (e.g. inside some container/chroot setups)
+    reports True so we don't punish hosts where the check itself can't run.
+    """
+    try:
+        val = (
+            Path("/sys/devices/system/clocksource/clocksource0/current_clocksource")
+            .read_text()
+            .strip()
+        )
+    except OSError:
+        return True
+    return val == "tsc"
+
+
 def _read_cpu_vendor() -> str:
     try:
         text = Path("/proc/cpuinfo").read_text()
@@ -281,7 +308,7 @@ def detect_tuning_capability(*, vm_cpu_cores: int, vm_ram_gb: int) -> TuningCapa
     (`dedicated_host`). Other fields are pure host-side facts.
     """
     flags = _read_cpuinfo_flags()
-    invtsc = ("constant_tsc" in flags) and ("nonstop_tsc" in flags)
+    invtsc = ("constant_tsc" in flags) and ("nonstop_tsc" in flags) and _host_clocksource_is_tsc()
     kernel = _read_kernel_version()
     io_uring = kernel is not None and (kernel[0], kernel[1]) >= (5, 6)
     hugepages = _read_hugepages_total() > 0

--- a/src/winpodx/utils/specs.py
+++ b/src/winpodx/utils/specs.py
@@ -203,8 +203,8 @@ def _host_clocksource_is_tsc() -> bool:
     produce a UEFI/DXE-stage boot hang (RDTSC-calibrated delay loop never
     converges, vCPU spins at 100% host/kernel time, 0% guest time).
 
-    Missing/unreadable sysfs (e.g. inside some container/chroot setups)
-    reports True so we don't punish hosts where the check itself can't run.
+    Missing/unreadable sysfs reports False because granting ``invtsc`` without
+    a positive kernel verdict can hang guest boot.
     """
     try:
         val = (
@@ -213,7 +213,7 @@ def _host_clocksource_is_tsc() -> bool:
             .strip()
         )
     except OSError:
-        return True
+        return False
     return val == "tsc"
 
 

--- a/tests/test_compose_arch.py
+++ b/tests/test_compose_arch.py
@@ -61,9 +61,34 @@ def _cfg() -> Config:
 
 
 def test_compose_cpu_flags_x86_64(monkeypatch):
-    """x86_64 hosts emit ``arch_capabilities=off`` via CPU_FLAGS env."""
+    """x86_64 hosts emit ``arch_capabilities=off`` via CPU_FLAGS env.
+
+    ``tuning_profile = "off"`` (set by ``_cfg()``) alone no longer fully
+    isolates this from the real host's TSC capability: the invtsc
+    "-invtsc" override (added to counter dockur's own independent
+    tsc_scale/tsc_scaling-based +invtsc) applies whenever ``cap.invtsc``
+    is False, regardless of tuning_profile -- that override is a safety
+    fix, not a performance tuning, so it can't be gated on user
+    preference. Mock the capability to an invtsc-True host explicitly so
+    this test only exercises the arch-detection branch.
+    """
+    import winpodx.utils.specs as specs
+
     monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(_config_module.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(
+        specs,
+        "detect_tuning_capability",
+        lambda *, vm_cpu_cores, vm_ram_gb: specs.TuningCapability(
+            invtsc=True,
+            io_uring=True,
+            hugepages_enabled=False,
+            dedicated_host=False,
+            kernel_version=(6, 18),
+            cpu_vendor="intel",
+            nested_kvm=False,
+        ),
+    )
     content = _build_compose_content(_cfg())
     assert 'CPU_FLAGS: "arch_capabilities=off"' in content
 
@@ -105,9 +130,28 @@ def test_compose_cpu_flags_unknown_arch_falls_through_to_x86(monkeypatch):
     behaviour. Intentional: an unsupported platform should surface a
     clear QEMU error at pod start rather than silently using a partly-
     correct ARM config.
+
+    Mocks the tuning capability to an invtsc-True host (see
+    ``test_compose_cpu_flags_x86_64`` for why ``tuning_profile = "off"``
+    alone isn't enough anymore) so this only exercises the arch fallback.
     """
+    import winpodx.utils.specs as specs
+
     monkeypatch.setattr(_compose_module.platform, "machine", lambda: "riscv64")
     monkeypatch.setattr(_config_module.platform, "machine", lambda: "riscv64")
+    monkeypatch.setattr(
+        specs,
+        "detect_tuning_capability",
+        lambda *, vm_cpu_cores, vm_ram_gb: specs.TuningCapability(
+            invtsc=True,
+            io_uring=True,
+            hugepages_enabled=False,
+            dedicated_host=False,
+            kernel_version=(6, 18),
+            cpu_vendor="intel",
+            nested_kvm=False,
+        ),
+    )
     content = _build_compose_content(_cfg())
     assert 'CPU_FLAGS: "arch_capabilities=off"' in content
 

--- a/tests/test_compose_arch.py
+++ b/tests/test_compose_arch.py
@@ -468,11 +468,8 @@ def test_compose_cpu_flags_invtsc_auto_profile_appends_when_supported(monkeypatc
     assert 'VMX: "N"' in content
 
 
-def test_compose_cpu_flags_invtsc_skipped_when_host_lacks_flag(monkeypatch):
-    """Even with ``tuning_profile = "auto"``, a host without
-    ``constant_tsc + nonstop_tsc`` must not get ``+invtsc`` in CPU_FLAGS
-    -- QEMU would either silently drop it or refuse to start.
-    """
+@pytest.mark.parametrize("profile", ["auto", "off"])
+def test_compose_cpu_flags_invtsc_false_overrides_dockur(monkeypatch, profile):
     import winpodx.utils.specs as specs
 
     monkeypatch.setattr(_compose_module.platform, "machine", lambda: "x86_64")
@@ -491,9 +488,9 @@ def test_compose_cpu_flags_invtsc_skipped_when_host_lacks_flag(monkeypatch):
         ),
     )
     cfg = _cfg()
-    cfg.pod.tuning_profile = "auto"
+    cfg.pod.tuning_profile = profile
     content = _build_compose_content(cfg)
-    assert "+invtsc" not in content
+    assert 'CPU_FLAGS: "arch_capabilities=off,-invtsc"' in content
 
 
 def test_compose_cpu_flags_aarch64_ignores_tuning_profile(monkeypatch):

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -281,6 +281,54 @@ class TestFormatTuningSummary:
         assert "hv-evmcs" in out
 
 
+class TestHostClocksourceGatesInvtsc:
+    """`invtsc` must not be granted on CPUID bits alone when the host
+    kernel's own boot-time TSC sync check already rejected the TSC
+    clocksource (see .temp investigation notes / upstream issue #780).
+
+    ``constant_tsc``/``nonstop_tsc`` only report hardware capability; a
+    kernel-level cross-core sync failure is a different, more specific
+    fact the kernel surfaces via ``current_clocksource`` and CPUID can't
+    see.
+    """
+
+    def test_tsc_clocksource_reports_true(self):
+        from winpodx.utils.specs import _host_clocksource_is_tsc
+
+        with patch("pathlib.Path.read_text", return_value="tsc\n"):
+            assert _host_clocksource_is_tsc() is True
+
+    def test_non_tsc_clocksource_reports_false(self):
+        from winpodx.utils.specs import _host_clocksource_is_tsc
+
+        with patch("pathlib.Path.read_text", return_value="hpet\n"):
+            assert _host_clocksource_is_tsc() is False
+
+    def test_unreadable_sysfs_defaults_true(self):
+        # Missing/unreadable sysfs shouldn't punish hosts where the check
+        # itself can't run (e.g. some container/chroot setups).
+        from winpodx.utils.specs import _host_clocksource_is_tsc
+
+        with patch("pathlib.Path.read_text", side_effect=OSError):
+            assert _host_clocksource_is_tsc() is True
+
+    def test_invtsc_capability_false_when_kernel_rejected_tsc(self, monkeypatch):
+        from winpodx.utils import specs
+
+        monkeypatch.setattr(specs, "_read_cpuinfo_flags", lambda: {"constant_tsc", "nonstop_tsc"})
+        monkeypatch.setattr(specs, "_host_clocksource_is_tsc", lambda: False)
+        cap = specs.detect_tuning_capability(vm_cpu_cores=4, vm_ram_gb=6)
+        assert cap.invtsc is False
+
+    def test_invtsc_capability_true_when_kernel_confirms_tsc(self, monkeypatch):
+        from winpodx.utils import specs
+
+        monkeypatch.setattr(specs, "_read_cpuinfo_flags", lambda: {"constant_tsc", "nonstop_tsc"})
+        monkeypatch.setattr(specs, "_host_clocksource_is_tsc", lambda: True)
+        cap = specs.detect_tuning_capability(vm_cpu_cores=4, vm_ram_gb=6)
+        assert cap.invtsc is True
+
+
 class TestDetectTuningCapabilityIntegration:
     """`detect_tuning_capability` reads /proc + os.uname; smoke-test that it
     runs to completion on the actual test host without raising."""

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -304,13 +304,11 @@ class TestHostClocksourceGatesInvtsc:
         with patch("pathlib.Path.read_text", return_value="hpet\n"):
             assert _host_clocksource_is_tsc() is False
 
-    def test_unreadable_sysfs_defaults_true(self):
-        # Missing/unreadable sysfs shouldn't punish hosts where the check
-        # itself can't run (e.g. some container/chroot setups).
+    def test_unreadable_sysfs_defaults_false(self):
         from winpodx.utils.specs import _host_clocksource_is_tsc
 
         with patch("pathlib.Path.read_text", side_effect=OSError):
-            assert _host_clocksource_is_tsc() is True
+            assert _host_clocksource_is_tsc() is False
 
     def test_invtsc_capability_false_when_kernel_rejected_tsc(self, monkeypatch):
         from winpodx.utils import specs


### PR DESCRIPTION
<!-- recovery-replacement-for-pr-782 -->
## Recovery notice

This PR replaces [#782](https://github.com/kernalix7/winpodx/pull/782), originally opened by @p4tit0 from `birb-labs:fix/invtsc-clocksource-cross-check`. During a repository-history cleanup, I force-pushed `main`; GitHub closed the original PR and retained a stale rewritten base SHA, so it could not be reopened even after the affected branches were rolled back exactly. I apologize to @p4tit0 and everyone who participated for the disruption.

The original contributor branch is used directly here. Its three commits and their author metadata are unchanged:

- `191c364757110ccf6f92623c06ac3e4e111d8433` — fix(tuning): cross-check host clocksource before granting +invtsc
- `46acbbe9a8992c3bc9027d3d7961b13bf0a10a` — fix(compose): override the dockur default via an explicit -invtsc flag
- `e5e74f4762cd7acbc720f1599c5ed85cc0dc4000` — fix(tuning): fail closed on unreadable clocksource sysfs

Original metadata: opened `2026-07-22T21:13:20Z`; assignee @kernalix7; no labels or milestone; review decision was **changes requested**; the closed PR currently exposes no check-rollup entries. Review state and checks cannot be transferred by GitHub, so the complete pre-recovery discussion is preserved below.

## Original description

<details>
<summary>Verbatim description from #782</summary>

## Summary

- `detect_tuning_capability()` (`src/winpodx/utils/specs.py`) granted `+invtsc` based solely on the static `constant_tsc`/`nonstop_tsc` CPUID bits in `/proc/cpuinfo`. Those bits report hardware *capability* for an invariant TSC — they say nothing about whether **this kernel's own cross-core synchronization check at boot** actually accepted the TSC as usable.
- On a host where that check fails (`dmesg`: `tsc: Marking TSC unstable due to check_tsc_sync_source failed`), the kernel falls back its own clocksource away from `"tsc"` (typically to `hpet`/`acpi_pm`) while the CPUID bits stay set regardless — so `invtsc` was still reported `True`, and `-cpu host,...,+invtsc,...` was handed to the guest.
- UEFI/DXE calibrates its boot delay loop directly off RDTSC, before any guest-side clocksource fallback exists. Telling the guest to trust a clock the host itself had just rejected produces a vCPU thread pinned at 100% host/kernel time, 0% guest time — Windows never gets past the "Windows started successfully" firmware splash.
- **First fix**: `detect_tuning_capability()` now also requires `/sys/devices/system/clocksource/clocksource0/current_clocksource == "tsc"` before granting `invtsc`, deferring to the kernel's own verdict instead of trusting CPUID alone. Missing/unreadable sysfs reports `True` (unaffected) so hosts where the check can't run aren't punished.
- **This alone was not sufficient** — empirically verified on the affected host. dockur's own base image (`qemus/qemu`'s `proc.sh`, `configureKvmAmdFeatures`/`configureKvmIntelFeatures`) independently adds its own `+invtsc` to `CPU_FEATURES` whenever the host reports the `tsc_scale` (AMD) / `tsc_scaling` (Intel) CPUID flag — a check that never cross-references the kernel's clocksource verdict either, and runs regardless of what WinPodX puts in `CPU_FLAGS`. Since dockur assembles `-cpu $CPU_MODEL,$CPU_FEATURES,$CPU_FLAGS` and QEMU applies `-cpu` sub-flags left-to-right with the last occurrence of a feature winning, merely omitting our own `+invtsc` left dockur's addition in effect.
- **Second fix**: `_cpu_flags_for_host()` (`src/winpodx/core/pod/compose.py`) now explicitly emits `-invtsc` whenever `cap.invtsc` is `False`, overriding dockur's addition instead of just not adding our own. This is gated on `cap.invtsc` (the actual hardware+kernel verdict), not `profile.apply_invtsc` (which also folds in user preference) — so a user who sets `tuning_profile = off` on an otherwise-healthy host does not get an unnecessary override; only hosts where the capability check itself failed are affected.

Verified end-to-end on the host that motivated this fix (AMD Ryzen 7 4800H, Nobara 44, kernel rejected TSC sync, `tsc_scale` CPUID flag present): before both fixes, the guest hung indefinitely at the firmware splash with **zero forward disk I/O** and a vCPU thread pinned at 100% host/kernel time (confirmed via `/proc/<qemu_pid>/io` and per-thread `/proc/<tid>/stat`, and via QMP `info registers` showing a completely static `RIP` across multiple samples). After both fixes: Windows Setup completes, reboots through the OEM pass, and RDP comes up — `winpodx doctor` reports all green.

Opened against #780.

## Test plan

- [x] Added `TestHostClocksourceGatesInvtsc` in `tests/test_specs.py` (5 cases covering the clocksource cross-check + `detect_tuning_capability` integration)
- [x] Updated `test_compose_cpu_flags_x86_64` / `test_compose_cpu_flags_unknown_arch_falls_through_to_x86` in `tests/test_compose_arch.py` to explicitly mock an invtsc-capable host, since `tuning_profile = "off"` alone no longer isolates them from the real host's TSC state (the `-invtsc` override is intentionally unconditional on `cap.invtsc`, not gated on profile)
- [x] `pytest tests/ -v` — 2170 passed, 27 skipped, 0 failed (full suite, pre-second-fix baseline) + 536 passed / 1 skipped on every test file touching compose/specs (post-second-fix, targeted re-run)
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] **Live end-to-end verification** on the affected host: fresh `winpodx setup` with the fix reaches `OK Windows ready` / `OK OEM reboot pass complete` and a responding RDP port, where it previously hung indefinitely

</details>

## Original discussion

<details>
<summary>All 8 issue comments recorded before recovery</summary>

#### Comment by @kernalix7 — 2026-08-18T04:00:01Z

[Open the original comment](https://github.com/kernalix7/winpodx/pull/782#issuecomment-5323423719)

I prepared the requested follow-up fixes, but GitHub rejected direct pushes to the PR head because `birb-labs/winpodx` is an organization-owned fork. The commits are published on the upstream handoff branch:

https://github.com/kernalix7/winpodx/tree/fix/pr-782-maintainer

Please apply them to `fix/invtsc-clocksource-cross-check`:

```bash
git fetch https://github.com/kernalix7/winpodx.git fix/pr-782-maintainer
git cherry-pick 75938c0 d1b0405
```

The commits:

- `75938c0` adds regression coverage for unreadable clocksource sysfs and exact `-invtsc` output under both `auto` and `off`.
- `d1b0405` makes an unreadable clocksource fail closed instead of granting `invtsc` without a positive kernel verdict.

Verification completed:

- focused tests: 58 passed
- clean branch venv: 2,171 passed, 27 skipped
- latest `main` synthetic merge: 3,590 passed, 10 skipped; one pre-existing unrelated CLI output assertion failed
- Ruff check and format check passed
- manual matrix confirmed unreadable sysfs -> false, unsafe auto/off -> `-invtsc`, safe auto -> `+invtsc`, and safe off -> baseline flags


---

#### Comment by @ismikes — 2026-08-18T06:09:15Z

[Open the original comment](https://github.com/kernalix7/winpodx/pull/782#issuecomment-5324311467)

Are you preparing the next release or is that a ways off still?

---

#### Comment by @kroese — 2026-08-24T01:08:44Z

[Open the original comment](https://github.com/kernalix7/winpodx/pull/782#issuecomment-5389577612)

@p4tit0 Thanks for reporting! I fixed this in `qemus/qemu` now in v7.49, so ideally WinPodX doesnt need this workaround from the PR anymore as it will not happen anymore as soon as it upgrades to the upcoming `dockur/windows` image.

---

#### Comment by @kernalix7 — 2026-08-24T01:12:13Z

[Open the original comment](https://github.com/kernalix7/winpodx/pull/782#issuecomment-5389597346)

> Are you preparing the next release or is that a ways off still?

Now, I’m going to make a significant improvement to this project, so please be patient with the project delay. :)

---

#### Comment by @kernalix7 — 2026-08-24T01:12:58Z

[Open the original comment](https://github.com/kernalix7/winpodx/pull/782#issuecomment-5389601274)

> @p4tit0 Thanks for reporting! I fixed this in `qemus/qemu` now in v7.49, so ideally WinPodX doesnt need this workaround from the PR anymore as it will not happen anymore as soon as it upgrades to the upcoming `dockur/windows` image.

Thanks for your improvement!!

---

#### Comment by @ismikes — 2026-08-24T07:17:06Z

[Open the original comment](https://github.com/kernalix7/winpodx/pull/782#issuecomment-5391931060)

> > Are you preparing the next release or is that a ways off still?
> 
> Now, I’m going to make a significant improvement to this project, so please be patient with the project delay. :)

I did not mean to indicate impatience. I was just curious what the time-frame was likely to be. I apologize if my tone indicated otherwise.

This is an important project and I am very happy with all the progress that is happening. :clap: :heart: 

---

#### Comment by @p4tit0 — 2026-08-25T03:18:43Z

[Open the original comment](https://github.com/kernalix7/winpodx/pull/782#issuecomment-5404609155)

Applied the requested test coverage (exact `CPU_FLAGS` assertions, parametrized over `auto`/`off`) and hardened `_host_clocksource_is_tsc()` to fail closed on unreadable sysfs instead of fail-open — pushed as e5e74f4.

Re-verified on the same host that motivated this PR (AMD Ryzen 7 4800H, Nobara/Fedora, kernel 7.2.0-202.nobara.fc44.x86_64):

- `/proc/cmdline`: `root=UUID=... ro rootflags=subvol=@ rd.driver.blacklist=nouveau rd.driver.blacklist=nova-core quiet splash resume=UUID=...` (UUIDs redacted)
- Active clocksource: `hpet` (available: `hpet acpi_pm`)
- Kernel log: `Measured 4379 cycles TSC warp between CPUs, turning off TSC clock` / `tsc: Marking TSC unstable due to check_tsc_sync_source failed`; `kvm_amd: TSC scaling supported`
- `detect_tuning_capability().invtsc` → `False`
- Generated `CPU_FLAGS` for both `auto` and `off`: `arch_capabilities=off,-invtsc,-hypervisor,kvm=off,-kvm-pv-eoi,-kvm-pv-unhalt,-kvm-pv-tlb-flush,-kvm-asyncpf`

Full suite: 2172 passed, 27 skipped, 0 failed. `ruff check`/`ruff format --check` clean.

---

#### Comment by @p4tit0 — 2026-08-25T03:18:52Z

[Open the original comment](https://github.com/kernalix7/winpodx/pull/782#issuecomment-5404610191)

@kroese Thanks for the heads-up and for the fix on the `qemus/qemu` side, genuinely appreciated.

That said, this PR's still worth keeping, for two reasons:

1. WinPodX pins `dockurr/windows` by digest (not `:latest`), so hosts don't pick up your v7.49 change automatically, only once WinPodX itself bumps the pinned digest to an image built on top of it. Until then, the second fix here (explicitly emitting `-invtsc` to override dockur's own addition) is still doing real work on affected hosts.
2. The first fix (cross-checking the kernel's own clocksource verdict via sysfs before trusting the `constant_tsc`/`tsc_scale` CPUID bits) isn't just about countering dockur's behavior, `cap.invtsc` also feeds WinPodX's own diagnostics (`winpodx doctor`'s capability summary) and tuning decisions independently of what any base image does with it. So it stays correct regardless of upstream.

Happy to revisit dropping the dockur-override half of this once WinPodX's pinned image is updated past v7.49, if that turns out to be the right call at that point.

</details>

## Original reviews

<details>
<summary>The recorded review from #782</summary>

#### Review by @kernalix7 — CHANGES_REQUESTED — 2026-08-04T03:07:00Z

Original review commit: `46acbbe9a8992c3bc9027d3d3d7961b13bf0a10a`

Thanks for tracking this down. Before merge, please:

- Add direct exact-output tests for generated `CPU_FLAGS`: `cap.invtsc=False` must emit `arch_capabilities=off,-invtsc` under both `auto` and `off`, while `cap.invtsc=True` with profile `off` must not emit `-invtsc`.
- To resolve the `tsc=reliable` ambiguity, share the successful host’s `/proc/cmdline`, active clocksource, and either the generated `CPU_FLAGS` or assembled QEMU `-cpu` ordering. Please redact any unrelated sensitive values.

A local integration probe found the production patch and these added tests pass: 58 focused tests, Ruff clean.

</details>

The original PR remains the canonical historical record; this replacement exists only because GitHub will not reopen it after the force-push rollback.

