### PR TITLE
feat(progress): use Dockur msg.html as primary progress source

### DIFF
--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -1409,6 +1409,7 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
 
     log_proc: Popen | None = None
     log_stop = threading.Event()
+    progress_thread: threading.Thread | None = None
 
     # Self-erasing transient line for the clean (non-verbose) view. Owns the
     # download progress + boot heartbeat; permanent lines go through say().
@@ -1430,6 +1431,54 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
     _log_tail = "0" if _already_up else "100"
 
     if show_logs:
+        from winpodx.core.dockur_progress import DockurProgress, DockurProgressReader
+
+        progress_reader = DockurProgressReader(cfg.pod.vnc_port)
+        http_progress: DockurProgress | None = None
+        http_progress_lock = threading.Lock()
+        http_complete = threading.Event()
+        last_http_text: str | None = None
+
+        def _current_http_progress() -> DockurProgress | None:
+            with http_progress_lock:
+                return http_progress
+
+        def _poll_http_progress() -> None:
+            nonlocal http_progress, last_http_text
+
+            progress = progress_reader.poll()
+            with http_progress_lock:
+                http_progress = progress
+            if progress is None:
+                return
+            if not progress.is_loading:
+                http_complete.set()
+            if progress.text == last_http_text:
+                return
+            if verbose:
+                print(f"       [progress] {progress.text}")
+            elif _live.usable:
+                _live.set(f"  {progress.text}")
+            else:
+                print(f"  {progress.text}")
+            last_http_text = progress.text
+
+        def _poll_http_progress_until_done() -> None:
+            while not log_stop.wait(1.0):
+                if log_proc is not None and log_proc.poll() is not None:
+                    return
+                _poll_http_progress()
+                if http_complete.is_set():
+                    return
+
+        _poll_http_progress()
+        if not http_complete.is_set():
+            progress_thread = threading.Thread(
+                target=_poll_http_progress_until_done,
+                daemon=True,
+            )
+            progress_thread.start()
+
         try:
             # --tail surfaces recent context (Windows ISO download, current boot
             # stage) on a fresh boot; 0 on an established pod so we don't replay
@@ -1513,8 +1562,9 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
                         line = "(btrfs warning suppressed: NoCoW bind mount in use)"
                     # Always watch dockur's wget ETA to extend the deadline
                     # (#126), whether or not we render the line.
+                    current_http_progress = _current_http_progress()
                     eta_secs = _parse_wget_eta_secs(line)
-                    if eta_secs is not None:
+                    if eta_secs is not None and current_http_progress is None:
                         _maybe_extend_deadline(eta_secs)
 
                     # Mark the download window off the "Downloading Windows"
@@ -1546,6 +1596,8 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
                     # permanent output.
                     prog = _format_wget_progress(line)
                     if prog is not None:
+                        if current_http_progress is not None:
+                            continue
                         if _live.usable:
                             _live.set(prog[1])  # in-place, self-erasing
                         else:
@@ -1568,9 +1620,23 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
                         print(f"       [container] {_LINT_BLOCK_SUMMARY}")
                         continue
                     if any(noise in line for noise in _CONTAINER_NOISE):
+                        if current_http_progress is not None:
+                            continue
                         # UEFI boot-loader / tun spam: keep a transient
                         # heartbeat so the screen isn't dead, but never scroll.
                         _live.set("  Windows is booting...")
+                        continue
+                    if current_http_progress is not None and any(
+                        marker in line
+                        for marker in (
+                            "Downloading",
+                            "Extracting",
+                            "Adding",
+                            "Building",
+                            "Creating",
+                            "Booting",
+                        )
+                    ):
                         continue
                     # A real dockur line (e.g. "> Extracting Windows image"):
                     # erase the transient line, print it permanently.
@@ -1595,6 +1661,11 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
                 # isn't (older dockur, or before the first "%" line arrives).
                 last_verbose = [0.0]
                 while not log_stop.is_set():
+                    if http_complete.is_set():
+                        return
+                    if _current_http_progress() is not None:
+                        log_stop.wait(1.0)
+                        continue
                     dl = dl_state["start"]
                     if dl is not None:
                         _maybe_extend_deadline_liveness()
@@ -1738,6 +1809,8 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
             )
     finally:
         log_stop.set()
+        if progress_thread is not None:
+            progress_thread.join(timeout=3)
         _live.close()
         if log_proc is not None:
             try:

--- a/src/winpodx/cli/pod.py
+++ b/src/winpodx/cli/pod.py
@@ -1436,7 +1436,6 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
         progress_reader = DockurProgressReader(cfg.pod.vnc_port)
         http_progress: DockurProgress | None = None
         http_progress_lock = threading.Lock()
-        http_complete = threading.Event()
         last_http_text: str | None = None
 
         def _current_http_progress() -> DockurProgress | None:
@@ -1450,9 +1449,8 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
             with http_progress_lock:
                 http_progress = progress
             if progress is None:
+                last_http_text = None
                 return
-            if not progress.is_loading:
-                http_complete.set()
             if progress.text == last_http_text:
                 return
             if verbose:
@@ -1468,16 +1466,13 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
                 if log_proc is not None and log_proc.poll() is not None:
                     return
                 _poll_http_progress()
-                if http_complete.is_set():
-                    return
 
         _poll_http_progress()
-        if not http_complete.is_set():
-            progress_thread = threading.Thread(
-                target=_poll_http_progress_until_done,
-                daemon=True,
-            )
-            progress_thread.start()
+        progress_thread = threading.Thread(
+            target=_poll_http_progress_until_done,
+            daemon=True,
+        )
+        progress_thread.start()
 
         try:
             # --tail surfaces recent context (Windows ISO download, current boot
@@ -1564,7 +1559,7 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
                     # (#126), whether or not we render the line.
                     current_http_progress = _current_http_progress()
                     eta_secs = _parse_wget_eta_secs(line)
-                    if eta_secs is not None and current_http_progress is None:
+                    if eta_secs is not None:
                         _maybe_extend_deadline(eta_secs)
 
                     # Mark the download window off the "Downloading Windows"
@@ -1661,14 +1656,12 @@ def _wait_ready(timeout: int, show_logs: bool, verbose: bool = False) -> None:
                 # isn't (older dockur, or before the first "%" line arrives).
                 last_verbose = [0.0]
                 while not log_stop.is_set():
-                    if http_complete.is_set():
-                        return
-                    if _current_http_progress() is not None:
-                        log_stop.wait(1.0)
-                        continue
                     dl = dl_state["start"]
                     if dl is not None:
                         _maybe_extend_deadline_liveness()
+                        if _current_http_progress() is not None:
+                            log_stop.wait(1.0)
+                            continue
                         el = int(_time.monotonic() - dl)
                         clock = f"{el // 60}m {el % 60:02d}s"
                         pct = dl_state.get("pct")

--- a/src/winpodx/core/dockur_progress.py
+++ b/src/winpodx/core/dockur_progress.py
@@ -33,7 +33,7 @@ _VOID_ELEMENTS = frozenset(
 )
 
 
-@dataclass(frozen=True)  # noqa: SLOTS_OK - Python 3.9 uses the manual slots below.
+@dataclass(frozen=True)  # Python 3.9 uses the manual slots below.
 class DockurProgress:
     """Normalized text exposed by dockur's progress document."""
 

--- a/src/winpodx/core/dockur_progress.py
+++ b/src/winpodx/core/dockur_progress.py
@@ -45,14 +45,23 @@ class DockurProgress:
 
 
 class _Target:
-    __slots__ = ("closed", "depth", "is_loading", "parts", "tag")
+    __slots__ = ("closed", "depth", "is_loading", "parts", "tag", "text_chars")
 
     def __init__(self, tag: str, depth: int, is_loading: bool) -> None:
         self.tag = tag
         self.depth = depth
         self.is_loading = is_loading
         self.parts: list[str] = []
+        self.text_chars = 0
         self.closed = False
+
+    def append(self, data: str) -> bool:
+        remaining = _MAX_TEXT_CHARS + 1 - self.text_chars
+        if remaining > 0:
+            part = data[:remaining]
+            self.parts.append(part)
+            self.text_chars += len(part)
+        return len(data) <= remaining
 
 
 class _ProgressParser(HTMLParser):
@@ -77,11 +86,16 @@ class _ProgressParser(HTMLParser):
         class_value = attribute_values.get("class", [None])[0]
         classes = class_value.split() if class_value is not None else []
         is_loading = "loading" in classes
-        target = _Target(tag, len(self.stack), is_loading)
         if element_id == "info":
-            self.info_targets.append(target)
+            if self.info_targets:
+                self.malformed = True
+            else:
+                self.info_targets.append(_Target(tag, len(self.stack), is_loading))
         elif tag == "p" and is_loading:
-            self.loading_targets.append(target)
+            if self.loading_targets:
+                self.malformed = True
+            else:
+                self.loading_targets.append(_Target(tag, len(self.stack), is_loading))
 
         if tag not in _VOID_ELEMENTS:
             self.stack.append(tag)
