### PR TITLE
ci: pin star history action to v0.1.0

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   update:
-    uses: kernalix7/GH-Star-History-for-Actions/.github/workflows/reusable-star-history.yml@5f5887b0c9f3302b5afe3648ffa8994a245db508
+    uses: kernalix7/GH-Star-History-for-Actions/.github/workflows/reusable-star-history.yml@9aa57516df1a649cb628f14f0691bb8ae72dec6f


### PR DESCRIPTION
## Summary

- move the Star History reusable workflow pin from the reviewed prerelease commit to the commit published as `v0.1.0`
- keep the dependency immutable by using the release commit SHA rather than the movable tag name

## Release provenance

- release: `v0.1.0`
- annotated tag object: `01584d7631caa7de8cc149d6a6c09200e7b33db9`
- peeled release commit: `9aa57516df1a649cb628f14f0691bb8ae72dec6f`
- upstream CI, self-hosted update workflow, and release job all passed for the pinned commit

## Verification

- parsed `.github/workflows/star-history.yml` as YAML
- verified the old SHA is absent and the `v0.1.0` commit SHA is present
- ran `git diff --check`
- confirmed the branch changes exactly one workflow line

## Runtime note

On the next Star History run, `v0.1.0` will migrate the managed branch marker from format 1 to format 2 and add the new chart variants. Existing `chart.svg` and `chart-dark.svg` paths remain unchanged.