### PR TITLE
fix: self-host star history charts

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,13 @@
+name: Update star history
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    uses: kernalix7/GH-Star-History-for-Actions/.github/workflows/reusable-star-history.yml@5f5887b0c9f3302b5afe3648ffa8994a245db508

--- a/README.md
+++ b/README.md
@@ -303,11 +303,11 @@ For security issues, follow the process in [SECURITY.md](SECURITY.md).
 
 ## Star History
 
-<a href="https://star-history.com/#kernalix7/winpodx&Date">
+<a href="https://github.com/kernalix7/winpodx/tree/star-history">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/kernalix7/winpodx/star-history/chart-dark.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/kernalix7/winpodx/star-history/chart.svg" />
+    <img alt="WinPodX GitHub star history" src="https://raw.githubusercontent.com/kernalix7/winpodx/star-history/chart.svg" width="900" />
   </picture>
 </a>
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -299,11 +299,11 @@ pytest tests/ -n auto --cov=winpodx --cov-report=term-missing:skip-covered --cov
 
 ## Star History
 
-<a href="https://star-history.com/#kernalix7/winpodx&Date">
+<a href="https://github.com/kernalix7/winpodx/tree/star-history">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=kernalix7/winpodx&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/kernalix7/winpodx/star-history/chart-dark.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/kernalix7/winpodx/star-history/chart.svg" />
+    <img alt="WinPodX GitHub 별 기록" src="https://raw.githubusercontent.com/kernalix7/winpodx/star-history/chart.svg" width="900" />
   </picture>
 </a>
 


### PR DESCRIPTION
## Summary

- add a daily and manually dispatchable Star History workflow
- pin the reusable workflow to reviewed commit `5f5887b0c9f3302b5afe3648ffa8994a245db508`
- replace the broken external embeds in the English and Korean READMEs with repository-owned light/dark SVGs

## Related pull requests and attribution

This supersedes #857, the recovery replacement for #835. The original PR was opened by @FaintFlower and identified the broken Star History embed, then proposed restoring it in both the English and Korean READMEs. Thank you to @FaintFlower for reporting the problem and contributing the original fix.

This PR addresses the same issue with a different implementation: instead of switching to another hosted chart endpoint, it generates and serves repository-owned history data and SVGs through a dedicated GitHub Actions workflow. No code from the original contribution is copied here, so attribution is preserved through the canonical PR links rather than a `Co-authored-by` trailer.

## Security

- scopes `GITHUB_TOKEN` to `contents: write` for this workflow
- stores generated history only on the dedicated orphan `star-history` branch
- uses an immutable full commit SHA instead of a moving branch reference

## Verification

- parsed `.github/workflows/star-history.yml` as YAML
- validated both README files contain the expected light/dark raw URLs and no old API URL
- ran `git diff --check`
- passed the full GitHub CI matrix, lint, coverage, audit, and PowerShell discovery checks

## Post-merge

Manually dispatch **Update star history** once to bootstrap the `star-history` branch, then verify both README themes render the generated SVG.