@@ -109,7 +123,8 @@ class _ProgressParser(HTMLParser):
             self.plain_parts.append(data)
         for target in (*self.info_targets, *self.loading_targets):
             if not target.closed and depth > target.depth:
-                target.parts.append(data)
+                if not target.append(data):
+                    self.malformed = True
 
     def valid(self) -> bool:
         targets = (*self.info_targets, *self.loading_targets)
@@ -157,6 +172,16 @@ def parse_dockur_progress(body: bytes) -> DockurProgress | None:
     return DockurProgress(text=text, is_loading=is_loading)
 
 
+class _PollAttempt:
+    __slots__ = ("done", "error", "expired", "result")
+
+    def __init__(self) -> None:
+        self.done = threading.Event()
+        self.error: BaseException | None = None
+        self.expired = False
+        self.result: DockurProgress | None = None
+
+
 class DockurProgressReader:
     """Poll dockur progress and suppress values unchanged for 60 seconds."""
 
@@ -164,32 +189,18 @@ class DockurProgressReader:
         self._vnc_port = vnc_port
         self._last_progress: DockurProgress | None = None
         self._first_seen_at: float | None = None
+        self._attempt: _PollAttempt | None = None
+        self._attempt_lock = threading.Lock()
 
-    def poll(self) -> DockurProgress | None:
-        """Fetch one progress document, returning None when unavailable or stale."""
+    def _fetch(self) -> DockurProgress | None:
+        connection: http.client.HTTPConnection | None = None
+        close_failed = False
         try:
             connection = http.client.HTTPConnection(
                 "127.0.0.1",
                 self._vnc_port,
                 timeout=_REQUEST_TIMEOUT_SECONDS,
             )
-        except (OSError, ValueError, http.client.HTTPException):
-            return None
-
-        expired = threading.Event()
-
-        def expire_request() -> None:
-            expired.set()
-            try:
-                connection.close()
-            except (OSError, http.client.HTTPException):
-                return
-
-        deadline = threading.Timer(_REQUEST_TIMEOUT_SECONDS, expire_request)
-        deadline.daemon = True
-        deadline.start()
-        close_failed = False
-        try:
             connection.request("GET", "/msg.html")
             response = connection.getresponse()
             if response.status != 200:
@@ -204,17 +215,65 @@ class DockurProgressReader:
         except (OSError, ValueError, http.client.HTTPException):
             return None
         finally:
-            deadline.cancel()
-            deadline.join()
-            try:
-                connection.close()
-            except (OSError, http.client.HTTPException):
-                close_failed = True
+            if connection is not None:
+                try:
+                    connection.close()
+                except (OSError, http.client.HTTPException):
+                    close_failed = True
 
-        if expired.is_set() or close_failed:
+        if close_failed:
             return None
+        return parse_dockur_progress(body)
 
-        progress = parse_dockur_progress(body)
+    def _run_attempt(self, attempt: _PollAttempt) -> None:
+        try:
+            result = self._fetch()
+        except BaseException as error:  # noqa: BLE001 -- transfer across thread boundary
+            with self._attempt_lock:
+                if not attempt.expired:
+                    attempt.error = error
+        else:
+            with self._attempt_lock:
+                if not attempt.expired:
+                    attempt.result = result
+        finally:
+            attempt.done.set()
+
+    def poll(self) -> DockurProgress | None:
+        """Fetch one progress document, returning None when unavailable or stale."""
+        start_attempt = False
+        with self._attempt_lock:
+            attempt = self._attempt
+            if attempt is not None and attempt.expired:
+                if not attempt.done.is_set():
+                    return None
+                self._attempt = None
+                attempt = None
+            if attempt is None:
+                attempt = _PollAttempt()
+                self._attempt = attempt
+                start_attempt = True
+
+        if start_attempt:
+            threading.Thread(target=self._run_attempt, args=(attempt,), daemon=True).start()
+
+        if not attempt.done.wait(_REQUEST_TIMEOUT_SECONDS):
+            with self._attempt_lock:
+                if not attempt.done.is_set():
+                    attempt.expired = True
+                    return None
+
+        with self._attempt_lock:
+            if self._attempt is attempt:
+                self._attempt = None
+            if attempt.expired:
+                return None
+            error = attempt.error
+            progress = attempt.result
+
+        if error is not None:
+            raise error
+
         if progress is None:
             return None
         now = time.monotonic()

--- a/src/winpodx/core/dockur_progress.py
+++ b/src/winpodx/core/dockur_progress.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: MIT
+"""Safely read display-only installation progress from dockur's VNC endpoint."""
+
+from __future__ import annotations
+
+import http.client
+import threading
+import time
+from dataclasses import dataclass
+from html.parser import HTMLParser
+
+_MAX_BODY_BYTES = 64 * 1024
+_MAX_TEXT_CHARS = 512
+_REQUEST_TIMEOUT_SECONDS = 1.0
+_STALE_SECONDS = 60.0
+_VOID_ELEMENTS = frozenset(
+    {
+        "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "link",
+        "meta",
+        "param",
+        "source",
+        "track",
+        "wbr",
+    }
+)
+
+
+@dataclass(frozen=True)  # noqa: SLOTS_OK - Python 3.9 uses the manual slots below.
+class DockurProgress:
+    """Normalized text exposed by dockur's progress document."""
+
+    # Python 3.9 lacks dataclass(slots=True), so declare slots explicitly.
+    __slots__ = ("text", "is_loading")
+
+    text: str
+    is_loading: bool
+
+
+class _Target:
+    __slots__ = ("closed", "depth", "is_loading", "parts", "tag")
+
+    def __init__(self, tag: str, depth: int, is_loading: bool) -> None:
+        self.tag = tag
+        self.depth = depth
+        self.is_loading = is_loading
+        self.parts: list[str] = []
+        self.closed = False
+
+
+class _ProgressParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.info_targets: list[_Target] = []
+        self.loading_targets: list[_Target] = []
+        self.plain_parts: list[str] = []
+        self.saw_tag = False
+        self.stack: list[str] = []
+        self.malformed = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.saw_tag = True
+        attribute_values: dict[str, list[str | None]] = {}
+        for name, value in attrs:
+            attribute_values.setdefault(name, []).append(value)
+        if any(len(values) != 1 for values in attribute_values.values()):
+            self.malformed = True
+
+        element_id = attribute_values.get("id", [None])[0]
+        class_value = attribute_values.get("class", [None])[0]
+        classes = class_value.split() if class_value is not None else []
+        is_loading = "loading" in classes
+        target = _Target(tag, len(self.stack), is_loading)
+        if element_id == "info":
+            self.info_targets.append(target)
+        elif tag == "p" and is_loading:
+            self.loading_targets.append(target)
+
+        if tag not in _VOID_ELEMENTS:
+            self.stack.append(tag)
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.handle_starttag(tag, attrs)
+        if tag not in _VOID_ELEMENTS:
+            self.handle_endtag(tag)
+
+    def handle_endtag(self, tag: str) -> None:
+        if not self.stack or self.stack[-1] != tag:
+            self.malformed = True
+            return
+        depth = len(self.stack) - 1
+        self.stack.pop()
+        for target in (*self.info_targets, *self.loading_targets):
+            if target.tag == tag and target.depth == depth and not target.closed:
+                target.closed = True
+
+    def handle_data(self, data: str) -> None:
+        if "script" in self.stack or "style" in self.stack:
+            return
+        depth = len(self.stack)
+        if depth == 0:
+            self.plain_parts.append(data)
+        for target in (*self.info_targets, *self.loading_targets):
+            if not target.closed and depth > target.depth:
+                target.parts.append(data)
+
+    def valid(self) -> bool:
+        targets = (*self.info_targets, *self.loading_targets)
+        return not self.malformed and not self.stack and all(target.closed for target in targets)
+
+
+def parse_dockur_progress(body: bytes) -> DockurProgress | None:
+    """Parse a bounded UTF-8 dockur response into normalized progress."""
+    if not body or len(body) > _MAX_BODY_BYTES:
+        return None
+    try:
+        document = body.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        return None
+
+    parser = _ProgressParser()
+    try:
+        parser.feed(document)
+        parser.close()
+    except ValueError:
+        return None
+    if not parser.valid() or len(parser.info_targets) > 1:
+        return None
+    if parser.info_targets:
+        target = parser.info_targets[0]
+        parts = target.parts
+        is_loading = target.is_loading
+    elif len(parser.loading_targets) == 1:
+        target = parser.loading_targets[0]
+        parts = target.parts
+        is_loading = target.is_loading
+    elif not parser.saw_tag and "<" not in document and ">" not in document:
+        parts = parser.plain_parts
+        is_loading = False
+    else:
+        return None
+
+    text = " ".join("".join(parts).split())
+    if (
+        not text
+        or len(text) > _MAX_TEXT_CHARS
+        or any(ord(character) < 32 or 127 <= ord(character) <= 159 for character in text)
+    ):
+        return None
+    return DockurProgress(text=text, is_loading=is_loading)
+
+
+class DockurProgressReader:
+    """Poll dockur progress and suppress values unchanged for 60 seconds."""
+
+    def __init__(self, vnc_port: int) -> None:
+        self._vnc_port = vnc_port
+        self._last_progress: DockurProgress | None = None
+        self._first_seen_at: float | None = None
+
+    def poll(self) -> DockurProgress | None:
+        """Fetch one progress document, returning None when unavailable or stale."""
+        try:
+            connection = http.client.HTTPConnection(
+                "127.0.0.1",
+                self._vnc_port,
+                timeout=_REQUEST_TIMEOUT_SECONDS,
+            )
+        except (OSError, ValueError, http.client.HTTPException):
+            return None
+
+        expired = threading.Event()
+
+        def expire_request() -> None:
+            expired.set()
+            try:
+                connection.close()
+            except (OSError, http.client.HTTPException):
+                return
+
+        deadline = threading.Timer(_REQUEST_TIMEOUT_SECONDS, expire_request)
+        deadline.daemon = True
+        deadline.start()
+        close_failed = False
+        try:
+            connection.request("GET", "/msg.html")
+            response = connection.getresponse()
+            if response.status != 200:
+                return None
+            content_encoding = response.getheader("Content-Encoding")
+            if content_encoding is not None and content_encoding.strip().lower() not in (
+                "",
+                "identity",
+            ):
+                return None
+            body = response.read(_MAX_BODY_BYTES + 1)
+        except (OSError, ValueError, http.client.HTTPException):
+            return None
+        finally:
+            deadline.cancel()
+            deadline.join()
+            try:
+                connection.close()
+            except (OSError, http.client.HTTPException):
+                close_failed = True
+
+        if expired.is_set() or close_failed:
+            return None
+
+        progress = parse_dockur_progress(body)
+        if progress is None:
+            return None
+        now = time.monotonic()
+        if progress != self._last_progress:
+            self._last_progress = progress
+            self._first_seen_at = now
+            return progress
+        if self._first_seen_at is None or now - self._first_seen_at >= _STALE_SECONDS:
+            return None
+        return progress

--- a/src/winpodx/gui/_main_window_bringup.py
+++ b/src/winpodx/gui/_main_window_bringup.py
@@ -302,7 +302,7 @@ class BringUpProgressDialog(QDialog):
 
         # Sub-detail: attempt counters / probe outcomes go here. Kept on
         # its own line so the header stays scannable.
-        self.sub_detail = QLabel("")
+        self.sub_detail = QLabel("", textFormat=Qt.TextFormat.PlainText)
         self.sub_detail.setWordWrap(True)
         layout.addWidget(self.sub_detail)
 
@@ -1097,7 +1097,6 @@ class BringUpMixin:
         self._emit_phase("phase_1_pod", "Waiting for the pod...")
 
         progress_reader = DockurProgressReader(self.cfg.pod.vnc_port)
-        final_http_progress: str | None = None
         err_streak = 0
         stopped_streak = 0
         while True:
@@ -1114,14 +1113,9 @@ class BringUpMixin:
             if state not in (PodState.STOPPED, PodState.ERROR):
                 if self._is_cancelled():
                     return self._emit_cancelled()
-                if final_http_progress is not None:
-                    progress = final_http_progress
-                else:
-                    http_progress = progress_reader.poll()
-                    if http_progress is not None:
-                        progress = http_progress.text
-                        if not http_progress.is_loading:
-                            final_http_progress = http_progress.text
+                http_progress = progress_reader.poll()
+                if http_progress is not None:
+                    progress = http_progress.text
 
             # Fail fast on a boot-looping QEMU error (e.g. a rejected -device).
             if qemu_error:

--- a/src/winpodx/gui/_main_window_bringup.py
+++ b/src/winpodx/gui/_main_window_bringup.py
@@ -1021,16 +1021,16 @@ class BringUpMixin:
     # ----- phase 1: wait pod ready ---------------------------------------
 
     def _dockur_progress(self) -> tuple[str | None, str | None, bool]:
-        """Peek at the dockur container log: ``(qemu_error, progress, installing)``.
+        """Read QEMU errors and fallback progress from the dockur container log.
 
         * ``qemu_error`` — the latest fatal ``ERROR: qemu-system-...`` line if the
           container is failing to boot (e.g. a rejected ``-device``), else None.
           With dockur's ``restart: unless-stopped`` a bad QEMU arg boot-loops, so
           this lets phase 1 fail fast with the real reason instead of waiting out
           the whole budget.
-        * ``progress`` — the latest ``❯`` status line (or ``Downloading
-          Windows NN%`` from the wget dot-rows); full text — the dialog
-          wraps it for the summary display.
+        * ``progress`` — compatibility fallback when ``msg.html`` is unavailable:
+          the latest ``❯`` status line (or ``Downloading Windows NN%`` from the
+          wget dot-rows); full text — the dialog wraps it for the summary display.
         * ``installing`` — True when dockur is actively downloading/installing, so
           phase 1 can extend its budget past the normal pod-ready window.
         """
@@ -1085,6 +1085,7 @@ class BringUpMixin:
         return qemu_error, progress, installing
 
     def _phase1_wait_pod_ready(self) -> bool:
+        from winpodx.core.dockur_progress import DockurProgressReader
         from winpodx.core.pod import PodState, check_rdp_port, pod_status
 
         # No fixed timeout — a fresh install (ISO download + Sysprep) takes
@@ -1095,6 +1096,8 @@ class BringUpMixin:
         # container has actually exited; the user can Cancel at any time.
         self._emit_phase("phase_1_pod", "Waiting for the pod...")
 
+        progress_reader = DockurProgressReader(self.cfg.pod.vnc_port)
+        final_http_progress: str | None = None
         err_streak = 0
         stopped_streak = 0
         while True:
@@ -1105,7 +1108,20 @@ class BringUpMixin:
             except Exception:  # noqa: BLE001
                 state = None
 
-            qemu_error, progress, _installing = self._dockur_progress()
+            qemu_error, log_progress, _installing = self._dockur_progress()
+            progress = log_progress
+
+            if state not in (PodState.STOPPED, PodState.ERROR):
+                if self._is_cancelled():
+                    return self._emit_cancelled()
+                if final_http_progress is not None:
+                    progress = final_http_progress
+                else:
+                    http_progress = progress_reader.poll()
+                    if http_progress is not None:
+                        progress = http_progress.text
+                        if not http_progress.is_loading:
+                            final_http_progress = http_progress.text
 
             # Fail fast on a boot-looping QEMU error (e.g. a rejected -device).
             if qemu_error:

--- a/src/winpodx/gui/_main_window_header.py
+++ b/src/winpodx/gui/_main_window_header.py
@@ -329,7 +329,7 @@ class HeaderMixin:
         # Two lines stacked: most-recent on top, previous below it
         # (one tick of history). The "previous" line is dimmer so the
         # eye snaps to the freshest line first.
-        self.log_bar_line1 = QLabel("")
+        self.log_bar_line1 = QLabel("", textFormat=Qt.TextFormat.PlainText)
         self.log_bar_line1.setStyleSheet(
             f"background: transparent; color: {C.SUBTEXT1};"
             " font-family: 'JetBrains Mono', 'Fira Code', monospace; font-size: 10px;"
@@ -337,7 +337,7 @@ class HeaderMixin:
         self.log_bar_line1.setTextInteractionFlags(Qt.TextSelectableByMouse)
         layout.addWidget(self.log_bar_line1)
 
-        self.log_bar_line2 = QLabel("")
+        self.log_bar_line2 = QLabel("", textFormat=Qt.TextFormat.PlainText)
         self.log_bar_line2.setStyleSheet(
             f"background: transparent; color: {C.OVERLAY0};"
             " font-family: 'JetBrains Mono', 'Fira Code', monospace; font-size: 10px;"

--- a/tests/fixtures/dockur/README.md
+++ b/tests/fixtures/dockur/README.md
@@ -1,0 +1,13 @@
+# Dockur progress fixture
+
+The two `msg-v6.05-32cc9271-*.html` files reproduce the exact `/msg.html` bytes
+written by Dockur v6.05's `qemux/qemu:7.48` base scripts. `progress.sh` wraps a
+message ending in `...` with `<p class="loading">`; `finish.sh` sends a bare
+non-loading message through the same HTML escape/write path. `record.json`
+binds both samples and their source URLs to the shipped `DOCKUR_IMAGE_PIN`.
+Tests never start a container or contact localhost.
+
+When the image pin changes, verify the new Dockur Dockerfile's base image and
+refresh these source-derived samples. A manual runtime capture, when available,
+must use an isolated disposable container on a random loopback port with no user
+storage; it must never run in pytest or CI.

--- a/tests/fixtures/dockur/msg-v6.05-32cc9271-complete.html
+++ b/tests/fixtures/dockur/msg-v6.05-32cc9271-complete.html
@@ -1,0 +1,1 @@
+The virtual machine was booted successfully.

--- a/tests/fixtures/dockur/msg-v6.05-32cc9271-loading.html
+++ b/tests/fixtures/dockur/msg-v6.05-32cc9271-loading.html
@@ -1,0 +1,1 @@
+<p class="loading">Downloading Windows 11</p>

--- a/tests/fixtures/dockur/record.json
+++ b/tests/fixtures/dockur/record.json
@@ -1,0 +1,26 @@
+{
+  "DOCKUR_IMAGE_PIN": "ghcr.io/dockur/windows@sha256:32cc92715a6c5dc1f63142d3be11059279d64d0faa7519618a07290b3076f9f2",
+  "dockur_tag": "v6.05",
+  "base_image": "qemux/qemu:7.48",
+  "endpoint": "/msg.html",
+  "provenance": {
+    "method": "source-derived",
+    "dockur_dockerfile": "https://raw.githubusercontent.com/dockur/windows/v6.05/Dockerfile",
+    "progress_script": "https://raw.githubusercontent.com/qemus/qemu/v7.48/src/progress.sh",
+    "finish_script": "https://raw.githubusercontent.com/qemus/qemu/v7.48/src/finish.sh"
+  },
+  "samples": [
+    {
+      "file": "msg-v6.05-32cc9271-loading.html",
+      "sha256": "33fa31b67828f5b1e4a452c35851a0bda8e91a84c728b288b452b55f50cc051f",
+      "expected_text": "Downloading Windows 11",
+      "is_loading": true
+    },
+    {
+      "file": "msg-v6.05-32cc9271-complete.html",
+      "sha256": "b7b88c2fda5a2cad0c8b209bf8ef8b67d3a9587dcb9db19dc6f6ff8c11894b63",
+      "expected_text": "The virtual machine was booted successfully.",
+      "is_loading": false
+    }
+  ]
+}

--- a/tests/test_cli_pod.py
+++ b/tests/test_cli_pod.py
@@ -819,7 +819,7 @@ def test_wait_ready_prefers_msg_html_progress_on_configured_port(
     assert "OK OEM reboot pass complete" in output
 
 
-def test_wait_ready_http_progress_does_not_extend_readiness_deadline(
+def test_wait_ready_log_eta_extends_deadline_while_http_progress_is_visible(
     cfg: Config, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # Given
@@ -852,7 +852,140 @@ def test_wait_ready_http_progress_does_not_extend_readiness_deadline(
     pod._wait_ready(60, show_logs=True)
 
     # Then
+    assert len(responsive_timeouts) == 1
+    assert responsive_timeouts[0] > 60
+
+
+def test_wait_ready_http_progress_alone_does_not_extend_readiness_deadline(
+    cfg: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    responsive_timeouts: list[int] = []
+
+    class _Reader:
+        def __init__(self, vnc_port: int) -> None:
+            return None
+
+        def poll(self) -> DockurProgress:
+            return DockurProgress(text="Preparing Windows", is_loading=True)
+
+    class _NoDownloadProcess(_LogProcess):
+        def __init__(self, command, **kwargs) -> None:
+            super().__init__(command, **kwargs)
+            self.stdout = io.BytesIO(b"ordinary container status\n")
+            self.stderr = io.BytesIO()
+
+    monkeypatch.setattr("winpodx.cli.setup_cmd._container_exists_on_backend", lambda config: True)
+    monkeypatch.setattr("winpodx.core.pod.pod_status", lambda config: PodStatus(PodState.RUNNING))
+    monkeypatch.setattr("winpodx.core.pod.check_rdp_port", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        "winpodx.core.provisioner.wait_for_windows_responsive",
+        lambda config, timeout: responsive_timeouts.append(timeout) or True,
+    )
+    monkeypatch.setattr(pod, "_wait_for_oem_reboot", lambda config, timeout: True)
+    monkeypatch.setattr("winpodx.core.dockur_progress.DockurProgressReader", _Reader)
+    monkeypatch.setattr(subprocess, "Popen", _NoDownloadProcess)
+    monkeypatch.setattr(pod.threading, "Thread", _ImmediateThread)
+
+    pod._wait_ready(60, show_logs=True)
+
     assert responsive_timeouts == [60]
+
+
+def test_wait_ready_download_liveness_extends_deadline_while_http_is_visible(
+    cfg: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    responsive_timeouts: list[int] = []
+
+    class _Reader:
+        def __init__(self, vnc_port: int) -> None:
+            return None
+
+        def poll(self) -> DockurProgress:
+            return DockurProgress(text="Downloading Windows", is_loading=True)
+
+    class _DownloadProcess(_LogProcess):
+        def __init__(self, command, **kwargs) -> None:
+            super().__init__(command, **kwargs)
+            self.stdout = io.BytesIO(b"Downloading Windows\n")
+            self.stderr = io.BytesIO()
+
+    class _OnePassEvent:
+        def __init__(self) -> None:
+            self.stopped = False
+
+        def is_set(self) -> bool:
+            return self.stopped
+
+        def set(self) -> None:
+            self.stopped = True
+
+        def wait(self, timeout: float | None = None) -> bool:
+            self.stopped = True
+            return True
+
+    class _SelectedImmediateThread(_ImmediateThread):
+        def start(self) -> None:
+            if self.target.__name__ in ("_drain", "_download_heartbeat"):
+                self.target(*self.args)
+
+    monkeypatch.setattr("winpodx.cli.setup_cmd._container_exists_on_backend", lambda config: True)
+    monkeypatch.setattr("winpodx.core.pod.pod_status", lambda config: PodStatus(PodState.RUNNING))
+    monkeypatch.setattr("winpodx.core.pod.check_rdp_port", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        "winpodx.core.provisioner.wait_for_windows_responsive",
+        lambda config, timeout: responsive_timeouts.append(timeout) or True,
+    )
+    monkeypatch.setattr(pod, "_wait_for_oem_reboot", lambda config, timeout: True)
+    monkeypatch.setattr("winpodx.core.dockur_progress.DockurProgressReader", _Reader)
+    monkeypatch.setattr(subprocess, "Popen", _DownloadProcess)
+    monkeypatch.setattr(pod.threading, "Event", _OnePassEvent)
+    monkeypatch.setattr(pod.threading, "Thread", _SelectedImmediateThread)
+
+    pod._wait_ready(60, show_logs=True)
+
+    assert len(responsive_timeouts) == 1
+    assert responsive_timeouts[0] > 60
+
+
+def test_wait_ready_continues_polling_after_non_loading_http_progress(
+    cfg: Config, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Given
+    recovered = threading.Event()
+    poll_count = 0
+
+    class _Reader:
+        def __init__(self, vnc_port: int) -> None:
+            return None
+
+        def poll(self) -> DockurProgress | None:
+            nonlocal poll_count
+            poll_count += 1
+            if poll_count == 2:
+                return None
+            if poll_count >= 3:
+                recovered.set()
+            return DockurProgress(text="HTTP progress primary", is_loading=False)
+
+    monkeypatch.setattr("winpodx.cli.setup_cmd._container_exists_on_backend", lambda config: True)
+    monkeypatch.setattr("winpodx.core.pod.pod_status", lambda config: PodStatus(PodState.RUNNING))
+    monkeypatch.setattr("winpodx.core.pod.check_rdp_port", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        "winpodx.core.provisioner.wait_for_windows_responsive",
+        lambda config, timeout: recovered.wait(4.0),
+    )
+    monkeypatch.setattr(pod, "_wait_for_oem_reboot", lambda config, timeout: True)
+    monkeypatch.setattr("winpodx.core.dockur_progress.DockurProgressReader", _Reader)
+    monkeypatch.setattr(subprocess, "Popen", _LogProcess)
+
+    # When
+    pod._wait_ready(60, show_logs=True)
+
+    # Then
+    output = capsys.readouterr().out
+    assert poll_count >= 3
+    assert output.count("HTTP progress primary") >= 2
+    assert "OK Windows ready" in output
 
 
 def test_wait_ready_rejects_manual_backend_and_missing_container(

--- a/tests/test_cli_pod.py
+++ b/tests/test_cli_pod.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import io
 import subprocess
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -14,6 +15,7 @@ import pytest
 
 from winpodx.cli import pod
 from winpodx.core.config import Config
+from winpodx.core.dockur_progress import DockurProgress
 from winpodx.core.pod import PodState, PodStatus
 from winpodx.core.transport.base import ExecResult
 
@@ -702,6 +704,9 @@ class _ImmediateThread:
         if self.target.__name__ == "_drain":
             self.target(*self.args)
 
+    def join(self, timeout: int) -> None:
+        assert timeout == 3
+
 
 class _LogProcess:
     def __init__(self, command, **kwargs):
@@ -726,6 +731,9 @@ class _LogProcess:
     def wait(self, timeout: int) -> None:
         assert timeout == 3
 
+    def poll(self) -> int | None:
+        return None
+
 
 def test_wait_ready_streams_clean_logs_and_completes_all_phases(
     cfg: Config, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -740,6 +748,13 @@ def test_wait_ready_streams_clean_logs_and_completes_all_phases(
         created.append(process)
         return process
 
+    class _UnavailableReader:
+        def __init__(self, vnc_port: int) -> None:
+            assert vnc_port == 8007
+
+        def poll(self) -> None:
+            return None
+
     monkeypatch.setattr("winpodx.cli.setup_cmd._container_exists_on_backend", lambda config: True)
     monkeypatch.setattr("winpodx.core.pod.pod_status", lambda config: PodStatus(PodState.RUNNING))
     monkeypatch.setattr("winpodx.core.pod.check_rdp_port", lambda *args, **kwargs: True)
@@ -750,6 +765,7 @@ def test_wait_ready_streams_clean_logs_and_completes_all_phases(
     monkeypatch.setattr("winpodx.core.guest_sync.maybe_autosync", lambda config: True)
     monkeypatch.setattr(subprocess, "Popen", fake_popen)
     monkeypatch.setattr(pod.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr("winpodx.core.dockur_progress.DockurProgressReader", _UnavailableReader)
 
     pod._wait_ready(60, show_logs=True)
 
@@ -765,6 +781,78 @@ def test_wait_ready_streams_clean_logs_and_completes_all_phases(
     assert "Guest synced to the upgraded host" in out
     assert created[0].command == ["podman", "logs", "-f", "--tail", "0", "test-windows"]
     assert created[0].terminated
+
+
+def test_wait_ready_prefers_msg_html_progress_on_configured_port(
+    cfg: Config, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cfg.pod.vnc_port = 18006
+    progress_seen = threading.Event()
+    ports: list[int] = []
+
+    class _Reader:
+        def __init__(self, vnc_port: int) -> None:
+            ports.append(vnc_port)
+
+        def poll(self) -> DockurProgress:
+            progress_seen.set()
+            return DockurProgress(text="HTTP progress primary", is_loading=False)
+
+    monkeypatch.setattr("winpodx.cli.setup_cmd._container_exists_on_backend", lambda config: True)
+    monkeypatch.setattr("winpodx.core.pod.pod_status", lambda config: PodStatus(PodState.RUNNING))
+    monkeypatch.setattr("winpodx.core.pod.check_rdp_port", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        "winpodx.core.provisioner.wait_for_windows_responsive",
+        lambda config, timeout: progress_seen.wait(1.0),
+    )
+    monkeypatch.setattr(pod, "_wait_for_oem_reboot", lambda config, timeout: True)
+    monkeypatch.setattr("winpodx.core.dockur_progress.DockurProgressReader", _Reader)
+    monkeypatch.setattr(subprocess, "Popen", _LogProcess)
+
+    pod._wait_ready(60, show_logs=True)
+
+    output = capsys.readouterr().out
+    assert ports == [18006]
+    assert "HTTP progress primary" in output
+    assert "50%" not in output
+    assert "OK Windows ready" in output
+    assert "OK OEM reboot pass complete" in output
+
+
+def test_wait_ready_http_progress_does_not_extend_readiness_deadline(
+    cfg: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Given
+    responsive_timeouts: list[int] = []
+
+    class _LoadingReader:
+        def __init__(self, vnc_port: int) -> None:
+            return None
+
+        def poll(self) -> DockurProgress:
+            return DockurProgress(text="Downloading Windows", is_loading=True)
+
+    def wait_for_windows_responsive(config: Config, timeout: int) -> bool:
+        responsive_timeouts.append(timeout)
+        return True
+
+    monkeypatch.setattr("winpodx.cli.setup_cmd._container_exists_on_backend", lambda config: True)
+    monkeypatch.setattr("winpodx.core.pod.pod_status", lambda config: PodStatus(PodState.RUNNING))
+    monkeypatch.setattr("winpodx.core.pod.check_rdp_port", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        "winpodx.core.provisioner.wait_for_windows_responsive",
+        wait_for_windows_responsive,
+    )
+    monkeypatch.setattr(pod, "_wait_for_oem_reboot", lambda config, timeout: True)
+    monkeypatch.setattr("winpodx.core.dockur_progress.DockurProgressReader", _LoadingReader)
+    monkeypatch.setattr(subprocess, "Popen", _LogProcess)
+    monkeypatch.setattr(pod.threading, "Thread", _ImmediateThread)
+
+    # When
+    pod._wait_ready(60, show_logs=True)
+
+    # Then
+    assert responsive_timeouts == [60]
 
 
 def test_wait_ready_rejects_manual_backend_and_missing_container(

--- a/tests/test_main_window_bringup.py
+++ b/tests/test_main_window_bringup.py
@@ -557,10 +557,15 @@ def test_dialog_appends_pod_log_lines() -> None:
 
 def test_dialog_phase_detail_preserves_complete_wrapped_text() -> None:
     _ensure_qapp()
+    from PySide6.QtCore import Qt
+
+    from winpodx.core.dockur_progress import parse_dockur_progress
     from winpodx.gui._main_window_bringup import BringUpProgressDialog
 
-    # Given a phase detail longer than the old 80-character limit.
-    detail = "Windows setup status " * 6 + "DETAIL-END"
+    # Given entity-decoded upstream text that resembles Qt rich text.
+    progress = parse_dockur_progress(b'<p class="loading">&lt;b&gt;DETAIL-END&lt;/b&gt;</p>')
+    assert progress is not None
+    detail = progress.text
     dlg = BringUpProgressDialog(None, on_cancel=lambda: None, cfg=None)
     try:
         # When the dialog renders the active phase.
@@ -569,6 +574,7 @@ def test_dialog_phase_detail_preserves_complete_wrapped_text() -> None:
         # Then Qt receives the complete string and wraps it visually.
         assert dlg.sub_detail.text() == detail
         assert dlg.sub_detail.wordWrap() is True
+        assert dlg.sub_detail.textFormat() == Qt.TextFormat.PlainText
     finally:
         dlg.reject()
 
@@ -825,15 +831,23 @@ def test_phase1_prefers_msg_html_without_bypassing_rdp(
     cfg.pod.vnc_port = 18006
     ports: list[int] = []
     polls: list[None] = []
-    rdp_results = iter((False, True))
+    rdp_results = iter((False, False, False, True))
+    http_results = iter(
+        (
+            DockurProgress(text="HTTP phase progress", is_loading=False),
+            None,
+            DockurProgress(text="HTTP phase progress", is_loading=False),
+            DockurProgress(text="HTTP phase progress", is_loading=False),
+        )
+    )
 
     class _Reader:
         def __init__(self, vnc_port: int) -> None:
             ports.append(vnc_port)
 
-        def poll(self) -> DockurProgress:
+        def poll(self) -> DockurProgress | None:
             polls.append(None)
-            return DockurProgress(text="HTTP phase progress", is_loading=False)
+            return next(http_results)
 
     monkeypatch.setattr(
         "winpodx.core.pod.pod_status",
@@ -858,9 +872,9 @@ def test_phase1_prefers_msg_html_without_bypassing_rdp(
         detail for phase, detail in harness.bringup_phase.emissions if phase == "phase_1_pod"
     ]
     assert ports == [18006]
-    assert polls == [None]
-    assert "HTTP phase progress" in details
-    assert "LOG fallback progress" not in details
+    assert polls == [None, None, None, None]
+    assert details.count("HTTP phase progress") == 2
+    assert "LOG fallback progress" in details
     assert details[-1] == "Remote Desktop is up"
 
 

--- a/tests/test_main_window_bringup.py
+++ b/tests/test_main_window_bringup.py
@@ -34,6 +34,7 @@ import pytest
 pytest.importorskip("PySide6")
 
 from winpodx.core.config import Config  # noqa: E402
+from winpodx.core.dockur_progress import DockurProgress  # noqa: E402
 from winpodx.core.pod import PodState, PodStatus  # noqa: E402
 from winpodx.gui._main_window_bringup import BringUpMixin  # noqa: E402
 
@@ -73,7 +74,25 @@ def _stub_dockur_progress(monkeypatch):
     Tests that exercise the boot-error path override this per-test."""
     from winpodx.gui._main_window_bringup import BringUpMixin
 
+    def unexpected_http(*args, **kwargs):
+        pytest.fail("phase 1 test attempted a real Dockur HTTP connection")
+
+    class _UnavailableReader:
+        def __init__(self, vnc_port: int) -> None:
+            return None
+
+        def poll(self) -> None:
+            return None
+
     monkeypatch.setattr(BringUpMixin, "_dockur_progress", lambda self: (None, None, False))
+    monkeypatch.setattr(
+        "winpodx.core.dockur_progress.DockurProgressReader",
+        _UnavailableReader,
+    )
+    monkeypatch.setattr(
+        "winpodx.core.dockur_progress.http.client.HTTPConnection",
+        unexpected_http,
+    )
 
 
 def _make_cfg() -> Config:
@@ -797,6 +816,52 @@ def test_phase1_fails_when_container_exits(monkeypatch: pytest.MonkeyPatch) -> N
     ok, msg = harness.bringup_done.emissions[0]
     assert ok is False
     assert "stopped" in msg.lower()
+
+
+def test_phase1_prefers_msg_html_without_bypassing_rdp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _make_cfg()
+    cfg.pod.vnc_port = 18006
+    ports: list[int] = []
+    polls: list[None] = []
+    rdp_results = iter((False, True))
+
+    class _Reader:
+        def __init__(self, vnc_port: int) -> None:
+            ports.append(vnc_port)
+
+        def poll(self) -> DockurProgress:
+            polls.append(None)
+            return DockurProgress(text="HTTP phase progress", is_loading=False)
+
+    monkeypatch.setattr(
+        "winpodx.core.pod.pod_status",
+        lambda _cfg: PodStatus(state=PodState.RUNNING, ip="127.0.0.1"),
+    )
+    monkeypatch.setattr(
+        "winpodx.core.pod.check_rdp_port",
+        lambda _ip, _port, timeout=3.0: next(rdp_results),
+    )
+    monkeypatch.setattr("winpodx.core.dockur_progress.DockurProgressReader", _Reader)
+    monkeypatch.setattr(
+        BringUpMixin,
+        "_dockur_progress",
+        lambda self: (None, "LOG fallback progress", True),
+    )
+
+    harness = Harness(cfg)
+    monkeypatch.setattr(harness, "_sleep_cancellable", lambda seconds: None)
+
+    assert harness._phase1_wait_pod_ready() is True
+    details = [
+        detail for phase, detail in harness.bringup_phase.emissions if phase == "phase_1_pod"
+    ]
+    assert ports == [18006]
+    assert polls == [None]
+    assert "HTTP phase progress" in details
+    assert "LOG fallback progress" not in details
+    assert details[-1] == "Remote Desktop is up"
 
 
 def test_phase4_does_not_retry_real_script_failure(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_main_window_settings.py
+++ b/tests/test_main_window_settings.py
@@ -31,6 +31,7 @@ import pytest  # noqa: E402
 
 pytest.importorskip("PySide6")
 
+from PySide6.QtCore import Qt  # noqa: E402
 from PySide6.QtWidgets import (  # noqa: E402
     QApplication,
     QLabel,
@@ -204,6 +205,8 @@ def test_log_bar_exposes_two_empty_ticker_lines() -> None:
     assert bar.height() == 38
     assert host.log_bar_line1.text() == ""
     assert host.log_bar_line2.text() == ""
+    assert host.log_bar_line1.textFormat() == Qt.TextFormat.PlainText
+    assert host.log_bar_line2.textFormat() == Qt.TextFormat.PlainText
 
 
 # ----- NavigationMixin ---------------------------------------------------

--- a/tests/test_pod_progress.py
+++ b/tests/test_pod_progress.py
@@ -7,6 +7,7 @@ import pytest
 
 from winpodx.core.dockur_progress import (
     DockurProgress,
+    _ProgressParser,
     parse_dockur_progress,
 )
 
@@ -108,3 +109,33 @@ def test_parse_rejects_untrusted_or_ambiguous_html(body: bytes) -> None:
 
     # Then
     assert result is None
+
+
+def test_parser_does_not_retain_duplicate_progress_targets() -> None:
+    # Given
+    parser = _ProgressParser()
+    body = "".join('<p class="loading">status</p>' for _ in range(300))
+
+    # When
+    parser.feed(body)
+    parser.close()
+
+    # Then
+    assert parser.valid() is False
+    assert len(parser.loading_targets) == 1
+
+
+def test_parser_caps_fragmented_target_text_while_rejecting_overflow() -> None:
+    # Given
+    parser = _ProgressParser()
+    parser.feed('<div id="info">')
+
+    # When
+    for _ in range(600):
+        parser.feed("x")
+    parser.feed("</div>")
+    parser.close()
+
+    # Then
+    assert parser.valid() is False
+    assert sum(len(part) for part in parser.info_targets[0].parts) <= 513

--- a/tests/test_pod_progress.py
+++ b/tests/test_pod_progress.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Final
+
+import pytest
+
+from winpodx.core.dockur_progress import (
+    DockurProgress,
+    parse_dockur_progress,
+)
+
+MAX_BODY_BYTES: Final = 64 * 1024
+VNC_PORT: Final = 8006
+
+
+def test_dockur_progress_is_frozen() -> None:
+    # Given
+    progress = DockurProgress(text="Installing Windows", is_loading=True)
+
+    # When / Then
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(progress, "text", "Changed")
+
+
+def test_parse_v605_loading_html_normalizes_machine_status() -> None:
+    # Given
+    body = b"""<!doctype html><html><head><title>Windows</title></head><body>
+        <main><p class="loading">Downloading <strong>Windows&nbsp;11</strong>
+        &amp; preparing <span>drivers</span></p></main></body></html>"""
+
+    # When
+    result = parse_dockur_progress(body)
+
+    # Then
+    assert result == DockurProgress(
+        text="Downloading Windows 11 & preparing drivers",
+        is_loading=True,
+    )
+
+
+def test_parse_v605_bare_completion_text() -> None:
+    # Given: qemux/qemu 7.48 writes escaped bare text when the message is not loading.
+    body = b"The virtual machine was booted successfully.\n"
+
+    # When
+    result = parse_dockur_progress(body)
+
+    # Then
+    assert result == DockurProgress(
+        text="The virtual machine was booted successfully.",
+        is_loading=False,
+    )
+
+
+def test_parse_prefers_unique_info_target_over_loading() -> None:
+    # Given
+    body = b"""<html><body>
+        <p class="loading">Old loading status</p>
+        <section id="info">Windows <b>is&nbsp;ready</b> &amp; reachable</section>
+        </body></html>"""
+
+    # When
+    result = parse_dockur_progress(body)
+
+    # Then
+    assert result == DockurProgress(text="Windows is ready & reachable", is_loading=False)
+
+
+@pytest.mark.parametrize(
+    "control",
+    ["\x00", "\x1b", "\x7f", "\x80", "\x9f"],
+    ids=["nul", "esc", "del", "c1-80", "c1-9f"],
+)
+def test_parse_rejects_control_characters_in_text(control: str) -> None:
+    body = f'<p class="loading">safe{control}text</p>'.encode("utf-8")
+    assert parse_dockur_progress(body) is None
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        b"",
+        b"<html><body></body></html>",
+        b'<p class="loading">invalid \xff</p>',
+        b'<p class="loading">x</p>' + (b" " * MAX_BODY_BYTES),
+        b'<p class="loading">a</p><p class="loading">b</p>',
+        b'<div id="info">a</div><div id="info">b</div>',
+        b'<p class="loading">never closed',
+        b'<div id="info">never closed',
+        b'<p class="loading">' + (b"x" * 513) + b"</p>",
+    ],
+    ids=[
+        "empty",
+        "missing-target",
+        "invalid-utf8",
+        "oversized-body",
+        "duplicate-loading",
+        "duplicate-info",
+        "unclosed-loading",
+        "unclosed-info",
+        "oversized-text",
+    ],
+)
+def test_parse_rejects_untrusted_or_ambiguous_html(body: bytes) -> None:
+    # Given / When
+    result = parse_dockur_progress(body)
+
+    # Then
+    assert result is None

--- a/tests/test_pod_progress_reader.py
+++ b/tests/test_pod_progress_reader.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import socket
+import threading
+import time
+
+import pytest
+
+import winpodx.core.dockur_progress as dockur_progress
+from winpodx.core.dockur_progress import DockurProgress, DockurProgressReader
+
+MAX_BODY_BYTES = 64 * 1024
+VNC_PORT = 8006
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        status: int = 200,
+        body: bytes = b'<p class="loading">Installing Windows</p>',
+        content_encoding: str | None = None,
+        read_error: OSError | None = None,
+        read_amounts: list[int | None] | None = None,
+    ) -> None:
+        self.status = status
+        self._body = body
+        self._content_encoding = content_encoding
+        self._read_error = read_error
+        self.read_amounts = read_amounts if read_amounts is not None else []
+
+    def read(self, amount: int | None = None) -> bytes:
+        self.read_amounts.append(amount)
+        if self._read_error is not None:
+            raise self._read_error
+        return self._body if amount is None else self._body[:amount]
+
+    def getheader(self, name: str, default: str | None = None) -> str | None:
+        return self._content_encoding if name.lower() == "content-encoding" else default
+
+
+class _FakeConnection:
+    def __init__(
+        self,
+        response: _FakeResponse,
+        response_error: OSError | None,
+        request_error: OSError | None,
+        close_error: OSError | None,
+    ) -> None:
+        self._response = response
+        self._response_error = response_error
+        self._request_error = request_error
+        self._close_error = close_error
+        self.requests: list[tuple[str, str]] = []
+        self.closed = False
+
+    def request(self, method: str, path: str) -> None:
+        if self._request_error is not None:
+            raise self._request_error
+        self.requests.append((method, path))
+
+    def getresponse(self) -> _FakeResponse:
+        if self._response_error is not None:
+            raise self._response_error
+        return self._response
+
+    def close(self) -> None:
+        if self._close_error is not None:
+            raise self._close_error
+        self.closed = True
+
+
+class _ConnectionHarness:
+    def __init__(self) -> None:
+        self.response = _FakeResponse()
+        self.constructor_error: OSError | None = None
+        self.response_error: OSError | None = None
+        self.request_error: OSError | None = None
+        self.close_error: OSError | None = None
+        self.calls: list[tuple[str, int, float]] = []
+        self.connections: list[_FakeConnection] = []
+
+    def __call__(self, host: str, port: int, timeout: float) -> _FakeConnection:
+        self.calls.append((host, port, timeout))
+        if self.constructor_error is not None:
+            raise self.constructor_error
+        connection = _FakeConnection(
+            self.response, self.response_error, self.request_error, self.close_error
+        )
+        self.connections.append(connection)
+        return connection
+
+
+@pytest.fixture
+def http_harness(monkeypatch: pytest.MonkeyPatch) -> _ConnectionHarness:
+    harness = _ConnectionHarness()
+    monkeypatch.setattr(dockur_progress.http.client, "HTTPConnection", harness)
+    return harness
+
+
+def test_reader_uses_fixed_loopback_request_and_closes(http_harness: _ConnectionHarness) -> None:
+    reader = DockurProgressReader(vnc_port=VNC_PORT)
+    result = reader.poll()
+    assert result == DockurProgress(text="Installing Windows", is_loading=True)
+    assert http_harness.calls == [("127.0.0.1", VNC_PORT, 1.0)]
+    assert http_harness.connections[0].requests == [("GET", "/msg.html")]
+    assert http_harness.connections[0].closed is True
+
+
+def test_reader_reads_at_most_64_kibibytes_plus_one(http_harness: _ConnectionHarness) -> None:
+    DockurProgressReader(vnc_port=VNC_PORT).poll()
+    assert http_harness.response.read_amounts == [64 * 1024 + 1]
+
+
+def test_reader_passes_configured_non_default_port(http_harness: _ConnectionHarness) -> None:
+    DockurProgressReader(vnc_port=18006).poll()
+    assert http_harness.calls == [("127.0.0.1", 18006, 1.0)]
+
+
+@pytest.mark.parametrize("status", [201, 302, 404])
+def test_reader_accepts_only_http_200_without_redirects(
+    status: int, http_harness: _ConnectionHarness
+) -> None:
+    http_harness.response = _FakeResponse(status=status)
+    result = DockurProgressReader(vnc_port=VNC_PORT).poll()
+    assert result is None
+    assert http_harness.connections[0].requests == [("GET", "/msg.html")]
+    assert http_harness.connections[0].closed is True
+
+
+@pytest.mark.parametrize(
+    "response",
+    [_FakeResponse(content_encoding="gzip"), _FakeResponse(body=b"x" * (MAX_BODY_BYTES + 1))],
+    ids=["compressed", "oversized"],
+)
+def test_reader_rejects_unsafe_bodies_and_closes(
+    response: _FakeResponse, http_harness: _ConnectionHarness
+) -> None:
+    http_harness.response = response
+    result = DockurProgressReader(vnc_port=VNC_PORT).poll()
+    assert result is None
+    assert http_harness.connections[0].closed is True
+
+
+def test_reader_safely_handles_connection_refusal(http_harness: _ConnectionHarness) -> None:
+    http_harness.constructor_error = ConnectionRefusedError()
+    assert DockurProgressReader(vnc_port=VNC_PORT).poll() is None
+
+
+def test_reader_safely_handles_request_error(http_harness: _ConnectionHarness) -> None:
+    http_harness.request_error = OSError("request failed")
+    assert DockurProgressReader(vnc_port=VNC_PORT).poll() is None
+
+
+@pytest.mark.parametrize("error", [TimeoutError("read timeout"), OSError("read failed")])
+def test_reader_safely_handles_body_read_errors(
+    error: OSError, http_harness: _ConnectionHarness
+) -> None:
+    http_harness.response = _FakeResponse(read_error=error)
+    assert DockurProgressReader(vnc_port=VNC_PORT).poll() is None
+    assert http_harness.connections[0].closed is True
+
+
+def test_reader_safely_handles_close_error(http_harness: _ConnectionHarness) -> None:
+    http_harness.close_error = OSError("close failed")
+    assert DockurProgressReader(vnc_port=VNC_PORT).poll() is None
+
+
+def test_close_error_does_not_suppress_cancellation(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _InterruptingConnection:
+        def request(self, method: str, path: str) -> None:
+            raise KeyboardInterrupt
+
+        def close(self) -> None:
+            raise OSError("close failed")
+
+    connection = _InterruptingConnection()
+
+    def connect(host: str, port: int, timeout: float) -> _InterruptingConnection:
+        return connection
+
+    monkeypatch.setattr(dockur_progress.http.client, "HTTPConnection", connect)
+
+    with pytest.raises(KeyboardInterrupt):
+        DockurProgressReader(vnc_port=VNC_PORT).poll()
+
+
+def test_reader_rejects_malformed_body(http_harness: _ConnectionHarness) -> None:
+    http_harness.response = _FakeResponse(body=b'<p class="loading">unfinished')
+    assert DockurProgressReader(vnc_port=VNC_PORT).poll() is None
+
+
+def test_reader_safely_handles_timeout_and_closes(http_harness: _ConnectionHarness) -> None:
+    http_harness.response_error = socket.timeout()
+    assert DockurProgressReader(vnc_port=VNC_PORT).poll() is None
+    assert http_harness.connections[0].closed is True
+
+
+def test_reader_enforces_total_wall_clock_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Given
+    released = threading.Event()
+
+    class _BlockingResponse:
+        status = 200
+
+        def getheader(self, name: str, default: str | None = None) -> str | None:
+            return default
+
+        def read(self, amount: int | None = None) -> bytes:
+            released.wait(2.0)
+            return b'<p class="loading">Installing Windows</p>'
+
+    class _BlockingConnection:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def request(self, method: str, path: str) -> None:
+            return None
+
+        def getresponse(self) -> _BlockingResponse:
+            return _BlockingResponse()
+
+        def close(self) -> None:
+            self.closed = True
+            released.set()
+
+    connection = _BlockingConnection()
+    monkeypatch.setattr(
+        dockur_progress.http.client,
+        "HTTPConnection",
+        lambda host, port, timeout: connection,
+    )
+
+    # When
+    started = time.monotonic()
+    result = DockurProgressReader(vnc_port=VNC_PORT).poll()
+    elapsed = time.monotonic() - started
+
+    # Then
+    assert result is None
+    assert elapsed < 1.5
+    assert connection.closed is True
+
+
+def _set_clock(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    now = [0.0]
+
+    def monotonic() -> float:
+        return now[0]
+
+    monkeypatch.setattr(dockur_progress.time, "monotonic", monotonic)
+    return now
+
+
+def test_unchanged_normalized_progress_becomes_stale_at_60_seconds(
+    monkeypatch: pytest.MonkeyPatch, http_harness: _ConnectionHarness
+) -> None:
+    now = _set_clock(monkeypatch)
+    reader = DockurProgressReader(vnc_port=VNC_PORT)
+    assert reader.poll() == DockurProgress(text="Installing Windows", is_loading=True)
+    http_harness.response = _FakeResponse(
+        body=b'<p class="loading"> Installing <b>Windows</b> </p>'
+    )
+    now[0] = 60.0
+    assert reader.poll() is None
+
+
+def test_changed_progress_reactivates_after_staleness(
+    monkeypatch: pytest.MonkeyPatch, http_harness: _ConnectionHarness
+) -> None:
+    now = _set_clock(monkeypatch)
+    reader = DockurProgressReader(vnc_port=VNC_PORT)
+    assert reader.poll() is not None
+    now[0] = 60.0
+    assert reader.poll() is None
+    http_harness.response = _FakeResponse(body=b'<div id="info">Windows ready</div>')
+    now[0] = 61.0
+    assert reader.poll() == DockurProgress(text="Windows ready", is_loading=False)
+
+
+def test_unavailable_poll_does_not_refresh_stale_age(
+    monkeypatch: pytest.MonkeyPatch, http_harness: _ConnectionHarness
+) -> None:
+    now = _set_clock(monkeypatch)
+    reader = DockurProgressReader(vnc_port=VNC_PORT)
+    assert reader.poll() is not None
+    now[0] = 30.0
+    http_harness.response = _FakeResponse(status=404)
+    assert reader.poll() is None
+    now[0] = 60.0
+    http_harness.response = _FakeResponse()
+    assert reader.poll() is None

--- a/tests/test_pod_progress_reader.py
+++ b/tests/test_pod_progress_reader.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import socket
-import threading
-import time
 
 import pytest
 
@@ -193,52 +191,6 @@ def test_reader_safely_handles_timeout_and_closes(http_harness: _ConnectionHarne
     http_harness.response_error = socket.timeout()
     assert DockurProgressReader(vnc_port=VNC_PORT).poll() is None
     assert http_harness.connections[0].closed is True
-
-
-def test_reader_enforces_total_wall_clock_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Given
-    released = threading.Event()
-
-    class _BlockingResponse:
-        status = 200
-
-        def getheader(self, name: str, default: str | None = None) -> str | None:
-            return default
-
-        def read(self, amount: int | None = None) -> bytes:
-            released.wait(2.0)
-            return b'<p class="loading">Installing Windows</p>'
-
-    class _BlockingConnection:
-        def __init__(self) -> None:
-            self.closed = False
-
-        def request(self, method: str, path: str) -> None:
-            return None
-
-        def getresponse(self) -> _BlockingResponse:
-            return _BlockingResponse()
-
-        def close(self) -> None:
-            self.closed = True
-            released.set()
-
-    connection = _BlockingConnection()
-    monkeypatch.setattr(
-        dockur_progress.http.client,
-        "HTTPConnection",
-        lambda host, port, timeout: connection,
-    )
-
-    # When
-    started = time.monotonic()
-    result = DockurProgressReader(vnc_port=VNC_PORT).poll()
-    elapsed = time.monotonic() - started
-
-    # Then
-    assert result is None
-    assert elapsed < 1.5
-    assert connection.closed is True
 
 
 def _set_clock(monkeypatch: pytest.MonkeyPatch) -> list[float]:

--- a/tests/test_pod_progress_reader_deadline.py
+++ b/tests/test_pod_progress_reader_deadline.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+import winpodx.core.dockur_progress as dockur_progress
+from winpodx.core.dockur_progress import DockurProgress, DockurProgressReader
+
+VNC_PORT = 8006
+
+
+def test_reader_enforces_total_wall_clock_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Given
+    released = threading.Event()
+    closed = threading.Event()
+    read_thread_ids: list[int] = []
+    close_thread_ids: list[int] = []
+
+    class _BlockingResponse:
+        status = 200
+
+        def getheader(self, name: str, default: str | None = None) -> str | None:
+            return default
+
+        def read(self, amount: int | None = None) -> bytes:
+            read_thread_ids.append(threading.get_ident())
+            released.wait(3.0)
+            return b'<p class="loading">Installing Windows</p>'
+
+    class _BlockingConnection:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def request(self, method: str, path: str) -> None:
+            return None
+
+        def getresponse(self) -> _BlockingResponse:
+            return _BlockingResponse()
+
+        def close(self) -> None:
+            self.closed = True
+            close_thread_ids.append(threading.get_ident())
+            closed.set()
+
+    connection = _BlockingConnection()
+    monkeypatch.setattr(
+        dockur_progress.http.client,
+        "HTTPConnection",
+        lambda host, port, timeout: connection,
+    )
+
+    # When
+    started = time.monotonic()
+    result = DockurProgressReader(vnc_port=VNC_PORT).poll()
+    elapsed = time.monotonic() - started
+    released.set()
+
+    # Then
+    assert result is None
+    assert elapsed < 1.5
+    assert closed.wait(1.0)
+    assert connection.closed is True
+    assert close_thread_ids == read_thread_ids
+
+
+def test_reader_keeps_only_one_timed_out_request_in_flight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given
+    released = threading.Event()
+    read_started = threading.Event()
+    closed = threading.Event()
+    connections: list[_BlockingConnection] = []
+
+    class _BlockingResponse:
+        status = 200
+
+        def getheader(self, name: str, default: str | None = None) -> str | None:
+            return default
+
+        def read(self, amount: int | None = None) -> bytes:
+            read_started.set()
+            released.wait(3.0)
+            return b'<p class="loading">Late progress</p>'
+
+    class _BlockingConnection:
+        def request(self, method: str, path: str) -> None:
+            return None
+
+        def getresponse(self) -> _BlockingResponse:
+            return _BlockingResponse()
+
+        def close(self) -> None:
+            closed.set()
+
+    def connect(host: str, port: int, timeout: float) -> _BlockingConnection:
+        connection = _BlockingConnection()
+        connections.append(connection)
+        return connection
+
+    monkeypatch.setattr(dockur_progress.http.client, "HTTPConnection", connect)
+    reader = DockurProgressReader(vnc_port=VNC_PORT)
+
+    # When
+    assert reader.poll() is None
+    assert read_started.is_set()
+    started = time.monotonic()
+    assert reader.poll() is None
+    second_elapsed = time.monotonic() - started
+    released.set()
+
+    # Then
+    assert second_elapsed < 0.2
+    assert len(connections) == 1
+    assert closed.wait(1.0)
+    assert reader._last_progress is None
+    assert reader.poll() == DockurProgress(text="Late progress", is_loading=True)

--- a/tests/test_pod_progress_smoke.py
+++ b/tests/test_pod_progress_smoke.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+import winpodx.core.dockur_progress as dockur_progress
+from winpodx.core.config import DOCKUR_IMAGE_PIN
+from winpodx.core.dockur_progress import DockurProgress, DockurProgressReader
+
+
+class _FixtureResponse:
+    status = 200
+
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+
+    def getheader(self, name: str, default: str | None = None) -> str | None:
+        return default
+
+    def read(self, amount: int | None = None) -> bytes:
+        return self.body if amount is None else self.body[:amount]
+
+
+class _FixtureConnection:
+    def __init__(self, response: _FixtureResponse) -> None:
+        self.response = response
+        self.requests: list[tuple[str, str]] = []
+
+    def request(self, method: str, endpoint: str) -> None:
+        self.requests.append((method, endpoint))
+
+    def getresponse(self) -> _FixtureResponse:
+        return self.response
+
+    def close(self) -> None:
+        return None
+
+
+@pytest.mark.parametrize("sample_index", [0, 1], ids=["loading", "complete"])
+def test_pinned_dockur_msg_fixture_smoke(
+    monkeypatch: pytest.MonkeyPatch,
+    sample_index: int,
+) -> None:
+    fixture_dir = Path(__file__).parent / "fixtures" / "dockur"
+    record = json.loads((fixture_dir / "record.json").read_text())
+    sample = record["samples"][sample_index]
+    body = (fixture_dir / sample["file"]).read_bytes()
+    connection = _FixtureConnection(_FixtureResponse(body))
+    monkeypatch.setattr(
+        dockur_progress.http.client, "HTTPConnection", lambda *args, **kwargs: connection
+    )
+
+    result = DockurProgressReader(vnc_port=8006).poll()
+
+    assert DOCKUR_IMAGE_PIN == record["DOCKUR_IMAGE_PIN"]
+    assert record["dockur_tag"] == "v6.05"
+    assert record["base_image"] == "qemux/qemu:7.48"
+    assert record["endpoint"] == "/msg.html"
+    assert hashlib.sha256(body).hexdigest() == sample["sha256"]
+    assert result == DockurProgress(
+        text=sample["expected_text"],
+        is_loading=sample["is_loading"],
+    )
+    assert connection.requests == [("GET", "/msg.html")]


### PR DESCRIPTION
## Summary

Use Dockur's loopback-only `/msg.html` endpoint as the primary source of Windows image and installation progress while preserving the existing container-log parser as a fallback.

## Changes

- Add a bounded, stale-aware `DockurProgressReader` for configured VNC ports.
- Keep at most one HTTP request in flight per reader and let its worker own connection cleanup.
- Feed HTTP progress into the existing CLI and GUI display state without changing readiness checks.
- Retain and test log fallback for unavailable, invalid, empty, or stale HTTP responses.
- Render endpoint-derived Qt labels as plain text and bound fragmented/duplicate parser input.
- Add source-derived Dockur v6.05 fixtures, provenance metadata, isolated regression tests, and a fixture contract tied to the shipped image digest.

## Related Issues

Closes #852

## Checklist

- [x] `pytest tests/`: 3699 passed, 10 skipped
- [x] Coverage: 89.22% (88% required)
- [x] TDD red run before the final fixes: 9 failed, 208 passed; final focused run: 221 passed
- [x] `ruff check src/ tests/`: zero errors
- [x] `ruff format --check src/ tests/`: formatted
- [x] Documentation updated where applicable (fixture provenance; no user-facing workflow change)
- [x] No hardcoded paths, credentials, or personal info

## Screenshots

The existing dialog layout is unchanged. Commit `a58b372d` was verified with an offscreen Qt render at 640x443 using long CJK and markup-like progress text; the text remained literal and no clipping, overlap, or fallback-glyph issues were observed.

The smoke test uses source-derived endpoint bytes recorded in `tests/fixtures/dockur/record.json`; it asserts that the record matches the exact `DOCKUR_IMAGE_PIN` shipped by WinPodX. It does not start a real container or contact the host.
